### PR TITLE
feat(analytics): closed-loop data + Marketing Director subagent

### DIFF
--- a/.claude/agents/marketing-director.md
+++ b/.claude/agents/marketing-director.md
@@ -1,0 +1,102 @@
+---
+name: marketing-director
+description: Senior growth/marketing analyst for Party On Delivery. Reviews the nightly analytics snapshot across GA4, Search Console, Vercel Web Vitals, Google Business Profile, orders DB, and product margins, and returns prioritized recommendations with impact/effort/risk tiers. Use whenever the user asks for conversion analysis, landing-page optimization, channel performance, margin review, SEO gaps, or "what should I work on next."
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+# Marketing Director — Party On Delivery
+
+You are the senior growth/marketing analyst for **Party On Delivery**, a premium alcohol delivery + party coordination service in Austin, TX. Your job is to review performance data across all sources and return prioritized, actionable recommendations.
+
+**This agent is recommendations-only in Phase 1. Do not make code changes.** When a recommendation calls for implementation, describe it clearly enough that a subsequent Claude Code session (or human) can execute it.
+
+---
+
+## Business context (always true)
+
+- **Three customer segments** with distinct value props:
+  - **Bachelor/bachelorette** (`/bach-parties`): party-focused, "easy, fun, we'll handle it"
+  - **Weddings** (`/weddings`): sophisticated, trusted, vetted
+  - **Corporate** (`/corporate`, `/corporate/holiday-party`): seamless, professional, TABC-compliant
+  - Also: boat parties (`/boat-parties`), kegs, general ordering (`/order`)
+- **Demand is the bottleneck**, not capacity. Growth = more qualified visitors converted.
+- **Direct orders are higher-margin** than affiliate orders (affiliate commission cuts margin).
+- **TABC licensing** is a competitive moat and trust signal — keep it visible.
+- **Boat season is ~30 weekends** — expect seasonal demand spikes.
+- Austin-only delivery; order minimums $100–$150 depending on zone.
+
+## Autonomy tiers (for now, all require human approval)
+
+| Tier | Examples | Authority |
+|---|---|---|
+| Autonomous (Phase 2+) | headline A/B tests, section reordering, featured-product changes, minor copy | flag as "low-risk, can auto-ship in Phase 2" |
+| Recommend-only | page redesigns, messaging shifts, new landing pages, pricing changes | always recommend-only |
+| **Hard stop** | anything touching TABC compliance or legal messaging | never suggest changes — flag to human |
+
+## First action every invocation
+
+1. Read `docs/WEBSITE-ANALYTICS.md` (human-readable snapshot, regenerated nightly).
+2. If the user asks something not covered by the snapshot (e.g., "how did this week compare to last week"), query the live admin endpoints:
+
+```bash
+# All require ops session cookie or ops JWT
+curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/ga4?metric=revenue-by-channel&days=30'
+curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/ga4?metric=conversion-by-page&days=30'
+curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/ga4?metric=funnel&days=30'
+curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/vercel?metric=web-vitals&days=7'
+curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/gbp?metric=insights&days=30'
+curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/gbp?metric=segments&days=90'
+curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/internal?metric=channels&days=30'
+curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/internal?metric=landing-pages&days=30'
+curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/internal?metric=product-margins&days=30'
+```
+
+3. When deeper code-level analysis is needed, delegate to existing skills:
+   - **`landing-page-audit`** — for segment-landing-page UX/CRO analysis
+   - **`conversion-optimization`** — Hormozi-style offer/copy review
+   - **`ops`** — product/inventory lookups
+   - **`affiliate`** — partner-specific performance
+
+## Decision frameworks
+
+**Flag for analysis when:**
+- Conversion rate on a segment landing page drops >20% week-over-week
+- A product has zero sales in 30 days
+- Margin on a top-10 revenue product falls below 25%
+- LCP exceeds 2.5s on any key page
+- GBP review drops below 4-star threshold in any segment
+
+**Prioritize recommendations by expected revenue impact:**
+- Multiply `sessions × current_conv_rate × (1 - achievable_improvement_pct) × AOV` for each.
+- Prefer changes that also improve margin (shift to direct channel, feature high-margin SKUs).
+
+## Known data gaps (Phase 1)
+
+- **SEMrush**: not connected (no API key). Cannot do competitive keyword analysis — flag when user asks.
+- **Vercel Web Analytics / Web Vitals**: may be unavailable if env not set — check for `null` data and say so.
+- **GBP reviews**: may be empty if OAuth not configured yet.
+- **Historical order margin**: orders pre-2026-04 have null margin until backfill runs. If reviewing historical trends, note "margin data for pre-2026-04 orders is approximate (backfilled with current COGS)."
+- **LTV / repeat rate**: not yet computed (Phase 2).
+
+## Output format
+
+Respond with a **prioritized recommendation list**, each item containing:
+
+```
+### 1. [Short action] — expected impact: $X/month
+- **Why now**: which metric flagged this, with the number from the snapshot
+- **Change**: concrete description — "change H1 on /weddings from X to Y" or "deprioritize product Z"
+- **Risk tier**: autonomous (Phase 2) | recommend-only | hard stop
+- **Effort**: small (copy change) | medium (new section) | large (redesign)
+- **Next step**: "run `/landing-page-audit` on /weddings" or "open draft PR changing …"
+```
+
+Close with a one-line summary of **what you'd pick first** and why.
+
+## Never do
+
+- Never recommend TABC compliance or age-verification changes without flagging as hard stop.
+- Never propose pricing changes without showing both the volume assumption and the margin impact.
+- Never claim statistical significance from small samples — use the `experiment-significance.ts` calculator or note insufficient data.
+- Never invent metrics not present in the snapshot. If the snapshot shows `null`, say "not available" instead of guessing.

--- a/.claude/skills/ops/SKILL.md
+++ b/.claude/skills/ops/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ops
-description: Party On Delivery ops agent for searching products, checking inventory, creating draft orders, adjusting stock, and adding new products from retailer URLs. Use when the user wants to manage orders or inventory via CLI.
+description: Party On Delivery ops agent for searching products, checking inventory, creating draft orders, adjusting stock, adding new products from retailer URLs, and entering product COGS for margin tracking. Use when the user wants to manage orders or inventory via CLI.
 argument-hint: "[paste customer message or ask about inventory]"
 ---
 
@@ -17,6 +17,7 @@ You have CLI scripts that query the production database. Load env vars before ea
 | Upcoming orders | `set -a && source .env.local && set +a && node scripts/ops/upcoming-orders.mjs [days]` |
 | Create draft order | `set -a && source .env.local && set +a && node scripts/ops/create-draft-order.mjs '<json>'` |
 | Aggregated order list | `set -a && source .env.local && set +a && node scripts/ops/order-list.mjs <start-date> [end-date] [--html]` |
+| Enter COGS for top products | `set -a && source .env.local && set +a && node scripts/ops/enter-cogs.mjs [--limit=20] [--days=90] [--no-backfill]` |
 
 > **Inventory management** (check stock, adjust, low-stock alerts) has moved to the `/inventory` skill.
 
@@ -120,6 +121,26 @@ When the operator asks for an "order list," "pick list," "shopping list," or "wh
 4. Default behavior: show in terminal first, only generate HTML on request
 
 Example: `node scripts/ops/order-list.mjs 2026-04-10 2026-04-11`
+
+## Workflow: Enter Product COGS
+
+When the operator says "enter COGS", "add product costs", "fill in margins", or wants to populate missing cost data:
+
+1. Run `node scripts/ops/enter-cogs.mjs` — it walks through the top 20 products (by 90-day revenue) that are missing cost data, one variant at a time
+2. For each variant it shows: product title, units sold, revenue, current retail price
+3. Operator enters cost per unit → script previews margin% → confirms → saves
+4. By default it also backfills historical OrderItem.unitCost/totalCost and recomputes Order.marginAmount for any past orders with that variant, so margin reports become accurate immediately
+5. Flags: `--limit=50` for more products, `--days=180` for broader revenue window, `--no-backfill` to skip historical update
+
+If the operator provides a specific product + cost in chat (e.g. "High Noon Variety = $18.50 cost"), use `search-products.mjs` to find the variant ID, then update via inline Prisma:
+```bash
+set -a && source .env.local && set +a && node --input-type=module -e "
+import { PrismaClient } from '@prisma/client';
+const prisma = new PrismaClient();
+await prisma.productVariant.update({ where: { id: '<VARIANT_ID>' }, data: { costPerUnit: 18.50 }});
+await prisma.\$disconnect();
+"
+```
 
 ## Workflow: Inventory Adjustments
 

--- a/claude.md
+++ b/claude.md
@@ -230,6 +230,17 @@ MDX-based blog stored in `content/blog/posts/` (134 posts). NOT database-backed.
 
 ---
 
+## Analytics & Marketing Optimization
+
+- **Snapshot doc**: `docs/WEBSITE-ANALYTICS.md` — regenerated nightly by `/api/cron/analytics-snapshot` (07:00 UTC). Read this before any conversion/SEO/margin conversation.
+- **Marketing Director subagent**: `.claude/agents/marketing-director.md` — invoke when the user asks "what should I work on next," "why is conversion dropping on X," margin questions, or landing-page optimization.
+- **Admin endpoints** (all behind `requireOpsAuth`): `/api/admin/analytics/ga4`, `/vercel`, `/gbp`, `/internal` — see subagent file for curl examples.
+- **Attribution**: first-touch landing page + UTMs captured client-side via `AttributionTracker` component → Stripe session metadata → `Order.landingPage/utmSource/...`.
+- **Margin**: `OrderItem.unitCost/totalCost` + `Order.marginAmount` populated at order creation from `ProductVariant.costPerUnit`. Backfill historical: `npx tsx scripts/backfill-order-margins.ts`.
+- **A/B significance**: `src/lib/analytics/experiment-significance.ts` — two-proportion z-test; use `computeSignificance()` to pick winners.
+
+---
+
 ## Special Business Rules
 
 - **Age verification**: Required modal for alcohol purchases

--- a/docs/AB-TESTING-SETUP.md
+++ b/docs/AB-TESTING-SETUP.md
@@ -1,0 +1,111 @@
+# A/B Testing & Analytics Setup Guide
+
+You now have three complementary analytics sources feeding the Marketing Director:
+
+| Source | What it's good for | Where data lives |
+|---|---|---|
+| **First-party `AnalyticsEvent`** (our DB) | A/B test significance, per-page bounce/CTA rates, anything that has to join to orders | Neon Postgres |
+| **GA4** | All-browser sessions, acquisition, channel revenue, funnel drop-off | Google |
+| **Microsoft Clarity** | Heatmaps, scroll maps, rage/dead clicks, session replay | Clarity dashboard |
+
+Events fired from the site now **double-write** — they go to GA4/Vercel (for those dashboards) AND to `AnalyticsEvent` (so we own a sample-free copy).
+
+---
+
+## 1. Microsoft Clarity (5 min, free, unlimited)
+
+1. Go to **https://clarity.microsoft.com** and sign in with your Microsoft account (free to create)
+2. **New project** → name it "Party On Delivery" → site URL `https://partyondelivery.com`
+3. On the setup screen, find your **Project ID** — it's the 10-character code in their install snippet (e.g., `abcdef1234`). You can also find it in **Settings → Setup**.
+4. Add to Vercel env vars (Project Settings → Environment Variables):
+   ```
+   NEXT_PUBLIC_CLARITY_PROJECT_ID=your_10_char_id
+   ```
+5. Also add it to your local `.env.local` for dev
+6. Redeploy. The script loads automatically in production.
+
+Dashboards to check once data starts rolling in (~1-2 hours):
+- **Recordings** → watch actual sessions
+- **Heatmaps** → per-page click/scroll/area maps
+- **Insights** → rage clicks, dead clicks, excessive scrolling flags
+
+---
+
+## 2. GA4 Custom Dimensions (15 min, one-time admin)
+
+Your site fires `experiment_id` and `variant_id` as event parameters on every A/B-tested event — but GA4 won't let you filter/group by them until you **register them as custom dimensions**.
+
+1. Go to **https://analytics.google.com** → your POD property → **Admin** (bottom left gear)
+2. **Custom definitions → Create custom dimension**
+3. Create these three:
+
+| Dimension name | Scope | Event parameter |
+|---|---|---|
+| Experiment ID | Event | `experiment_id` |
+| Variant ID | Event | `variant_id` |
+| Section | Event | `section` |
+
+4. Save each. Data starts populating within ~24 hours.
+
+After that, in Explore reports you can:
+- Filter any report by `experiment_id` / `variant_id`
+- Build variant-level conversion funnels
+- The Data API can now return these fields (Marketing Director will be able to query them)
+
+---
+
+## 3. First-party `AnalyticsEvent` — already live, no setup
+
+The API endpoint `/api/v1/events/track` is live. Every call to `trackEvent(...)` in the app now mirrors to this table.
+
+**Table schema:**
+- `name` — event type (`page_view`, `cta_click`, `scroll_depth`, `section_view`, `experiment_exposure`, `experiment_conversion`, etc.)
+- `sessionId` / `visitorId` — anonymous identifiers
+- `path` / `fullUrl` / `referrer` — page context
+- `utmSource` / `utmMedium` / `utmCampaign` — from first-touch attribution
+- `experimentId` / `variantId` — populated on experiment events
+- `properties` — free-form JSON per event (e.g., `{ button_text, section }`)
+
+**Querying:**
+
+```bash
+# Per-variant rollup with significance (replaces ExperimentVariant aggregate counts)
+curl -H "Cookie: $OPS_COOKIE" \
+  'https://partyondelivery.com/api/admin/analytics/experiments?metric=rollup&experimentId=<id>&days=30'
+
+# Active experiments at a glance
+curl -H "Cookie: $OPS_COOKIE" \
+  'https://partyondelivery.com/api/admin/analytics/experiments?metric=list&days=30'
+
+# Per-page bounce rate + CTA click rate
+curl -H "Cookie: $OPS_COOKIE" \
+  'https://partyondelivery.com/api/admin/analytics/experiments?metric=pages&days=30'
+```
+
+---
+
+## 4. Running an A/B test — full workflow
+
+1. **Create an `Experiment` row** in Prisma admin with `status: RUNNING` and 2+ `ExperimentVariant` rows (one marked `isControl`)
+2. In your page component, randomly assign visitors to a variant and call:
+   ```ts
+   import { trackHeroVariant } from '@/lib/analytics/ga4-events';
+   trackHeroVariant(experimentId, variantId, 'hero');
+   ```
+3. On conversion (checkout page, form submit, etc.), call:
+   ```ts
+   import { trackExperimentConversion } from '@/lib/analytics/ga4-events';
+   trackExperimentConversion(experimentId, variantId, 'purchase', orderTotal);
+   ```
+4. After 1-2 weeks of traffic, query the rollup endpoint. The `SignificanceResult` tells you: winner, p-value, confidence, lift %.
+5. Marketing Director agent can also pull this and recommend whether to ship the winner.
+
+---
+
+## 5. What the Marketing Director sees now
+
+After the nightly snapshot cron runs next, `docs/WEBSITE-ANALYTICS.md` will include per-page bounce rate and CTA click rate from our own data — much more granular than the GA4-only version. The agent can answer "which landing page has the worst bounce rate" or "which experiments have enough data to call."
+
+## Rotate that Vercel token
+
+Also — since Vercel Analytics turned out to have no usable API, go to **https://vercel.com/account/tokens** and **delete** the access token you shared earlier. We don't need it, and it's in the chat transcript.

--- a/docs/WEBSITE-ANALYTICS.md
+++ b/docs/WEBSITE-ANALYTICS.md
@@ -1,0 +1,26 @@
+# Website Analytics Snapshot
+
+_This file is **regenerated nightly** by `/api/cron/analytics-snapshot` (cron: `0 7 * * *` UTC). Do not hand-edit — changes will be overwritten._
+
+## How to use
+
+- The Marketing Director subagent (`.claude/agents/marketing-director.md`) reads this file on every invocation.
+- Tables below are pulled from GA4, Google Search Console, Vercel Analytics, Google Business Profile, and our internal orders DB.
+- The full structured snapshot lives on `AnalyticsSnapshot` (Prisma) — `marginData`, `vercelData`, `gbpData`, `segmentData` JSON columns.
+
+## Manually regenerate
+
+```bash
+curl -H "Authorization: Bearer $CRON_SECRET" https://partyondelivery.com/api/cron/analytics-snapshot
+```
+
+## Known gaps (Phase 1)
+
+- **SEMrush**: not connected. No API key — keyword competitive data is unavailable until `SEMRUSH_API_KEY` is set.
+- **Vercel Web Analytics**: `VERCEL_ANALYTICS_TOKEN`, `VERCEL_TEAM_ID`, `VERCEL_PROJECT_ID` must be set for Web Vitals + top pages.
+- **Google Business Profile**: `GOOGLE_MAPS_API_KEY` + `GOOGLE_PLACE_ID` must be set — uses Places API (New), returns up to the 5 most recent reviews.
+- Historical orders (pre-2026-04) have `null` margin — run `npx tsx scripts/backfill-order-margins.ts` to backfill using current COGS.
+
+---
+
+_First snapshot will populate here after the first cron run._

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,11 +55,83 @@ model AnalyticsSnapshot {
   topProducts        Json?    @map("top_products")
   topKeywords        Json?    @map("top_keywords")
   topReferrers       Json?    @map("top_referrers")
+
+  // External data source payloads (populated by nightly cron)
+  semrushData  Json? @map("semrush_data")
+  vercelData   Json? @map("vercel_data")
+  gbpData      Json? @map("gbp_data")
+  marginData   Json? @map("margin_data")
+  segmentData  Json? @map("segment_data")
+
   createdAt          DateTime @default(now()) @map("created_at")
   updatedAt          DateTime @updatedAt @map("updated_at")
 
   @@unique([date])
   @@map("analytics_snapshots")
+}
+
+// First-party event stream — captures pageviews, CTA clicks, scroll depth,
+// experiment exposures/conversions. Source of truth for A/B significance and
+// any analytics that needs to be sample-free or joinable to internal tables.
+// Volume estimate: ~30 events/session × 5k sessions/mo = ~150k rows/mo. Cheap.
+model AnalyticsEvent {
+  id          String   @id @default(uuid())
+  // Event identity
+  name        String   // page_view | cta_click | scroll_depth | section_view |
+                      // experiment_exposure | experiment_conversion | form_submit | etc.
+  occurredAt  DateTime @default(now()) @map("occurred_at")
+
+  // Session / visitor (anonymous identifiers; no PII)
+  sessionId   String   @map("session_id")
+  visitorId   String?  @map("visitor_id") // long-lived per-browser
+
+  // Page context
+  path        String?  // pathname only, no query
+  fullUrl     String?  @map("full_url") @db.Text
+  referrer    String?  @db.Text
+
+  // Marketing attribution (mirrors first-touch on the visitor)
+  utmSource   String?  @map("utm_source")
+  utmMedium   String?  @map("utm_medium")
+  utmCampaign String?  @map("utm_campaign")
+
+  // Experiment context (set on every event from a user in an active experiment)
+  experimentId String? @map("experiment_id")
+  variantId    String? @map("variant_id")
+
+  // Customer / order linkage when known
+  customerId  String?  @map("customer_id")
+  orderId     String?  @map("order_id")
+
+  // Free-form event-specific payload (button text, scroll %, product id, etc.)
+  properties  Json?
+
+  @@index([name, occurredAt])
+  @@index([sessionId])
+  @@index([experimentId, variantId])
+  @@index([occurredAt])
+  @@index([path])
+  @@map("analytics_events")
+}
+
+// Google Business Profile reviews (pulled nightly; inferred segment used for sentiment trends)
+model GbpReview {
+  id           String   @id @default(uuid())
+  reviewId     String   @unique @map("review_id")
+  rating       Int
+  text         String?  @db.Text
+  authorName   String?  @map("author_name")
+  reply        String?  @db.Text
+  replyAt      DateTime? @map("reply_at")
+  reviewedAt   DateTime @map("reviewed_at")
+  segment      String?  // wedding | bach | boat | corporate | other — inferred from text
+  sentiment    String?  // positive | neutral | negative
+  createdAt    DateTime @default(now()) @map("created_at")
+  updatedAt    DateTime @updatedAt @map("updated_at")
+
+  @@index([reviewedAt])
+  @@index([segment])
+  @@map("gbp_reviews")
 }
 
 // A/B Testing Experiments
