### PR TITLE
feat(analytics): close the marketing director loop

### DIFF
--- a/.claude/agents/marketing-director.md
+++ b/.claude/agents/marketing-director.md
@@ -36,23 +36,36 @@ You are the senior growth/marketing analyst for **Party On Delivery**, a premium
 
 ## First action every invocation
 
-1. Read `docs/WEBSITE-ANALYTICS.md` (human-readable snapshot, regenerated nightly).
-2. If the user asks something not covered by the snapshot (e.g., "how did this week compare to last week"), query the live admin endpoints:
+1. Read the **latest weekly briefing** if it exists: `docs/marketing/weekly/YYYY-Www.md` (deterministic) and `docs/marketing/weekly/YYYY-Www-director.md` (narrative). Newest file is the relevant week.
+2. Read `docs/WEBSITE-ANALYTICS.md` (human-readable snapshot, regenerated nightly).
+3. Read **open recommendations** so you don't re-suggest what's already in the queue:
+   ```bash
+   curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/recommendations?status=open,approved'
+   ```
+   Before generating a new recommendation, check this list — if a similar one is already open, don't duplicate. If you have a stronger version, suggest updating the existing rec's `notes` (POST to the same endpoint with `{ id, status, notes }`).
+4. If the user asks something not covered by the snapshot (e.g., "how did this week compare to last week"), query the live admin endpoints:
 
 ```bash
 # All require ops session cookie or ops JWT
+# GA4 / Vercel / GBP — same as before
 curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/ga4?metric=revenue-by-channel&days=30'
 curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/ga4?metric=conversion-by-page&days=30'
 curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/ga4?metric=funnel&days=30'
 curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/vercel?metric=web-vitals&days=7'
 curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/gbp?metric=insights&days=30'
 curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/gbp?metric=segments&days=90'
+
+# Internal DB — extended set, includes segment / repeat-rate / LTV / affiliate ROI
 curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/internal?metric=channels&days=30'
 curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/internal?metric=landing-pages&days=30'
 curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/internal?metric=product-margins&days=30'
+curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/internal?metric=segments&days=30'
+curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/internal?metric=repeat-rate&days=30'
+curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/internal?metric=ltv&monthsBack=12'
+curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/internal?metric=affiliate-roi&days=30'
 ```
 
-3. When deeper code-level analysis is needed, delegate to existing skills:
+5. When deeper code-level analysis is needed, delegate to existing skills:
    - **`landing-page-audit`** — for segment-landing-page UX/CRO analysis
    - **`conversion-optimization`** — Hormozi-style offer/copy review
    - **`ops`** — product/inventory lookups
@@ -77,7 +90,7 @@ curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/inte
 - **Vercel Web Analytics / Web Vitals**: may be unavailable if env not set — check for `null` data and say so.
 - **GBP reviews**: may be empty if OAuth not configured yet.
 - **Historical order margin**: orders pre-2026-04 have null margin until backfill runs. If reviewing historical trends, note "margin data for pre-2026-04 orders is approximate (backfilled with current COGS)."
-- **LTV / repeat rate**: not yet computed (Phase 2).
+- **Order segments**: orders created before the segment column was added are bucketed under `'unknown'` until `npx tsx scripts/backfill-order-segments.ts` runs. If a segment row shows up as `unknown` in rollups, that's the cause.
 
 ## Output format
 
@@ -90,9 +103,30 @@ Respond with a **prioritized recommendation list**, each item containing:
 - **Risk tier**: autonomous (Phase 2) | recommend-only | hard stop
 - **Effort**: small (copy change) | medium (new section) | large (redesign)
 - **Next step**: "run `/landing-page-audit` on /weddings" or "open draft PR changing …"
