### PR TITLE
fix(affiliates): attribution gaps + Link Past Order admin UI

### DIFF
--- a/src/app/admin/affiliates/[id]/page.tsx
+++ b/src/app/admin/affiliates/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, ReactElement } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
+import LinkPastOrderSection from '@/components/ops/LinkPastOrderSection';
 
 
 interface Commission {
@@ -71,6 +72,7 @@ export default function AffiliateDetailPage(): ReactElement {
   const [editPayoutDetails, setEditPayoutDetails] = useState('');
   const [sendingWelcome, setSendingWelcome] = useState(false);
   const [welcomeResult, setWelcomeResult] = useState<{ success: boolean; message: string } | null>(null);
+  const [refreshTick, setRefreshTick] = useState(0);
 
   useEffect(() => {
     fetch(`/api/admin/affiliates/${id}`)
@@ -94,7 +96,7 @@ export default function AffiliateDetailPage(): ReactElement {
         }
       })
       .finally(() => setLoading(false));
-  }, [id]);
+  }, [id, refreshTick]);
 
   const handleSave = async () => {
     setSaving(true);
@@ -428,6 +430,9 @@ export default function AffiliateDetailPage(): ReactElement {
           </div>
         </div>
       </div>
+
+      {/* Link Past Order */}
+      <LinkPastOrderSection affiliateId={affiliate.id} onLinked={() => setRefreshTick((n) => n + 1)} />
 
       {/* Commissions */}
       <div className="mb-8">

--- a/src/app/api/admin/affiliates/[id]/link-order/route.ts
+++ b/src/app/api/admin/affiliates/[id]/link-order/route.ts
@@ -1,0 +1,64 @@
+/**
+ * POST /api/admin/affiliates/[id]/link-order
+ *
+ * Two modes, selected by request body:
+ *
+ *   { "mode": "existing", "orderNumber": 144 }
+ *     -- Stamps Order.affiliateId and creates an APPROVED AffiliateCommission.
+ *
+ *   { "mode": "external", "label": "Rice/Gaudreau Wedding", "totalAmount": 839, "eventDate": "2026-01-10", "notes": "..." }
+ *     -- Creates a placeholder Customer + Order + Commission for a sale captured
+ *        outside the platform (so the commission has an Order to hang off of).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdminRole } from '@/lib/auth/ops-session';
+import {
+  linkExistingOrderToAffiliate,
+  createExternalOrderForAffiliate,
+} from '@/lib/affiliates/manual-attribution';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  try {
+    const auth = await requireAdminRole();
+    if (auth instanceof NextResponse) return auth;
+
+    const { id: affiliateId } = await params;
+    const body = await request.json();
+
+    if (body.mode === 'existing') {
+      const orderNumber = Number(body.orderNumber);
+      if (!Number.isInteger(orderNumber) || orderNumber <= 0) {
+        return NextResponse.json({ success: false, error: 'orderNumber is required' }, { status: 400 });
+      }
+      const result = await linkExistingOrderToAffiliate({ affiliateId, orderNumber });
+      if (result.alreadyAttributedTo) {
+        return NextResponse.json(
+          { success: false, error: `Order #${orderNumber} is already attributed to a different affiliate.` },
+          { status: 409 }
+        );
+      }
+      return NextResponse.json({ success: true, data: result });
+    }
+
+    if (body.mode === 'external') {
+      const result = await createExternalOrderForAffiliate({
+        affiliateId,
+        label: String(body.label ?? ''),
+        totalAmount: Number(body.totalAmount),
+        eventDate: String(body.eventDate ?? ''),
+        notes: body.notes ? String(body.notes) : undefined,
+      });
+      return NextResponse.json({ success: true, data: result });
+    }
+
+    return NextResponse.json({ success: false, error: 'mode must be "existing" or "external"' }, { status: 400 });
+  } catch (error) {
+    console.error('[Admin Affiliate Link Order] Error:', error);
+    const message = error instanceof Error ? error.message : 'Failed to link order';
+    return NextResponse.json({ success: false, error: message }, { status: 400 });
+  }
+}

--- a/src/components/ops/LinkPastOrderSection.tsx
+++ b/src/components/ops/LinkPastOrderSection.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import { useState, ReactElement } from 'react';
+
+type Mode = 'existing' | 'external';
+
+interface Props {
+  affiliateId: string;
+  onLinked: () => void;
+}
+
+/**
+ * Admin-only UI for retroactively attributing an order to an affiliate.
+ * - "Existing order" mode: enter an order number, creates an APPROVED commission.
+ * - "External order" mode: create a placeholder Order for a sale captured
+ *    outside the platform (e.g. DTR handed off a booking via another system).
+ */
+export default function LinkPastOrderSection({ affiliateId, onLinked }: Props): ReactElement {
+  const [mode, setMode] = useState<Mode>('existing');
+  const [submitting, setSubmitting] = useState(false);
+  const [message, setMessage] = useState<{ kind: 'success' | 'error'; text: string } | null>(null);
+
+  const [orderNumber, setOrderNumber] = useState('');
+
+  const [label, setLabel] = useState('');
+  const [totalAmount, setTotalAmount] = useState('');
+  const [eventDate, setEventDate] = useState('');
+  const [notes, setNotes] = useState('');
+
+  async function submit(): Promise<void> {
+    setSubmitting(true);
+    setMessage(null);
+    try {
+      const body = mode === 'existing'
+        ? { mode, orderNumber: Number(orderNumber) }
+        : { mode, label, totalAmount: Number(totalAmount), eventDate, notes: notes || undefined };
+      const res = await fetch(`/api/admin/affiliates/${affiliateId}/link-order`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json();
+      if (!res.ok || !data.success) {
+        setMessage({ kind: 'error', text: data.error || 'Failed to link order' });
+        return;
+      }
+      const commission = data.data?.commission;
+      const commissionAmt = commission
+        ? `$${(commission.commissionAmountCents / 100).toFixed(2)}`
+        : '$0.00 (no commission row created)';
+      setMessage({
+        kind: 'success',
+        text: `Linked order #${data.data?.order?.orderNumber}. Commission: ${commissionAmt}.`,
+      });
+      setOrderNumber('');
+      setLabel('');
+      setTotalAmount('');
+      setEventDate('');
+      setNotes('');
+      onLinked();
+    } catch {
+      setMessage({ kind: 'error', text: 'Network error' });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const canSubmit = mode === 'existing'
+    ? orderNumber.trim().length > 0 && !submitting
+    : label.trim().length > 0 && totalAmount.trim().length > 0 && eventDate.length > 0 && !submitting;
+
+  return (
+    <div className="mb-8">
+      <h2 className="text-lg font-semibold text-gray-800 mb-3">Link Past Order</h2>
+      <div className="bg-white rounded-lg shadow p-4">
+        <div className="flex gap-1 mb-4 border-b border-gray-200">
+          <button
+            type="button"
+            onClick={() => { setMode('existing'); setMessage(null); }}
+            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+              mode === 'existing' ? 'border-blue-600 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            Existing order #
+          </button>
+          <button
+            type="button"
+            onClick={() => { setMode('external'); setMessage(null); }}
+            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+              mode === 'external' ? 'border-blue-600 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            External (captured elsewhere)
+          </button>
+        </div>
+
+        {mode === 'existing' ? (
+          <div className="space-y-3">
+            <p className="text-sm text-gray-600">
+              Stamps the existing order with this affiliate and creates an APPROVED commission.
+              Use this when an order was paid through the site but didn&apos;t capture the affiliate link.
+            </p>
+            <div className="flex items-end gap-3">
+              <div className="flex-1 max-w-[200px]">
+                <label className="block text-sm text-gray-700 mb-1" htmlFor="order-number-input">Order number</label>
+                <input
+                  id="order-number-input"
+                  type="number"
+                  value={orderNumber}
+                  onChange={(e) => setOrderNumber(e.target.value)}
+                  placeholder="e.g. 144"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-base focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+              <button
+                type="button"
+                onClick={submit}
+                disabled={!canSubmit}
+                className="px-4 py-2 text-sm font-semibold text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-50"
+              >
+                {submitting ? 'Linking...' : 'Link Order'}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <p className="text-sm text-gray-600">
+              Creates a placeholder Order record for a sale captured outside Party On Delivery
+              (e.g. a booking tracked in another system) and attributes it to this affiliate.
+            </p>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <div>
+                <label className="block text-sm text-gray-700 mb-1" htmlFor="ext-label-input">Label (shown as customer name)</label>
+                <input
+                  id="ext-label-input"
+                  type="text"
+                  value={label}
+                  onChange={(e) => setLabel(e.target.value)}
+                  placeholder="e.g. Rice/Gaudreau Wedding"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-base focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+              <div>
+                <label className="block text-sm text-gray-700 mb-1" htmlFor="ext-amount-input">Total amount ($)</label>
+                <input
+                  id="ext-amount-input"
+                  type="number"
+                  step="0.01"
+                  value={totalAmount}
+                  onChange={(e) => setTotalAmount(e.target.value)}
+                  placeholder="839.00"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-base focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+              <div>
+                <label className="block text-sm text-gray-700 mb-1" htmlFor="ext-date-input">Event date</label>
+                <input
+                  id="ext-date-input"
+                  type="date"
+                  value={eventDate}
+                  onChange={(e) => setEventDate(e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-base focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+              <div>
+                <label className="block text-sm text-gray-700 mb-1" htmlFor="ext-notes-input">Notes (optional)</label>
+                <input
+                  id="ext-notes-input"
+                  type="text"
+                  value={notes}
+                  onChange={(e) => setNotes(e.target.value)}
+                  placeholder="e.g. Captured in Square"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-base focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+            </div>
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={submit}
+                disabled={!canSubmit}
+                className="px-4 py-2 text-sm font-semibold text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-50"
+              >
+                {submitting ? 'Creating...' : 'Create External Order'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {message && (
+          <div
+            className={`mt-3 text-sm rounded-lg px-3 py-2 ${
+              message.kind === 'success' ? 'bg-green-50 text-green-800' : 'bg-red-50 text-red-700'
+            }`}
+          >
+            {message.text}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/affiliates/affiliate-service.ts
+++ b/src/lib/affiliates/affiliate-service.ts
@@ -11,8 +11,8 @@ import crypto from 'crypto';
  * Get an active affiliate by referral code
  */
 export async function getAffiliateByCode(code: string) {
-  return prisma.affiliate.findUnique({
-    where: { code: code.toUpperCase() },
+  return prisma.affiliate.findFirst({
+    where: { code: { equals: code, mode: 'insensitive' } },
   });
 }
 
@@ -26,9 +26,9 @@ export async function getAffiliateBySlug(slug: string) {
     where: { partnerSlug: lower },
   });
   if (bySlug) return bySlug;
-  // Fall back to code lookup
-  return prisma.affiliate.findUnique({
-    where: { code: slug.toUpperCase() },
+  // Fall back to code lookup (case-insensitive)
+  return prisma.affiliate.findFirst({
+    where: { code: { equals: slug, mode: 'insensitive' } },
   });
 }
 

--- a/src/lib/affiliates/commission-engine.ts
+++ b/src/lib/affiliates/commission-engine.ts
@@ -198,8 +198,8 @@ export async function linkOrderToAffiliate(
   },
   affiliateCode: string
 ) {
-  const affiliate = await prisma.affiliate.findUnique({
-    where: { code: affiliateCode.toUpperCase() },
+  const affiliate = await prisma.affiliate.findFirst({
+    where: { code: { equals: affiliateCode, mode: 'insensitive' } },
   });
 
   if (!affiliate || affiliate.status !== 'ACTIVE') {

--- a/src/lib/affiliates/manual-attribution.ts
+++ b/src/lib/affiliates/manual-attribution.ts
@@ -1,0 +1,208 @@
+/**
+ * Manual (retroactive) affiliate attribution.
+ *
+ * Used by the /admin/affiliates/[id] UI to attribute past orders that were not
+ * captured by the normal ?ref= + cookie flow — e.g. when a partner created a
+ * draft order outside the tracking context, or when a sale was captured in
+ * an external system entirely.
+ */
+
+import { prisma } from '@/lib/database/client';
+import {
+  CommissionStatus,
+  OrderStatus,
+  FinancialStatus,
+  FulfillmentStatus,
+  type AffiliateCommission,
+  type Order,
+} from '@prisma/client';
+import { calculateCommission } from './commission-engine';
+
+export interface LinkExistingOrderInput {
+  affiliateId: string;
+  orderNumber: number;
+}
+
+export interface LinkExistingOrderResult {
+  order: Pick<Order, 'id' | 'orderNumber' | 'customerName' | 'subtotal' | 'total'>;
+  commission: AffiliateCommission | null;
+  alreadyAttributedTo: string | null;
+}
+
+/**
+ * Attribute an existing order to an affiliate and create an APPROVED commission.
+ * Status is APPROVED (not HELD) since these orders are past their refund window
+ * by the time an admin is manually attributing them.
+ */
+export async function linkExistingOrderToAffiliate(
+  input: LinkExistingOrderInput
+): Promise<LinkExistingOrderResult> {
+  const order = await prisma.order.findFirst({
+    where: { orderNumber: input.orderNumber },
+    select: {
+      id: true, orderNumber: true, customerName: true, customerEmail: true,
+      subtotal: true, discountAmount: true, total: true, affiliateId: true,
+      createdAt: true,
+    },
+  });
+  if (!order) throw new Error(`Order #${input.orderNumber} not found`);
+  if (order.affiliateId && order.affiliateId !== input.affiliateId) {
+    return {
+      order,
+      commission: null,
+      alreadyAttributedTo: order.affiliateId,
+    };
+  }
+
+  const affiliate = await prisma.affiliate.findUnique({
+    where: { id: input.affiliateId },
+    select: { id: true, email: true, commissionRateOverride: true },
+  });
+  if (!affiliate) throw new Error('Affiliate not found');
+
+  const subtotalCents = Math.round(Number(order.subtotal) * 100);
+  const discountCents = Math.round(Number(order.discountAmount) * 100);
+  const baseCents = Math.max(subtotalCents - discountCents, 0);
+
+  const overrideRate = affiliate.commissionRateOverride !== null
+    ? Number(affiliate.commissionRateOverride)
+    : undefined;
+  const { commissionAmountCents, commissionRate, tierAtTime } = await calculateCommission(
+    affiliate.id,
+    baseCents,
+    overrideRate
+  );
+
+  const isSelfReferral = (order.customerEmail || '').toLowerCase() === (affiliate.email || '').toLowerCase();
+
+  const commission = await prisma.$transaction(async (tx) => {
+    if (!order.affiliateId) {
+      await tx.order.update({ where: { id: order.id }, data: { affiliateId: affiliate.id } });
+    }
+    const existing = await tx.affiliateCommission.findFirst({
+      where: { orderId: order.id, affiliateId: affiliate.id },
+    });
+    if (existing) return existing;
+    if (commissionAmountCents <= 0) return null;
+    return tx.affiliateCommission.create({
+      data: {
+        affiliateId: affiliate.id,
+        orderId: order.id,
+        commissionBaseCents: baseCents,
+        commissionRate,
+        commissionAmountCents,
+        tierAtTime,
+        status: CommissionStatus.APPROVED,
+        isSelfReferral,
+        deliveredAt: order.createdAt,
+      },
+    });
+  });
+
+  return { order, commission, alreadyAttributedTo: null };
+}
+
+export interface ExternalOrderInput {
+  affiliateId: string;
+  /** Short label for the order — e.g. "Rice/Gaudreau Wedding". Used as customerName. */
+  label: string;
+  /** Total amount to use as the commission base (in dollars). */
+  totalAmount: number;
+  /** Event/delivery date as YYYY-MM-DD. */
+  eventDate: string;
+  /** Optional free-form note stored on the Order. */
+  notes?: string;
+}
+
+export interface ExternalOrderResult {
+  order: Pick<Order, 'id' | 'orderNumber' | 'customerName' | 'total'>;
+  commission: AffiliateCommission | null;
+}
+
+/**
+ * Create a placeholder Order for an externally-captured sale and attribute it
+ * to an affiliate. Commission base = totalAmount.
+ */
+export async function createExternalOrderForAffiliate(
+  input: ExternalOrderInput
+): Promise<ExternalOrderResult> {
+  if (!input.label.trim()) throw new Error('Label is required');
+  if (!Number.isFinite(input.totalAmount) || input.totalAmount <= 0) {
+    throw new Error('totalAmount must be a positive number');
+  }
+  const eventDate = new Date(`${input.eventDate}T18:00:00Z`);
+  if (Number.isNaN(eventDate.getTime())) throw new Error('Invalid eventDate (use YYYY-MM-DD)');
+
+  const affiliate = await prisma.affiliate.findUnique({
+    where: { id: input.affiliateId },
+    select: { id: true, code: true, email: true, commissionRateOverride: true },
+  });
+  if (!affiliate) throw new Error('Affiliate not found');
+
+  const baseCents = Math.round(input.totalAmount * 100);
+  const overrideRate = affiliate.commissionRateOverride !== null
+    ? Number(affiliate.commissionRateOverride)
+    : undefined;
+  const { commissionAmountCents, commissionRate, tierAtTime } = await calculateCommission(
+    affiliate.id,
+    baseCents,
+    overrideRate
+  );
+
+  const placeholderEmail = `external+${affiliate.code.toLowerCase()}-${Date.now()}@placeholder.partyondelivery.com`;
+
+  const created = await prisma.$transaction(async (tx) => {
+    const customer = await tx.customer.create({
+      data: {
+        email: placeholderEmail,
+        firstName: input.label.slice(0, 50),
+        lastName: '(External)',
+      },
+    });
+    const order = await tx.order.create({
+      data: {
+        customerId: customer.id,
+        status: OrderStatus.DELIVERED,
+        financialStatus: FinancialStatus.PAID,
+        fulfillmentStatus: FulfillmentStatus.DELIVERED,
+        subtotal: input.totalAmount,
+        discountAmount: 0,
+        taxAmount: 0,
+        deliveryFee: 0,
+        tipAmount: 0,
+        total: input.totalAmount,
+        deliveryDate: eventDate,
+        deliveryTime: 'N/A (external)',
+        deliveryAddress: { address1: 'Externally captured', city: 'Austin', province: 'TX', zip: '', country: 'US' },
+        deliveryPhone: 'N/A',
+        customerEmail: placeholderEmail,
+        customerName: input.label,
+        affiliateId: affiliate.id,
+        internalNote:
+          `External order — captured outside Party On Delivery platform. ` +
+          `Added for ${affiliate.code} commission tracking. ` +
+          `Total $${input.totalAmount.toFixed(2)} treated as commission base.` +
+          (input.notes ? `\nNotes: ${input.notes}` : ''),
+      },
+      select: { id: true, orderNumber: true, customerName: true, total: true, createdAt: true },
+    });
+    const commission = commissionAmountCents > 0
+      ? await tx.affiliateCommission.create({
+          data: {
+            affiliateId: affiliate.id,
+            orderId: order.id,
+            commissionBaseCents: baseCents,
+            commissionRate,
+            commissionAmountCents,
+            tierAtTime,
+            status: CommissionStatus.APPROVED,
+            isSelfReferral: false,
+            deliveredAt: order.createdAt,
+          },
+        })
+      : null;
+    return { order, commission };
+  });
+
+  return created;
+}

--- a/src/lib/stripe/group-v2-payments.ts
+++ b/src/lib/stripe/group-v2-payments.ts
@@ -593,17 +593,27 @@ export async function handleGroupV2PaymentCompleted(
     }
   }
 
-  // Link order to affiliate if attributed
-  const affiliateCode = session.metadata?.affiliateCode;
+  // Link order to affiliate if attributed.
+  // Prefer the Stripe metadata code (set at checkout). If missing — e.g. orders
+  // created before metadata propagation landed — fall back to the group's
+  // affiliateId so attribution still flows through.
+  let resolvedAffiliateCode = session.metadata?.affiliateCode;
+  if (!resolvedAffiliateCode) {
+    const group = await prisma.groupOrderV2.findUnique({
+      where: { id: groupOrderId },
+      select: { affiliate: { select: { code: true } } },
+    });
+    resolvedAffiliateCode = group?.affiliate?.code;
+  }
   let affiliateEmail: string | null = null;
-  if (affiliateCode) {
+  if (resolvedAffiliateCode) {
     try {
-      await linkOrderToAffiliate(order, affiliateCode);
-      const affiliate = await getAffiliateByCode(affiliateCode);
+      await linkOrderToAffiliate(order, resolvedAffiliateCode);
+      const affiliate = await getAffiliateByCode(resolvedAffiliateCode);
       if (affiliate?.email) {
         affiliateEmail = affiliate.email;
       }
-      console.log('[Group V2 Payment] Linked to affiliate:', affiliateCode);
+      console.log('[Group V2 Payment] Linked to affiliate:', resolvedAffiliateCode);
     } catch (affiliateErr) {
       console.error('[Group V2 Payment] Failed to link affiliate:', affiliateErr);
     }


### PR DESCRIPTION
## Summary
- **Bug fix 1:** `linkOrderToAffiliate` looked up affiliates with `code: affiliateCode.toUpperCase()`, but `Affiliate.code` stores canonical case (e.g. `DTRbartending`). Mixed-case codes silently missed the lookup → no commission created. Switched to case-insensitive `findFirst`. Same fix for `getAffiliateByCode` and `getAffiliateBySlug`.
- **Bug fix 2:** The group-v2 Stripe webhook only read `session.metadata.affiliateCode`, which is populated only since [commit 130068a3](https://github.com/allan-cmyk/PartyOn2/commit/130068a3) (2026-04-06). Any GroupOrderV2 order paid before that landed never ran commission-creation. Added a DB fallback that reads `group.affiliate.code` when metadata is absent.
- **New admin UI:** `/admin/affiliates/[id]` gains a **Link Past Order** section with two modes:
  - **Existing order #** — stamps `Order.affiliateId` and creates an APPROVED commission for an order that slipped through tracking.
  - **External (captured elsewhere)** — creates a placeholder `Customer` + `Order` + commission for a sale recorded in another system (needed because `AffiliateCommission.orderId` is NOT NULL).

Shared retroactive-attribution logic lives in `src/lib/affiliates/manual-attribution.ts`; a single dispatch route `POST /api/admin/affiliates/[id]/link-order` handles both modes.

## Production data backfill (already run separately)
A one-off script stamped 44 previously-unattributed orders and created 11 APPROVED commissions totaling **$803.06** across DTR, TapTruck, BigTex, and the POUR24 leftovers — details in the session that produced this PR. Premier orders (37) were attributed but produced $0 commissions since Premier's override rate is 0. Not included in this PR (data change, not code).

## Test plan
- [ ] Visit `/admin/affiliates/[id]` for any affiliate; confirm the new **Link Past Order** section renders above Commissions
- [ ] Try **Existing order #** with a known unattributed order number — verify new commission appears in the Commissions table
- [ ] Try **External** mode with a label, amount, and date — verify a placeholder Order gets created with `internalNote` flagging it external
- [ ] Double-attribution guard: try linking an order that's already attributed to a different affiliate → expect 409 error message
- [ ] Smoke-check that the normal V2 group-order checkout still creates commissions correctly (regression guard on the case-insensitive + fallback changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)