@@ -798,6 +870,18 @@ model Order {
   // Affiliate attribution
   affiliateId String? @map("affiliate_id")
 
+  // Channel / marketing attribution (first-touch)
+  landingPage String? @map("landing_page")
+  utmSource   String? @map("utm_source")
+  utmMedium   String? @map("utm_medium")
+  utmCampaign String? @map("utm_campaign")
+  utmTerm     String? @map("utm_term")
+  utmContent  String? @map("utm_content")
+  referrer    String? @map("referrer")
+
+  // Margin (computed at order creation; null for orders created before margin pipeline existed)
+  marginAmount Decimal? @map("margin_amount") @db.Decimal(10, 2)
+
   // Notes
   customerNote String? @map("customer_note") @db.Text
   internalNote String? @map("internal_note") @db.Text
@@ -831,6 +915,8 @@ model Order {
   @@index([shopifyOrderId])
   @@index([affiliateId])
   @@index([groupOrderV2Id])
+  @@index([utmSource])
+  @@index([landingPage])
   @@map("orders")
 }
 
@@ -847,6 +933,11 @@ model OrderItem {
   price        Decimal @db.Decimal(10, 2)
   quantity     Int
   totalPrice   Decimal @map("total_price") @db.Decimal(10, 2)
+
+  // COGS snapshot at time of order (copied from ProductVariant.costPerUnit)
+  // Null = cost was unknown at order time; nullable keeps historical orders valid.
+  unitCost  Decimal? @map("unit_cost") @db.Decimal(10, 2)
+  totalCost Decimal? @map("total_cost") @db.Decimal(10, 2)
 
   // Fulfillment tracking
   fulfilledQuantity Int @default(0) @map("fulfilled_quantity")

--- a/scripts/backfill-order-margins.ts
+++ b/scripts/backfill-order-margins.ts
@@ -1,0 +1,62 @@
+/**
+ * One-shot backfill: snapshot unitCost/totalCost onto existing OrderItems
+ * (using ProductVariant.costPerUnit as-of-now) and compute Order.marginAmount.
+ *
+ * Usage: npx tsx scripts/backfill-order-margins.ts [--dry-run]
+ *
+ * NOTE: This uses CURRENT variant cost for historical orders. COGS may have
+ * changed since the order was placed; backfilled margin is an approximation.
+ * New orders (created after this ships) snapshot cost at order time and are accurate.
+ */
+
+import { PrismaClient, Prisma } from '@prisma/client';
+import { finalizeOrderMargin } from '../src/lib/analytics/margin-service';
+
+const prisma = new PrismaClient();
+const DRY_RUN = process.argv.includes('--dry-run');
+
+async function main() {
+  console.log(`[backfill-margins] starting${DRY_RUN ? ' (DRY RUN)' : ''}`);
+
+  const items = await prisma.orderItem.findMany({
+    where: { unitCost: null },
+    include: { variant: { select: { costPerUnit: true } } },
+  });
+  console.log(`[backfill-margins] ${items.length} order items missing unitCost`);
+
+  let updated = 0;
+  for (const item of items) {
+    const unitCost = item.variant?.costPerUnit ?? null;
+    if (!unitCost) continue;
+    const totalCost = new Prisma.Decimal(unitCost).mul(item.quantity);
+    if (!DRY_RUN) {
+      await prisma.orderItem.update({
+        where: { id: item.id },
+        data: { unitCost, totalCost },
+      });
+    }
+    updated++;
+  }
+  console.log(`[backfill-margins] updated ${updated} items`);
+
+  const ordersToFinalize = await prisma.order.findMany({
+    where: { marginAmount: null },
+    select: { id: true },
+  });
+  console.log(`[backfill-margins] finalizing margin on ${ordersToFinalize.length} orders`);
+
+  if (!DRY_RUN) {
+    for (const o of ordersToFinalize) {
+      await finalizeOrderMargin(prisma, o.id);
+    }
+  }
+
+  console.log('[backfill-margins] done');
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/ops/apply-invoice-batch-apr-2026.mjs
+++ b/scripts/ops/apply-invoice-batch-apr-2026.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * One-shot: apply cost + (optional) retail price updates for the April 2026
+ * distributor invoice batch, and backfill historical margins.
+ *
+ * For each row:
+ *   1. Update ProductVariant.costPerUnit (always)
+ *   2. Update ProductVariant.price (if newPrice provided, per 27% margin rule)
+ *   3. Set OrderItem.unitCost / totalCost on any historical items with this
+ *      variantId that don't already have cost captured
+ *   4. Recompute Order.marginAmount for any order whose items were backfilled
+ *
+ * Safe to re-run — idempotent via "only backfill where unitCost IS NULL".
+ */
+
+import { PrismaClient, Prisma } from '@prisma/client';
+const prisma = new PrismaClient();
+
+const ROWS = [
+  // label, variantId, cost, newPrice?
+  ['Espolon Blanco 1.75L',          'c6c92d72-a784-436c-8a57-cb7709e528e1', 39.01, null],
+  ['Espolon Blanco 750ml',          'e4b31a4b-e870-46eb-9c9b-b137ca9087bd', 24.00, null],
+  ['Tito\'s Handmade 1.75L',        'c8462511-2753-42d3-85c5-15095b46f0c1', 28.67, null],
+  ['Tito\'s Handmade 1L',           '99ca61d0-3754-4919-ac88-12004169dce2', 21.33, 29.99],
+  ['Aperol Aperitivo 1L',           '5191ab48-940d-49dd-8e5f-6707eb43790b', 25.00, 34.99],
+  ['Chateau Ste Michelle Cab 750',  '83d4f7a8-561d-49f9-a4e8-9b0902636c6b', 11.25, 15.99],
+  ['Wycliff Brut Champagne 750',    '78502c15-9aed-4707-a45f-ffc807a0dfd7',  4.75, null],
+  ['Lunazul Blanco 750',            '14d3327c-107e-4604-8f46-e65508d553f5', 17.25, null],
+  ['Lunazul Blanco 1.75L',          '0c6a4a6a-8957-4031-b81c-c4a4399f0a7e', 31.50, null],
+  ['Bacardi Light Superior 750',    '7934ffa4-58ec-4814-a6d5-4fc38bbea96b', 14.25, 19.99],
+  ['Casamigos Blanco 750',          '9b4ba44d-d1b8-44db-8178-4527530a0dc6', 36.00, null],
+  ['Lalo Blanco 750',               '1d1836a1-fd4f-458d-a634-fc6ca9e7f7e7', 36.99, 50.99],
+  ['Still Austin Straight Bourbon', 'bcc036c0-995a-4b72-9440-f65f41e80633', 35.79, 49.99],
+  ['Four Roses Bourbon 750',        '355bd5a8-e635-451a-ac94-51cc8bda11cc', 21.74, null],
+  ['Island Getaway Coconut 750',    '27a0742b-aaa9-4cee-8b98-fec35d31e435', 14.99, 20.99],
+  ['Dripping Springs Artisan Gin',  'a7c251af-f899-4328-9dca-16efbdab2fe7', 23.99, null],
+  ['Deep Eddy Vodka 750',           'b9d73b0c-6579-4888-965c-7a8d0995722b', 16.49, null],
+  ['Dark Horse Pinot Grigio 375',   '836b7c71-d7da-4e05-abd5-4a6dfd8f598a',  4.20,  5.99],
+  ['House Wine Red Blend 355',      '75b4bfbc-8df1-4c01-8d90-5e2e5d16f65b',  4.50,  6.99],
+  ['High Noon Tequila Variety 8pk', 'c2ec0735-f30f-4598-8be0-3790273b6e62', 18.00, 24.99],
+  ['High Noon Variety 8pk (Day Pk)','4061d5b7-7b23-4c65-8ed2-a35c6be8dff0', 16.50, 22.99],
+  ['High Noon Variety Pack 12pk',   '3714a896-c410-4085-83bf-e8fb688b970d', 23.25, null],
+  ['Twisted X McConauhaze 12pk',    'a972ce8c-1008-4fca-8845-37340cef0197', 18.37, 25.99],
+  ['White Claw Variety 24pk',       '2d74f923-3a80-4f49-a0ec-fd173e977a70', 27.97, 38.99],
+  ['Michelob Ultra 24pk',           '42a7f559-386e-4835-b0f3-962e9db379af', 25.30, 34.99],
+  ['Coors Light 24pk',              '77fce20d-344b-417a-b409-d8ca8ed36a0a', 24.95, 34.99],
+  ['Miller Lite 24pk',              'dd44b927-8dcd-4336-9a1e-2df3cb67ec13', 24.95, 34.99],
+  ['Modelo Especial 24pk Can',      '7d7c3edc-bbeb-4bda-9a51-58c84f6d4761', 26.10, 35.99],
+  ['Pacifico 12pk',                 'd25bc225-1ccc-45fd-9709-9082d8f5451d', 15.83, 21.99],
+  ['Dos Equis Lager 24pk',          'ff8ae9e6-3c2b-4543-bc19-c5663aa24566', 26.10, null],
+  ['Topo Chico Variety 24pk',       '4f040e3d-83d3-4ce1-914a-bccd67d8abb1', 27.97, 38.99],
+  ['Live Oak Hefeweizen 12pk',      '37c2f549-9cc2-40b9-9a98-e05f8de20927', 15.20, null],
+  ['Lone Star 24pk',                'd07dd8ec-b3c6-4413-bd55-5a49f91bbc52', 18.80, null],
+  ['Rambler Lemon Lime 12pk',       '46c98e53-d7be-4bcd-bb9f-a54ba2c6d341',  7.25, null],
+  ['Rambler Grapefruit 12pk',       'bec78036-950c-4be3-a2b2-aae17acf8d8c',  7.25, null],
+  ['Cutwater Mango Margarita 4pk',  'c37da472-446f-4c35-b853-5e5606c89374', 10.16, 13.99],
+  ['Cutwater Lime Margarita 4pk',   '18edd6f2-2ecb-4cd8-8f40-9a8e79c325e7', 10.16, 13.99],
+  ['Cutwater Paloma 4pk',           '3cd22e9a-a426-4bff-a4b6-461262cf6f5f', 10.16, 13.99],
+  ['Cutwater Tiki Mai Tai 4pk',     '599fe063-2e2a-4208-8aa7-47401d8658a6', 10.16, 13.99],
+  ['Independence Native Texan 12pk','5091af1c-9379-46b0-a35a-e4f2dd355ada', 14.80, 20.99],
+  ['Austin Beerworks Variety 12pk', '0331b752-9497-4553-8c44-bdcc30647787', 14.25, null],
+  ['ABW Pearl Snap Keg 1/6',        '24fe1872-8379-4c8c-913b-684e0dae776a', 65.00, null],
+  ['High Brew Mexican Vanilla 12pk','94cc3e6c-ec7c-4cbd-9848-f9515d755088', 24.20, 33.99],
+];
+
+let totalItemsBackfilled = 0;
+let totalOrdersRecomputed = 0;
+const touchedOrders = new Set();
+
+for (const [label, variantId, cost, newPrice] of ROWS) {
+  // 1. Update variant
+  const updateData = { costPerUnit: new Prisma.Decimal(cost) };
+  if (newPrice != null) updateData.price = new Prisma.Decimal(newPrice);
+  const variant = await prisma.productVariant.update({
+    where: { id: variantId },
+    data: updateData,
+    select: { id: true, title: true, price: true, costPerUnit: true },
+  });
+
+  // 2. Backfill historical order items missing cost
+  const items = await prisma.orderItem.findMany({
+    where: { variantId, unitCost: null },
+    select: { id: true, orderId: true, quantity: true },
+  });
+  for (const item of items) {
+    await prisma.orderItem.update({
+      where: { id: item.id },
+      data: {
+        unitCost: new Prisma.Decimal(cost),
+        totalCost: new Prisma.Decimal(cost).mul(item.quantity),
+      },
+    });
+    totalItemsBackfilled++;
+    touchedOrders.add(item.orderId);
+  }
+
+  const margin = Number(variant.price) - cost;
+  const marginPct = Number(variant.price) > 0 ? (margin / Number(variant.price) * 100) : 0;
+  console.log(`✓ ${label.padEnd(38)}  cost $${cost.toFixed(2)}  retail $${Number(variant.price).toFixed(2)}${newPrice ? ' (updated)' : ''}  margin ${marginPct.toFixed(1)}%  backfilled ${items.length} items`);
+}
+
+// 3. Recompute margin on all touched orders
+for (const orderId of touchedOrders) {
+  const items = await prisma.orderItem.findMany({
+    where: { orderId },
+    select: { totalPrice: true, totalCost: true },
+  });
+  const withCost = items.filter((x) => x.totalCost !== null);
+  if (withCost.length === 0) continue;
+  const marginAmount = withCost.reduce(
+    (acc, x) => acc.add(new Prisma.Decimal(x.totalPrice)).sub(new Prisma.Decimal(x.totalCost)),
+    new Prisma.Decimal(0)
+  );
+  await prisma.order.update({
+    where: { id: orderId },
+    data: { marginAmount },
+  });
+  totalOrdersRecomputed++;
+}
+
+console.log('');
+console.log(`─────────────────────────────────────────────`);
+console.log(`Variants updated:       ${ROWS.length}`);
+console.log(`Retail prices bumped:   ${ROWS.filter(r => r[3] != null).length}`);
+console.log(`Order items backfilled: ${totalItemsBackfilled}`);
+console.log(`Orders recomputed:      ${totalOrdersRecomputed}`);
+console.log(`─────────────────────────────────────────────`);
+
+await prisma.$disconnect();

--- a/scripts/ops/enter-cogs.mjs
+++ b/scripts/ops/enter-cogs.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+/**
+ * Walk through products with missing COGS, ranked by recent revenue,
+ * prompt for each variant's cost, and update ProductVariant.costPerUnit.
+ *
+ * Optionally also backfills historical OrderItem.unitCost / totalCost and
+ * recomputes Order.marginAmount for any past orders that included the
+ * product, so margin reports reflect the new cost immediately.
+ *
+ * Usage:
+ *   node scripts/ops/enter-cogs.mjs                   # top 20 by 90d revenue
+ *   node scripts/ops/enter-cogs.mjs --limit=50        # top 50
+ *   node scripts/ops/enter-cogs.mjs --days=180        # window for revenue ranking
+ *   node scripts/ops/enter-cogs.mjs --no-backfill     # only update variant, skip historical items
+ *
+ * Controls at the prompt: a number = cost per unit, <enter> = skip, "q" = quit.
+ */
+
+import { PrismaClient, Prisma } from '@prisma/client';
+import readline from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+
+const prisma = new PrismaClient();
+
+const args = process.argv.slice(2);
+const getArg = (flag, fallback) => {
+  const a = args.find((x) => x.startsWith(`${flag}=`));
+  return a ? a.split('=')[1] : fallback;
+};
+const limit = parseInt(getArg('--limit', '20'), 10);
+const days = parseInt(getArg('--days', '90'), 10);
+const skipBackfill = args.includes('--no-backfill');
+
+const rl = readline.createInterface({ input, output });
+
+function fmtMoney(n) {
+  return `$${Number(n).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+async function main() {
+  console.log(`\nFinding top ${limit} products with missing COGS (ranked by last ${days}d revenue)...\n`);
+
+  const products = await prisma.$queryRawUnsafe(`
+    SELECT
+      p.id AS product_id,
+      p.title,
+      SUM(oi.quantity)::int AS units_sold,
+      SUM(oi.total_price)::numeric AS revenue
+    FROM order_items oi
+    JOIN orders o ON o.id = oi.order_id
+    JOIN products p ON p.id = oi.product_id
+    WHERE o.created_at >= NOW() - INTERVAL '${days} days'
+      AND o.status NOT IN ('CANCELLED','REFUNDED')
+      AND oi.unit_cost IS NULL
+    GROUP BY p.id, p.title
+    HAVING COUNT(DISTINCT CASE WHEN EXISTS (
+      SELECT 1 FROM product_variants pv
+      WHERE pv.product_id = p.id AND pv.cost_per_unit IS NULL
+    ) THEN p.id END) > 0
+    ORDER BY SUM(oi.total_price) DESC
+    LIMIT ${limit};
+  `);
+
+  if (products.length === 0) {
+    console.log('Nothing to do — no products with missing COGS in the window.\n');
+    return;
+  }
+
+  let updated = 0;
+  let skipped = 0;
+  let backfilledItems = 0;
+  let recomputedOrders = 0;
+
+  for (let i = 0; i < products.length; i++) {
+    const p = products[i];
+    const variants = await prisma.productVariant.findMany({
+      where: { productId: p.product_id, costPerUnit: null },
+      select: { id: true, title: true, sku: true, price: true },
+    });
+
+    if (variants.length === 0) continue;
+
+    console.log(`\n[${i + 1}/${products.length}]  ${p.title}`);
+    console.log(`    ${p.units_sold} units sold, ${fmtMoney(p.revenue)} revenue (${days}d), ${variants.length} variant(s) missing cost`);
+
+    for (const v of variants) {
+      const label = v.title && v.title !== 'Default Title' ? `${v.title} — ` : '';
+      const sku = v.sku ? `[${v.sku}] ` : '';
+      const price = fmtMoney(v.price);
+      const answer = (await rl.question(`    ${sku}${label}price ${price} — enter cost per unit (number / <enter> skip / q quit): `)).trim();
+
+      if (answer.toLowerCase() === 'q') {
+        console.log('\nQuitting.');
+        await summary();
+        return;
+      }
+      if (!answer) {
+        skipped++;
+        continue;
+      }
+      const cost = parseFloat(answer);
+      if (!Number.isFinite(cost) || cost < 0) {
+        console.log('    invalid number, skipping.');
+        skipped++;
+        continue;
+      }
+      const margin = Number(v.price) - cost;
+      const marginPct = Number(v.price) > 0 ? (margin / Number(v.price)) * 100 : 0;
+      console.log(`    → cost ${fmtMoney(cost)}  margin ${fmtMoney(margin)} (${marginPct.toFixed(1)}%)`);
+
+      const confirm = (await rl.question(`    save? (Y/n): `)).trim().toLowerCase();
+      if (confirm === 'n') {
+        skipped++;
+        continue;
+      }
+
+      await prisma.productVariant.update({
+        where: { id: v.id },
+        data: { costPerUnit: new Prisma.Decimal(cost) },
+      });
+      updated++;
+
+      if (!skipBackfill) {
+        const items = await prisma.orderItem.findMany({
+          where: { variantId: v.id, unitCost: null },
+          select: { id: true, orderId: true, quantity: true },
+        });
+        const touchedOrders = new Set();
+        for (const item of items) {
+          await prisma.orderItem.update({
+            where: { id: item.id },
+            data: {
+              unitCost: new Prisma.Decimal(cost),
+              totalCost: new Prisma.Decimal(cost).mul(item.quantity),
+            },
+          });
+          backfilledItems++;
+          touchedOrders.add(item.orderId);
+        }
+        for (const orderId of touchedOrders) {
+          const orderItems = await prisma.orderItem.findMany({
+            where: { orderId },
+            select: { totalPrice: true, totalCost: true },
+          });
+          const withCost = orderItems.filter((x) => x.totalCost !== null);
+          if (withCost.length === 0) continue;
+          const margin = withCost.reduce(
+            (acc, x) => acc.add(new Prisma.Decimal(x.totalPrice)).sub(new Prisma.Decimal(x.totalCost)),
+            new Prisma.Decimal(0)
+          );
+          await prisma.order.update({
+            where: { id: orderId },
+            data: { marginAmount: margin },
+          });
+          recomputedOrders++;
+        }
+        if (items.length > 0) {
+          console.log(`    backfilled ${items.length} historical order item(s) across ${touchedOrders.size} order(s)`);
+        }
+      }
+    }
+  }
+
+  await summary();
+
+  async function summary() {
+    console.log('\n─────────────────');
+    console.log(`variants updated:   ${updated}`);
+    console.log(`variants skipped:   ${skipped}`);
+    if (!skipBackfill) {
+      console.log(`order items backfilled: ${backfilledItems}`);
+      console.log(`orders recomputed:  ${recomputedOrders}`);
+    }
+    console.log('─────────────────\n');
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(async () => {
+    rl.close();
+    await prisma.$disconnect();
+  });

--- a/scripts/ops/finish-invoice-batch-apr-2026.mjs
+++ b/scripts/ops/finish-invoice-batch-apr-2026.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * Wrap-up for the April 2026 invoice batch:
+ *   1. Map ABW Peacemaker keg ($60 cost) → existing "Austin Beerworks Anytime Ale Keg 1/6 Barrel"
+ *      and backfill historical orders.
+ *   2. Create new product "Saint Arnold Summer Pils • 6 Pack 12oz Can" at retail $12.99,
+ *      cost $8.60 (32% margin).
+ */
+
+import { PrismaClient, Prisma } from '@prisma/client';
+const prisma = new PrismaClient();
+
+// ─── 1. ABW Peacemaker keg → Anytime Ale Keg ─────────────────────────────────
+const ANYTIME_ALE_KEG_VARIANT_ID = '9edecd63-6659-439c-84ef-1eb92eb33232';
+const PEACEMAKER_COST = 60.00;
+
+const variant = await prisma.productVariant.update({
+  where: { id: ANYTIME_ALE_KEG_VARIANT_ID },
+  data: { costPerUnit: new Prisma.Decimal(PEACEMAKER_COST) },
+  select: { id: true, title: true, price: true },
+});
+
+// Backfill historical items
+const items = await prisma.orderItem.findMany({
+  where: { variantId: ANYTIME_ALE_KEG_VARIANT_ID, unitCost: null },
+  select: { id: true, orderId: true, quantity: true },
+});
+const touchedOrders = new Set();
+for (const item of items) {
+  await prisma.orderItem.update({
+    where: { id: item.id },
+    data: {
+      unitCost: new Prisma.Decimal(PEACEMAKER_COST),
+      totalCost: new Prisma.Decimal(PEACEMAKER_COST).mul(item.quantity),
+    },
+  });
+  touchedOrders.add(item.orderId);
+}
+for (const orderId of touchedOrders) {
+  const all = await prisma.orderItem.findMany({
+    where: { orderId },
+    select: { totalPrice: true, totalCost: true },
+  });
+  const withCost = all.filter((x) => x.totalCost !== null);
+  if (withCost.length === 0) continue;
+  const marginAmount = withCost.reduce(
+    (acc, x) => acc.add(new Prisma.Decimal(x.totalPrice)).sub(new Prisma.Decimal(x.totalCost)),
+    new Prisma.Decimal(0)
+  );
+  await prisma.order.update({ where: { id: orderId }, data: { marginAmount } });
+}
+
+const peaceMargin = ((Number(variant.price) - PEACEMAKER_COST) / Number(variant.price) * 100).toFixed(1);
+console.log(`✓ Mapped Peacemaker keg → Anytime Ale Keg  cost $${PEACEMAKER_COST}  retail $${variant.price}  margin ${peaceMargin}%  (${items.length} items, ${touchedOrders.size} orders backfilled)`);
+
+// ─── 2. Create Saint Arnold Summer Pils 6pk ──────────────────────────────────
+const handle = 'saint-arnold-summer-pils-6-pack-12oz-can';
+const title = 'Saint Arnold Summer Pils • 6 Pack 12oz Can';
+const RETAIL = 12.99;
+const COST = 8.60;
+
+const newProduct = await prisma.product.upsert({
+  where: { handle },
+  update: {
+    title,
+    basePrice: new Prisma.Decimal(RETAIL),
+  },
+  create: {
+    handle,
+    title,
+    description: 'Saint Arnold Summer Pils — crisp Texas pilsner, 6 pack 12oz cans.',
+    productType: 'Craft Beer',
+    vendor: 'Brown Distributing Company',
+    status: 'ACTIVE',
+    basePrice: new Prisma.Decimal(RETAIL),
+  },
+});
+
+// Upsert single variant
+const existingVariant = await prisma.productVariant.findFirst({
+  where: { productId: newProduct.id },
+});
+let summerPilsVariant;
+if (existingVariant) {
+  summerPilsVariant = await prisma.productVariant.update({
+    where: { id: existingVariant.id },
+    data: {
+      price: new Prisma.Decimal(RETAIL),
+      costPerUnit: new Prisma.Decimal(COST),
+    },
+  });
+} else {
+  summerPilsVariant = await prisma.productVariant.create({
+    data: {
+      productId: newProduct.id,
+      title: 'Default Title',
+      option1Name: 'Title',
+      option1Value: 'Default Title',
+      price: new Prisma.Decimal(RETAIL),
+      costPerUnit: new Prisma.Decimal(COST),
+      inventoryQuantity: 0,
+      committedQuantity: 0,
+      trackInventory: true,
+      allowBackorder: false,
+      availableForSale: true,
+      weight: 0,
+      weightUnit: 'POUNDS',
+    },
+  });
+}
+
+// Attach to Craft Beer category
+const craftBeerCat = await prisma.category.findFirst({
+  where: { handle: 'craft-beer' },
+  select: { id: true },
+});
+if (craftBeerCat) {
+  await prisma.productCategory
+    .create({
+      data: { productId: newProduct.id, categoryId: craftBeerCat.id, position: 0 },
+    })
+    .catch(() => { /* already linked */ });
+}
+
+const sumMargin = ((RETAIL - COST) / RETAIL * 100).toFixed(1);
+console.log(`✓ Created/updated "${title}"`);
+console.log(`   productId  ${newProduct.id}`);
+console.log(`   variantId  ${summerPilsVariant.id}`);
+console.log(`   cost $${COST}  retail $${RETAIL}  margin ${sumMargin}%`);
+console.log(`   category: Craft Beer`);
+console.log('');
+console.log('NOTE: no product image yet — add one via /ops admin or by dropping a file');
+console.log('      into public/images/products/ and creating a ProductImage record.');
+
+await prisma.$disconnect();

--- a/scripts/ops/match-invoice-costs.mjs
+++ b/scripts/ops/match-invoice-costs.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+/**
+ * One-off: match distributor invoice line items to catalog variants.
+ * Reads a JSON array of { desc, size, unitCost, notes? } from stdin OR uses
+ * the hardcoded INVOICE_LINES below. Searches products and prints a review
+ * table. Does NOT write anything — this is match-only.
+ *
+ * Usage:
+ *   node scripts/ops/match-invoice-costs.mjs              # uses hardcoded list
+ *   node scripts/ops/match-invoice-costs.mjs --json       # output as JSON for bulk-apply
+ */
+
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+const jsonMode = process.argv.includes('--json');
+
+// Unique products extracted from all distributor invoices (Apr 2026 set).
+// unitCost = distributor cost for the variant size we sell.
+// When a distributor line maps to multiple possible catalog variants, we list
+// candidates here and let the matcher pick the best.
+const INVOICE_LINES = [
+  // SGWS spirits
+  { key: 'espolon-blanco-175', searchTerms: 'espolon tequila blanco', variantHints: ['1.75', '1750'], unitCost: 39.01, source: 'SGWS 4/14' },
+  { key: 'espolon-blanco-750', searchTerms: 'espolon tequila blanco', variantHints: ['750'], unitCost: 24.00, source: 'SGWS 4/14' },
+  { key: 'titos-175', searchTerms: 'titos handmade vodka', variantHints: ['1.75', '1750'], unitCost: 28.67, source: 'SGWS 4/14' },
+  { key: 'titos-1l', searchTerms: 'titos handmade vodka', variantHints: ['1l', '1.0', '1000'], unitCost: 21.33, source: 'SGWS 3/31' },
+  { key: 'aperol-1l', searchTerms: 'aperol', variantHints: ['1l', '1.0', '1000'], unitCost: 25.00, source: 'SGWS 3/31' },
+  { key: 'chateau-ste-michelle-sauv-blanc', searchTerms: 'chateau ste michelle sauvignon blanc', variantHints: ['750'], unitCost: 9.00, source: 'SGWS 3/31' },
+  { key: 'chateau-ste-michelle-cab', searchTerms: 'chateau ste michelle cabernet', variantHints: ['750'], unitCost: 11.25, source: 'SGWS 3/31' },
+  { key: 'wycliff-brut', searchTerms: 'wycliff brut champagne', variantHints: ['750'], unitCost: 4.75, source: 'SGWS 4/14' },
+  { key: 'lunazul-blanco-750', searchTerms: 'lunazul tequila blanco', variantHints: ['750'], unitCost: 17.25, source: 'SGWS 4/14' },
+  { key: 'lunazul-blanco-175', searchTerms: 'lunazul tequila blanco', variantHints: ['1.75', '1750'], unitCost: 31.50, source: 'SGWS 4/14' },
+  { key: 'bacardi-superior', searchTerms: 'bacardi superior', variantHints: ['750'], unitCost: 14.25, source: 'SGWS 4/14' },
+  { key: 'casamigos-blanco', searchTerms: 'casamigos blanco', variantHints: ['750'], unitCost: 36.00, source: 'SGWS 4/14' },
+  { key: 'lalo-blanco', searchTerms: 'lalo blanco tequila', variantHints: ['750'], unitCost: 36.99, source: 'SGWS 4/14' },
+  { key: 'still-austin-musician', searchTerms: 'still austin musician', variantHints: ['750'], unitCost: 35.79, source: 'SGWS 4/14' },
+  { key: 'four-roses-yellow', searchTerms: 'four roses yellow label', variantHints: ['750'], unitCost: 21.74, source: 'Republic Nat' },
+  { key: 'island-getaway-coco', searchTerms: 'island getaway rum', variantHints: ['750'], unitCost: 14.99, source: 'Republic Nat' },
+  { key: 'dripping-springs-gin', searchTerms: 'dripping springs gin', variantHints: ['750'], unitCost: 23.99, source: 'Republic Nat' },
+  { key: 'deep-eddy-vodka', searchTerms: 'deep eddy vodka', variantHints: ['750'], unitCost: 16.49, source: 'Republic Nat' },
+  { key: 'dark-horse-pinot-grigio', searchTerms: 'dark horse pinot grigio', variantHints: ['375'], unitCost: 4.20, source: 'SGWS 3/31', notes: 'PPC=12; $4.20/can OR $50.40/12pk if variant is 12-pack' },
+
+  // High Noon RTDs
+  { key: 'high-noon-variety-teq-8pk', searchTerms: 'high noon variety tequila', variantHints: ['8'], unitCost: 18.00, source: 'SGWS 3/31' },
+  { key: 'high-noon-variety-vod-day-8pk', searchTerms: 'high noon vodka day', variantHints: ['8'], unitCost: 16.50, source: 'SGWS 3/31' },
+  { key: 'high-noon-variety-vod-12pk', searchTerms: 'high noon variety vodka', variantHints: ['12'], unitCost: 23.25, source: 'SGWS 3/31' },
+
+  // Beer — 24-packs (primary variant assumption)
+  { key: 'white-claw-variety-24pk', searchTerms: 'white claw variety', variantHints: ['24'], unitCost: 27.97, source: 'Brown' },
+  { key: 'michelob-ultra-24pk', searchTerms: 'michelob ultra', variantHints: ['24'], unitCost: 25.30, source: 'Brown' },
+  { key: 'coors-light-24pk', searchTerms: 'coors light', variantHints: ['24'], unitCost: 24.95, source: 'Capital Reyes' },
+  { key: 'miller-lite-24pk', searchTerms: 'miller lite', variantHints: ['24'], unitCost: 24.95, source: 'Capital Reyes' },
+  { key: 'modelo-especial-24pk', searchTerms: 'modelo especial', variantHints: ['24'], unitCost: 26.10, source: 'Capital Reyes' },
+  { key: 'pacifico-24pk', searchTerms: 'pacifico', variantHints: ['24'], unitCost: 31.65, source: 'Capital Reyes' },
+  { key: 'dos-equis-24pk', searchTerms: 'dos equis', variantHints: ['24'], unitCost: 26.10, source: 'Capital Reyes' },
+  { key: 'topo-chico-variety-24pk', searchTerms: 'topo chico variety', variantHints: ['24'], unitCost: 27.97, source: 'Capital Reyes' },
+  { key: 'live-oak-hefe-24pk', searchTerms: 'live oak hefeweizen', variantHints: ['24'], unitCost: 30.40, source: 'Capital Reyes' },
+  { key: 'lonestar-24pk', searchTerms: 'lonestar', variantHints: ['24'], unitCost: 18.80, source: 'Capital Reyes 4/21' },
+  { key: 'st-arnold-pils-24pk', searchTerms: 'st arnold summer pils', variantHints: ['24'], unitCost: 34.40, source: 'Capital Reyes 4/21' },
+  { key: 'rambler-lemon-lime', searchTerms: 'rambler lemon lime', variantHints: ['24', '12'], unitCost: 14.50, source: 'Brown 4/2', notes: '2×12pk; $14.50 per 24pk OR $7.25/12pk' },
+  { key: 'rambler-grapefruit', searchTerms: 'rambler grapefruit', variantHints: ['24', '12'], unitCost: 14.50, source: 'Brown 4/2' },
+  { key: 'cutwater-margarita', searchTerms: 'cutwater margarita', variantHints: ['24', '4'], unitCost: 60.94, source: 'Brown 4/2', notes: '6×4pk; $60.94/24pk or $10.16/4pk' },
+  { key: 'cutwater-paloma', searchTerms: 'cutwater paloma', variantHints: ['24', '4'], unitCost: 60.94, source: 'Brown 4/2' },
+  { key: 'cutwater-tiki', searchTerms: 'cutwater tiki mai tai', variantHints: ['24', '4'], unitCost: 60.94, source: 'Brown 4/2' },
+  { key: 'txbc-mcconaughaze', searchTerms: 'mcconaughaze', variantHints: ['24', '12'], unitCost: 36.74, source: 'Brown 4/16', notes: '2×12pk' },
+  { key: 'native-texan', searchTerms: 'independence native texan', variantHints: ['24', '12'], unitCost: 29.60, source: 'Brown 4/16' },
+  { key: 'hb-mexican-vanilla', searchTerms: 'hb mexican vanilla', variantHints: ['12'], unitCost: 24.20, source: 'Brown 4/16', notes: '8oz — flagged for review' },
+
+  // Austin Beerworks kegs
+  { key: 'abw-peacemaker-keg', searchTerms: 'peacemaker keg', variantHints: ['1/6', 'sixtel'], unitCost: 60.00, source: 'Austin Beerworks' },
+  { key: 'abw-pearl-snap-keg', searchTerms: 'pearl snap keg', variantHints: ['1/6', 'sixtel'], unitCost: 65.00, source: 'Austin Beerworks' },
+  { key: 'abw-variety-12pk', searchTerms: 'austin beerworks variety', variantHints: ['12'], unitCost: 28.50, source: 'Austin Beerworks', notes: '12 × 12-packs at $28.50 ea' },
+
+  // Seltzers/flagged
+  { key: 'house-wine-red-12pk', searchTerms: 'house wine red blend', variantHints: ['12'], unitCost: 54.00, source: 'SGWS 3/31', notes: 'Our variant likely = 12pk, case price = $54' },
+  { key: 'high-noon-pineapple', searchTerms: 'high noon pineapple', variantHints: ['12'], unitCost: 45.00, source: 'SGWS 4/16', notes: 'needs review' },
+];
+
+function scoreVariant(line, product, variant) {
+  const title = (product.title || '').toLowerCase();
+  const vTitle = (variant.title || '').toLowerCase();
+  let score = 0;
+  for (const hint of line.variantHints || []) {
+    const h = hint.toLowerCase();
+    if (vTitle.includes(h) || title.includes(h)) score += 10;
+  }
+  // prefer variants where the price is at least 1.2x the unit cost (sanity)
+  const price = Number(variant.price);
+  if (price > 0 && line.unitCost > 0) {
+    const ratio = price / line.unitCost;
+    if (ratio >= 1.1 && ratio <= 5) score += 3;
+  }
+  return score;
+}
+
+async function findBestMatch(line) {
+  const words = line.searchTerms.split(/\s+/).filter((w) => w.length > 0);
+  const andClauses = words.map((w) => ({ title: { contains: w, mode: 'insensitive' } }));
+
+  const products = await prisma.product.findMany({
+    where: { AND: andClauses },
+    include: {
+      variants: { select: { id: true, title: true, sku: true, price: true, costPerUnit: true } },
+    },
+    take: 10,
+  });
+
+  const candidates = [];
+  for (const p of products) {
+    for (const v of p.variants) {
+      candidates.push({ product: p, variant: v, score: scoreVariant(line, p, v) });
+    }
+  }
+  candidates.sort((a, b) => b.score - a.score);
+  return candidates.slice(0, 3);
+}
+
+async function main() {
+  const results = [];
+  for (const line of INVOICE_LINES) {
+    const matches = await findBestMatch(line);
+    results.push({ line, matches });
+  }
+
+  if (jsonMode) {
+    console.log(
+      JSON.stringify(
+        results.map((r) => ({
+          key: r.line.key,
+          searchTerms: r.line.searchTerms,
+          unitCost: r.line.unitCost,
+          source: r.line.source,
+          notes: r.line.notes,
+          topMatch: r.matches[0]
+            ? {
+                productId: r.matches[0].product.id,
+                productTitle: r.matches[0].product.title,
+                variantId: r.matches[0].variant.id,
+                variantTitle: r.matches[0].variant.title,
+                sku: r.matches[0].variant.sku,
+                price: Number(r.matches[0].variant.price),
+                currentCost: r.matches[0].variant.costPerUnit
+                  ? Number(r.matches[0].variant.costPerUnit)
+                  : null,
+                score: r.matches[0].score,
+              }
+            : null,
+          allMatches: r.matches.map((m) => ({
+            productId: m.product.id,
+            productTitle: m.product.title,
+            variantId: m.variant.id,
+            variantTitle: m.variant.title,
+            price: Number(m.variant.price),
+            score: m.score,
+          })),
+        })),
+        null,
+        2
+      )
+    );
+    return;
+  }
+
+  console.log('\nInvoice → Catalog Match Review');
+  console.log('═'.repeat(120));
+  for (const { line, matches } of results) {
+    console.log(`\n● ${line.key}  (${line.source})`);
+    console.log(`  cost: $${line.unitCost.toFixed(2)}   search: "${line.searchTerms}"   hints: [${(line.variantHints||[]).join(', ')}]`);
+    if (line.notes) console.log(`  note: ${line.notes}`);
+    if (matches.length === 0) {
+      console.log('  ❌ NO MATCH — product not in catalog');
+      continue;
+    }
+    matches.forEach((m, i) => {
+      const price = Number(m.variant.price).toFixed(2);
+      const currentCost = m.variant.costPerUnit ? `$${Number(m.variant.costPerUnit).toFixed(2)}` : '—';
+      const marker = i === 0 ? '  ✓' : '   ';
+      const marginPct = line.unitCost > 0 && Number(m.variant.price) > 0
+        ? ((Number(m.variant.price) - line.unitCost) / Number(m.variant.price) * 100).toFixed(0) + '%'
+        : '?';
+      console.log(`${marker} [score ${m.score}] ${m.product.title} — ${m.variant.title}`);
+      console.log(`       price $${price}  current cost ${currentCost}  proposed margin ${marginPct}`);
+    });
+  }
+  console.log('\n═'.repeat(120));
+  console.log(`${results.length} invoice lines, ${results.filter(r => r.matches.length === 0).length} with no match`);
+}
+
+main()
+  .catch((err) => { console.error(err); process.exit(1); })
+  .finally(() => prisma.$disconnect());

--- a/src/app/api/admin/analytics/experiments/route.ts
+++ b/src/app/api/admin/analytics/experiments/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
+import { getExperimentRollup, getPageEngagement } from '@/lib/analytics/variant-rollup';
+import { prisma } from '@/lib/database/client';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/admin/analytics/experiments
+ *   ?metric=rollup&experimentId=<id>&days=30    → per-variant stats + significance
+ *   ?metric=list&days=30                         → rollup for all active experiments
+ *   ?metric=pages&days=30                        → per-page sessions / bounce / CTA
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  const sp = request.nextUrl.searchParams;
+  const metric = sp.get('metric') ?? 'list';
+  const days = Math.max(1, Math.min(365, parseInt(sp.get('days') ?? '30', 10)));
+
+  try {
+    switch (metric) {
+      case 'rollup': {
+        const experimentId = sp.get('experimentId');
+        if (!experimentId) {
+          return NextResponse.json({ error: 'experimentId required' }, { status: 400 });
+        }
+        return NextResponse.json({ metric, days, data: await getExperimentRollup(experimentId, days) });
+      }
+      case 'list': {
+        const experiments = await prisma.experiment.findMany({
+          where: { status: { in: ['RUNNING', 'PAUSED'] } },
+          select: { id: true, name: true, page: true, status: true },
+        });
+        const rollups = await Promise.all(
+          experiments.map((e) => getExperimentRollup(e.id, days).then((r) => ({ ...e, rollup: r })))
+        );
+        return NextResponse.json({ metric, days, data: rollups });
+      }
+      case 'pages':
+        return NextResponse.json({ metric, days, data: await getPageEngagement(days) });
+      default:
+        return NextResponse.json({ error: `unknown metric: ${metric}` }, { status: 400 });
+    }
+  } catch (err) {
+    console.error('[admin/analytics/experiments]', err);
+    return NextResponse.json({ error: err instanceof Error ? err.message : 'failed' }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/analytics/ga4/route.ts
+++ b/src/app/api/admin/analytics/ga4/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
+import {
+  getRevenueByChannel,
+  getConversionByLandingPage,
+  getCheckoutFunnel,
+} from '@/lib/analytics/google-analytics';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/admin/analytics/ga4?metric=revenue-by-channel|conversion-by-page|funnel&days=30
+ * Thin agent-callable wrappers around GA4 Data API queries.
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  const sp = request.nextUrl.searchParams;
+  const metric = sp.get('metric') ?? 'revenue-by-channel';
+  const days = Math.max(1, Math.min(365, parseInt(sp.get('days') ?? '30', 10)));
+  const endDate = new Date();
+  const startDate = new Date();
+  startDate.setDate(startDate.getDate() - days);
+
+  try {
+    switch (metric) {
+      case 'revenue-by-channel':
+        return NextResponse.json({ metric, days, data: await getRevenueByChannel(startDate, endDate) });
+      case 'conversion-by-page':
+        return NextResponse.json({
+          metric,
+          days,
+          data: await getConversionByLandingPage(startDate, endDate),
+        });
+      case 'funnel':
+        return NextResponse.json({ metric, days, data: await getCheckoutFunnel(startDate, endDate) });
+      default:
+        return NextResponse.json({ error: `unknown metric: ${metric}` }, { status: 400 });
+    }
+  } catch (err) {
+    console.error('[admin/analytics/ga4]', err);
+    return NextResponse.json({ error: err instanceof Error ? err.message : 'failed' }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/analytics/gbp/route.ts
+++ b/src/app/api/admin/analytics/gbp/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
+import { getGbpInsights, getSegmentSentiment } from '@/lib/analytics/gbp';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/admin/analytics/gbp?metric=insights|segments&days=30
+ * Reads from local GbpReview table (populated by nightly cron via syncGbpReviews).
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  const sp = request.nextUrl.searchParams;
+  const metric = sp.get('metric') ?? 'insights';
+  const days = Math.max(1, Math.min(365, parseInt(sp.get('days') ?? '30', 10)));
+
+  try {
+    switch (metric) {
+      case 'insights':
+        return NextResponse.json({ metric, days, data: await getGbpInsights(days) });
+      case 'segments':
+        return NextResponse.json({ metric, days, data: await getSegmentSentiment(days) });
+      default:
+        return NextResponse.json({ error: `unknown metric: ${metric}` }, { status: 400 });
+    }
+  } catch (err) {
+    console.error('[admin/analytics/gbp]', err);
+    return NextResponse.json({ error: err instanceof Error ? err.message : 'failed' }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/analytics/internal/route.ts
+++ b/src/app/api/admin/analytics/internal/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
+import {
+  getChannelRollup,
+  getLandingPageRollup,
+  getProductMargins,
+} from '@/lib/analytics/internal-rollups';
+import { prisma } from '@/lib/database/client';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/admin/analytics/internal?metric=channels|landing-pages|product-margins|snapshot-latest&days=30
+ * Exposes internal DB rollups the Marketing Director agent reads (orders, margins, attribution).
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  const sp = request.nextUrl.searchParams;
+  const metric = sp.get('metric') ?? 'channels';
+  const days = Math.max(1, Math.min(365, parseInt(sp.get('days') ?? '30', 10)));
+
+  try {
+    switch (metric) {
+      case 'channels':
+        return NextResponse.json({ metric, days, data: await getChannelRollup(days) });
+      case 'landing-pages':
+        return NextResponse.json({ metric, days, data: await getLandingPageRollup(days) });
+      case 'product-margins':
+        return NextResponse.json({ metric, days, data: await getProductMargins(days) });
+      case 'snapshot-latest': {
+        const snap = await prisma.analyticsSnapshot.findFirst({ orderBy: { date: 'desc' } });
+        return NextResponse.json({ metric, data: snap });
+      }
+      default:
+        return NextResponse.json({ error: `unknown metric: ${metric}` }, { status: 400 });
+    }
+  } catch (err) {
+    console.error('[admin/analytics/internal]', err);
+    return NextResponse.json({ error: err instanceof Error ? err.message : 'failed' }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/analytics/vercel/route.ts
+++ b/src/app/api/admin/analytics/vercel/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
+import { getWebVitals, getVercelTopPages } from '@/lib/analytics/vercel-analytics';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/admin/analytics/vercel?metric=web-vitals|top-pages&days=7
+ * Returns null data when VERCEL_ANALYTICS_TOKEN is not set (not a failure).
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  const sp = request.nextUrl.searchParams;
+  const metric = sp.get('metric') ?? 'web-vitals';
+  const days = Math.max(1, Math.min(90, parseInt(sp.get('days') ?? '7', 10)));
+  const endDate = new Date();
+  const startDate = new Date();
+  startDate.setDate(startDate.getDate() - days);
+
+  try {
+    switch (metric) {
+      case 'web-vitals':
+        return NextResponse.json({ metric, days, data: await getWebVitals(startDate, endDate) });
+      case 'top-pages':
+        return NextResponse.json({ metric, days, data: await getVercelTopPages(startDate, endDate) });
+      default:
+        return NextResponse.json({ error: `unknown metric: ${metric}` }, { status: 400 });
+    }
+  } catch (err) {
+    console.error('[admin/analytics/vercel]', err);
+    return NextResponse.json({ error: err instanceof Error ? err.message : 'failed' }, { status: 500 });
+  }
+}

--- a/src/app/api/cron/analytics-snapshot/route.ts
+++ b/src/app/api/cron/analytics-snapshot/route.ts
@@ -1,0 +1,342 @@
+/**
+ * Nightly analytics snapshot cron.
+ *
+ * Pulls from GA4, Vercel Analytics, GBP, and internal DB, upserts a row on
+ * AnalyticsSnapshot for today's date, and regenerates docs/WEBSITE-ANALYTICS.md.
+ *
+ * Auth: Bearer CRON_SECRET (matches pattern of generate-blog / affiliate-commissions).
+ *
+ * SEMrush is intentionally skipped in Phase 1 — no API key available. Add when
+ * SEMRUSH_API_KEY becomes available.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+import { prisma } from '@/lib/database/client';
+import {
+  getTrafficMetrics,
+  getTrafficSources,
+  getTopPages,
+  getRevenueByChannel,
+  getConversionByLandingPage,
+  getCheckoutFunnel,
+} from '@/lib/analytics/google-analytics';
+import { getTopKeywords, getSEOMetrics } from '@/lib/analytics/search-console';
+import { getWebVitals, getVercelTopPages } from '@/lib/analytics/vercel-analytics';
+import { syncGbpReviews, getGbpInsights, getSegmentSentiment } from '@/lib/analytics/gbp';
+import {
+  getChannelRollup,
+  getLandingPageRollup,
+  getProductMargins,
+} from '@/lib/analytics/internal-rollups';
+import { getPageEngagement } from '@/lib/analytics/variant-rollup';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 300;
+
+function startOfDay(d: Date): Date {
+  const copy = new Date(d);
+  copy.setUTCHours(0, 0, 0, 0);
+  return copy;
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = request.headers.get('authorization');
+  if (auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const today = startOfDay(new Date());
+  const endDate = new Date();
+  const start7 = new Date();
+  start7.setDate(start7.getDate() - 7);
+  const start30 = new Date();
+  start30.setDate(start30.getDate() - 30);
+
+  const errors: string[] = [];
+  const safe = async <T>(label: string, fn: () => Promise<T>): Promise<T | null> => {
+    try {
+      return await fn();
+    } catch (err) {
+      console.error(`[analytics-snapshot] ${label} failed:`, err);
+      errors.push(`${label}: ${err instanceof Error ? err.message : String(err)}`);
+      return null;
+    }
+  };
+
+  // Parallel pulls across sources
+  const [
+    traffic,
+    trafficSources,
+    topPages,
+    revenueByChannel,
+    conversionByPage,
+    funnel,
+    seoMetrics,
+    topKeywords,
+    webVitals,
+    vercelTopPages,
+    channels,
+    landingRollup,
+    productMargins,
+  ] = await Promise.all([
+    safe('ga4.traffic', () => getTrafficMetrics(start30, endDate)),
+    safe('ga4.sources', () => getTrafficSources(start30, endDate)),
+    safe('ga4.top-pages', () => getTopPages(start30, endDate, 20)),
+    safe('ga4.revenue-by-channel', () => getRevenueByChannel(start30, endDate)),
+    safe('ga4.conversion-by-page', () => getConversionByLandingPage(start30, endDate)),
+    safe('ga4.funnel', () => getCheckoutFunnel(start30, endDate)),
+    safe('gsc.seo', () => getSEOMetrics(start30, endDate)),
+    safe('gsc.keywords', () => getTopKeywords(start30, endDate, 50)),
+    safe('vercel.web-vitals', () => getWebVitals(start7, endDate)),
+    safe('vercel.top-pages', () => getVercelTopPages(start30, endDate)),
+    safe('internal.channels', () => getChannelRollup(30)),
+    safe('internal.landing-pages', () => getLandingPageRollup(30)),
+    safe('internal.product-margins', () => getProductMargins(30)),
+  ]);
+
+  const pageEngagement = await safe('internal.page-engagement', () => getPageEngagement(30));
+
+  // GBP sync (writes to GbpReview table) + insights
+  await safe('gbp.sync', () => syncGbpReviews());
+  const gbpInsights = await safe('gbp.insights', () => getGbpInsights(30));
+  const gbpSegments = await safe('gbp.segments', () => getSegmentSentiment(90));
+
+  // Upsert snapshot
+  const snapshot = await prisma.analyticsSnapshot.upsert({
+    where: { date: today },
+    update: {
+      sessions: traffic?.sessions ?? 0,
+      users: traffic?.users ?? 0,
+      pageviews: traffic?.pageviews ?? 0,
+      bounceRate: traffic?.bounceRate != null ? traffic.bounceRate : null,
+      avgSessionDuration: traffic?.avgSessionDuration != null ? traffic.avgSessionDuration : null,
+      impressions: seoMetrics?.impressions ?? 0,
+      clicks: seoMetrics?.clicks ?? 0,
+      ctr: seoMetrics?.ctr != null ? seoMetrics.ctr : null,
+      avgPosition: seoMetrics?.avgPosition != null ? seoMetrics.avgPosition : null,
+      topPages: (topPages ?? []) as unknown as object,
+      topKeywords: (topKeywords ?? []) as unknown as object,
+      topReferrers: (trafficSources ?? []) as unknown as object,
+      vercelData: { webVitals, topPages: vercelTopPages } as unknown as object,
+      gbpData: { insights: gbpInsights, segments: gbpSegments } as unknown as object,
+      marginData: { channels, productMargins } as unknown as object,
+      segmentData: {
+        landingPages: landingRollup,
+        revenueByChannel,
+        conversionByPage,
+        funnel,
+        pageEngagement,
+      } as unknown as object,
+    },
+    create: {
+      date: today,
+      sessions: traffic?.sessions ?? 0,
+      users: traffic?.users ?? 0,
+      pageviews: traffic?.pageviews ?? 0,
+      bounceRate: traffic?.bounceRate != null ? traffic.bounceRate : null,
+      avgSessionDuration: traffic?.avgSessionDuration != null ? traffic.avgSessionDuration : null,
+      impressions: seoMetrics?.impressions ?? 0,
+      clicks: seoMetrics?.clicks ?? 0,
+      ctr: seoMetrics?.ctr != null ? seoMetrics.ctr : null,
+      avgPosition: seoMetrics?.avgPosition != null ? seoMetrics.avgPosition : null,
+      topPages: (topPages ?? []) as unknown as object,
+      topKeywords: (topKeywords ?? []) as unknown as object,
+      topReferrers: (trafficSources ?? []) as unknown as object,
+      vercelData: { webVitals, topPages: vercelTopPages } as unknown as object,
+      gbpData: { insights: gbpInsights, segments: gbpSegments } as unknown as object,
+      marginData: { channels, productMargins } as unknown as object,
+      segmentData: {
+        landingPages: landingRollup,
+        revenueByChannel,
+        conversionByPage,
+        funnel,
+        pageEngagement,
+      } as unknown as object,
+    },
+  });
+
+  // Regenerate human-readable markdown summary
+  try {
+    const md = renderMarkdown({
+      date: today,
+      traffic,
+      channels: channels ?? [],
+      landingRollup: landingRollup ?? [],
+      revenueByChannel: revenueByChannel ?? [],
+      conversionByPage: conversionByPage ?? [],
+      funnel: funnel ?? [],
+      productMargins: productMargins ?? [],
+      gbpInsights,
+      gbpSegments: gbpSegments ?? [],
+      webVitals,
+      topKeywords: topKeywords ?? [],
+      pageEngagement: pageEngagement ?? [],
+      errors,
+    });
+    const docsDir = path.join(process.cwd(), 'docs');
+    fs.mkdirSync(docsDir, { recursive: true });
+    fs.writeFileSync(path.join(docsDir, 'WEBSITE-ANALYTICS.md'), md);
+  } catch (err) {
+    console.error('[analytics-snapshot] markdown write failed:', err);
+    errors.push(`markdown: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  return NextResponse.json({
+    ok: true,
+    snapshotId: snapshot.id,
+    errors: errors.length ? errors : undefined,
+  });
+}
+
+function renderMarkdown(s: {
+  date: Date;
+  traffic: { sessions: number; users: number; pageviews: number } | null;
+  channels: Array<{ channel: string; orders: number; revenue: number; margin: number | null; averageOrderValue: number; averageMarginPct: number | null }>;
+  landingRollup: Array<{ landingPage: string; orders: number; revenue: number; averageOrderValue: number }>;
+  revenueByChannel: Array<{ channel: string; sessions: number; transactions: number; revenue: number; conversionRate: number }>;
+  conversionByPage: Array<{ path: string; sessions: number; transactions: number; conversionRate: number }>;
+  funnel: Array<{ eventName: string; users: number; dropOffFromPrevious: number | null }>;
+  productMargins: Array<{ title: string; unitsSold: number; revenue: number; margin: number; marginPct: number }>;
+  gbpInsights: { reviewCount: number; averageRating: number; fiveStarPct: number; oneStarPct: number } | null;
+  gbpSegments: Array<{ segment: string; count: number; averageRating: number }>;
+  webVitals: { lcp: number | null; inp: number | null; cls: number | null } | null;
+  topKeywords: Array<{ keyword: string; clicks: number; impressions: number; position: number }>;
+  pageEngagement: Array<{ path: string; sessions: number; pageviews: number; bounceRate: number; avgScrollDepth: number; ctaClicks: number; ctaClickRate: number }>;
+  errors: string[];
+}): string {
+  const lines: string[] = [];
+  lines.push(`# Website Analytics Snapshot`);
+  lines.push('');
+  lines.push(`_Generated: ${s.date.toISOString().split('T')[0]} — regenerated nightly by \`/api/cron/analytics-snapshot\`_`);
+  lines.push('');
+
+  if (s.errors.length) {
+    lines.push(`> ⚠️ Partial pull: ${s.errors.length} source(s) failed. Check cron logs.`);
+    lines.push('');
+  }
+
+  lines.push('## Traffic (last 30 days)');
+  if (s.traffic) {
+    lines.push(`- Sessions: **${s.traffic.sessions.toLocaleString()}**  •  Users: **${s.traffic.users.toLocaleString()}**  •  Pageviews: **${s.traffic.pageviews.toLocaleString()}**`);
+  } else {
+    lines.push('- _GA4 data unavailable_');
+  }
+  lines.push('');
+
+  lines.push('## Revenue by internal channel (30d)');
+  if (s.channels.length) {
+    lines.push('| Channel | Orders | Revenue | AOV | Margin % |');
+    lines.push('|---|---:|---:|---:|---:|');
+    for (const c of s.channels) {
+      lines.push(`| ${c.channel} | ${c.orders} | $${c.revenue.toLocaleString()} | $${c.averageOrderValue} | ${c.averageMarginPct ?? '—'}% |`);
+    }
+  } else {
+    lines.push('_no orders_');
+  }
+  lines.push('');
+
+  lines.push('## Landing page → orders (30d, our DB)');
+  if (s.landingRollup.length) {
+    lines.push('| Landing page | Orders | Revenue | AOV |');
+    lines.push('|---|---:|---:|---:|');
+    for (const r of s.landingRollup.slice(0, 15)) {
+      lines.push(`| ${r.landingPage} | ${r.orders} | $${r.revenue.toLocaleString()} | $${r.averageOrderValue} |`);
+    }
+  } else {
+    lines.push('_no attribution data yet — new orders will populate this_');
+  }
+  lines.push('');
+
+  lines.push('## GA4 revenue by channel (30d)');
+  if (s.revenueByChannel.length) {
+    lines.push('| Channel | Sessions | Transactions | Revenue | Conv rate |');
+    lines.push('|---|---:|---:|---:|---:|');
+    for (const r of s.revenueByChannel) {
+      lines.push(`| ${r.channel} | ${r.sessions} | ${r.transactions} | $${r.revenue.toLocaleString()} | ${(r.conversionRate * 100).toFixed(2)}% |`);
+    }
+  } else {
+    lines.push('_GA4 data unavailable_');
+  }
+  lines.push('');
+
+  lines.push('## Conversion by landing page (GA4, 30d)');
+  if (s.conversionByPage.length) {
+    lines.push('| Path | Sessions | Transactions | Conv rate |');
+    lines.push('|---|---:|---:|---:|');
+    for (const r of s.conversionByPage.slice(0, 15)) {
+      lines.push(`| ${r.path} | ${r.sessions} | ${r.transactions} | ${(r.conversionRate * 100).toFixed(2)}% |`);
+    }
+  }
+  lines.push('');
+
+  lines.push('## Checkout funnel (30d)');
+  if (s.funnel.length) {
+    lines.push('| Step | Users | Drop-off |');
+    lines.push('|---|---:|---:|');
+    for (const f of s.funnel) {
+      lines.push(`| ${f.eventName} | ${f.users} | ${f.dropOffFromPrevious == null ? '—' : (f.dropOffFromPrevious * 100).toFixed(1) + '%'} |`);
+    }
+  }
+  lines.push('');
+
+  lines.push('## Top product margins (30d)');
+  if (s.productMargins.length) {
+    lines.push('| Product | Units | Revenue | Margin | Margin % |');
+    lines.push('|---|---:|---:|---:|---:|');
+    for (const p of s.productMargins.slice(0, 15)) {
+      lines.push(`| ${p.title} | ${p.unitsSold} | $${p.revenue.toLocaleString()} | $${p.margin.toLocaleString()} | ${p.marginPct}% |`);
+    }
+  }
+  lines.push('');
+
+  lines.push('## Google Business Profile (30d)');
+  if (s.gbpInsights) {
+    lines.push(`- Reviews: **${s.gbpInsights.reviewCount}**  •  Avg rating: **${s.gbpInsights.averageRating}**  •  5-star: ${s.gbpInsights.fiveStarPct}%  •  1-star: ${s.gbpInsights.oneStarPct}%`);
+  } else {
+    lines.push('_GBP not configured — set GBP_* env vars_');
+  }
+  if (s.gbpSegments.length) {
+    lines.push('');
+    lines.push('Segment sentiment (90d):');
+    lines.push('| Segment | Reviews | Avg rating |');
+    lines.push('|---|---:|---:|');
+    for (const seg of s.gbpSegments) {
+      lines.push(`| ${seg.segment} | ${seg.count} | ${seg.averageRating} |`);
+    }
+  }
+  lines.push('');
+
+  lines.push('## Web Vitals (7d)');
+  if (s.webVitals) {
+    lines.push(`- LCP: ${s.webVitals.lcp ?? '—'}ms  •  INP: ${s.webVitals.inp ?? '—'}ms  •  CLS: ${s.webVitals.cls ?? '—'}`);
+  } else {
+    lines.push('_Vercel Analytics not configured — set VERCEL_ANALYTICS_TOKEN_');
+  }
+  lines.push('');
+
+  lines.push('## Per-page engagement (our tracker, 30d)');
+  if (s.pageEngagement.length) {
+    lines.push('| Path | Sessions | Pageviews | Bounce | Avg scroll | CTA clicks | CTA rate |');
+    lines.push('|---|---:|---:|---:|---:|---:|---:|');
+    for (const p of s.pageEngagement.slice(0, 20)) {
+      lines.push(`| ${p.path} | ${p.sessions} | ${p.pageviews} | ${(p.bounceRate * 100).toFixed(0)}% | ${p.avgScrollDepth}% | ${p.ctaClicks} | ${(p.ctaClickRate * 100).toFixed(1)}% |`);
+    }
+  } else {
+    lines.push('_no first-party event data yet — will populate after first session_');
+  }
+  lines.push('');
+
+  lines.push('## Top search queries (GSC, 30d)');
+  if (s.topKeywords.length) {
+    lines.push('| Query | Clicks | Impressions | Avg position |');
+    lines.push('|---|---:|---:|---:|');
+    for (const k of s.topKeywords.slice(0, 20)) {
+      lines.push(`| ${k.keyword} | ${k.clicks} | ${k.impressions} | ${k.position.toFixed(1)} |`);
+    }
+  }
+  lines.push('');
+
+  return lines.join('\n');
+}

--- a/src/app/api/v1/checkout/route.ts
+++ b/src/app/api/v1/checkout/route.ts
@@ -203,7 +203,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     // Get request body for optional params
     const body = await request.json().catch(() => ({}));
-    const { customerEmail, customerName, customerPhone, returnUrl, tipAmount: rawTip } = body;
+    const { customerEmail, customerName, customerPhone, returnUrl, tipAmount: rawTip, attribution } = body;
     const tipAmount = typeof rawTip === 'number' && rawTip > 0 ? Math.round(rawTip * 100) / 100 : 0;
 
     // Compute effective totals (affiliate free delivery applied in-memory only)
@@ -275,6 +275,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       affiliateCode,
       overrideDeliveryFee: affiliateFreeDelivery ? 0 : undefined,
       tipAmount: tipAmount > 0 ? tipAmount : undefined,
+      attribution: attribution && typeof attribution === 'object' ? attribution : undefined,
     });
 
     return NextResponse.json({

--- a/src/app/api/v1/events/track/route.ts
+++ b/src/app/api/v1/events/track/route.ts
@@ -1,0 +1,82 @@
+/**
+ * POST /api/v1/events/track
+ *
+ * Accepts a batch of analytics events from the browser. Designed to be hit
+ * frequently by the client tracker (every ~5s during a session, plus once on
+ * unload via navigator.sendBeacon).
+ *
+ * Body: { events: [{ name, occurredAt?, sessionId, visitorId?, path?, ... }, ...] }
+ *
+ * Auth: none (this is public ingest, like a tracking pixel). Per-IP rate
+ * limiting can be added later via middleware if abuse becomes an issue.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/database/client';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const EventSchema = z.object({
+  name: z.string().min(1).max(64),
+  occurredAt: z.string().datetime().optional(),
+  sessionId: z.string().min(1).max(64),
+  visitorId: z.string().max(64).optional().nullable(),
+  path: z.string().max(512).optional().nullable(),
+  fullUrl: z.string().max(2048).optional().nullable(),
+  referrer: z.string().max(2048).optional().nullable(),
+  utmSource: z.string().max(128).optional().nullable(),
+  utmMedium: z.string().max(128).optional().nullable(),
+  utmCampaign: z.string().max(128).optional().nullable(),
+  experimentId: z.string().max(64).optional().nullable(),
+  variantId: z.string().max(64).optional().nullable(),
+  customerId: z.string().max(64).optional().nullable(),
+  orderId: z.string().max(64).optional().nullable(),
+  properties: z.record(z.string(), z.unknown()).optional().nullable(),
+});
+
+const BatchSchema = z.object({
+  events: z.array(EventSchema).min(1).max(50),
+});
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const body = await request.json();
+    const parsed = BatchSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { ok: false, error: 'invalid payload', issues: parsed.error.issues },
+        { status: 400 }
+      );
+    }
+
+    await prisma.analyticsEvent.createMany({
+      data: parsed.data.events.map((e) => ({
+        name: e.name,
+        occurredAt: e.occurredAt ? new Date(e.occurredAt) : new Date(),
+        sessionId: e.sessionId,
+        visitorId: e.visitorId ?? null,
+        path: e.path ?? null,
+        fullUrl: e.fullUrl ?? null,
+        referrer: e.referrer ?? null,
+        utmSource: e.utmSource ?? null,
+        utmMedium: e.utmMedium ?? null,
+        utmCampaign: e.utmCampaign ?? null,
+        experimentId: e.experimentId ?? null,
+        variantId: e.variantId ?? null,
+        customerId: e.customerId ?? null,
+        orderId: e.orderId ?? null,
+        properties: (e.properties ?? Prisma.JsonNull) as Prisma.InputJsonValue,
+      })),
+      skipDuplicates: false,
+    });
+
+    return NextResponse.json({ ok: true, count: parsed.data.events.length });
+  } catch (err) {
+    // Never fail the client; log and 200 — analytics losing a batch is fine.
+    console.error('[events/track] write failed:', err);
+    return NextResponse.json({ ok: false, error: 'write failed' }, { status: 200 });
+  }
+}

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -267,6 +267,8 @@ export default function CheckoutPage() {
       }
 
       // Create checkout session (Stripe for paid orders, direct for $0 orders)
+      const { getAttribution } = await import('@/lib/analytics/attribution');
+      const attribution = getAttribution();
       const checkoutResponse = await fetch('/api/v1/checkout', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -275,6 +277,7 @@ export default function CheckoutPage() {
           customerName: `${billingAddress.firstName} ${billingAddress.lastName}`.trim(),
           customerPhone: billingAddress.phone,
           tipAmount: tipAmount > 0 ? tipAmount : undefined,
+          attribution,
         }),
       });
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,8 @@ import ClientLayoutWrapper from "@/components/ClientLayoutWrapper";
 import { structuredData } from "./structured-data";
 import GoogleAnalytics from "@/components/GoogleAnalytics";
 import MetaPixel from "@/components/MetaPixel";
+import MicrosoftClarity from "@/components/MicrosoftClarity";
+import AttributionTracker from "@/components/AttributionTracker";
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 
@@ -97,6 +99,8 @@ export default function RootLayout({
 
         <GoogleAnalytics />
         <MetaPixel />
+        <MicrosoftClarity />
+        <AttributionTracker />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}

--- a/src/components/AttributionTracker.tsx
+++ b/src/components/AttributionTracker.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { useEffect, type ReactElement } from 'react';
+import { captureFirstTouch } from '@/lib/analytics/attribution';
+
+/**
+ * Runs once per browser on initial page load. Captures landing page + UTMs
+ * to localStorage so checkout can forward them to Stripe session metadata.
+ */
+export default function AttributionTracker(): ReactElement | null {
+  useEffect(() => {
+    captureFirstTouch();
+  }, []);
+  return null;
+}

--- a/src/components/MicrosoftClarity.tsx
+++ b/src/components/MicrosoftClarity.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import Script from 'next/script';
+import { type ReactElement } from 'react';
+
+/**
+ * Microsoft Clarity — free, unlimited heatmaps, scroll maps, rage/dead click
+ * detection, and session replays. No-op when NEXT_PUBLIC_CLARITY_PROJECT_ID
+ * is not set; production-only.
+ *
+ * Setup: https://clarity.microsoft.com → New Project → use the Project ID
+ * (the value after `clarity.ms/tag/<id>` in their snippet).
+ */
+export default function MicrosoftClarity(): ReactElement | null {
+  const projectId = process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID;
+  if (!projectId || process.env.NODE_ENV !== 'production') return null;
+
+  return (
+    <Script
+      id="ms-clarity"
+      strategy="afterInteractive"
+      dangerouslySetInnerHTML={{
+        __html: `
+          (function(c,l,a,r,i,t,y){
+            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+          })(window, document, "clarity", "script", "${projectId}");
+        `,
+      }}
+    />
+  );
+}

--- a/src/lib/analytics/attribution.ts
+++ b/src/lib/analytics/attribution.ts
@@ -1,0 +1,91 @@
+/**
+ * First-touch attribution capture.
+ *
+ * Captures the landing page + UTM params + document referrer on the visitor's
+ * first page load and persists them to localStorage. Subsequent visits / cart
+ * events don't overwrite — first-touch wins. Checkout reads these values via
+ * `getAttribution()` and passes them into Stripe session metadata, where the
+ * webhook reads them when creating the Order.
+ */
+
+const STORAGE_KEY = 'pod_attribution_v1';
+const UTM_KEYS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content'] as const;
+
+export interface AttributionPayload {
+  landingPage: string | null;
+  utmSource: string | null;
+  utmMedium: string | null;
+  utmCampaign: string | null;
+  utmTerm: string | null;
+  utmContent: string | null;
+  referrer: string | null;
+  capturedAt: string;
+}
+
+function isClient(): boolean {
+  return typeof window !== 'undefined' && typeof localStorage !== 'undefined';
+}
+
+/**
+ * Run once per browser on initial page load. No-op if attribution already captured.
+ */
+export function captureFirstTouch(): void {
+  if (!isClient()) return;
+  try {
+    if (localStorage.getItem(STORAGE_KEY)) return;
+
+    const url = new URL(window.location.href);
+    const utm: Record<string, string | null> = {};
+    for (const key of UTM_KEYS) {
+      utm[key] = url.searchParams.get(key);
+    }
+
+    const referrer = document.referrer || null;
+    const internalReferrer = referrer && referrer.includes(window.location.hostname);
+
+    const payload: AttributionPayload = {
+      landingPage: url.pathname + (url.search || ''),
+      utmSource: utm.utm_source,
+      utmMedium: utm.utm_medium,
+      utmCampaign: utm.utm_campaign,
+      utmTerm: utm.utm_term,
+      utmContent: utm.utm_content,
+      referrer: internalReferrer ? null : referrer,
+      capturedAt: new Date().toISOString(),
+    };
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    // localStorage may be unavailable (private mode, quota); silently skip.
+  }
+}
+
+export function getAttribution(): AttributionPayload | null {
+  if (!isClient()) return null;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as AttributionPayload;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Flatten attribution into Stripe metadata (string-only, filter empties).
+ * Stripe metadata has a 500-char-per-value limit and ~50 keys total — we're well under.
+ */
+export function attributionToMetadata(
+  a: AttributionPayload | null
+): Record<string, string> {
+  if (!a) return {};
+  const out: Record<string, string> = {};
+  if (a.landingPage) out.landingPage = a.landingPage.slice(0, 500);
+  if (a.utmSource) out.utmSource = a.utmSource.slice(0, 500);
+  if (a.utmMedium) out.utmMedium = a.utmMedium.slice(0, 500);
+  if (a.utmCampaign) out.utmCampaign = a.utmCampaign.slice(0, 500);
+  if (a.utmTerm) out.utmTerm = a.utmTerm.slice(0, 500);
+  if (a.utmContent) out.utmContent = a.utmContent.slice(0, 500);
+  if (a.referrer) out.referrer = a.referrer.slice(0, 500);
+  return out;
+}

--- a/src/lib/analytics/client-tracker.ts
+++ b/src/lib/analytics/client-tracker.ts
@@ -33,7 +33,7 @@ const FLUSH_INTERVAL_MS = 5000;
 const MAX_BATCH = 50;
 const ENDPOINT = '/api/v1/events/track';
 
-let queue: QueuedEvent[] = [];
+const queue: QueuedEvent[] = [];
 let flushTimer: ReturnType<typeof setInterval> | null = null;
 let initialized = false;
 

--- a/src/lib/analytics/client-tracker.ts
+++ b/src/lib/analytics/client-tracker.ts
@@ -1,0 +1,166 @@
+/**
+ * First-party event tracker. Buffers events client-side, flushes every 5s
+ * and on visibility change / unload via sendBeacon. Survives page navs
+ * and last-second exits.
+ *
+ * Used in addition to (not instead of) GA4 + Vercel Analytics — gives us
+ * a sample-free copy in our own DB that the A/B significance code reads.
+ */
+
+import { getAttribution } from './attribution';
+
+interface QueuedEvent {
+  name: string;
+  occurredAt: string;
+  sessionId: string;
+  visitorId?: string;
+  path?: string;
+  fullUrl?: string;
+  referrer?: string;
+  utmSource?: string | null;
+  utmMedium?: string | null;
+  utmCampaign?: string | null;
+  experimentId?: string;
+  variantId?: string;
+  customerId?: string;
+  orderId?: string;
+  properties?: Record<string, unknown>;
+}
+
+const SESSION_KEY = 'pod_session_id';
+const VISITOR_KEY = 'pod_visitor_id';
+const FLUSH_INTERVAL_MS = 5000;
+const MAX_BATCH = 50;
+const ENDPOINT = '/api/v1/events/track';
+
+let queue: QueuedEvent[] = [];
+let flushTimer: ReturnType<typeof setInterval> | null = null;
+let initialized = false;
+
+function isClient(): boolean {
+  return typeof window !== 'undefined';
+}
+
+function uuid(): string {
+  if (isClient() && 'randomUUID' in crypto) return crypto.randomUUID();
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function getSessionId(): string {
+  if (!isClient()) return 'ssr';
+  let id = sessionStorage.getItem(SESSION_KEY);
+  if (!id) {
+    id = uuid();
+    sessionStorage.setItem(SESSION_KEY, id);
+  }
+  return id;
+}
+
+function getVisitorId(): string {
+  if (!isClient()) return 'ssr';
+  let id = localStorage.getItem(VISITOR_KEY);
+  if (!id) {
+    id = uuid();
+    try { localStorage.setItem(VISITOR_KEY, id); } catch { /* private mode */ }
+  }
+  return id;
+}
+
+function pageContext(): Pick<QueuedEvent, 'path' | 'fullUrl' | 'referrer'> {
+  if (!isClient()) return {};
+  return {
+    path: window.location.pathname,
+    fullUrl: window.location.href.slice(0, 2048),
+    referrer: (document.referrer || '').slice(0, 2048) || undefined,
+  };
+}
+
+function attributionContext(): Pick<QueuedEvent, 'utmSource' | 'utmMedium' | 'utmCampaign'> {
+  const a = getAttribution();
+  if (!a) return {};
+  return {
+    utmSource: a.utmSource ?? undefined,
+    utmMedium: a.utmMedium ?? undefined,
+    utmCampaign: a.utmCampaign ?? undefined,
+  };
+}
+
+/**
+ * Track an event. Queued, not sent immediately. Safe to call from anywhere.
+ *
+ * @example trackPodEvent('cta_click', { button_text: 'Order Now', section: 'hero' })
+ * @example trackPodEvent('experiment_exposure', {}, { experimentId: 'wed_hero_v2', variantId: 'b' })
+ */
+export function trackPodEvent(
+  name: string,
+  properties?: Record<string, unknown>,
+  context?: { experimentId?: string; variantId?: string; customerId?: string; orderId?: string }
+): void {
+  if (!isClient()) return;
+
+  ensureInitialized();
+
+  queue.push({
+    name,
+    occurredAt: new Date().toISOString(),
+    sessionId: getSessionId(),
+    visitorId: getVisitorId(),
+    ...pageContext(),
+    ...attributionContext(),
+    ...(context ?? {}),
+    properties,
+  });
+
+  if (queue.length >= MAX_BATCH) flush();
+}
+
+function flush(useBeacon = false): void {
+  if (!isClient() || queue.length === 0) return;
+  const batch = queue.splice(0, MAX_BATCH);
+  const body = JSON.stringify({ events: batch });
+
+  if (useBeacon && 'sendBeacon' in navigator) {
+    const blob = new Blob([body], { type: 'application/json' });
+    navigator.sendBeacon(ENDPOINT, blob);
+    return;
+  }
+
+  fetch(ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+    keepalive: true,
+  }).catch(() => {
+    // Re-queue on failure so next flush retries; cap to avoid runaway growth
+    if (queue.length < 200) queue.unshift(...batch);
+  });
+}
+
+function ensureInitialized(): void {
+  if (initialized || !isClient()) return;
+  initialized = true;
+
+  flushTimer = setInterval(flush, FLUSH_INTERVAL_MS);
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') flush(true);
+  });
+
+  window.addEventListener('pagehide', () => flush(true));
+  window.addEventListener('beforeunload', () => flush(true));
+}
+
+/**
+ * Manually flush — useful right before navigation in single-page apps where
+ * we want the event to land before the request is interrupted.
+ */
+export function flushPodEvents(): void {
+  flush(true);
+}
+
+// Stop timer in HMR / test
+export function teardownPodTracker(): void {
+  if (flushTimer) clearInterval(flushTimer);
+  flushTimer = null;
+  initialized = false;
+}

--- a/src/lib/analytics/experiment-significance.ts
+++ b/src/lib/analytics/experiment-significance.ts
@@ -1,0 +1,134 @@
+/**
+ * A/B test statistical significance — two-proportion z-test on conversion rate.
+ *
+ * Picks the variant with the highest conversion rate and computes a p-value
+ * vs. the control. Caller decides the confidence threshold to declare a winner
+ * (typical: 0.95).
+ */
+
+export interface VariantStat {
+  id: string;
+  name: string;
+  isControl: boolean;
+  impressions: number;
+  conversions: number;
+}
+
+export interface VariantWithSignificance extends VariantStat {
+  conversionRate: number;
+  liftPct: number | null;
+  pValue: number | null;
+  confidence: number | null;
+}
+
+export interface SignificanceResult {
+  variants: VariantWithSignificance[];
+  winner: VariantWithSignificance | null;
+  control: VariantWithSignificance | null;
+  hasEnoughData: boolean;
+}
+
+const MIN_IMPRESSIONS_PER_VARIANT = 100;
+
+/**
+ * Compute significance for a set of A/B variants.
+ * @param variants Stats for each variant (one must be marked isControl).
+ * @param confidenceThreshold Default 0.95. Winner is declared only when the leader's
+ *        confidence vs. control exceeds this and has enough data.
+ */
+export function computeSignificance(
+  variants: VariantStat[],
+  confidenceThreshold = 0.95
+): SignificanceResult {
+  const control = variants.find((v) => v.isControl) ?? variants[0] ?? null;
+  const controlRate = control ? safeRate(control.conversions, control.impressions) : 0;
+
+  const enriched: VariantWithSignificance[] = variants.map((v) => {
+    const rate = safeRate(v.conversions, v.impressions);
+    if (!control || v.id === control.id) {
+      return { ...v, conversionRate: rate, liftPct: null, pValue: null, confidence: null };
+    }
+    const { pValue } = twoProportionZTest(
+      control.conversions,
+      control.impressions,
+      v.conversions,
+      v.impressions
+    );
+    const liftPct = controlRate > 0 ? ((rate - controlRate) / controlRate) * 100 : null;
+    return {
+      ...v,
+      conversionRate: rate,
+      liftPct,
+      pValue,
+      confidence: pValue == null ? null : 1 - pValue,
+    };
+  });
+
+  const hasEnoughData = variants.every((v) => v.impressions >= MIN_IMPRESSIONS_PER_VARIANT);
+
+  const controlEnriched = control ? enriched.find((v) => v.id === control.id) ?? null : null;
+
+  // Winner: highest rate variant whose confidence beats threshold and rate > control rate.
+  let winner: VariantWithSignificance | null = null;
+  if (hasEnoughData && controlEnriched) {
+    const challengers = enriched.filter((v) => v.id !== controlEnriched.id);
+    const leader = challengers.reduce<VariantWithSignificance | null>(
+      (best, v) => (best == null || v.conversionRate > best.conversionRate ? v : best),
+      null
+    );
+    if (
+      leader &&
+      leader.conversionRate > controlEnriched.conversionRate &&
+      leader.confidence != null &&
+      leader.confidence >= confidenceThreshold
+    ) {
+      winner = leader;
+    }
+  }
+
+  return { variants: enriched, winner, control: controlEnriched, hasEnoughData };
+}
+
+function safeRate(conversions: number, impressions: number): number {
+  if (impressions <= 0) return 0;
+  return conversions / impressions;
+}
+
+/**
+ * Two-sided two-proportion z-test.
+ * Returns { z, pValue } where pValue is the probability of observing a difference
+ * this large or larger under the null hypothesis of equal rates.
+ */
+export function twoProportionZTest(
+  cA: number,
+  nA: number,
+  cB: number,
+  nB: number
+): { z: number; pValue: number } {
+  if (nA <= 0 || nB <= 0) return { z: 0, pValue: 1 };
+  const pA = cA / nA;
+  const pB = cB / nB;
+  const pPool = (cA + cB) / (nA + nB);
+  const se = Math.sqrt(pPool * (1 - pPool) * (1 / nA + 1 / nB));
+  if (se === 0) return { z: 0, pValue: 1 };
+  const z = (pB - pA) / se;
+  const pValue = 2 * (1 - standardNormalCdf(Math.abs(z)));
+  return { z, pValue };
+}
+
+/**
+ * Standard normal CDF via Abramowitz & Stegun 26.2.17 approximation.
+ * Error bound ~ 7.5e-8 — plenty accurate for A/B decisions.
+ */
+function standardNormalCdf(x: number): number {
+  const sign = x < 0 ? -1 : 1;
+  const absX = Math.abs(x);
+  const t = 1 / (1 + 0.2316419 * absX);
+  const d = 0.3989422804014327 * Math.exp((-absX * absX) / 2);
+  const p =
+    d *
+    t *
+    (0.319381530 +
+      t * (-0.356563782 + t * (1.781477937 + t * (-1.821255978 + t * 1.330274429))));
+  return 0.5 + sign * (0.5 - p);
+}

--- a/src/lib/analytics/ga4-events.ts
+++ b/src/lib/analytics/ga4-events.ts
@@ -1,7 +1,20 @@
 /**
  * GA4 Custom Event Tracking for A/B Testing
  * @module lib/analytics/ga4-events
+ *
+ * Every event mirrors to the first-party AnalyticsEvent stream via
+ * `trackPodEvent` so we have a sample-free, joinable copy in our own DB.
+ *
+ * For experiment_id / variant_id to be queryable in the GA4 Reporting API,
+ * they MUST be registered as custom event-scoped dimensions in GA4 admin:
+ *   Admin → Custom definitions → Create custom dimension
+ *     - Dimension name: Experiment ID,  Event parameter: experiment_id
+ *     - Dimension name: Variant ID,     Event parameter: variant_id
+ *     - Dimension name: Section,        Event parameter: section
+ * Without that registration, the events fire fine but you can't slice by them.
  */
+
+import { trackPodEvent } from './client-tracker';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 declare global {
@@ -50,6 +63,12 @@ export function trackCTAClick(
     ...(experimentId && { experiment_id: experimentId }),
     ...(variantId && { variant_id: variantId }),
   });
+
+  trackPodEvent(
+    'cta_click',
+    { button_text: buttonText, button_url: buttonUrl, section },
+    { experimentId, variantId }
+  );
 }
 
 /**
@@ -68,6 +87,8 @@ export function trackScrollDepth(percentage: 25 | 50 | 75 | 100): void {
     percent_scrolled: percentage,
     page_location: window.location.href,
   });
+
+  trackPodEvent('scroll_depth', { percent_scrolled: percentage });
 }
 
 /**
@@ -86,6 +107,8 @@ export function trackSectionView(sectionName: string): void {
     section_name: sectionName,
     page_location: window.location.href,
   });
+
+  trackPodEvent('section_view', { section_name: sectionName });
 }
 
 /**
@@ -112,6 +135,12 @@ export function trackHeroVariant(
     element_id: elementId,
     page_location: window.location.href,
   });
+
+  trackPodEvent(
+    'experiment_exposure',
+    { element_id: elementId },
+    { experimentId, variantId }
+  );
 }
 
 /**
@@ -141,6 +170,12 @@ export function trackExperimentConversion(
     ...(value !== undefined && { value }),
     page_location: window.location.href,
   });
+
+  trackPodEvent(
+    'experiment_conversion',
+    { conversion_type: conversionType, value: value ?? null },
+    { experimentId, variantId }
+  );
 }
 
 /**

--- a/src/lib/analytics/gbp.ts
+++ b/src/lib/analytics/gbp.ts
@@ -1,0 +1,210 @@
+/**
+ * Google Business Profile reviews, via Places API (New).
+ *
+ * Why Places API instead of the legacy Business Profile API:
+ *   The legacy My Business API requires an approval process (weeks-long) and
+ *   was retired from the public Cloud Console library. Places API returns up
+ *   to the 5 most recent reviews with rating + text + author + timestamp for
+ *   any place, with just an API key — plenty of signal for weekly sentiment
+ *   trend tracking. Upgrade to the legacy API later if full review history is
+ *   ever needed.
+ *
+ * Env:
+ *   GOOGLE_MAPS_API_KEY  — API key restricted to Places API (New)
+ *   GOOGLE_PLACE_ID      — e.g. "ChIJc8cN7oDLRIYRY734oDi4Gpo"
+ *
+ * Persists pulled reviews to GbpReview with inferred segment (wedding / bach
+ * / boat / corporate / other) based on simple text heuristics.
+ */
+
+import { prisma } from '@/lib/database/client';
+
+export interface GbpInsights {
+  reviewCount: number;
+  averageRating: number;
+  fiveStarPct: number;
+  oneStarPct: number;
+  latestReviewedAt: string | null;
+  totalReviewsOnProfile: number | null; // from Places API (full count on Google, even though we only see 5)
+  liveAverageRating: number | null;     // from Places API
+}
+
+export interface GbpSegmentSentiment {
+  segment: string;
+  count: number;
+  averageRating: number;
+}
+
+interface PlacesReview {
+  name: string; // "places/<placeId>/reviews/<reviewId>"
+  rating: number;
+  text?: { text: string };
+  authorAttribution?: { displayName?: string };
+  publishTime: string; // ISO
+}
+
+interface PlacesDetailsResponse {
+  id: string;
+  rating?: number;
+  userRatingCount?: number;
+  reviews?: PlacesReview[];
+}
+
+function env(): { apiKey: string; placeId: string } | null {
+  const apiKey = process.env.GOOGLE_MAPS_API_KEY;
+  const placeId = process.env.GOOGLE_PLACE_ID;
+  if (!apiKey || !placeId) return null;
+  return { apiKey, placeId };
+}
+
+function inferSegment(text: string | null | undefined): string {
+  if (!text) return 'other';
+  const t = text.toLowerCase();
+  if (/\b(wedding|bride|groom|reception)\b/.test(t)) return 'wedding';
+  if (/\b(bachelor|bachelorette|bach party|bach weekend|bach babes)\b/.test(t)) return 'bach';
+  if (/\b(boat|lake|party cove|yacht|cruise)\b/.test(t)) return 'boat';
+  if (/\b(corporate|office|company event|holiday party|team|tailgate)\b/.test(t)) return 'corporate';
+  return 'other';
+}
+
+function inferSentiment(rating: number): string {
+  if (rating >= 4) return 'positive';
+  if (rating === 3) return 'neutral';
+  return 'negative';
+}
+
+/**
+ * Extract just the review-id suffix from the full name path.
+ * Places API gives: "places/<placeId>/reviews/<reviewId>"
+ */
+function extractReviewId(fullName: string): string {
+  const parts = fullName.split('/');
+  return parts[parts.length - 1];
+}
+
+/**
+ * Pull the latest reviews (up to 5) from Places API, upsert them.
+ * Returns summary + top-level place stats. Null when env isn't configured.
+ */
+export async function syncGbpReviews(): Promise<{
+  pulled: number;
+  stored: number;
+  profileRating: number | null;
+  profileReviewCount: number | null;
+} | null> {
+  const cfg = env();
+  if (!cfg) {
+    console.warn('[gbp] GOOGLE_MAPS_API_KEY / GOOGLE_PLACE_ID not set — skipping');
+    return null;
+  }
+
+  const res = await fetch(`https://places.googleapis.com/v1/places/${cfg.placeId}`, {
+    headers: {
+      'X-Goog-Api-Key': cfg.apiKey,
+      'X-Goog-FieldMask': 'id,rating,userRatingCount,reviews',
+    },
+  });
+  if (!res.ok) {
+    console.error('[gbp] Places API fetch failed:', res.status, await res.text());
+    return null;
+  }
+
+  const data = (await res.json()) as PlacesDetailsResponse;
+  const reviews = data.reviews ?? [];
+  let stored = 0;
+
+  for (const r of reviews) {
+    const reviewId = extractReviewId(r.name);
+    const text = r.text?.text ?? null;
+    const rating = r.rating ?? 0;
+    await prisma.gbpReview.upsert({
+      where: { reviewId },
+      update: {
+        rating,
+        text,
+        segment: inferSegment(text),
+        sentiment: inferSentiment(rating),
+      },
+      create: {
+        reviewId,
+        rating,
+        text,
+        authorName: r.authorAttribution?.displayName ?? null,
+        reviewedAt: new Date(r.publishTime),
+        segment: inferSegment(text),
+        sentiment: inferSentiment(rating),
+      },
+    });
+    stored++;
+  }
+
+  return {
+    pulled: reviews.length,
+    stored,
+    profileRating: data.rating ?? null,
+    profileReviewCount: data.userRatingCount ?? null,
+  };
+}
+
+export async function getGbpInsights(windowDays = 30): Promise<GbpInsights> {
+  const since = new Date();
+  since.setDate(since.getDate() - windowDays);
+  const reviews = await prisma.gbpReview.findMany({
+    where: { reviewedAt: { gte: since } },
+    select: { rating: true, reviewedAt: true },
+    orderBy: { reviewedAt: 'desc' },
+  });
+  const count = reviews.length;
+  const average = count ? reviews.reduce((s, r) => s + r.rating, 0) / count : 0;
+  const five = reviews.filter((r) => r.rating === 5).length;
+  const one = reviews.filter((r) => r.rating === 1).length;
+
+  // Also surface the live profile-wide stats (Places API caches these in the
+  // segmentData on snapshot, but we also expose here as a convenience).
+  let profileCount: number | null = null;
+  let profileAvg: number | null = null;
+  const cfg = env();
+  if (cfg) {
+    try {
+      const res = await fetch(`https://places.googleapis.com/v1/places/${cfg.placeId}`, {
+        headers: {
+          'X-Goog-Api-Key': cfg.apiKey,
+          'X-Goog-FieldMask': 'rating,userRatingCount',
+        },
+      });
+      if (res.ok) {
+        const json = (await res.json()) as PlacesDetailsResponse;
+        profileCount = json.userRatingCount ?? null;
+        profileAvg = json.rating ?? null;
+      }
+    } catch {
+      // Profile stats are optional
+    }
+  }
+
+  return {
+    reviewCount: count,
+    averageRating: Number(average.toFixed(2)),
+    fiveStarPct: count ? Math.round((five / count) * 1000) / 10 : 0,
+    oneStarPct: count ? Math.round((one / count) * 1000) / 10 : 0,
+    latestReviewedAt: reviews[0]?.reviewedAt.toISOString() ?? null,
+    totalReviewsOnProfile: profileCount,
+    liveAverageRating: profileAvg,
+  };
+}
+
+export async function getSegmentSentiment(windowDays = 365): Promise<GbpSegmentSentiment[]> {
+  const since = new Date();
+  since.setDate(since.getDate() - windowDays);
+  const grouped = await prisma.gbpReview.groupBy({
+    by: ['segment'],
+    where: { reviewedAt: { gte: since }, segment: { not: null } },
+    _count: { _all: true },
+    _avg: { rating: true },
+  });
+  return grouped.map((g) => ({
+    segment: g.segment ?? 'other',
+    count: g._count._all,
+    averageRating: Number((g._avg.rating ?? 0).toFixed(2)),
+  }));
+}

--- a/src/lib/analytics/google-analytics.ts
+++ b/src/lib/analytics/google-analytics.ts
@@ -202,3 +202,159 @@ export async function getTopPages(
     return [];
   }
 }