+- **Already in queue?**: yes / no (and the open recommendation's id if yes — propose updating its notes rather than creating a duplicate)
 ```
 
 Close with a one-line summary of **what you'd pick first** and why.
+
+## Persisting your output
+
+The snapshot cron auto-persists heuristic recs (negative-ROI affiliates, segment WoW drops, low-margin top products). Your job is to add what those heuristics miss — narrative patterns, cross-metric synthesis, novel angles.
+
+When the user wants a recommendation captured for later review:
+
+```bash
+# Create new (omit id, supply title + details)
+curl -s -H "Cookie: $OPS_COOKIE" -X POST 'http://localhost:3000/api/admin/analytics/recommendations' \
+  -H 'Content-Type: application/json' \
+  -d '{ "title": "...", "body": "...", "segment": "wedding", "impactDollarsMonthly": 1200, "effortTier": "s", "riskTier": "recommend", "source": "director" }'
+
+# Update existing (supply id + status)
+curl -s -H "Cookie: $OPS_COOKIE" -X POST 'http://localhost:3000/api/admin/analytics/recommendations' \
+  -H 'Content-Type: application/json' \
+  -d '{ "id": "<rec-id>", "status": "approved", "notes": "rationale" }'
+```
+
+Title+segment dedupe is enforced server-side: an identical open/approved rec won't insert again.
 
 ## Never do
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,11 +57,12 @@ model AnalyticsSnapshot {
   topReferrers       Json?    @map("top_referrers")
 
   // External data source payloads (populated by nightly cron)
-  semrushData  Json? @map("semrush_data")
-  vercelData   Json? @map("vercel_data")
-  gbpData      Json? @map("gbp_data")
-  marginData   Json? @map("margin_data")
-  segmentData  Json? @map("segment_data")
+  semrushData    Json? @map("semrush_data")
+  vercelData     Json? @map("vercel_data")
+  gbpData        Json? @map("gbp_data")
+  marginData     Json? @map("margin_data")
+  segmentData    Json? @map("segment_data")
+  comparisonData Json? @map("comparison_data") // Prior-period rollups + WoW/MoM deltas
 
   createdAt          DateTime @default(now()) @map("created_at")
   updatedAt          DateTime @updatedAt @map("updated_at")
@@ -879,6 +880,10 @@ model Order {
   utmContent  String? @map("utm_content")
   referrer    String? @map("referrer")
 
+  // Customer segment (bach | wedding | corporate | boat | kegs | general),
+  // derived from landingPage + utmCampaign at order creation. See segment-classifier.ts.
+  segment     String? @map("segment")
+
   // Margin (computed at order creation; null for orders created before margin pipeline existed)
   marginAmount Decimal? @map("margin_amount") @db.Decimal(10, 2)
 
@@ -917,6 +922,7 @@ model Order {
   @@index([groupOrderV2Id])
   @@index([utmSource])
   @@index([landingPage])
+  @@index([segment])
   @@map("orders")
 }
 
@@ -2457,6 +2463,39 @@ model ScheduleOrderMatch {
   @@index([orderId])
   @@index([status])
   @@map("schedule_order_matches")
+}
+
+// Persisted output of the Marketing Director / heuristic engine. Each row is a single
+// proposed action; status workflow is open → approved → shipped (or rejected/invalidated).
+// `riskTier` enables the Phase 2 autonomy ramp: 'autonomous' rows can be picked up by a
+// worker for auto-PR, 'recommend' rows always require human approval, 'hard_stop' rows
+// (e.g. anything touching TABC) never ship.
+model RecommendationItem {
+  id                    String    @id @default(uuid())
+  generatedAt           DateTime  @default(now()) @map("generated_at")
+  source                String    // 'auto-snapshot' | 'director' | 'manual'
+  title                 String
+  body                  String?   @db.Text
+  segment               String?   // bach | wedding | corporate | boat | kegs | general | null (cross-segment)
+  metric                String?   // e.g. 'conversion-by-page:/weddings'
+  currentValue          String?   @map("current_value")
+  targetValue           String?   @map("target_value")
+  impactDollarsMonthly  Int?      @map("impact_dollars_monthly")
+  effortTier            String?   @map("effort_tier")  // s | m | l
+  riskTier              String    @default("recommend") @map("risk_tier")  // autonomous | recommend | hard_stop
+  status                String    @default("open")   // open | approved | shipped | rejected | invalidated
+  shippedAt             DateTime? @map("shipped_at")
+  resultMetricBefore    Json?     @map("result_metric_before")
+  resultMetricAfter     Json?     @map("result_metric_after")
+  notes                 String?   @db.Text
+  createdAt             DateTime  @default(now()) @map("created_at")
+  updatedAt             DateTime  @updatedAt @map("updated_at")
+
+  @@index([status])
+  @@index([generatedAt])
+  @@index([segment])
+  @@index([title, segment])
+  @@map("recommendation_items")
 }
 
 model SyncLog {

--- a/scripts/apply-analytics-schema.ts
+++ b/scripts/apply-analytics-schema.ts
@@ -1,0 +1,77 @@
+/**
+ * One-shot DDL applier for the analytics closed-loop schema additions.
+ *
+ * Run BEFORE deploying the new code so prod has the columns/tables the new
+ * Prisma client references. Otherwise Stripe checkout webhooks will start
+ * erroring on missing `orders.segment`.
+ *
+ * Usage:
+ *   DATABASE_URL=<prod> npx tsx scripts/apply-analytics-schema.ts
+ *
+ * Idempotent — safe to run multiple times. Mirrors the inline ALTERs the
+ * analytics-snapshot cron applies; this just lets you apply them on demand.
+ */
+
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const STATEMENTS: Array<[string, string]> = [
+  [
+    'analytics_snapshots.comparison_data',
+    'ALTER TABLE analytics_snapshots ADD COLUMN IF NOT EXISTS comparison_data JSONB',
+  ],
+  [
+    'orders.segment',
+    'ALTER TABLE orders ADD COLUMN IF NOT EXISTS segment TEXT',
+  ],
+  [
+    'orders.segment idx',
+    'CREATE INDEX IF NOT EXISTS orders_segment_idx ON orders(segment)',
+  ],
+  [
+    'recommendation_items table',
+    `CREATE TABLE IF NOT EXISTS recommendation_items (
+      id TEXT PRIMARY KEY,
+      generated_at TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      source TEXT NOT NULL,
+      title TEXT NOT NULL,
+      body TEXT,
+      segment TEXT,
+      metric TEXT,
+      current_value TEXT,
+      target_value TEXT,
+      impact_dollars_monthly INTEGER,
+      effort_tier TEXT,
+      risk_tier TEXT NOT NULL DEFAULT 'recommend',
+      status TEXT NOT NULL DEFAULT 'open',
+      shipped_at TIMESTAMP(3),
+      result_metric_before JSONB,
+      result_metric_after JSONB,
+      notes TEXT,
+      created_at TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )`,
+  ],
+  ['rec_status_idx', 'CREATE INDEX IF NOT EXISTS rec_status_idx ON recommendation_items(status)'],
+  ['rec_generated_idx', 'CREATE INDEX IF NOT EXISTS rec_generated_idx ON recommendation_items(generated_at)'],
+  ['rec_segment_idx', 'CREATE INDEX IF NOT EXISTS rec_segment_idx ON recommendation_items(segment)'],
+  ['rec_title_segment_idx', 'CREATE INDEX IF NOT EXISTS rec_title_segment_idx ON recommendation_items(title, segment)'],
+];
+
+async function main() {
+  console.log('[apply-analytics-schema] applying additive DDL…');
+  for (const [label, sql] of STATEMENTS) {
+    process.stdout.write(`  • ${label.padEnd(40)} `);
+    await prisma.$executeRawUnsafe(sql);
+    console.log('OK');
+  }
+  console.log('[apply-analytics-schema] done. Safe to deploy now.');
+}
+
+main()
+  .catch((err) => {
+    console.error('[apply-analytics-schema] FAILED:', err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/backfill-order-segments.ts
+++ b/scripts/backfill-order-segments.ts
@@ -1,0 +1,56 @@
+/**
+ * One-shot backfill: classify Order.segment for existing rows from landingPage + utmCampaign.
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-order-segments.ts [--dry-run]
+ *
+ * Run after the prod DB has the `segment` column added (the analytics-snapshot cron
+ * applies the `ALTER TABLE` automatically on first run, but this script can also
+ * apply it idempotently below).
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { classifySegment, type Segment } from '../src/lib/analytics/segment-classifier';
+
+const prisma = new PrismaClient();
+const DRY_RUN = process.argv.includes('--dry-run');
+
+async function main() {
+  console.log(`[backfill-segments] starting${DRY_RUN ? ' (DRY RUN)' : ''}`);
+
+  // Idempotent column add — same DDL the cron runs.
+  await prisma.$executeRawUnsafe(
+    `ALTER TABLE orders ADD COLUMN IF NOT EXISTS segment TEXT`
+  );
+
+  const orders = await prisma.order.findMany({
+    where: { segment: null },
+    select: { id: true, landingPage: true, utmCampaign: true },
+  });
+  console.log(`[backfill-segments] ${orders.length} orders with null segment`);
+
+  const counts: Record<Segment, number> = {
+    bach: 0, wedding: 0, corporate: 0, boat: 0, kegs: 0, general: 0,
+  };
+
+  for (const o of orders) {
+    const segment = classifySegment(o.landingPage, o.utmCampaign);
+    counts[segment]++;
+    if (!DRY_RUN) {
+      await prisma.order.update({ where: { id: o.id }, data: { segment } });
+    }
+  }
+
+  console.log('[backfill-segments] distribution:');
+  for (const [seg, n] of Object.entries(counts)) {
+    console.log(`  ${seg.padEnd(10)} ${n}`);
+  }
+  console.log('[backfill-segments] done');
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/app/api/admin/analytics/internal/route.ts
+++ b/src/app/api/admin/analytics/internal/route.ts
@@ -4,13 +4,16 @@ import {
   getChannelRollup,
   getLandingPageRollup,
   getProductMargins,
+  getSegmentRollup,
+  getAffiliateRoi,
 } from '@/lib/analytics/internal-rollups';
+import { getRepeatRateBySegment, getLtvBySegment } from '@/lib/analytics/cohort-rollups';
 import { prisma } from '@/lib/database/client';
 
 export const dynamic = 'force-dynamic';
 
 /**
- * GET /api/admin/analytics/internal?metric=channels|landing-pages|product-margins|snapshot-latest&days=30
+ * GET /api/admin/analytics/internal?metric=channels|landing-pages|product-margins|segments|repeat-rate|ltv|affiliate-roi|snapshot-latest&days=30
  * Exposes internal DB rollups the Marketing Director agent reads (orders, margins, attribution).
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
@@ -29,6 +32,16 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         return NextResponse.json({ metric, days, data: await getLandingPageRollup(days) });
       case 'product-margins':
         return NextResponse.json({ metric, days, data: await getProductMargins(days) });
+      case 'segments':
+        return NextResponse.json({ metric, days, data: await getSegmentRollup(days) });
+      case 'repeat-rate':
+        return NextResponse.json({ metric, days, data: await getRepeatRateBySegment(days) });
+      case 'ltv': {
+        const monthsBack = Math.max(1, Math.min(36, parseInt(sp.get('monthsBack') ?? '12', 10)));
+        return NextResponse.json({ metric, monthsBack, data: await getLtvBySegment(monthsBack) });
+      }
+      case 'affiliate-roi':
+        return NextResponse.json({ metric, days, data: await getAffiliateRoi(days) });
       case 'snapshot-latest': {
         const snap = await prisma.analyticsSnapshot.findFirst({ orderBy: { date: 'desc' } });
         return NextResponse.json({ metric, data: snap });

--- a/src/app/api/admin/analytics/recommendations/route.ts
+++ b/src/app/api/admin/analytics/recommendations/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
+import {
+  listRecommendations,
+  persistRecommendations,
+  updateRecommendationStatus,
+  type RecommendationStatus,
+} from '@/lib/analytics/recommendation-store';
+
+export const dynamic = 'force-dynamic';
+
+const STATUSES: RecommendationStatus[] = ['open', 'approved', 'shipped', 'rejected', 'invalidated'];
+
+/**
+ * GET  /api/admin/analytics/recommendations?status=open&segment=wedding&limit=50
+ * POST /api/admin/analytics/recommendations  body: { id, status, notes? }
+ *
+ * Lists Director-generated and heuristic recommendations from the persistent queue,
+ * and lets ops move them through the open → approved → shipped (or rejected) workflow.
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  const sp = request.nextUrl.searchParams;
+  const statusParam = sp.get('status');
+  const segment = sp.get('segment') ?? undefined;
+  const limit = Math.min(500, Math.max(1, parseInt(sp.get('limit') ?? '100', 10)));
+
+  let status: RecommendationStatus | RecommendationStatus[] | undefined;
+  if (statusParam) {
+    const requested = statusParam.split(',').map((s) => s.trim()) as RecommendationStatus[];
+    const valid = requested.filter((s): s is RecommendationStatus => STATUSES.includes(s));
+    status = valid.length === 1 ? valid[0] : valid;
+  }
+
+  const data = await listRecommendations({ status, segment, limit });
+  return NextResponse.json({ data });
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  const body = await request.json().catch(() => null);
+
+  // Update path: { id, status, notes? }
+  if (typeof body?.id === 'string') {
+    const status = typeof body.status === 'string' ? body.status : null;
+    const notes = typeof body.notes === 'string' ? body.notes : undefined;
+    if (!status || !STATUSES.includes(status as RecommendationStatus)) {
+      return NextResponse.json(
+        { error: 'when id is given, status (open|approved|shipped|rejected|invalidated) is required' },
+        { status: 400 }
+      );
+    }
+    const updated = await updateRecommendationStatus(body.id, status as RecommendationStatus, notes);
+    return NextResponse.json({ data: updated });
+  }
+
+  // Create path: { title, body?, segment?, impactDollarsMonthly?, effortTier?, riskTier?, source? }
+  if (typeof body?.title === 'string') {
+    const result = await persistRecommendations(
+      [{
+        title: body.title,
+        body: typeof body.body === 'string' ? body.body : undefined,
+        segment: typeof body.segment === 'string' ? body.segment : undefined,
+        metric: typeof body.metric === 'string' ? body.metric : undefined,
+        impactDollarsMonthly:
+          typeof body.impactDollarsMonthly === 'number' ? body.impactDollarsMonthly : undefined,
+        effortTier: ['s', 'm', 'l'].includes(body.effortTier) ? body.effortTier : undefined,
+        riskTier: ['autonomous', 'recommend', 'hard_stop'].includes(body.riskTier)
+          ? body.riskTier
+          : undefined,
+      }],
+      body.source === 'director' || body.source === 'manual' ? body.source : 'manual'
+    );
+    return NextResponse.json({ data: result });
+  }
+
+  return NextResponse.json(
+    { error: 'POST body must include either { id, status } to update or { title, ... } to create' },
+    { status: 400 }
+  );
+}

--- a/src/app/api/cron/analytics-snapshot/route.ts
+++ b/src/app/api/cron/analytics-snapshot/route.ts
@@ -29,7 +29,12 @@ import {
   getChannelRollup,
   getLandingPageRollup,
   getProductMargins,
+  getSegmentRollup,
+  getAffiliateRoi,
 } from '@/lib/analytics/internal-rollups';
+import { getRepeatRateBySegment, getLtvBySegment } from '@/lib/analytics/cohort-rollups';
+import { buildSnapshotRecommendations } from '@/lib/analytics/snapshot-recommendations';
+import { persistRecommendations, listRecommendations } from '@/lib/analytics/recommendation-store';
 import { getPageEngagement } from '@/lib/analytics/variant-rollup';
 
 export const dynamic = 'force-dynamic';
@@ -47,12 +52,57 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  // Idempotent additive migrations — schema.prisma drift means we can't `prisma db push`,
+  // so apply additive DDL inline. No-ops once columns/tables exist.
+  await prisma.$executeRawUnsafe(
+    `ALTER TABLE analytics_snapshots ADD COLUMN IF NOT EXISTS comparison_data JSONB`
+  );
+  await prisma.$executeRawUnsafe(
+    `ALTER TABLE orders ADD COLUMN IF NOT EXISTS segment TEXT`
+  );
+  await prisma.$executeRawUnsafe(
+    `CREATE INDEX IF NOT EXISTS orders_segment_idx ON orders(segment)`
+  );
+  await prisma.$executeRawUnsafe(`
+    CREATE TABLE IF NOT EXISTS recommendation_items (
+      id TEXT PRIMARY KEY,
+      generated_at TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      source TEXT NOT NULL,
+      title TEXT NOT NULL,
+      body TEXT,
+      segment TEXT,
+      metric TEXT,
+      current_value TEXT,
+      target_value TEXT,
+      impact_dollars_monthly INTEGER,
+      effort_tier TEXT,
+      risk_tier TEXT NOT NULL DEFAULT 'recommend',
+      status TEXT NOT NULL DEFAULT 'open',
+      shipped_at TIMESTAMP(3),
+      result_metric_before JSONB,
+      result_metric_after JSONB,
+      notes TEXT,
+      created_at TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )
+  `);
+  await prisma.$executeRawUnsafe(`CREATE INDEX IF NOT EXISTS rec_status_idx ON recommendation_items(status)`);
+  await prisma.$executeRawUnsafe(`CREATE INDEX IF NOT EXISTS rec_generated_idx ON recommendation_items(generated_at)`);
+  await prisma.$executeRawUnsafe(`CREATE INDEX IF NOT EXISTS rec_segment_idx ON recommendation_items(segment)`);
+  await prisma.$executeRawUnsafe(`CREATE INDEX IF NOT EXISTS rec_title_segment_idx ON recommendation_items(title, segment)`);
+
   const today = startOfDay(new Date());
   const endDate = new Date();
   const start7 = new Date();
   start7.setDate(start7.getDate() - 7);
   const start30 = new Date();
   start30.setDate(start30.getDate() - 30);
+
+  // Prior 30-day window (for WoW/MoM deltas) — 30 days ending 30 days ago.
+  const prior30End = new Date();
+  prior30End.setDate(prior30End.getDate() - 30);
+  const prior30Start = new Date();
+  prior30Start.setDate(prior30Start.getDate() - 60);
 
   const errors: string[] = [];
   const safe = async <T>(label: string, fn: () => Promise<T>): Promise<T | null> => {
@@ -65,43 +115,79 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     }
   };
 
-  // Parallel pulls across sources
+  // Parallel pulls across sources. GA4/GSC traffic & SEO metrics natively support
+  // a compare period; for other slices we issue a parallel "prior" call below.
   const [
     traffic,
     trafficSources,
     topPages,
     revenueByChannel,
+    revenueByChannelPrior,
     conversionByPage,
+    conversionByPagePrior,
     funnel,
     seoMetrics,
     topKeywords,
     webVitals,
     vercelTopPages,
     channels,
+    channelsPrior,
     landingRollup,
+    landingRollupPrior,
     productMargins,
+    productMarginsPrior,
   ] = await Promise.all([
-    safe('ga4.traffic', () => getTrafficMetrics(start30, endDate)),
+    safe('ga4.traffic', () => getTrafficMetrics(start30, endDate, prior30Start, prior30End)),
     safe('ga4.sources', () => getTrafficSources(start30, endDate)),
     safe('ga4.top-pages', () => getTopPages(start30, endDate, 20)),
     safe('ga4.revenue-by-channel', () => getRevenueByChannel(start30, endDate)),
+    safe('ga4.revenue-by-channel.prior', () => getRevenueByChannel(prior30Start, prior30End)),
     safe('ga4.conversion-by-page', () => getConversionByLandingPage(start30, endDate)),
+    safe('ga4.conversion-by-page.prior', () => getConversionByLandingPage(prior30Start, prior30End)),
     safe('ga4.funnel', () => getCheckoutFunnel(start30, endDate)),
-    safe('gsc.seo', () => getSEOMetrics(start30, endDate)),
+    safe('gsc.seo', () => getSEOMetrics(start30, endDate, prior30Start, prior30End)),
     safe('gsc.keywords', () => getTopKeywords(start30, endDate, 50)),
     safe('vercel.web-vitals', () => getWebVitals(start7, endDate)),
     safe('vercel.top-pages', () => getVercelTopPages(start30, endDate)),
     safe('internal.channels', () => getChannelRollup(30)),
+    safe('internal.channels.prior', () => getChannelRollup(30, 30)),
     safe('internal.landing-pages', () => getLandingPageRollup(30)),
+    safe('internal.landing-pages.prior', () => getLandingPageRollup(30, 30)),
     safe('internal.product-margins', () => getProductMargins(30)),
+    safe('internal.product-margins.prior', () => getProductMargins(30, 25, 30)),
   ]);
 
   const pageEngagement = await safe('internal.page-engagement', () => getPageEngagement(30));
+  const [segmentRollup, segmentRollupPrior, repeatRate, ltvBySegment, affiliateRoi] = await Promise.all([
+    safe('internal.segments', () => getSegmentRollup(30)),
+    safe('internal.segments.prior', () => getSegmentRollup(30, 30)),
+    safe('internal.repeat-rate', () => getRepeatRateBySegment(30)),
+    safe('internal.ltv', () => getLtvBySegment(12)),
+    safe('internal.affiliate-roi', () => getAffiliateRoi(30)),
+  ]);
 
   // GBP sync (writes to GbpReview table) + insights
   await safe('gbp.sync', () => syncGbpReviews());
   const gbpInsights = await safe('gbp.insights', () => getGbpInsights(30));
   const gbpSegments = await safe('gbp.segments', () => getSegmentSentiment(90));
+
+  const comparisonPayload = {
+    windowDays: 30,
+    priorWindow: { startDate: prior30Start.toISOString(), endDate: prior30End.toISOString() },
+    channels: channelsPrior,
+    landingPages: landingRollupPrior,
+    productMargins: productMarginsPrior,
+    revenueByChannel: revenueByChannelPrior,
+    conversionByPage: conversionByPagePrior,
+    trafficDeltas: {
+      sessionsChange: traffic?.sessionsChange ?? null,
+      usersChange: traffic?.usersChange ?? null,
+    },
+    seoDeltas: {
+      impressionsChange: seoMetrics?.impressionsChange ?? null,
+      clicksChange: seoMetrics?.clicksChange ?? null,
+    },
+  };
 
   // Upsert snapshot
   const snapshot = await prisma.analyticsSnapshot.upsert({
@@ -121,14 +207,18 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       topReferrers: (trafficSources ?? []) as unknown as object,
       vercelData: { webVitals, topPages: vercelTopPages } as unknown as object,
       gbpData: { insights: gbpInsights, segments: gbpSegments } as unknown as object,
-      marginData: { channels, productMargins } as unknown as object,
+      marginData: { channels, productMargins, affiliateRoi } as unknown as object,
       segmentData: {
         landingPages: landingRollup,
         revenueByChannel,
         conversionByPage,
         funnel,
         pageEngagement,
+        segments: segmentRollup,
+        repeatRate,
+        ltvBySegment,
       } as unknown as object,
+      comparisonData: { ...comparisonPayload, segments: segmentRollupPrior } as unknown as object,
     },
     create: {
       date: today,
@@ -146,16 +236,35 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       topReferrers: (trafficSources ?? []) as unknown as object,
       vercelData: { webVitals, topPages: vercelTopPages } as unknown as object,
       gbpData: { insights: gbpInsights, segments: gbpSegments } as unknown as object,
-      marginData: { channels, productMargins } as unknown as object,
+      marginData: { channels, productMargins, affiliateRoi } as unknown as object,
       segmentData: {
         landingPages: landingRollup,
         revenueByChannel,
         conversionByPage,
         funnel,
         pageEngagement,
+        segments: segmentRollup,
+        repeatRate,
+        ltvBySegment,
       } as unknown as object,
+      comparisonData: { ...comparisonPayload, segments: segmentRollupPrior } as unknown as object,
     },
   });
+
+  // Generate + persist recommendations from this snapshot's rollups, then pull the open queue
+  // so the markdown can show what ops should pay attention to.
+  const snapshotRecs = buildSnapshotRecommendations({
+    segments: segmentRollup ?? [],
+    segmentsPrior: segmentRollupPrior ?? [],
+    affiliateRoi: affiliateRoi ?? [],
+    productMargins: productMargins ?? [],
+  });
+  const persistResult = await safe('recs.persist', () =>
+    persistRecommendations(snapshotRecs, 'auto-snapshot')
+  );
+  const openRecs = (await safe('recs.list-open', () =>
+    listRecommendations({ status: ['open', 'approved'], limit: 25 })
+  )) ?? [];
 
   // Regenerate human-readable markdown summary
   try {
@@ -163,15 +272,27 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       date: today,
       traffic,
       channels: channels ?? [],
+      channelsPrior: channelsPrior ?? [],
       landingRollup: landingRollup ?? [],
+      landingRollupPrior: landingRollupPrior ?? [],
       revenueByChannel: revenueByChannel ?? [],
+      revenueByChannelPrior: revenueByChannelPrior ?? [],
       conversionByPage: conversionByPage ?? [],
+      conversionByPagePrior: conversionByPagePrior ?? [],
       funnel: funnel ?? [],
       productMargins: productMargins ?? [],
+      productMarginsPrior: productMarginsPrior ?? [],
+      segmentRollup: segmentRollup ?? [],
+      segmentRollupPrior: segmentRollupPrior ?? [],
+      repeatRate: repeatRate ?? [],
+      ltvBySegment: ltvBySegment ?? [],
+      affiliateRoi: affiliateRoi ?? [],
+      openRecs,
       gbpInsights,
       gbpSegments: gbpSegments ?? [],
       webVitals,
       topKeywords: topKeywords ?? [],
+      seoMetrics,
       pageEngagement: pageEngagement ?? [],
       errors,
     });
@@ -186,23 +307,69 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   return NextResponse.json({
     ok: true,
     snapshotId: snapshot.id,
+    recommendations: persistResult,
+    openRecCount: openRecs.length,
     errors: errors.length ? errors : undefined,
   });
 }
 
+type ChannelRow = { channel: string; orders: number; revenue: number; margin: number | null; averageOrderValue: number; averageMarginPct: number | null };
+type SegmentRow = { segment: string; orders: number; revenue: number; margin: number | null; averageOrderValue: number; averageMarginPct: number | null };
+type LandingRow = { landingPage: string; orders: number; revenue: number; averageOrderValue: number };
+type GaChannelRow = { channel: string; sessions: number; transactions: number; revenue: number; conversionRate: number };
+type GaPageRow = { path: string; sessions: number; transactions: number; conversionRate: number };
+type ProductMarginRow = { title: string; unitsSold: number; revenue: number; margin: number; marginPct: number };
+
+/** "▲ 18%" / "▼ 7%" / "—" / "🆕". Prior=0 with current>0 is treated as new-from-zero. */
+function fmtDelta(current: number, prior: number | null | undefined): string {
+  if (prior == null) return '—';
+  if (prior === 0 && current === 0) return '—';
+  if (prior === 0) return '🆕';
+  const pct = ((current - prior) / prior) * 100;
+  if (Math.abs(pct) < 1) return '—';
+  return `${pct > 0 ? '▲' : '▼'} ${Math.abs(pct).toFixed(0)}%`;
+}
+
+/** Format a precomputed change (e.g. from GA4/GSC's built-in compare) the same way. */
+function fmtChangePct(change: number | null | undefined): string {
+  if (change == null) return '—';
+  if (Math.abs(change) < 1) return '—';
+  return `${change > 0 ? '▲' : '▼'} ${Math.abs(change).toFixed(0)}%`;
+}
+
+function findBy<T>(arr: T[] | undefined, keyFn: (t: T) => string, key: string): T | undefined {
+  return arr?.find((x) => keyFn(x) === key);
+}
+
 function renderMarkdown(s: {
   date: Date;
-  traffic: { sessions: number; users: number; pageviews: number } | null;
-  channels: Array<{ channel: string; orders: number; revenue: number; margin: number | null; averageOrderValue: number; averageMarginPct: number | null }>;
-  landingRollup: Array<{ landingPage: string; orders: number; revenue: number; averageOrderValue: number }>;
-  revenueByChannel: Array<{ channel: string; sessions: number; transactions: number; revenue: number; conversionRate: number }>;
-  conversionByPage: Array<{ path: string; sessions: number; transactions: number; conversionRate: number }>;
+  traffic:
+    | { sessions: number; users: number; pageviews: number; sessionsChange?: number; usersChange?: number }
+    | null;
+  channels: ChannelRow[];
+  channelsPrior: ChannelRow[];
+  landingRollup: LandingRow[];
+  landingRollupPrior: LandingRow[];
+  revenueByChannel: GaChannelRow[];
+  revenueByChannelPrior: GaChannelRow[];
+  conversionByPage: GaPageRow[];
+  conversionByPagePrior: GaPageRow[];
   funnel: Array<{ eventName: string; users: number; dropOffFromPrevious: number | null }>;
-  productMargins: Array<{ title: string; unitsSold: number; revenue: number; margin: number; marginPct: number }>;
+  productMargins: ProductMarginRow[];
+  productMarginsPrior: ProductMarginRow[];
+  segmentRollup: SegmentRow[];
+  segmentRollupPrior: SegmentRow[];
+  repeatRate: Array<{ segment: string; orders: number; repeatOrders: number; repeatRatePct: number }>;
+  ltvBySegment: Array<{ segment: string; customers: number; totalRevenue: number; averageLtv: number }>;
+  affiliateRoi: Array<{ code: string; businessName: string; orders: number; revenue: number; margin: number | null; commissionPaid: number; netMargin: number | null; roiPct: number | null }>;
+  openRecs: Array<{ id: string; title: string; segment: string | null; impactDollarsMonthly: number | null; effortTier: string | null; riskTier: string; status: string; generatedAt: Date }>;
   gbpInsights: { reviewCount: number; averageRating: number; fiveStarPct: number; oneStarPct: number } | null;
   gbpSegments: Array<{ segment: string; count: number; averageRating: number }>;
   webVitals: { lcp: number | null; inp: number | null; cls: number | null } | null;
   topKeywords: Array<{ keyword: string; clicks: number; impressions: number; position: number }>;
+  seoMetrics:
+    | { impressions: number; clicks: number; ctr: number; avgPosition: number; impressionsChange?: number; clicksChange?: number }
+    | null;
   pageEngagement: Array<{ path: string; sessions: number; pageviews: number; bounceRate: number; avgScrollDepth: number; ctaClicks: number; ctaClickRate: number }>;
   errors: string[];
 }): string {
@@ -217,56 +384,140 @@ function renderMarkdown(s: {
     lines.push('');
   }
 
+  lines.push('## Open recommendations');
+  if (s.openRecs.length) {
+    lines.push('| Status | Risk | Effort | Impact $/mo | Segment | Title |');
+    lines.push('|---|---|---|---:|---|---|');
+    for (const r of s.openRecs) {
+      const impact = r.impactDollarsMonthly != null ? `$${r.impactDollarsMonthly.toLocaleString()}` : '—';
+      lines.push(
+        `| ${r.status} | ${r.riskTier} | ${r.effortTier ?? '—'} | ${impact} | ${r.segment ?? '—'} | ${r.title} |`
+      );
+    }
+    lines.push('');
+    lines.push('_Update status via `POST /api/admin/analytics/recommendations` with `{ id, status, notes? }`._');
+  } else {
+    lines.push('_no open recommendations — heuristics may not have flagged anything yet, or this is the first snapshot run_');
+  }
+  lines.push('');
+
   lines.push('## Traffic (last 30 days)');
   if (s.traffic) {
-    lines.push(`- Sessions: **${s.traffic.sessions.toLocaleString()}**  •  Users: **${s.traffic.users.toLocaleString()}**  •  Pageviews: **${s.traffic.pageviews.toLocaleString()}**`);
+    const sCh = fmtChangePct(s.traffic.sessionsChange);
+    const uCh = fmtChangePct(s.traffic.usersChange);
+    lines.push(
+      `- Sessions: **${s.traffic.sessions.toLocaleString()}** (${sCh})  •  Users: **${s.traffic.users.toLocaleString()}** (${uCh})  •  Pageviews: **${s.traffic.pageviews.toLocaleString()}**`
+    );
   } else {
     lines.push('- _GA4 data unavailable_');
   }
   lines.push('');
 
-  lines.push('## Revenue by internal channel (30d)');
+  lines.push('## SEO (Search Console, 30d)');
+  if (s.seoMetrics) {
+    const iCh = fmtChangePct(s.seoMetrics.impressionsChange);
+    const cCh = fmtChangePct(s.seoMetrics.clicksChange);
+    lines.push(
+      `- Impressions: **${s.seoMetrics.impressions.toLocaleString()}** (${iCh})  •  Clicks: **${s.seoMetrics.clicks.toLocaleString()}** (${cCh})  •  CTR: ${s.seoMetrics.ctr}%  •  Avg position: ${s.seoMetrics.avgPosition}`
+    );
+  } else {
+    lines.push('- _Search Console data unavailable_');
+  }
+  lines.push('');
+
+  lines.push('## Revenue by internal channel (30d, vs prior 30d)');
   if (s.channels.length) {
-    lines.push('| Channel | Orders | Revenue | AOV | Margin % |');
-    lines.push('|---|---:|---:|---:|---:|');
+    lines.push('| Channel | Orders | Revenue | AOV | Margin % | Rev WoW |');
+    lines.push('|---|---:|---:|---:|---:|---:|');
     for (const c of s.channels) {
-      lines.push(`| ${c.channel} | ${c.orders} | $${c.revenue.toLocaleString()} | $${c.averageOrderValue} | ${c.averageMarginPct ?? '—'}% |`);
+      const prior = findBy(s.channelsPrior, (x) => x.channel, c.channel);
+      lines.push(
+        `| ${c.channel} | ${c.orders} | $${c.revenue.toLocaleString()} | $${c.averageOrderValue} | ${c.averageMarginPct ?? '—'}% | ${fmtDelta(c.revenue, prior?.revenue ?? null)} |`
+      );
     }
   } else {
     lines.push('_no orders_');
   }
   lines.push('');
 
-  lines.push('## Landing page → orders (30d, our DB)');
-  if (s.landingRollup.length) {
-    lines.push('| Landing page | Orders | Revenue | AOV |');
+  lines.push('## Revenue & margin by customer segment (30d, vs prior 30d)');
+  if (s.segmentRollup.length) {
+    lines.push('| Segment | Orders | Revenue | AOV | Margin % | Rev WoW |');
+    lines.push('|---|---:|---:|---:|---:|---:|');
+    for (const r of s.segmentRollup) {
+      const prior = findBy(s.segmentRollupPrior, (x) => x.segment, r.segment);
+      lines.push(
+        `| ${r.segment} | ${r.orders} | $${r.revenue.toLocaleString()} | $${r.averageOrderValue} | ${r.averageMarginPct ?? '—'}% | ${fmtDelta(r.revenue, prior?.revenue ?? null)} |`
+      );
+    }
+  } else {
+    lines.push('_no segment data — run `npx tsx scripts/backfill-order-segments.ts` to populate Order.segment_');
+  }
+  lines.push('');
+
+  lines.push('## Repeat purchase rate by segment (30d)');
+  if (s.repeatRate.length) {
+    lines.push('| Segment | Orders | Repeat orders | Repeat rate |');
     lines.push('|---|---:|---:|---:|');
+    for (const r of s.repeatRate) {
+      lines.push(`| ${r.segment} | ${r.orders} | ${r.repeatOrders} | ${r.repeatRatePct}% |`);
+    }
+  } else {
+    lines.push('_no orders in window_');
+  }
+  lines.push('');
+
+  lines.push('## LTV by entry segment (customers whose first order was in last 12 months)');
+  if (s.ltvBySegment.length) {
+    lines.push('| Entry segment | Customers | Total revenue | Avg LTV |');
+    lines.push('|---|---:|---:|---:|');
+    for (const r of s.ltvBySegment) {
+      lines.push(`| ${r.segment} | ${r.customers} | $${r.totalRevenue.toLocaleString()} | $${r.averageLtv.toLocaleString()} |`);
+    }
+  } else {
+    lines.push('_no customer data_');
+  }
+  lines.push('');
+
+  lines.push('## Landing page → orders (30d, our DB, vs prior 30d)');
+  if (s.landingRollup.length) {
+    lines.push('| Landing page | Orders | Revenue | AOV | Rev WoW |');
+    lines.push('|---|---:|---:|---:|---:|');
     for (const r of s.landingRollup.slice(0, 15)) {
-      lines.push(`| ${r.landingPage} | ${r.orders} | $${r.revenue.toLocaleString()} | $${r.averageOrderValue} |`);
+      const prior = findBy(s.landingRollupPrior, (x) => x.landingPage, r.landingPage);
+      lines.push(
+        `| ${r.landingPage} | ${r.orders} | $${r.revenue.toLocaleString()} | $${r.averageOrderValue} | ${fmtDelta(r.revenue, prior?.revenue ?? null)} |`
+      );
     }
   } else {
     lines.push('_no attribution data yet — new orders will populate this_');
   }
   lines.push('');
 
-  lines.push('## GA4 revenue by channel (30d)');
+  lines.push('## GA4 revenue by channel (30d, vs prior 30d)');
   if (s.revenueByChannel.length) {
-    lines.push('| Channel | Sessions | Transactions | Revenue | Conv rate |');
-    lines.push('|---|---:|---:|---:|---:|');
+    lines.push('| Channel | Sessions | Transactions | Revenue | Conv rate | Rev WoW |');
+    lines.push('|---|---:|---:|---:|---:|---:|');
     for (const r of s.revenueByChannel) {
-      lines.push(`| ${r.channel} | ${r.sessions} | ${r.transactions} | $${r.revenue.toLocaleString()} | ${(r.conversionRate * 100).toFixed(2)}% |`);
+      const prior = findBy(s.revenueByChannelPrior, (x) => x.channel, r.channel);
+      lines.push(
+        `| ${r.channel} | ${r.sessions} | ${r.transactions} | $${r.revenue.toLocaleString()} | ${(r.conversionRate * 100).toFixed(2)}% | ${fmtDelta(r.revenue, prior?.revenue ?? null)} |`
+      );
     }
   } else {
     lines.push('_GA4 data unavailable_');
   }
   lines.push('');
 
-  lines.push('## Conversion by landing page (GA4, 30d)');
+  lines.push('## Conversion by landing page (GA4, 30d, vs prior 30d)');
   if (s.conversionByPage.length) {
-    lines.push('| Path | Sessions | Transactions | Conv rate |');
-    lines.push('|---|---:|---:|---:|');
+    lines.push('| Path | Sessions | Transactions | Conv rate | Conv WoW |');
+    lines.push('|---|---:|---:|---:|---:|');
     for (const r of s.conversionByPage.slice(0, 15)) {
-      lines.push(`| ${r.path} | ${r.sessions} | ${r.transactions} | ${(r.conversionRate * 100).toFixed(2)}% |`);
+      const prior = findBy(s.conversionByPagePrior, (x) => x.path, r.path);
+      lines.push(
+        `| ${r.path} | ${r.sessions} | ${r.transactions} | ${(r.conversionRate * 100).toFixed(2)}% | ${fmtDelta(r.conversionRate, prior?.conversionRate ?? null)} |`
+      );
     }
   }
   lines.push('');
@@ -281,12 +532,40 @@ function renderMarkdown(s: {
   }
   lines.push('');
 
-  lines.push('## Top product margins (30d)');
+  lines.push('## Affiliate ROI (30d) — top 10 by net margin');
+  if (s.affiliateRoi.length) {
+    lines.push('| Affiliate | Orders | Revenue | Margin | Commission paid | Net margin | ROI |');
+    lines.push('|---|---:|---:|---:|---:|---:|---:|');
+    for (const a of s.affiliateRoi.slice(0, 10)) {
+      const margin = a.margin == null ? '—' : `$${a.margin.toLocaleString()}`;
+      const netMargin = a.netMargin == null ? '—' : `$${a.netMargin.toLocaleString()}`;
+      const roi = a.roiPct == null ? '—' : `${a.roiPct}%`;
+      lines.push(
+        `| ${a.businessName} (${a.code}) | ${a.orders} | $${a.revenue.toLocaleString()} | ${margin} | $${a.commissionPaid.toLocaleString()} | ${netMargin} | ${roi} |`
+      );
+    }
+    const negative = s.affiliateRoi.filter((a) => a.netMargin != null && a.netMargin < 0);
+    if (negative.length) {
+      lines.push('');
+      lines.push('**⚠️ Negative-ROI partners (commission > margin):**');
+      for (const a of negative) {
+        lines.push(`- ${a.businessName} (${a.code}): commission $${a.commissionPaid.toLocaleString()} > margin $${a.margin?.toLocaleString() ?? '—'}`);
+      }
+    }
+  } else {
+    lines.push('_no affiliate orders in window_');
+  }
+  lines.push('');
+
+  lines.push('## Top product margins (30d, vs prior 30d)');
   if (s.productMargins.length) {
-    lines.push('| Product | Units | Revenue | Margin | Margin % |');
-    lines.push('|---|---:|---:|---:|---:|');
+    lines.push('| Product | Units | Revenue | Margin | Margin % | Units WoW |');
+    lines.push('|---|---:|---:|---:|---:|---:|');
     for (const p of s.productMargins.slice(0, 15)) {
-      lines.push(`| ${p.title} | ${p.unitsSold} | $${p.revenue.toLocaleString()} | $${p.margin.toLocaleString()} | ${p.marginPct}% |`);
+      const prior = findBy(s.productMarginsPrior, (x) => x.title, p.title);
+      lines.push(
+        `| ${p.title} | ${p.unitsSold} | $${p.revenue.toLocaleString()} | $${p.margin.toLocaleString()} | ${p.marginPct}% | ${fmtDelta(p.unitsSold, prior?.unitsSold ?? null)} |`
+      );
     }
   }
   lines.push('');

--- a/src/app/api/cron/weekly-briefing/route.ts
+++ b/src/app/api/cron/weekly-briefing/route.ts
@@ -1,0 +1,237 @@
+/**
+ * Weekly Marketing Director briefing cron — runs Monday 13:00 UTC (8am Central).
+ *
+ * Stage A (deterministic, always runs): pulls latest AnalyticsSnapshot + open recommendations,
+ *   renders docs/marketing/weekly/YYYY-Www.md with WoW deltas, threshold flags, top movers.
+ * Stage B (LLM, runs if OPENROUTER_API_KEY set): single Anthropic call (via OpenRouter) that
+ *   reads Stage A's brief + business context and writes a richer narrative analysis to
+ *   docs/marketing/weekly/YYYY-Www-director.md. Mirrors the generate-blog cron pattern.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+import { prisma } from '@/lib/database/client';
+import { listRecommendations } from '@/lib/analytics/recommendation-store';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 300;
+
+function isoWeek(date: Date): { year: number; week: number; label: string } {
+  // ISO 8601 week number — Monday-based, week 1 contains the year's first Thursday.
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const dayNum = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const week = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+  const label = `${d.getUTCFullYear()}-W${String(week).padStart(2, '0')}`;
+  return { year: d.getUTCFullYear(), week, label };
+}
+
+interface SegmentRow {
+  segment: string;
+  orders: number;
+  revenue: number;
+  margin: number | null;
+  averageOrderValue: number;
+  averageMarginPct: number | null;
+}
+
+interface AffiliateRoiRow {
+  code: string;
+  businessName: string;
+  orders: number;
+  revenue: number;
+  margin: number | null;
+  commissionPaid: number;
+  netMargin: number | null;
+  roiPct: number | null;
+}
+
+function pickTopMovers(
+  current: SegmentRow[],
+  prior: SegmentRow[]
+): Array<{ segment: string; deltaPct: number; revenue: number; priorRevenue: number }> {
+  const movers: Array<{ segment: string; deltaPct: number; revenue: number; priorRevenue: number }> = [];
+  for (const c of current) {
+    const p = prior.find((x) => x.segment === c.segment);
+    if (!p || p.revenue === 0) continue;
+    const deltaPct = ((c.revenue - p.revenue) / p.revenue) * 100;
+    movers.push({ segment: c.segment, deltaPct, revenue: c.revenue, priorRevenue: p.revenue });
+  }
+  return movers.sort((a, b) => Math.abs(b.deltaPct) - Math.abs(a.deltaPct)).slice(0, 5);
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = request.headers.get('authorization');
+  if (auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const now = new Date();
+  const week = isoWeek(now);
+
+  const snapshot = await prisma.analyticsSnapshot.findFirst({ orderBy: { date: 'desc' } });
+  if (!snapshot) {
+    return NextResponse.json({ error: 'no snapshot exists yet — run /api/cron/analytics-snapshot first' }, { status: 503 });
+  }
+
+  const segmentData = (snapshot.segmentData ?? {}) as {
+    segments?: SegmentRow[];
+    repeatRate?: Array<{ segment: string; orders: number; repeatRatePct: number }>;
+  };
+  const comparisonData = (snapshot.comparisonData ?? {}) as { segments?: SegmentRow[] };
+  const marginData = (snapshot.marginData ?? {}) as { affiliateRoi?: AffiliateRoiRow[] };
+
+  const segments = segmentData.segments ?? [];
+  const segmentsPrior = comparisonData.segments ?? [];
+  const repeatRate = segmentData.repeatRate ?? [];
+  const affiliateRoi = marginData.affiliateRoi ?? [];
+
+  const openRecs = await listRecommendations({ status: ['open', 'approved'], limit: 25 });
+  const movers = pickTopMovers(segments, segmentsPrior);
+  const negativeRoi = affiliateRoi.filter((a) => a.netMargin != null && a.netMargin < 0);
+
+  // Stage A — deterministic markdown
+  const lines: string[] = [];
+  lines.push(`# Marketing weekly briefing — ${week.label}`);
+  lines.push('');
+  lines.push(`_Generated ${now.toISOString()} from snapshot dated ${snapshot.date.toISOString().split('T')[0]}._`);
+  lines.push('');
+
+  lines.push('## What changed this week');
+  if (movers.length) {
+    for (const m of movers) {
+      const arrow = m.deltaPct >= 0 ? '▲' : '▼';
+      lines.push(`- **${m.segment}**: ${arrow} ${Math.abs(m.deltaPct).toFixed(0)}% revenue WoW — $${m.revenue.toLocaleString()} (was $${m.priorRevenue.toLocaleString()})`);
+    }
+  } else {
+    lines.push('_no comparable prior-period data yet — comes online next week_');
+  }
+  lines.push('');
+
+  lines.push('## Open recommendations');
+  if (openRecs.length) {
+    lines.push('| Status | Risk | Effort | Impact $/mo | Segment | Title |');
+    lines.push('|---|---|---|---:|---|---|');
+    for (const r of openRecs) {
+      const impact = r.impactDollarsMonthly != null ? `$${r.impactDollarsMonthly.toLocaleString()}` : '—';
+      lines.push(`| ${r.status} | ${r.riskTier} | ${r.effortTier ?? '—'} | ${impact} | ${r.segment ?? '—'} | ${r.title} |`);
+    }
+  } else {
+    lines.push('_no open recommendations_');
+  }
+  lines.push('');
+
+  lines.push('## Flags');
+  const flags: string[] = [];
+  if (negativeRoi.length) {
+    for (const a of negativeRoi) {
+      flags.push(`- ⚠️ Affiliate **${a.businessName} (${a.code})** ROI is negative — paid $${a.commissionPaid.toLocaleString()}, margin only $${a.margin?.toLocaleString() ?? '—'}.`);
+    }
+  }
+  for (const m of movers.filter((x) => x.deltaPct <= -20)) {
+    flags.push(`- ⚠️ **${m.segment}** revenue down ${Math.abs(m.deltaPct).toFixed(0)}% WoW.`);
+  }
+  if (!flags.length) flags.push('_no threshold breaches_');
+  for (const f of flags) lines.push(f);
+  lines.push('');
+
+  lines.push('## Repeat purchase rate by segment (30d)');
+  if (repeatRate.length) {
+    lines.push('| Segment | Orders | Repeat rate |');
+    lines.push('|---|---:|---:|');
+    for (const r of repeatRate) {
+      lines.push(`| ${r.segment} | ${r.orders} | ${r.repeatRatePct}% |`);
+    }
+  } else {
+    lines.push('_no data_');
+  }
+  lines.push('');
+
+  lines.push('## Top affiliate net margin (30d)');
+  if (affiliateRoi.length) {
+    lines.push('| Affiliate | Orders | Net margin | ROI |');
+    lines.push('|---|---:|---:|---:|');
+    for (const a of affiliateRoi.slice(0, 5)) {
+      const net = a.netMargin == null ? '—' : `$${a.netMargin.toLocaleString()}`;
+      const roi = a.roiPct == null ? '—' : `${a.roiPct}%`;
+      lines.push(`| ${a.businessName} (${a.code}) | ${a.orders} | ${net} | ${roi} |`);
+    }
+  }
+  lines.push('');
+
+  const stageA = lines.join('\n');
+  const outDir = path.join(process.cwd(), 'docs', 'marketing', 'weekly');
+  fs.mkdirSync(outDir, { recursive: true });
+  const stageAPath = path.join(outDir, `${week.label}.md`);
+  fs.writeFileSync(stageAPath, stageA);
+
+  // Stage B — LLM narrative analysis
+  let stageBPath: string | null = null;
+  let stageBError: string | null = null;
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (apiKey) {
+    try {
+      const businessContext = `You are the Marketing Director for Party On Delivery, a premium alcohol delivery + party coordination service in Austin, TX.
+Three customer segments: bach/bachelorette (party-focused), weddings (premium), corporate (professional/TABC-compliant).
+Demand is the bottleneck, not capacity. Direct orders are higher margin than affiliate. Boat season is ~30 weekends.
+Hard stop: never recommend changes that touch TABC compliance or legal messaging.`;
+
+      const userPrompt = `Below is this week's deterministic marketing briefing for Party On Delivery. Read it and produce a SHORT (under 600 words) narrative analysis covering:
+1. The single most important thing for the operator to act on this week, and why.
+2. One non-obvious pattern across the data that the deterministic briefing missed.
+3. Two-to-three specific, prioritized actions with reasoning. Each: title, why now, expected impact, effort tier (s/m/l), risk tier (autonomous | recommend | hard_stop).
+
+Don't restate tables verbatim. Don't invent numbers. If a metric is missing, say so. If something is hard_stop (TABC, legal), call it out and refuse to recommend.
+
+DETERMINISTIC BRIEFING:
+${stageA}`;
+
+      const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+          'HTTP-Referer': 'https://partyondelivery.com',
+          'X-Title': 'Party On Delivery Marketing Director',
+        },
+        body: JSON.stringify({
+          model: 'anthropic/claude-3.5-sonnet',
+          messages: [
+            { role: 'system', content: businessContext },
+            { role: 'user', content: userPrompt },
+          ],
+          max_tokens: 2048,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`OpenRouter ${response.status}: ${await response.text()}`);
+      }
+      const json = (await response.json()) as { choices?: Array<{ message?: { content?: string } }> };
+      const narrative = json.choices?.[0]?.message?.content?.trim();
+      if (!narrative) throw new Error('empty response from OpenRouter');
+
+      const stageB = `# Marketing Director — narrative briefing — ${week.label}\n\n_Generated ${now.toISOString()}. Layered on top of the deterministic briefing at \`${week.label}.md\`._\n\n${narrative}\n`;
+      stageBPath = path.join(outDir, `${week.label}-director.md`);
+      fs.writeFileSync(stageBPath, stageB);
+    } catch (err) {
+      stageBError = err instanceof Error ? err.message : String(err);
+      console.error('[weekly-briefing] Stage B failed:', err);
+    }
+  }
+
+  return NextResponse.json({
+    ok: true,
+    week: week.label,
+    stageAPath: path.relative(process.cwd(), stageAPath),
+    stageBPath: stageBPath ? path.relative(process.cwd(), stageBPath) : null,
+    stageBError,
+    counts: {
+      openRecs: openRecs.length,
+      movers: movers.length,
+      flags: flags.filter((f) => !f.startsWith('_')).length,
+    },
+  });
+}

