### PR TITLE
fix(affiliates): surface Payouts page + sweep late-approved commissions

### DIFF
--- a/src/app/admin/affiliates/page.tsx
+++ b/src/app/admin/affiliates/page.tsx
@@ -149,6 +149,12 @@ export default function AffiliatesPage(): ReactElement {
         <h1 className="text-2xl font-bold text-gray-900">Affiliates</h1>
         <div className="flex gap-2">
           <Link
+            href="/admin/affiliates/payouts"
+            className="px-4 py-2 text-sm font-semibold text-white bg-emerald-600 rounded-lg hover:bg-emerald-700 transition-all shadow-sm"
+          >
+            Payouts
+          </Link>
+          <Link
             href="/admin/affiliates/embed-generator"
             className="px-4 py-2 text-sm font-semibold text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-all shadow-sm"
           >

--- a/src/lib/affiliates/payout-service.ts
+++ b/src/lib/affiliates/payout-service.ts
@@ -13,19 +13,18 @@ import { CommissionStatus, PayoutStatus } from '@prisma/client';
 export async function generateMonthlyPayouts(year: number, month: number) {
   const payoutPeriod = `${year}-${String(month).padStart(2, '0')}`;
 
-  // Find the month range
-  const startOfMonth = new Date(year, month - 1, 1);
+  // End-of-month cutoff. We sweep every APPROVED+unpaid commission created on or
+  // before the end of the target month, regardless of when it was created. This
+  // catches late-approved commissions from prior months that would otherwise
+  // never roll into a payout (the previous window-only query silently skipped
+  // them forever).
   const endOfMonth = new Date(year, month, 1);
 
-  // Get all APPROVED commissions in this month that haven't been assigned a payout
   const commissions = await prisma.affiliateCommission.findMany({
     where: {
       status: CommissionStatus.APPROVED,
       payoutId: null,
-      createdAt: {
-        gte: startOfMonth,
-        lt: endOfMonth,
-      },
+      createdAt: { lt: endOfMonth },
     },
     orderBy: { affiliateId: 'asc' },
   });


### PR DESCRIPTION
## Summary
- Adds a **Payouts** link to `/admin/affiliates` header — the page existed but was orphaned (reachable only by direct URL).
- Fixes a silent data bug in `generateMonthlyPayouts`: the previous month-window query (`createdAt gte startOfMonth, lt endOfMonth`) skipped commissions approved in a later month, leaving them stuck in `APPROVED` forever. Now sweeps every `APPROVED`+unpaid commission created before the end of the target month.

Live DB check showed 14 APPROVED commissions worth \$932.83 were unreachable before this fix.

## Test plan
- [ ] Navigate to `/admin/affiliates` → green **Payouts** button visible
- [ ] Click through → `/admin/affiliates/payouts` loads
- [ ] Run Monthly Payout for April 2026 → sweeps the 14 backlogged commissions into new `PENDING` payouts (one per affiliate)
- [ ] Existing `2026-03 POUR24 $107.25 PENDING` payout is untouched (already has `payoutId`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)