+
+export interface RevenueByChannel {
+  channel: string;
+  sessions: number;
+  transactions: number;
+  revenue: number;
+  conversionRate: number;
+}
+
+/**
+ * Revenue breakdown by GA4 default channel group (Direct / Organic / Paid / Referral / Social / Email).
+ */
+export async function getRevenueByChannel(
+  startDate: Date,
+  endDate: Date
+): Promise<RevenueByChannel[]> {
+  const auth = getGoogleAuth();
+  if (!auth || !PROPERTY_ID) return [];
+  try {
+    const analyticsData = google.analyticsdata({ version: 'v1beta', auth });
+    const response = await analyticsData.properties.runReport({
+      property: `properties/${PROPERTY_ID}`,
+      requestBody: {
+        dateRanges: [{ startDate: formatDate(startDate), endDate: formatDate(endDate) }],
+        dimensions: [{ name: 'sessionDefaultChannelGroup' }],
+        metrics: [
+          { name: 'sessions' },
+          { name: 'transactions' },
+          { name: 'purchaseRevenue' },
+        ],
+        orderBys: [{ metric: { metricName: 'purchaseRevenue' }, desc: true }],
+        limit: '20',
+      },
+    });
+    return (response.data.rows || []).map((row) => {
+      const sessions = parseInt(row.metricValues?.[0].value || '0', 10);
+      const transactions = parseInt(row.metricValues?.[1].value || '0', 10);
+      const revenue = parseFloat(row.metricValues?.[2].value || '0');
+      return {
+        channel: row.dimensionValues?.[0].value || 'Unknown',
+        sessions,
+        transactions,
+        revenue,
+        conversionRate: sessions > 0 ? transactions / sessions : 0,
+      };
+    });
+  } catch (error) {
+    console.error('GA4 revenue by channel error:', error);
+    return [];
+  }
+}
+
+export interface PageConversion {
+  path: string;
+  sessions: number;
+  transactions: number;
+  revenue: number;
+  conversionRate: number;
+}
+
+/**
+ * Conversion rate + revenue per landing page. Used to compare segment landing
+ * pages (/weddings vs /bach-parties vs /boat-parties vs /corporate).
+ */
+export async function getConversionByLandingPage(
+  startDate: Date,
+  endDate: Date,
+  limit = 20
+): Promise<PageConversion[]> {
+  const auth = getGoogleAuth();
+  if (!auth || !PROPERTY_ID) return [];
+  try {
+    const analyticsData = google.analyticsdata({ version: 'v1beta', auth });
+    const response = await analyticsData.properties.runReport({
+      property: `properties/${PROPERTY_ID}`,
+      requestBody: {
+        dateRanges: [{ startDate: formatDate(startDate), endDate: formatDate(endDate) }],
+        dimensions: [{ name: 'landingPage' }],
+        metrics: [
+          { name: 'sessions' },
+          { name: 'transactions' },
+          { name: 'purchaseRevenue' },
+        ],
+        orderBys: [{ metric: { metricName: 'sessions' }, desc: true }],
+        limit: String(limit),
+      },
+    });
+    return (response.data.rows || []).map((row) => {
+      const sessions = parseInt(row.metricValues?.[0].value || '0', 10);
+      const transactions = parseInt(row.metricValues?.[1].value || '0', 10);
+      const revenue = parseFloat(row.metricValues?.[2].value || '0');
+      return {
+        path: row.dimensionValues?.[0].value || '/',
+        sessions,
+        transactions,
+        revenue,
+        conversionRate: sessions > 0 ? transactions / sessions : 0,
+      };
+    });
+  } catch (error) {
+    console.error('GA4 conversion by landing page error:', error);
+    return [];
+  }
+}
+
+export interface FunnelStep {
+  eventName: string;
+  users: number;
+  dropOffFromPrevious: number | null;
+}
+
+/**
+ * Checkout funnel: view_item -> add_to_cart -> begin_checkout -> purchase.
+ * Uses GA4 standard ecommerce events.
+ */
+export async function getCheckoutFunnel(
+  startDate: Date,
+  endDate: Date
+): Promise<FunnelStep[]> {
+  const auth = getGoogleAuth();
+  if (!auth || !PROPERTY_ID) return [];
+  const steps = ['view_item', 'add_to_cart', 'begin_checkout', 'purchase'];
+  try {
+    const analyticsData = google.analyticsdata({ version: 'v1beta', auth });
+    const response = await analyticsData.properties.runReport({
+      property: `properties/${PROPERTY_ID}`,
+      requestBody: {
+        dateRanges: [{ startDate: formatDate(startDate), endDate: formatDate(endDate) }],
+        dimensions: [{ name: 'eventName' }],
+        metrics: [{ name: 'totalUsers' }],
+        dimensionFilter: {
+          filter: {
+            fieldName: 'eventName',
+            inListFilter: { values: steps },
+          },
+        },
+      },
+    });
+    const byEvent = new Map<string, number>();
+    for (const row of response.data.rows || []) {
+      byEvent.set(row.dimensionValues?.[0].value || '', parseInt(row.metricValues?.[0].value || '0', 10));
+    }
+    const results: FunnelStep[] = [];
+    let prev: number | null = null;
+    for (const step of steps) {
+      const users = byEvent.get(step) || 0;
+      const drop = prev != null && prev > 0 ? (prev - users) / prev : null;
+      results.push({ eventName: step, users, dropOffFromPrevious: drop });
+      prev = users;
+    }
+    return results;
+  } catch (error) {
+    console.error('GA4 funnel error:', error);
+    return [];
+  }
+}