--- a/src/lib/analytics/cohort-rollups.ts
+++ b/src/lib/analytics/cohort-rollups.ts
@@ -1,0 +1,137 @@
+/**
+ * Cohort rollups — repeat rate and LTV bucketed by customer segment.
+ *
+ * Definitions:
+ * - Repeat purchase rate: of orders placed in the window, what fraction are from a customer
+ *   who had a prior order (any time before the order's createdAt). Bucketed by the order's segment.
+ * - LTV: for each customer, sum lifetime revenue across all orders. Bucketed by the segment
+ *   of their FIRST order — answers "what's a customer worth long-term if they enter via X?"
+ */
+
+import { prisma } from '@/lib/database/client';
+
+export interface RepeatRateRow {
+  segment: string;
+  orders: number;
+  repeatOrders: number;
+  repeatRatePct: number;
+}
+
+export interface LtvRow {
+  segment: string;          // segment of the customer's FIRST order
+  customers: number;
+  totalRevenue: number;
+  averageLtv: number;
+}
+
+function daysAgo(n: number): Date {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  d.setUTCHours(0, 0, 0, 0);
+  return d;
+}
+
+/**
+ * Repeat rate per segment for orders in the last `windowDays`.
+ * "Repeat" = the customer has at least one earlier order.
+ */
+export async function getRepeatRateBySegment(windowDays = 30): Promise<RepeatRateRow[]> {
+  const since = daysAgo(windowDays);
+
+  const orders = await prisma.order.findMany({
+    where: { createdAt: { gte: since }, status: { notIn: ['CANCELLED', 'REFUNDED'] } },
+    select: { customerId: true, segment: true, createdAt: true },
+  });
+
+  if (orders.length === 0) return [];
+
+  // For each (customer, order), check if they have an earlier order. Pull each customer's
+  // earliest createdAt once and compare.
+  const customerIds = Array.from(new Set(orders.map((o) => o.customerId)));
+  const earliestByCustomer = await prisma.order.groupBy({
+    by: ['customerId'],
+    where: { customerId: { in: customerIds }, status: { notIn: ['CANCELLED', 'REFUNDED'] } },
+    _min: { createdAt: true },
+  });
+  const firstOrderAt = new Map(earliestByCustomer.map((r) => [r.customerId, r._min.createdAt]));
+
+  const buckets = new Map<string, { orders: number; repeatOrders: number }>();
+  for (const o of orders) {
+    const seg = o.segment ?? 'unknown';
+    const b = buckets.get(seg) ?? { orders: 0, repeatOrders: 0 };
+    b.orders += 1;
+    const first = firstOrderAt.get(o.customerId);
+    if (first && first.getTime() < o.createdAt.getTime()) {
+      b.repeatOrders += 1;
+    }
+    buckets.set(seg, b);
+  }
+
+  return Array.from(buckets.entries())
+    .map(([segment, b]) => ({
+      segment,
+      orders: b.orders,
+      repeatOrders: b.repeatOrders,
+      repeatRatePct: b.orders > 0 ? Number(((b.repeatOrders / b.orders) * 100).toFixed(1)) : 0,
+    }))
+    .sort((a, b) => b.orders - a.orders);
+}
+
+/**
+ * Customer lifetime revenue, bucketed by the segment of their FIRST order.
+ * Looks at customers whose first order was within `monthsBack` months — capped by the data we have.
+ */
+export async function getLtvBySegment(monthsBack = 12): Promise<LtvRow[]> {
+  const since = daysAgo(monthsBack * 30);
+
+  // First-order date per customer (across all time, not just window).
+  const firstOrders = await prisma.order.groupBy({
+    by: ['customerId'],
+    where: { status: { notIn: ['CANCELLED', 'REFUNDED'] } },
+    _min: { createdAt: true },
+  });
+
+  // Customers whose first order falls inside the window.
+  const customerIds = firstOrders
+    .filter((r) => r._min.createdAt && r._min.createdAt >= since)
+    .map((r) => r.customerId);
+
+  if (customerIds.length === 0) return [];
+
+  const allOrders = await prisma.order.findMany({
+    where: { customerId: { in: customerIds }, status: { notIn: ['CANCELLED', 'REFUNDED'] } },
+    select: { customerId: true, segment: true, total: true, createdAt: true },
+    orderBy: { createdAt: 'asc' },
+  });
+
+  const firstSegmentByCustomer = new Map<string, string>();
+  const totalByCustomer = new Map<string, number>();
+  for (const o of allOrders) {
+    if (!firstSegmentByCustomer.has(o.customerId)) {
+      firstSegmentByCustomer.set(o.customerId, o.segment ?? 'unknown');
+    }
+    totalByCustomer.set(
+      o.customerId,
+      (totalByCustomer.get(o.customerId) ?? 0) + Number(o.total)
+    );
+  }
+
+  const buckets = new Map<string, { customers: number; totalRevenue: number }>();
+  for (const customerId of customerIds) {
+    const seg = firstSegmentByCustomer.get(customerId) ?? 'unknown';
+    const rev = totalByCustomer.get(customerId) ?? 0;
+    const b = buckets.get(seg) ?? { customers: 0, totalRevenue: 0 };
+    b.customers += 1;
+    b.totalRevenue += rev;
+    buckets.set(seg, b);
+  }
+
+  return Array.from(buckets.entries())
+    .map(([segment, b]) => ({
+      segment,
+      customers: b.customers,
+      totalRevenue: Number(b.totalRevenue.toFixed(2)),
+      averageLtv: b.customers > 0 ? Number((b.totalRevenue / b.customers).toFixed(2)) : 0,
+    }))
+    .sort((a, b) => b.averageLtv - a.averageLtv);
+}