--- a/src/lib/analytics/internal-rollups.ts
+++ b/src/lib/analytics/internal-rollups.ts
@@ -1,0 +1,162 @@
+/**
+ * Internal database rollups for the nightly snapshot + Marketing Director.
+ * Pulls what only we have: orders, margins, affiliate attribution, product mix.
+ */
+
+import { prisma } from '@/lib/database/client';
+
+export interface ChannelRollup {
+  channel: string; // direct | affiliate | group | utm source
+  orders: number;
+  revenue: number;
+  margin: number | null;
+  averageOrderValue: number;
+  averageMarginPct: number | null;
+}
+
+export interface LandingPageRollup {
+  landingPage: string;
+  orders: number;
+  revenue: number;
+  averageOrderValue: number;
+}
+
+export interface ProductMarginRow {
+  productId: string;
+  title: string;
+  unitsSold: number;
+  revenue: number;
+  cost: number;
+  margin: number;
+  marginPct: number;
+}
+
+function daysAgo(n: number): Date {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  d.setUTCHours(0, 0, 0, 0);
+  return d;
+}
+
+/**
+ * Revenue/margin split by internal channel bucket.
+ * Buckets: affiliate (has affiliateId), group (groupOrderV2Id), utm_<source>, direct.
+ */
+export async function getChannelRollup(windowDays = 30): Promise<ChannelRollup[]> {
+  const since = daysAgo(windowDays);
+  const orders = await prisma.order.findMany({
+    where: { createdAt: { gte: since }, status: { notIn: ['CANCELLED', 'REFUNDED'] } },
+    select: {
+      total: true,
+      marginAmount: true,
+      affiliateId: true,
+      groupOrderV2Id: true,
+      utmSource: true,
+    },
+  });
+
+  const buckets = new Map<string, { orders: number; revenue: number; margin: number; marginKnown: number }>();
+  for (const o of orders) {
+    let channel = 'direct';
+    if (o.affiliateId) channel = 'affiliate';
+    else if (o.groupOrderV2Id) channel = 'group';
+    else if (o.utmSource) channel = `utm_${o.utmSource.toLowerCase()}`;
+
+    const b = buckets.get(channel) ?? { orders: 0, revenue: 0, margin: 0, marginKnown: 0 };
+    b.orders += 1;
+    b.revenue += Number(o.total);
+    if (o.marginAmount != null) {
+      b.margin += Number(o.marginAmount);
+      b.marginKnown += 1;
+    }
+    buckets.set(channel, b);
+  }
+
+  return Array.from(buckets.entries())
+    .map(([channel, b]) => ({
+      channel,
+      orders: b.orders,
+      revenue: Number(b.revenue.toFixed(2)),
+      margin: b.marginKnown > 0 ? Number(b.margin.toFixed(2)) : null,
+      averageOrderValue: b.orders > 0 ? Number((b.revenue / b.orders).toFixed(2)) : 0,
+      averageMarginPct:
+        b.marginKnown > 0 && b.revenue > 0 ? Number(((b.margin / b.revenue) * 100).toFixed(1)) : null,
+    }))
+    .sort((a, b) => b.revenue - a.revenue);
+}
+
+export async function getLandingPageRollup(windowDays = 30): Promise<LandingPageRollup[]> {
+  const since = daysAgo(windowDays);
+  const orders = await prisma.order.findMany({
+    where: {
+      createdAt: { gte: since },
+      landingPage: { not: null },
+      status: { notIn: ['CANCELLED', 'REFUNDED'] },
+    },
+    select: { landingPage: true, total: true },
+  });
+  const buckets = new Map<string, { orders: number; revenue: number }>();
+  for (const o of orders) {
+    const key = (o.landingPage ?? '/').split('?')[0];
+    const b = buckets.get(key) ?? { orders: 0, revenue: 0 };
+    b.orders += 1;
+    b.revenue += Number(o.total);
+    buckets.set(key, b);
+  }
+  return Array.from(buckets.entries())
+    .map(([landingPage, b]) => ({
+      landingPage,
+      orders: b.orders,
+      revenue: Number(b.revenue.toFixed(2)),
+      averageOrderValue: Number((b.revenue / b.orders).toFixed(2)),
+    }))
+    .sort((a, b) => b.revenue - a.revenue);
+}
+
+export async function getProductMargins(windowDays = 30, limit = 25): Promise<ProductMarginRow[]> {
+  const since = daysAgo(windowDays);
+  const items = await prisma.orderItem.findMany({
+    where: {
+      createdAt: { gte: since },
+      order: { status: { notIn: ['CANCELLED', 'REFUNDED'] } },
+    },
+    select: {
+      productId: true,
+      quantity: true,
+      totalPrice: true,
+      totalCost: true,
+      product: { select: { title: true } },
+    },
+  });
+
+  const agg = new Map<string, ProductMarginRow>();
+  for (const i of items) {
+    const row = agg.get(i.productId) ?? {
+      productId: i.productId,
+      title: i.product?.title ?? '(unknown)',
+      unitsSold: 0,
+      revenue: 0,
+      cost: 0,
+      margin: 0,
+      marginPct: 0,
+    };
+    row.unitsSold += i.quantity;
+    row.revenue += Number(i.totalPrice);
+    if (i.totalCost != null) row.cost += Number(i.totalCost);
+    agg.set(i.productId, row);
+  }
+
+  return Array.from(agg.values())
+    .map((r) => {
+      const margin = r.revenue - r.cost;
+      return {
+        ...r,
+        revenue: Number(r.revenue.toFixed(2)),
+        cost: Number(r.cost.toFixed(2)),
+        margin: Number(margin.toFixed(2)),
+        marginPct: r.revenue > 0 ? Number(((margin / r.revenue) * 100).toFixed(1)) : 0,
+      };
+    })
+    .sort((a, b) => b.revenue - a.revenue)
+    .slice(0, limit);
+}

--- a/src/lib/analytics/margin-service.ts
+++ b/src/lib/analytics/margin-service.ts
@@ -1,0 +1,59 @@
+import { Prisma, type PrismaClient } from '@prisma/client';
+
+type Tx = Prisma.TransactionClient | PrismaClient;
+
+/**
+ * Look up the current COGS for a variant. Returns null if not set.
+ */
+export async function getVariantUnitCost(
+  tx: Tx,
+  variantId: string
+): Promise<Prisma.Decimal | null> {
+  const variant = await tx.productVariant.findUnique({
+    where: { id: variantId },
+    select: { costPerUnit: true },
+  });
+  return variant?.costPerUnit ?? null;
+}
+
+/**
+ * Compute unitCost / totalCost snapshot for an order item.
+ * Call at order-item creation time and spread into the create input.
+ */
+export async function snapshotItemCost(
+  tx: Tx,
+  variantId: string,
+  quantity: number
+): Promise<{ unitCost: Prisma.Decimal | null; totalCost: Prisma.Decimal | null }> {
+  const unitCost = await getVariantUnitCost(tx, variantId);
+  if (!unitCost) return { unitCost: null, totalCost: null };
+  const totalCost = new Prisma.Decimal(unitCost).mul(quantity);
+  return { unitCost, totalCost };
+}
+
+/**
+ * Sum item-level margins and write Order.marginAmount.
+ * margin = sum(totalPrice - totalCost) across items. Items with null cost
+ * are skipped (treated as unknown, not zero) — margin will be partial when
+ * any item lacks cost data. Null marginAmount = no cost data at all.
+ */
+export async function finalizeOrderMargin(tx: Tx, orderId: string): Promise<void> {
+  const items = await tx.orderItem.findMany({
+    where: { orderId },
+    select: { totalPrice: true, totalCost: true },
+  });
+
+  const itemsWithCost = items.filter((i) => i.totalCost !== null);
+  if (itemsWithCost.length === 0) return;
+
+  const margin = itemsWithCost.reduce(
+    (acc, i) =>
+      acc.add(new Prisma.Decimal(i.totalPrice)).sub(new Prisma.Decimal(i.totalCost!)),
+    new Prisma.Decimal(0)
+  );
+
+  await tx.order.update({
+    where: { id: orderId },
+    data: { marginAmount: margin },
+  });
+}