--- a/src/lib/analytics/internal-rollups.ts
+++ b/src/lib/analytics/internal-rollups.ts
@@ -31,6 +31,27 @@ export interface ProductMarginRow {
   marginPct: number;
 }
 
+export interface SegmentRollup {
+  segment: string; // bach | wedding | corporate | boat | kegs | general | unknown
+  orders: number;
+  revenue: number;
+  margin: number | null;
+  averageOrderValue: number;
+  averageMarginPct: number | null;
+}
+
+export interface AffiliateRoiRow {
+  affiliateId: string;
+  code: string;
+  businessName: string;
+  orders: number;
+  revenue: number;
+  margin: number | null;       // sum of Order.marginAmount (null if all orders missing margin)
+  commissionPaid: number;      // sum of AffiliateCommission.commissionAmountCents / 100, excluding VOIDED
+  netMargin: number | null;    // margin - commissionPaid
+  roiPct: number | null;       // (netMargin / commissionPaid) * 100, null if commissionPaid <= 0
+}
+
 function daysAgo(n: number): Date {
   const d = new Date();
   d.setDate(d.getDate() - n);
@@ -39,13 +60,24 @@ function daysAgo(n: number): Date {
 }
 
 /**
+ * `endDaysAgo` lets callers ask for a prior window: e.g. (30, 30) is "30 days ending 30 days ago" —
+ * the period we compare today's 30-day rollup against to compute WoW/MoM deltas.
+ */
+function dateWindow(windowDays: number, endDaysAgo = 0): { gte: Date; lt: Date } {
+  return {
+    gte: daysAgo(windowDays + endDaysAgo),
+    lt: daysAgo(endDaysAgo),
+  };
+}
+
+/**
  * Revenue/margin split by internal channel bucket.
  * Buckets: affiliate (has affiliateId), group (groupOrderV2Id), utm_<source>, direct.
  */
-export async function getChannelRollup(windowDays = 30): Promise<ChannelRollup[]> {
-  const since = daysAgo(windowDays);
+export async function getChannelRollup(windowDays = 30, endDaysAgo = 0): Promise<ChannelRollup[]> {
+  const window = dateWindow(windowDays, endDaysAgo);
   const orders = await prisma.order.findMany({
-    where: { createdAt: { gte: since }, status: { notIn: ['CANCELLED', 'REFUNDED'] } },
+    where: { createdAt: window, status: { notIn: ['CANCELLED', 'REFUNDED'] } },
     select: {
       total: true,
       marginAmount: true,
@@ -85,11 +117,11 @@ export async function getChannelRollup(windowDays = 30): Promise<ChannelRollup[]
     .sort((a, b) => b.revenue - a.revenue);
 }
 
-export async function getLandingPageRollup(windowDays = 30): Promise<LandingPageRollup[]> {
-  const since = daysAgo(windowDays);
+export async function getLandingPageRollup(windowDays = 30, endDaysAgo = 0): Promise<LandingPageRollup[]> {
+  const window = dateWindow(windowDays, endDaysAgo);
   const orders = await prisma.order.findMany({
     where: {
-      createdAt: { gte: since },
+      createdAt: window,
       landingPage: { not: null },
       status: { notIn: ['CANCELLED', 'REFUNDED'] },
     },
@@ -113,11 +145,147 @@ export async function getLandingPageRollup(windowDays = 30): Promise<LandingPage
     .sort((a, b) => b.revenue - a.revenue);
 }
 
-export async function getProductMargins(windowDays = 30, limit = 25): Promise<ProductMarginRow[]> {
-  const since = daysAgo(windowDays);
+/**
+ * Revenue/margin/AOV split by customer segment (bach/wedding/corporate/boat/kegs/general).
+ * Reads `Order.segment` directly — populated at order creation by classifySegment(); rows
+ * with null segment (older orders that haven't been backfilled yet) are bucketed as 'unknown'.
+ */
+export async function getSegmentRollup(windowDays = 30, endDaysAgo = 0): Promise<SegmentRollup[]> {
+  const window = dateWindow(windowDays, endDaysAgo);
+  const orders = await prisma.order.findMany({
+    where: { createdAt: window, status: { notIn: ['CANCELLED', 'REFUNDED'] } },
+    select: { segment: true, total: true, marginAmount: true },
+  });
+
+  const buckets = new Map<string, { orders: number; revenue: number; margin: number; marginKnown: number }>();
+  for (const o of orders) {
+    const seg = o.segment ?? 'unknown';
+    const b = buckets.get(seg) ?? { orders: 0, revenue: 0, margin: 0, marginKnown: 0 };
+    b.orders += 1;
+    b.revenue += Number(o.total);
+    if (o.marginAmount != null) {
+      b.margin += Number(o.marginAmount);
+      b.marginKnown += 1;
+    }
+    buckets.set(seg, b);
+  }
+
+  return Array.from(buckets.entries())
+    .map(([segment, b]) => ({
+      segment,
+      orders: b.orders,
+      revenue: Number(b.revenue.toFixed(2)),
+      margin: b.marginKnown > 0 ? Number(b.margin.toFixed(2)) : null,
+      averageOrderValue: b.orders > 0 ? Number((b.revenue / b.orders).toFixed(2)) : 0,
+      averageMarginPct:
+        b.marginKnown > 0 && b.revenue > 0 ? Number(((b.margin / b.revenue) * 100).toFixed(1)) : null,
+    }))
+    .sort((a, b) => b.revenue - a.revenue);
+}
+
+/**
+ * Per-affiliate ROI: revenue/margin attributed via Affiliate.code vs commission paid out.
+ * Joins Order.affiliateId with AffiliateCommission to compute net margin and ROI%.
+ * Excludes VOIDED commissions; HELD/CONFIRMED/PAID all count as paid (or owed).
+ */
+export async function getAffiliateRoi(windowDays = 30, endDaysAgo = 0): Promise<AffiliateRoiRow[]> {
+  const window = dateWindow(windowDays, endDaysAgo);
+
+  const orders = await prisma.order.findMany({
+    where: {
+      createdAt: window,
+      affiliateId: { not: null },
+      status: { notIn: ['CANCELLED', 'REFUNDED'] },
+    },
+    select: {
+      id: true,
+      total: true,
+      marginAmount: true,
+      affiliateId: true,
+      affiliate: { select: { id: true, code: true, businessName: true } },
+    },
+  });
+
+  if (orders.length === 0) return [];
+
+  const orderIds = orders.map((o) => o.id);
+  const commissions = await prisma.affiliateCommission.findMany({
+    where: { orderId: { in: orderIds }, status: { not: 'VOID' } },
+    select: { affiliateId: true, commissionAmountCents: true },
+  });
+
+  type Bucket = {
+    affiliateId: string;
+    code: string;
+    businessName: string;
+    orders: number;
+    revenue: number;
+    margin: number;
+    marginKnown: number;
+    commissionCents: number;
+  };
+  const buckets = new Map<string, Bucket>();
+
+  for (const o of orders) {
+    if (!o.affiliate) continue;
+    const aId = o.affiliate.id;
+    const b = buckets.get(aId) ?? {
+      affiliateId: aId,
+      code: o.affiliate.code,
+      businessName: o.affiliate.businessName,
+      orders: 0,
+      revenue: 0,
+      margin: 0,
+      marginKnown: 0,
+      commissionCents: 0,
+    };
+    b.orders += 1;
+    b.revenue += Number(o.total);
+    if (o.marginAmount != null) {
+      b.margin += Number(o.marginAmount);
+      b.marginKnown += 1;
+    }
+    buckets.set(aId, b);
+  }
+
+  for (const c of commissions) {
+    const b = buckets.get(c.affiliateId);
+    if (b) b.commissionCents += c.commissionAmountCents;
+  }
+
+  return Array.from(buckets.values())
+    .map((b) => {
+      const margin = b.marginKnown > 0 ? Number(b.margin.toFixed(2)) : null;
+      const commissionPaid = Number((b.commissionCents / 100).toFixed(2));
+      const netMargin = margin != null ? Number((margin - commissionPaid).toFixed(2)) : null;
+      const roiPct =
+        netMargin != null && commissionPaid > 0
+          ? Number(((netMargin / commissionPaid) * 100).toFixed(1))
+          : null;
+      return {
+        affiliateId: b.affiliateId,
+        code: b.code,
+        businessName: b.businessName,
+        orders: b.orders,
+        revenue: Number(b.revenue.toFixed(2)),
+        margin,
+        commissionPaid,
+        netMargin,
+        roiPct,
+      };
+    })
+    .sort((a, b) => (b.netMargin ?? -Infinity) - (a.netMargin ?? -Infinity));
+}
+
+export async function getProductMargins(
+  windowDays = 30,
+  limit = 25,
+  endDaysAgo = 0
+): Promise<ProductMarginRow[]> {
+  const window = dateWindow(windowDays, endDaysAgo);
   const items = await prisma.orderItem.findMany({
     where: {
-      createdAt: { gte: since },
+      createdAt: window,
       order: { status: { notIn: ['CANCELLED', 'REFUNDED'] } },
     },
     select: {

--- a/src/lib/analytics/recommendation-store.ts
+++ b/src/lib/analytics/recommendation-store.ts
@@ -1,0 +1,115 @@
+/**
+ * RecommendationItem persistence — stores generated recommendations so they:
+ *  - aren't re-suggested every snapshot run (dedupe by title+segment when an open/approved row exists)
+ *  - have an audit trail (status history, shippedAt, result metrics before/after)
+ *  - support the Phase 2 autonomy ramp: a worker can pick up `approved` + `autonomous` rows
+ *
+ * Heuristic recommendations (from `recommendations.ts`) and Director-generated recommendations
+ * both flow through `persistRecommendations()` with a different `source` tag.
+ */
+
+import { prisma } from '@/lib/database/client';
+
+export type RecommendationSource = 'auto-snapshot' | 'director' | 'manual';
+export type RiskTier = 'autonomous' | 'recommend' | 'hard_stop';
+export type RecommendationStatus = 'open' | 'approved' | 'shipped' | 'rejected' | 'invalidated';
+
+export interface RecommendationInput {
+  title: string;
+  body?: string;
+  segment?: string | null;
+  metric?: string;
+  currentValue?: string;
+  targetValue?: string;
+  impactDollarsMonthly?: number;
+  effortTier?: 's' | 'm' | 'l';
+  riskTier?: RiskTier;
+}
+
+export interface PersistResult {
+  inserted: number;
+  skippedExisting: number;
+}
+
+/**
+ * Insert recommendations with title+segment dedupe: if there's already an open or approved row
+ * with the same title+segment, skip. (Rejected/invalidated rows do NOT block re-insertion —
+ * the heuristic may now have stronger evidence.)
+ */
+export async function persistRecommendations(
+  recs: RecommendationInput[],
+  source: RecommendationSource
+): Promise<PersistResult> {
+  let inserted = 0;
+  let skippedExisting = 0;
+
+  for (const rec of recs) {
+    const existing = await prisma.recommendationItem.findFirst({
+      where: {
+        title: rec.title,
+        segment: rec.segment ?? null,
+        status: { in: ['open', 'approved'] },
+      },
+      select: { id: true },
+    });
+
+    if (existing) {
+      skippedExisting += 1;
+      continue;
+    }
+
+    await prisma.recommendationItem.create({
+      data: {
+        source,
+        title: rec.title,
+        body: rec.body ?? null,
+        segment: rec.segment ?? null,
+        metric: rec.metric ?? null,
+        currentValue: rec.currentValue ?? null,
+        targetValue: rec.targetValue ?? null,
+        impactDollarsMonthly: rec.impactDollarsMonthly ?? null,
+        effortTier: rec.effortTier ?? null,
+        riskTier: rec.riskTier ?? 'recommend',
+      },
+    });
+    inserted += 1;
+  }
+
+  return { inserted, skippedExisting };
+}
+
+export async function listRecommendations(opts?: {
+  status?: RecommendationStatus | RecommendationStatus[];
+  segment?: string;
+  limit?: number;
+}) {
+  const where: {
+    status?: RecommendationStatus | { in: RecommendationStatus[] };
+    segment?: string;
+  } = {};
+  if (opts?.status) {
+    where.status = Array.isArray(opts.status) ? { in: opts.status } : opts.status;
+  }
+  if (opts?.segment) where.segment = opts.segment;
+
+  return prisma.recommendationItem.findMany({
+    where,
+    orderBy: [{ status: 'asc' }, { impactDollarsMonthly: 'desc' }, { generatedAt: 'desc' }],
+    take: opts?.limit ?? 100,
+  });
+}
+
+export async function updateRecommendationStatus(
+  id: string,
+  status: RecommendationStatus,
+  notes?: string
+) {
+  return prisma.recommendationItem.update({
+    where: { id },
+    data: {
+      status,
+      ...(status === 'shipped' ? { shippedAt: new Date() } : {}),
+      ...(notes ? { notes } : {}),
+    },
+  });
+}

--- a/src/lib/analytics/segment-classifier.ts
+++ b/src/lib/analytics/segment-classifier.ts
@@ -1,0 +1,55 @@
+/**
+ * Customer segment classifier — derives a segment label from landing page + UTM campaign.
+ * The site serves three primary value propositions (bach, wedding, corporate) plus boat parties,
+ * kegs, and a general-order flow. Every other segment-aware metric (conversion-by-segment,
+ * repeat-rate-by-segment, AOV-by-segment) joins through this label.
+ */
+
+export type Segment =
+  | 'bach'
+  | 'wedding'
+  | 'corporate'
+  | 'boat'
+  | 'kegs'
+  | 'general';
+
+export const SEGMENTS: readonly Segment[] = ['bach', 'wedding', 'corporate', 'boat', 'kegs', 'general'];
+
+/**
+ * Path-prefix based classification with a UTM-campaign fallback. The prefix list is intentionally
+ * narrow — any path that doesn't match an explicit segment falls through to 'general'. Update this
+ * list when new segment landing pages are added.
+ */
+export function classifySegment(
+  landingPage: string | null | undefined,
+  utmCampaign: string | null | undefined
+): Segment {
+  const path = (landingPage || '').toLowerCase().split('?')[0];
+
+  if (path.startsWith('/bach-parties') || path.startsWith('/bachelor') || path.startsWith('/bachelorette')) {
+    return 'bach';
+  }
+  if (path.startsWith('/weddings') || path.startsWith('/wedding')) {
+    return 'wedding';
+  }
+  if (path.startsWith('/corporate')) {
+    return 'corporate';
+  }
+  if (path.startsWith('/boat-parties') || path.startsWith('/boat')) {
+    return 'boat';
+  }
+  if (path.startsWith('/kegs')) {
+    return 'kegs';
+  }
+
+  // UTM fallback when the visitor lands on a non-segment page (e.g. /order) but came from
+  // a segment-tagged campaign.
+  const campaign = (utmCampaign || '').toLowerCase();
+  if (campaign.includes('bach')) return 'bach';
+  if (campaign.includes('wedding')) return 'wedding';
+  if (campaign.includes('corporate')) return 'corporate';
+  if (campaign.includes('boat')) return 'boat';
+  if (campaign.includes('keg')) return 'kegs';
+
+  return 'general';
+}

--- a/src/lib/analytics/snapshot-recommendations.ts
+++ b/src/lib/analytics/snapshot-recommendations.ts
@@ -1,0 +1,86 @@
+/**
+ * Heuristic recommendations generated from nightly snapshot rollups.
+ * Different from `recommendations.ts` — those operate on first-party behavior/experiment/sales
+ * shapes; these consume the segment / affiliate / product-margin rollups the cron already pulls.
+ *
+ * Output is fed into persistRecommendations() so each finding shows up in the open queue.
+ * Title+segment dedupe in the store means the same finding doesn't insert again next night
+ * if it's still open (or if ops has already approved it).
+ */
+
+import type { SegmentRollup, AffiliateRoiRow, ProductMarginRow } from './internal-rollups';
+import type { RecommendationInput } from './recommendation-store';
+
+const SEGMENT_MIN_ORDERS = 5;          // segment must have at least this many orders to flag
+const AFFILIATE_NEG_ROI_MIN_COMMISSION = 50; // dollars — ignore tiny dust
+const PRODUCT_LOW_MARGIN_THRESHOLD = 25;     // %
+const PRODUCT_TOP_N_BY_REVENUE = 10;
+const SEGMENT_WOW_DROP_PCT = 20;             // flag segments down 20%+ WoW
+
+export function buildSnapshotRecommendations(input: {
+  segments: SegmentRollup[];
+  segmentsPrior: SegmentRollup[];
+  affiliateRoi: AffiliateRoiRow[];
+  productMargins: ProductMarginRow[];
+}): RecommendationInput[] {
+  const recs: RecommendationInput[] = [];
+
+  // 1. Negative-ROI affiliates (commission paid > attributable margin)
+  for (const a of input.affiliateRoi) {
+    if (a.netMargin == null || a.commissionPaid < AFFILIATE_NEG_ROI_MIN_COMMISSION) continue;
+    if (a.netMargin >= 0) continue;
+    recs.push({
+      title: `Review affiliate ${a.code} — negative ROI`,
+      body: [
+        `${a.businessName} (code ${a.code}) drove ${a.orders} orders and $${a.revenue.toLocaleString()} revenue this period,`,
+        `but generated only $${a.margin?.toLocaleString() ?? '—'} attributable margin against $${a.commissionPaid.toLocaleString()} in commission.`,
+        `Net margin is $${a.netMargin.toLocaleString()} (${a.roiPct ?? '—'}% ROI). Investigate: rate too high, product mix low-margin, or fraud/self-referral pattern.`,
+      ].join(' '),
+      metric: `affiliate-roi:${a.code}`,
+      currentValue: `${a.roiPct ?? '—'}% ROI`,
+      targetValue: '>0% ROI',
+      impactDollarsMonthly: Math.abs(Math.round(a.netMargin)),
+      effortTier: 's',
+      riskTier: 'recommend',
+    });
+  }
+
+  // 2. Segment WoW revenue drop
+  for (const s of input.segments) {
+    if (s.orders < SEGMENT_MIN_ORDERS) continue;
+    const prior = input.segmentsPrior.find((p) => p.segment === s.segment);
+    if (!prior || prior.revenue === 0) continue;
+    const dropPct = ((prior.revenue - s.revenue) / prior.revenue) * 100;
+    if (dropPct < SEGMENT_WOW_DROP_PCT) continue;
+    recs.push({
+      title: `Segment ${s.segment} revenue down ${dropPct.toFixed(0)}% WoW`,
+      body: `${s.segment} segment: ${s.orders} orders / $${s.revenue.toLocaleString()} (was ${prior.orders} / $${prior.revenue.toLocaleString()} prior 30 days). Investigate landing page changes, ad spend, seasonality.`,
+      segment: s.segment,
+      metric: `segment-revenue-wow:${s.segment}`,
+      currentValue: `$${s.revenue.toLocaleString()}`,
+      targetValue: `$${prior.revenue.toLocaleString()}`,
+      impactDollarsMonthly: Math.round(prior.revenue - s.revenue),
+      effortTier: 'm',
+      riskTier: 'recommend',
+    });
+  }
+
+  // 3. Top-revenue product with low margin
+  const top = [...input.productMargins].sort((a, b) => b.revenue - a.revenue).slice(0, PRODUCT_TOP_N_BY_REVENUE);
+  for (const p of top) {
+    if (p.marginPct >= PRODUCT_LOW_MARGIN_THRESHOLD) continue;
+    if (p.revenue === 0) continue;
+    recs.push({
+      title: `Low margin on top-revenue product: ${p.title}`,
+      body: `${p.title} drove $${p.revenue.toLocaleString()} revenue (${p.unitsSold} units) at only ${p.marginPct}% margin. Options: raise price (check elasticity), de-feature, or renegotiate COGS with distributor.`,
+      metric: `product-margin:${p.productId}`,
+      currentValue: `${p.marginPct}%`,
+      targetValue: `${PRODUCT_LOW_MARGIN_THRESHOLD}%+`,
+      impactDollarsMonthly: Math.round(p.revenue * ((PRODUCT_LOW_MARGIN_THRESHOLD - p.marginPct) / 100)),
+      effortTier: 's',
+      riskTier: 'recommend',
+    });
+  }
+
+  return recs;
+}

--- a/src/lib/inventory/services/order-service.ts
+++ b/src/lib/inventory/services/order-service.ts
@@ -9,6 +9,7 @@ import type Stripe from 'stripe';
 import { CartWithItems } from './cart-service';
 import type { DraftOrderWithTotal, DraftOrderItem } from '@/lib/draft-orders/types';
 import { snapshotItemCost, finalizeOrderMargin } from '@/lib/analytics/margin-service';
+import { classifySegment } from '@/lib/analytics/segment-classifier';
 
 /**
  * Order with all relations
@@ -471,6 +472,10 @@ export async function createOrderFromCheckout(
         utmTerm: session.metadata?.utmTerm || null,
         utmContent: session.metadata?.utmContent || null,
         referrer: session.metadata?.referrer || null,
+        segment: classifySegment(
+          session.metadata?.landingPage,
+          session.metadata?.utmCampaign
+        ),
       },
       include: { items: true },
     });

--- a/vercel.json
+++ b/vercel.json
@@ -19,6 +19,10 @@
     {
       "path": "/api/cron/analytics-snapshot",
       "schedule": "0 7 * * *"
+    },
+    {
+      "path": "/api/cron/weekly-briefing",
+      "schedule": "0 13 * * 1"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Follow-up to [#6](https://github.com/allan-cmyk/PartyOn2/pull/6) that closes the Marketing Director loop so it runs on a Monday cadence instead of only on demand.

- **Comparative metrics**: WoW/MoM deltas on every snapshot table, prior-period rollups stored in `AnalyticsSnapshot.comparisonData`.
- **Customer segment field**: `Order.segment` (bach / wedding / corporate / boat / kegs / general) classified at checkout from `landingPage` + `utmCampaign`. Includes backfill script.
- **New rollups**: segment, repeat-rate, LTV-by-entry-segment, affiliate ROI — all exposed via `/api/admin/analytics/internal` and rendered into [docs/WEBSITE-ANALYTICS.md](docs/WEBSITE-ANALYTICS.md).
- **Recommendation persistence**: new `RecommendationItem` table with status workflow (`open` → `approved` → `shipped` / `rejected`) and risk tier (`autonomous` | `recommend` | `hard_stop`). Snapshot cron auto-persists heuristic findings (negative-ROI affiliates, segment WoW drops, low-margin top products). Phase 2 autonomy ramp is unblocked.
- **Weekly briefing**: new cron at [/api/cron/weekly-briefing](src/app/api/cron/weekly-briefing/route.ts) runs Mon 13:00 UTC. Stage A deterministic markdown, Stage B LLM narrative via OpenRouter (skips if `OPENROUTER_API_KEY` not set).
- **Marketing Director prompt updated**: reads briefing → snapshot → open recs first, dedupes before suggesting, knows about all new endpoints.

## Rollout sequence

The new code references columns that don't exist in prod yet, so order matters:

1. **Apply schema first** — `DATABASE_URL=<prod> npx tsx scripts/apply-analytics-schema.ts` (idempotent, ~2 sec). Creates `comparison_data`, `orders.segment`, `recommendation_items` table + indexes.
2. **Merge / deploy** — Vercel picks up the new code.
3. **Trigger snapshot once** — `curl -H "Authorization: Bearer \$CRON_SECRET" .../api/cron/analytics-snapshot` to regenerate the markdown with new sections and persist initial recs.
4. **Backfill segments** — `DATABASE_URL=<prod> npx tsx scripts/backfill-order-segments.ts` to label historical orders.
5. **Trigger weekly briefing** — `curl -H "Authorization: Bearer \$CRON_SECRET" .../api/cron/weekly-briefing` (don't wait for Monday).

Without step 1, Stripe checkout webhooks will error on missing `orders.segment`. The snapshot cron also applies the DDL inline as a safety net, but that's only nightly.

## Test plan

- [ ] `npx tsc --noEmit` clean (only pre-existing test-file error)
- [ ] `npx next lint` clean (only pre-existing `<img>` warnings)
- [ ] Apply schema to prod, confirm columns exist
- [ ] Trigger snapshot cron in prod, confirm response includes `recommendations: { inserted, skippedExisting }` and `openRecCount`
- [ ] Open `docs/WEBSITE-ANALYTICS.md` in main, confirm new sections render with WoW deltas
- [ ] Run backfill script, query `select segment, count(*) from "Order" group by segment;` — distribution should look right (no "general" eating everything)
- [ ] Trigger weekly briefing, confirm `docs/marketing/weekly/YYYY-Www.md` and `-director.md` render
- [ ] Invoke `marketing-director` subagent cold with "what should I work on next" — output should reference WoW deltas, segment data, open recs

## Out of scope (Phase 2/3)

- SEMrush integration (still needs API key)
- Pricing elasticity / `PricingHistory` table
- Phase 2 autonomous code shipping (schema supports it via `riskTier`/`status`; worker not built)
- Other directors (Operations, Finance, etc.) — prove this loop end-to-end first
- Cowork as runtime — earns its place later for browser-driven work; today's runtime is Vercel cron + OpenRouter

🤖 Generated with [Claude Code](https://claude.com/claude-code)