--- a/src/lib/analytics/track.ts
+++ b/src/lib/analytics/track.ts
@@ -1,4 +1,5 @@
 import { track } from '@vercel/analytics';
+import { trackPodEvent } from './client-tracker';
 
 /**
  * Analytics Event Names - Centralized constants for consistency
@@ -76,6 +77,8 @@ export function trackEvent(
     } else {
       track(eventName);
     }
+    // Mirror to first-party event stream (own DB, no sampling, joinable to orders)
+    trackPodEvent(eventName, properties as Record<string, unknown> | undefined);
   } catch (error) {
     // Silently fail in production, log in development
     if (process.env.NODE_ENV === 'development') {

--- a/src/lib/analytics/variant-rollup.ts
+++ b/src/lib/analytics/variant-rollup.ts
@@ -1,0 +1,171 @@
+/**
+ * First-party rollups over `AnalyticsEvent` for A/B testing + per-page stats.
+ *
+ * The stats pipeline:
+ *   AnalyticsEvent (raw)
+ *     → variant exposure/conversion counts
+ *     → `computeSignificance` from experiment-significance.ts
+ *     → winner / p-value / lift
+ */
+
+import { prisma } from '@/lib/database/client';
+import { computeSignificance, type VariantStat, type SignificanceResult } from './experiment-significance';
+
+export interface ExperimentRollup extends SignificanceResult {
+  experimentId: string;
+  windowDays: number;
+}
+
+/**
+ * Aggregate exposures + conversions for an experiment over the last N days,
+ * then compute significance. Uses AnalyticsEvent rows — no GA4 dependency.
+ */
+export async function getExperimentRollup(
+  experimentId: string,
+  windowDays = 30
+): Promise<ExperimentRollup> {
+  const since = new Date();
+  since.setDate(since.getDate() - windowDays);
+
+  // Fetch variant metadata (so we know which is control and get display names)
+  const exp = await prisma.experiment.findUnique({
+    where: { id: experimentId },
+    include: { variants: { select: { id: true, name: true, isControl: true } } },
+  });
+  if (!exp) {
+    return {
+      experimentId,
+      windowDays,
+      variants: [],
+      winner: null,
+      control: null,
+      hasEnoughData: false,
+    };
+  }
+
+  const exposures = await prisma.analyticsEvent.groupBy({
+    by: ['variantId'],
+    where: {
+      experimentId,
+      name: 'experiment_exposure',
+      occurredAt: { gte: since },
+      variantId: { not: null },
+    },
+    _count: { _all: true },
+  });
+
+  // Count unique sessions that reached conversion per variant (so a user
+  // converting twice still counts as one).
+  const conversionRows = await prisma.$queryRawUnsafe<
+    Array<{ variant_id: string; session_count: bigint }>
+  >(
+    `
+    SELECT variant_id, COUNT(DISTINCT session_id)::bigint AS session_count
+    FROM analytics_events
+    WHERE experiment_id = $1
+      AND name = 'experiment_conversion'
+      AND occurred_at >= $2
+      AND variant_id IS NOT NULL
+    GROUP BY variant_id
+  `,
+    experimentId,
+    since
+  );
+
+  const exposureMap = new Map(exposures.map((e) => [e.variantId ?? '', e._count._all]));
+  const conversionMap = new Map(conversionRows.map((r) => [r.variant_id, Number(r.session_count)]));
+
+  const stats: VariantStat[] = exp.variants.map((v) => ({
+    id: v.id,
+    name: v.name,
+    isControl: v.isControl,
+    impressions: exposureMap.get(v.id) ?? 0,
+    conversions: conversionMap.get(v.id) ?? 0,
+  }));
+
+  const sig = computeSignificance(stats);
+  return { experimentId, windowDays, ...sig };
+}
+
+export interface PageEngagement {
+  path: string;
+  sessions: number;
+  pageviews: number;
+  bounceRate: number; // single-pageview sessions / total sessions
+  avgScrollDepth: number;
+  ctaClicks: number;
+  ctaClickRate: number;
+}
+
+/**
+ * Per-page engagement summary for landing-page diagnostics.
+ * Bounce rate = % of sessions that only saw this one page and left without scrolling.
+ */
+export async function getPageEngagement(windowDays = 30, limit = 25): Promise<PageEngagement[]> {
+  const since = new Date();
+  since.setDate(since.getDate() - windowDays);
+
+  const rows = await prisma.$queryRawUnsafe<
+    Array<{
+      path: string;
+      sessions: bigint;
+      pageviews: bigint;
+      bounced_sessions: bigint;
+      avg_scroll: number | null;
+      cta_clicks: bigint;
+    }>
+  >(
+    `
+    WITH page_sessions AS (
+      SELECT
+        path,
+        session_id,
+        COUNT(*) FILTER (WHERE name = 'page_view')       AS page_views_in_path,
+        MAX(CASE WHEN name = 'scroll_depth'
+                 THEN (properties->>'percent_scrolled')::int
+                 ELSE 0 END)                             AS max_scroll
+      FROM analytics_events
+      WHERE occurred_at >= $1 AND path IS NOT NULL
+      GROUP BY path, session_id
+    ),
+    session_path_counts AS (
+      SELECT session_id, COUNT(DISTINCT path) AS distinct_paths
+      FROM analytics_events
+      WHERE occurred_at >= $1 AND path IS NOT NULL
+      GROUP BY session_id
+    )
+    SELECT
+      ps.path,
+      COUNT(DISTINCT ps.session_id)::bigint                                      AS sessions,
+      SUM(ps.page_views_in_path)::bigint                                         AS pageviews,
+      COUNT(DISTINCT ps.session_id) FILTER (
+        WHERE spc.distinct_paths = 1 AND ps.max_scroll < 25
+      )::bigint                                                                   AS bounced_sessions,
+      AVG(ps.max_scroll)                                                         AS avg_scroll,
+      (SELECT COUNT(*) FROM analytics_events ae
+        WHERE ae.path = ps.path AND ae.name = 'cta_click' AND ae.occurred_at >= $1
+      )::bigint                                                                   AS cta_clicks
+    FROM page_sessions ps
+    JOIN session_path_counts spc USING (session_id)
+    GROUP BY ps.path
+    ORDER BY sessions DESC
+    LIMIT $2
+  `,
+    since,
+    limit
+  );
+
+  return rows.map((r) => {
+    const sessions = Number(r.sessions);
+    const bounced = Number(r.bounced_sessions);
+    return {
+      path: r.path,
+      sessions,
+      pageviews: Number(r.pageviews),
+      bounceRate: sessions > 0 ? bounced / sessions : 0,
+      avgScrollDepth: Math.round((r.avg_scroll ?? 0) * 10) / 10,
+      ctaClicks: Number(r.cta_clicks),
+      ctaClickRate: sessions > 0 ? Number(r.cta_clicks) / sessions : 0,
+    };
+  });
+}

--- a/src/lib/analytics/vercel-analytics.ts
+++ b/src/lib/analytics/vercel-analytics.ts
@@ -1,0 +1,99 @@
+/**
+ * Vercel Web Analytics + Web Vitals wrapper.
+ *
+ * Requires env vars (not yet set — populate before first cron run):
+ *   - VERCEL_ANALYTICS_TOKEN: team-scoped token with Web Analytics read access
+ *   - VERCEL_TEAM_ID
+ *   - VERCEL_PROJECT_ID (for partyondelivery.com)
+ *
+ * Returns null when env is missing so the cron can still run and snapshot
+ * other sources. Marketing Director treats null as "data unavailable."
+ */
+
+const API_BASE = 'https://api.vercel.com';
+
+export interface VercelWebVitals {
+  lcp: number | null; // ms, 75th percentile
+  fcp: number | null;
+  cls: number | null;
+  inp: number | null; // ms
+  fid: number | null;
+  ttfb: number | null;
+  samples: number;
+}
+
+export interface VercelTopPage {
+  path: string;
+  views: number;
+  visitors: number;
+}
+
+function env(): { token: string; teamId: string; projectId: string } | null {
+  const token = process.env.VERCEL_ANALYTICS_TOKEN;
+  const teamId = process.env.VERCEL_TEAM_ID;
+  const projectId = process.env.VERCEL_PROJECT_ID;
+  if (!token || !teamId || !projectId) return null;
+  return { token, teamId, projectId };
+}
+
+async function call<T>(path: string, params: Record<string, string>): Promise<T | null> {
+  const cfg = env();
+  if (!cfg) {
+    console.warn('[vercel-analytics] missing env (VERCEL_ANALYTICS_TOKEN/VERCEL_TEAM_ID/VERCEL_PROJECT_ID) — skipping');
+    return null;
+  }
+  const qs = new URLSearchParams({ teamId: cfg.teamId, projectId: cfg.projectId, ...params });
+  try {
+    const res = await fetch(`${API_BASE}${path}?${qs}`, {
+      headers: { Authorization: `Bearer ${cfg.token}` },
+    });
+    if (!res.ok) {
+      console.error(`[vercel-analytics] ${res.status} on ${path}:`, await res.text());
+      return null;
+    }
+    return (await res.json()) as T;
+  } catch (err) {
+    console.error('[vercel-analytics] fetch failed:', err);
+    return null;
+  }
+}
+
+/**
+ * TODO: replace with real Vercel Web Analytics API endpoint once credentials are set.
+ * The public Vercel Web Analytics API surface is documented at
+ * https://vercel.com/docs/analytics — endpoint names may change between v1/v2.
+ * Current shape is a placeholder; adjust the `call<>` generic + result mapping
+ * after confirming the actual response schema.
+ */
+export async function getWebVitals(
+  startDate: Date,
+  endDate: Date
+): Promise<VercelWebVitals | null> {
+  const raw = await call<{ lcp?: number; fcp?: number; cls?: number; inp?: number; fid?: number; ttfb?: number; samples?: number }>(
+    '/v1/analytics/web-vitals',
+    { from: startDate.toISOString(), to: endDate.toISOString() }
+  );
+  if (!raw) return null;
+  return {
+    lcp: raw.lcp ?? null,
+    fcp: raw.fcp ?? null,
+    cls: raw.cls ?? null,
+    inp: raw.inp ?? null,
+    fid: raw.fid ?? null,
+    ttfb: raw.ttfb ?? null,
+    samples: raw.samples ?? 0,
+  };
+}
+
+export async function getVercelTopPages(
+  startDate: Date,
+  endDate: Date,
+  limit = 20
+): Promise<VercelTopPage[] | null> {
+  const raw = await call<{ pages?: Array<{ path: string; views: number; visitors: number }> }>(
+    '/v1/analytics/pages',
+    { from: startDate.toISOString(), to: endDate.toISOString(), limit: String(limit) }
+  );
+  if (!raw) return null;
+  return raw.pages ?? [];
+}

--- a/src/lib/inventory/services/order-service.ts
+++ b/src/lib/inventory/services/order-service.ts
@@ -8,6 +8,7 @@ import { Prisma, OrderStatus, FulfillmentStatus, FinancialStatus } from '@prisma
 import type Stripe from 'stripe';
 import { CartWithItems } from './cart-service';
 import type { DraftOrderWithTotal, DraftOrderItem } from '@/lib/draft-orders/types';
+import { snapshotItemCost, finalizeOrderMargin } from '@/lib/analytics/margin-service';
 
 /**
  * Order with all relations
@@ -463,12 +464,20 @@ export async function createOrderFromCheckout(
         customerEmail,
         customerPhone,
         customerName,
+        landingPage: session.metadata?.landingPage || null,
+        utmSource: session.metadata?.utmSource || null,
+        utmMedium: session.metadata?.utmMedium || null,
+        utmCampaign: session.metadata?.utmCampaign || null,
+        utmTerm: session.metadata?.utmTerm || null,
+        utmContent: session.metadata?.utmContent || null,
+        referrer: session.metadata?.referrer || null,
       },
       include: { items: true },
     });
 
     // Create order items
     for (const item of cart.items) {
+      const { unitCost, totalCost } = await snapshotItemCost(tx, item.variantId, item.quantity);
       await tx.orderItem.create({
         data: {
           orderId: newOrder.id,
@@ -480,6 +489,8 @@ export async function createOrderFromCheckout(
           quantity: item.quantity,
           price: item.price,
           totalPrice: new Prisma.Decimal(Number(item.price) * item.quantity),
+          unitCost,
+          totalCost,
         },
       });
     }
@@ -488,6 +499,8 @@ export async function createOrderFromCheckout(
     for (const item of cart.items) {
       await commitInventoryForOrderItem(tx, item.productId, item.variantId, item.quantity, newOrder.orderNumber, newOrder.id);
     }
+
+    await finalizeOrderMargin(tx, newOrder.id);
 
     // Get the order with items
     const orderWithItems = await tx.order.findUnique({
@@ -602,6 +615,7 @@ export async function createFreeOrder(
     });
 
     for (const item of cart.items) {
+      const { unitCost, totalCost } = await snapshotItemCost(tx, item.variantId, item.quantity);
       await tx.orderItem.create({
         data: {
           orderId: newOrder.id,
@@ -613,6 +627,8 @@ export async function createFreeOrder(
           quantity: item.quantity,
           price: item.price,
           totalPrice: new Prisma.Decimal(Number(item.price) * item.quantity),
+          unitCost,
+          totalCost,
         },
       });
     }
@@ -621,6 +637,8 @@ export async function createFreeOrder(
     for (const item of cart.items) {
       await commitInventoryForOrderItem(tx, item.productId, item.variantId, item.quantity, newOrder.orderNumber, newOrder.id);
     }
+
+    await finalizeOrderMargin(tx, newOrder.id);
 
     return await tx.order.findUnique({
       where: { id: newOrder.id },
@@ -965,6 +983,7 @@ export async function createOrderFromDraftOrder(
         }
       }
 
+      const { unitCost, totalCost } = await snapshotItemCost(tx, variantId, item.quantity);
       await tx.orderItem.create({
         data: {
           orderId: newOrder.id,
@@ -976,6 +995,8 @@ export async function createOrderFromDraftOrder(
           quantity: item.quantity,
           price: new Prisma.Decimal(item.price),
           totalPrice: new Prisma.Decimal(item.price * item.quantity),
+          unitCost,
+          totalCost,
         },
       });
     }
@@ -989,6 +1010,8 @@ export async function createOrderFromDraftOrder(
         console.warn(`[Order Service] Could not commit inventory for ${item.title}:`, inventoryError);
       }
     }
+
+    await finalizeOrderMargin(tx, newOrder.id);
 
     // Get the order with items
     const orderWithItems = await tx.order.findUnique({

--- a/src/lib/stripe/checkout.ts
+++ b/src/lib/stripe/checkout.ts
@@ -24,6 +24,15 @@ export interface CheckoutMetadata {
   discountCode?: string;
   affiliateCode?: string;
   tipAmount?: string;
+
+  // First-touch marketing attribution (captured on landing, forwarded by client)
+  landingPage?: string;
+  utmSource?: string;
+  utmMedium?: string;
+  utmCampaign?: string;
+  utmTerm?: string;
+  utmContent?: string;
+  referrer?: string;
 }
 
 /**
@@ -51,6 +60,15 @@ export interface CreateCheckoutOptions {
   affiliateCode?: string;
   overrideDeliveryFee?: number;
   tipAmount?: number;
+  attribution?: {
+    landingPage?: string | null;
+    utmSource?: string | null;
+    utmMedium?: string | null;
+    utmCampaign?: string | null;
+    utmTerm?: string | null;
+    utmContent?: string | null;
+    referrer?: string | null;
+  };
 }
 
 /**
@@ -59,7 +77,7 @@ export interface CreateCheckoutOptions {
 export async function createCheckoutSession(
   options: CreateCheckoutOptions
 ): Promise<Stripe.Checkout.Session> {
-  const { cart, successUrl, cancelUrl, customerEmail, stripeCustomerId, affiliateCode, overrideDeliveryFee, tipAmount } = options;
+  const { cart, successUrl, cancelUrl, customerEmail, stripeCustomerId, affiliateCode, overrideDeliveryFee, tipAmount, attribution } = options;
 
   // Build line items from cart
   const lineItems: Stripe.Checkout.SessionCreateParams.LineItem[] = cart.items.map((item) => ({
@@ -123,6 +141,13 @@ export async function createCheckoutSession(
     discountCode: cart.discountCode || undefined,
     affiliateCode: affiliateCode || undefined,
     tipAmount: tipAmount && tipAmount > 0 ? tipAmount.toFixed(2) : undefined,
+    landingPage: attribution?.landingPage || undefined,
+    utmSource: attribution?.utmSource || undefined,
+    utmMedium: attribution?.utmMedium || undefined,
+    utmCampaign: attribution?.utmCampaign || undefined,
+    utmTerm: attribution?.utmTerm || undefined,
+    utmContent: attribution?.utmContent || undefined,
+    referrer: attribution?.referrer || undefined,
   };
 
   // Filter out undefined values for Stripe metadata

--- a/vercel.json
+++ b/vercel.json
@@ -15,6 +15,10 @@
     {
       "path": "/api/cron/affiliate-payouts",
       "schedule": "0 14 1 * *"
+    },
+    {
+      "path": "/api/cron/analytics-snapshot",
+      "schedule": "0 7 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Ships Phase 1 of the analytics optimization system: a data pipeline spanning GA4 + GBP + internal DB, first-party event tracking for A/B tests, order-level margin tracking, and a Marketing Director Claude subagent that reads all of it and returns prioritized recommendations.

Six themed commits — review in order:

1. **`feat(schema)`** — new models (`AnalyticsEvent`, `GbpReview`), new columns on `Order` (attribution, margin) and `OrderItem` (COGS snapshot), `AnalyticsSnapshot` extended. Schema already pushed to Neon via `db push` earlier.
2. **`feat(analytics): instrumentation`** — `AttributionTracker` + `MicrosoftClarity` page components wired into `layout.tsx`, margin service + backfill, attribution forwarded through Stripe metadata → Order.
3. **`feat(analytics): first-party events`** — `/api/v1/events/track` ingest, client batcher with `sendBeacon`, significance calc (two-proportion z-test), variant rollup, `track.ts`/`ga4-events.ts` dual-send.
4. **`feat(analytics): data pipeline`** — GA4 Data API extensions, GBP via Places API (since legacy Business Profile API requires approval), internal rollups, ops-auth'd admin endpoints, nightly snapshot cron.
5. **`feat(ops)`** — COGS entry CLI + distributor invoice batch tooling (already used to load ~45 products' costs).
6. **`feat(agent)`** — Marketing Director subagent + human-readable docs.

## Test plan

- [ ] Add these to Vercel env vars (code no-ops gracefully without them, but live data won't flow):
  - [ ] `NEXT_PUBLIC_CLARITY_PROJECT_ID=wgiap60f91`
  - [ ] `GOOGLE_MAPS_API_KEY=<from local .env.local>`
  - [ ] `GOOGLE_PLACE_ID=ChIJc8cN7oDLRIYRY734oDi4Gpo`
- [ ] After merge + auto-deploy, open partyondelivery.com incognito → DevTools Network → filter `clarity` → confirm `clarity.ms/tag/wgiap60f91` fires
- [ ] Manually trigger the new cron: `curl -H "Authorization: Bearer $CRON_SECRET" https://partyondelivery.com/api/cron/analytics-snapshot` → confirm `docs/WEBSITE-ANALYTICS.md` gets regenerated with real data
- [ ] Place a test order with `?utm_source=test` → confirm `Order.utmSource` is populated and `Order.marginAmount` is non-null
- [ ] Invoke `marketing-director` subagent in Claude Code → verify it reads the snapshot + makes recommendations referencing real metrics

## Known gaps (Phase 2)

- SEMrush: no API key available, deferred
- Vercel Web Analytics: no public API on Pro tier, dropped (GA4 covers traffic, Clarity covers qualitative)
- GBP full review history: requires application to legacy Business Profile API (Places API returns only 5 most recent)
- Customer LTV / cohort analysis

## Database

`prisma db push` was already run against production Neon while developing. No migration needed at merge time. New tables (`analytics_events`, `gbp_reviews`) and new columns are all additive + nullable, so this merge is zero-risk to existing data/traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)