### PR TITLE
fix(receiving): track case cost, not per-can

### DIFF
--- a/src/app/api/admin/inventory/receiving/reocr/route.ts
+++ b/src/app/api/admin/inventory/receiving/reocr/route.ts
@@ -1,7 +1,8 @@
 /**
- * Re-OCR every applied receiving invoice with the cost-aware parser, write
- * ReceivingInvoiceLine.unitCost, and (when ?applyToVariants=1) push to
- * ProductVariant.costPerUnit. Idempotent — safe to run multiple times.
+ * Re-OCR every applied receiving invoice with the case-cost parser, write
+ * ReceivingInvoiceLine.unitCost (semantic = invoice case cost), and
+ * (when ?applyToVariants=1) push a selling-unit cost to ProductVariant.costPerUnit.
+ * Idempotent — safe to run multiple times.
  *
  * Auth: Bearer CRON_SECRET. One-shot admin op, mirrors the cron auth pattern.
  *
@@ -14,7 +15,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/database/client';
 import { parseInvoiceImage, type ParsedInvoiceLine } from '@/lib/inventory/receiving/parser';
-import { extractPackSizeFromTitle } from '@/lib/inventory/receiving/service';
+import {
+  isCasePricedVariant,
+  computeCostPerSellingUnit,
+} from '@/lib/inventory/receiving/service';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 300;
@@ -64,14 +68,15 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     perLine: Array<{
       lineId: string;
       label: string;
-      action: 'updated' | 'no-match' | 'no-cost' | 'no-variant' | 'unchanged' | 'skipped-sanity';
-      invoiceUnitCost: number | null;     // per-bottle from OCR
-      packSize: number | null;             // multiplier derived from variant title
-      variantCost: number | null;          // invoiceUnitCost × packSize — what we'd write
+      action: 'updated' | 'no-match' | 'no-cost' | 'no-variant' | 'cost-guard-skip';
+      caseCost: number | null;          // case cost from OCR
+      isCasePriced: boolean | null;      // selling-unit detection
+      sellingUnitCost: number | null;    // what we'd write to costPerUnit
       variantId: string | null;
       variantLabel: string | null;
       previousVariantCost: number | null;
-      sanityNote?: string;
+      retailDollars: number | null;
+      guardNote?: string;
     }>;
     error: string | null;
   }> = [];
@@ -106,17 +111,19 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       if (!reocrLine) {
         invSummary.perLine.push({
           lineId: dbLine.id, label, action: 'no-match',
-          invoiceUnitCost: null, packSize: null, variantCost: null,
-          variantId: dbLine.matchedVariantId, variantLabel: null, previousVariantCost: null,
+          caseCost: null, isCasePriced: null, sellingUnitCost: null,
+          variantId: dbLine.matchedVariantId, variantLabel: null,
+          previousVariantCost: null, retailDollars: null,
         });
         continue;
       }
 
-      if (reocrLine.unitCost == null) {
+      if (reocrLine.caseCost == null) {
         invSummary.perLine.push({
           lineId: dbLine.id, label, action: 'no-cost',
-          invoiceUnitCost: null, packSize: null, variantCost: null,
-          variantId: dbLine.matchedVariantId, variantLabel: null, previousVariantCost: null,
+          caseCost: null, isCasePriced: null, sellingUnitCost: null,
+          variantId: dbLine.matchedVariantId, variantLabel: null,
+          previousVariantCost: null, retailDollars: null,
         });
         continue;
       }
@@ -124,44 +131,55 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       const variant = dbLine.matchedVariantId
         ? await prisma.productVariant.findUnique({
             where: { id: dbLine.matchedVariantId },
-            select: { id: true, title: true, costPerUnit: true, product: { select: { title: true } } },
+            select: {
+              id: true, title: true, costPerUnit: true, price: true,
+              product: { select: { title: true } },
+            },
           })
         : null;
       const variantLabel = variant
         ? `${variant.product.title}${variant.title && variant.title !== 'Default Title' ? ' / ' + variant.title : ''}`
         : null;
       const previousVariantCost = variant?.costPerUnit ? Number(variant.costPerUnit) : null;
-      const packSize = variant
-        ? extractPackSizeFromTitle(`${variant.product.title} ${variant.title ?? ''}`)
-        : 1;
-      const variantCost = Number((reocrLine.unitCost * packSize).toFixed(4));
+      const retailDollars = variant?.price != null ? Number(variant.price) : null;
+      const combinedTitle = variant ? `${variant.product.title} ${variant.title ?? ''}` : '';
+      const isCase = variant ? isCasePricedVariant(combinedTitle) : null;
+      const sellingUnitCost = variant
+        ? Number(
+            computeCostPerSellingUnit({
+              combinedTitle,
+              caseCost: reocrLine.caseCost,
+              unitsPerCase: reocrLine.unitsPerCase,
+            }).toFixed(4)
+          )
+        : null;
 
-      // Write to line (raw per-bottle invoice cost).
+      // Always update the line's stored case cost so the source-of-truth on the invoice row matches re-OCR.
       if (!dryRun) {
         await prisma.receivingInvoiceLine.update({
           where: { id: dbLine.id },
-          data: { unitCost: new Prisma.Decimal(reocrLine.unitCost) },
+          data: { unitCost: new Prisma.Decimal(reocrLine.caseCost) },
         });
         totalLineUpdates++;
       }
 
-      // Sanity check: skip variant update if existing cost differs from proposed by >50%.
-      // This catches OCR misreads where per-pack price was labeled as per-bottle (or vice versa).
-      const sanityOk =
-        previousVariantCost == null ||
-        previousVariantCost === 0 ||
-        Math.abs(variantCost - previousVariantCost) / previousVariantCost <= 0.5;
-      const sanityNote =
-        !sanityOk && previousVariantCost != null
-          ? `proposed $${variantCost.toFixed(2)} differs from existing $${previousVariantCost.toFixed(2)} by >50% — likely OCR ambiguity, leaving existing cost alone`
-          : undefined;
+      // Plausibility guard for single-bottle variants only.
+      const blocked =
+        variant != null &&
+        isCase === false &&
+        retailDollars != null &&
+        retailDollars > 0 &&
+        sellingUnitCost != null &&
+        sellingUnitCost > retailDollars * 3;
+      const guardNote = blocked
+        ? `proposed selling-unit cost $${sellingUnitCost!.toFixed(2)} > 3× retail $${retailDollars!.toFixed(2)} — likely OCR error on caseCost or unitsPerCase`
+        : undefined;
 
-      // Optionally write to variant (per-selling-unit cost = invoiceUnitCost × packSize).
-      const willTouchVariant = applyToVariants && variant != null && sanityOk;
+      const willTouchVariant = applyToVariants && variant != null && !blocked && sellingUnitCost != null;
       if (willTouchVariant && !dryRun) {
         await prisma.productVariant.update({
           where: { id: variant!.id },
-          data: { costPerUnit: new Prisma.Decimal(variantCost) },
+          data: { costPerUnit: new Prisma.Decimal(sellingUnitCost!) },
         });
         totalVariantUpdates++;
       }
@@ -169,14 +187,15 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       invSummary.perLine.push({
         lineId: dbLine.id,
         label,
-        action: !variant ? 'no-variant' : !sanityOk ? 'skipped-sanity' : 'updated',
-        invoiceUnitCost: reocrLine.unitCost,
-        packSize,
-        variantCost,
+        action: !variant ? 'no-variant' : blocked ? 'cost-guard-skip' : 'updated',
+        caseCost: reocrLine.caseCost,
+        isCasePriced: isCase,
+        sellingUnitCost,
         variantId: dbLine.matchedVariantId,
         variantLabel,
         previousVariantCost,
-        sanityNote,
+        retailDollars,
+        guardNote,
       });
     }
 

--- a/src/app/ops/inventory/receiving/[id]/page.tsx
+++ b/src/app/ops/inventory/receiving/[id]/page.tsx
@@ -120,7 +120,13 @@ export default function ReceivingReviewPage({ params }: { params: Promise<{ id: 
         return;
       }
       const mode = skipInventory ? ' (cost-only)' : '';
-      alert(`Applied${mode} ${data.appliedCount} line${data.appliedCount === 1 ? '' : 's'}. ${data.skipped} skipped.`);
+      const guardSkips: Array<{ label: string; reason: string }> = data.costGuardSkips ?? [];
+      const guardLine = guardSkips.length
+        ? `\n\nCost guard blocked ${guardSkips.length} write${guardSkips.length === 1 ? '' : 's'} (likely OCR error):\n` +
+          guardSkips.map((s) => `• ${s.label} — ${s.reason}`).join('\n') +
+          `\n\nLine status was applied; variant cost was NOT updated for these. Fix and re-OCR or set cost manually.`
+        : '';
+      alert(`Applied${mode} ${data.appliedCount} line${data.appliedCount === 1 ? '' : 's'}. ${data.skipped} skipped.${guardLine}`);
       router.push('/ops/inventory');
     } finally {
       setApplying(false);
@@ -237,7 +243,7 @@ export default function ReceivingReviewPage({ params }: { params: Promise<{ id: 
                   <span className="font-bold text-gray-900">{line.totalUnits} units</span>
                   <span className="text-gray-400 ml-3">·</span>
                   <label className="flex items-center gap-1">
-                    <span className="text-xs text-gray-500">Unit cost $</span>
+                    <span className="text-xs text-gray-500">Case cost $</span>
                     <input
                       type="number"
                       min={0}
@@ -249,9 +255,22 @@ export default function ReceivingReviewPage({ params }: { params: Promise<{ id: 
                         const v = raw === '' ? null : Math.max(0, Number(raw));
                         if (v !== line.unitCost) patchLine(line.id, { unitCost: v });
                       }}
-                      className="w-20 px-2 py-1 border border-gray-300 rounded text-sm"
+                      className="w-24 px-2 py-1 border border-gray-300 rounded text-sm"
                     />
                   </label>
+                  {(() => {
+                    if (line.unitCost == null || !line.matchedVariant) return null;
+                    const title = `${line.matchedVariant.productTitle} ${line.matchedVariant.variantTitle ?? ''}`;
+                    const isCase = /\b(\d+\s*pack|case)\b/i.test(title);
+                    const sellingUnitCost = isCase
+                      ? line.unitCost
+                      : line.unitCost / Math.max(1, line.unitsPerCase);
+                    return (
+                      <span className="text-xs text-gray-600">
+                        → ${sellingUnitCost.toFixed(2)} / {isCase ? 'case' : 'bottle'}
+                      </span>
+                    );
+                  })()}
                 </div>
 
                 {line.matchedVariant ? (

--- a/src/lib/inventory/receiving/parser.ts
+++ b/src/lib/inventory/receiving/parser.ts
@@ -5,8 +5,15 @@ export interface ParsedInvoiceLine {
   description: string;
   cases: number;
   unitsPerCase: number;
-  /** Per-unit COGS extracted from the invoice. Null if not present/legible. */
-  unitCost: number | null;
+  /**
+   * Case cost in dollars — the price the distributor charges per case for this line,
+   * as printed on the invoice. Null if not legible. The applyInvoice flow translates
+   * this into ProductVariant.costPerUnit using the matched variant's selling unit
+   * (case for multi-packs, bottle for single-bottle variants like wine and liquor).
+   *
+   * The DB column is still named `unitCost` for legacy reasons; this field maps to it.
+   */
+  caseCost: number | null;
 }
 
 export interface ParsedInvoice {
@@ -29,8 +36,7 @@ Return ONLY JSON matching this shape, no prose:
       "description": string,              // full product description as printed
       "cases": number,                    // number of cases ordered (integer)
       "unitsPerCase": number,             // bottles/cans per case. Infer from pack size (e.g. "12/750ML" -> 12, "24/12OZ" -> 24). Default to 1 if not inferable.
-      "unitCost": number | null,          // per-unit cost in dollars. See cost rules below.
-      "caseCost": number | null           // per-case cost in dollars. See cost rules below.
+      "caseCost": number | null           // PER-CASE price in dollars. See cost rules below.
     }
   ]
 }
@@ -43,12 +49,12 @@ Rules:
 - If the photo is blurry or you cannot read a field, use null.
 
 Cost rules:
-- Distributor invoices typically show one or more of: case price, unit/bottle price, line extension (cases × case price). Capture whichever the invoice shows directly.
-- "unitCost" = price per single bottle/can/container (NOT per case). If the invoice prints both a case price and a unit price, use the unit price.
-- "caseCost" = price per case. If only one cost is visible per line, populate the matching field and leave the other null — we'll derive the other side downstream.
-- Do NOT divide line totals or extensions. Only capture costs that are printed per-line as case price or unit price.
+- We only care about the CASE PRICE — the price for one full case as the distributor sells it.
+- "caseCost" = price per case as printed on the invoice. This is the dollar figure in the price column for the row, NOT a per-bottle/per-can price.
+- If the invoice ONLY shows a per-bottle/per-can unit price for a multi-bottle case, multiply it by unitsPerCase to get caseCost (e.g. 12 bottles × $15/bottle = $180 caseCost).
+- Do NOT use line-extension totals (cases × case price). Use the per-case price.
 - Exclude any deposit, freight, tax, fee, or discount adjustments — these are not COGS.
-- If no cost is legible, set both unitCost and caseCost to null. Do NOT guess.`;
+- If no case-level cost is legible, set caseCost to null. Do NOT guess.`;
 
 export async function parseInvoiceImage(imageUrl: string): Promise<ParsedInvoice> {
   const response = await callOpenRouter(
@@ -66,15 +72,14 @@ export async function parseInvoiceImage(imageUrl: string): Promise<ParsedInvoice
     { temperature: 0.1, maxTokens: 4000 }
   );
 
-  // The model may return either unitCost, caseCost, both, or neither — declare a loose
-  // shape here so the type checker doesn't reject the optional caseCost we look for below.
+  // Tolerate older response shapes (`unitCost`) so partial reocr / cached responses don't break.
   interface RawLine {
     distributorSku?: string | null;
     description?: string;
     cases?: number;
     unitsPerCase?: number;
-    unitCost?: number | null;
     caseCost?: number | null;
+    unitCost?: number | null; // legacy / fallback per-bottle field
   }
   interface RawInvoice {
     distributorName?: string | null;
@@ -96,19 +101,19 @@ export async function parseInvoiceImage(imageUrl: string): Promise<ParsedInvoice
     lines: parsed.lines.map((line) => {
       const cases = Math.max(0, Math.floor(Number(line.cases) || 0));
       const unitsPerCase = Math.max(1, Math.floor(Number(line.unitsPerCase) || 1));
-      // Prefer printed unitCost; otherwise derive from caseCost / unitsPerCase.
-      let unitCost: number | null = null;
-      if (typeof line.unitCost === 'number' && isFinite(line.unitCost) && line.unitCost > 0) {
-        unitCost = Number(line.unitCost.toFixed(4));
-      } else if (typeof line.caseCost === 'number' && isFinite(line.caseCost) && line.caseCost > 0 && unitsPerCase > 0) {
-        unitCost = Number((line.caseCost / unitsPerCase).toFixed(4));
+      let caseCost: number | null = null;
+      if (typeof line.caseCost === 'number' && isFinite(line.caseCost) && line.caseCost > 0) {
+        caseCost = Number(line.caseCost.toFixed(4));
+      } else if (typeof line.unitCost === 'number' && isFinite(line.unitCost) && line.unitCost > 0) {
+        // Legacy per-bottle path — promote to case cost.
+        caseCost = Number((line.unitCost * unitsPerCase).toFixed(4));
       }
       return {
         distributorSku: line.distributorSku ?? null,
         description: String(line.description ?? '').trim(),
         cases,
         unitsPerCase,
-        unitCost,
+        caseCost,
       };
     }).filter((line) => line.description.length > 0),
   };

--- a/src/lib/inventory/receiving/service.ts
+++ b/src/lib/inventory/receiving/service.ts
@@ -17,22 +17,30 @@ function normalizeKey(sku: string | null, description: string): string {
 }
 
 /**
- * Extract the pack-size multiplier from a variant's product+variant title.
- * Distributor invoices print per-bottle/can cost, but ProductVariant.costPerUnit is
- * per-selling-unit (which for our catalog is usually a multi-pack like "24 Pack").
- * So variant.costPerUnit = invoiceUnitCost * packSize.
+ * A variant is "case-priced" when its selling unit is the full distributor case —
+ * e.g. a "24 Pack" of beer or a pre-built "Mixed Case" of wine. For these,
+ * variant.costPerUnit equals the invoice case cost directly (no division).
  *
- * Examples:
- *   "Lone Star • 24 Pack 12oz Can"           → 24
- *   "Saint Arnold Summer Pils • 6 Pack 12oz" → 6
- *   "Casamigos Tequila Blanco • 750ml Bottle" → 1
- *   "Bottled Water • 32 Pack 16.9oz"          → 32
+ * Single-bottle variants (wine, liquor, single 750ml/1.75L) are bottle-priced —
+ * costPerUnit equals invoice case cost ÷ bottles per case.
  */
-export function extractPackSizeFromTitle(combinedTitle: string): number {
-  const match = combinedTitle.match(/(\d+)\s*Pack/i);
-  if (!match) return 1;
-  const n = parseInt(match[1], 10);
-  return Number.isFinite(n) && n > 0 ? n : 1;
+export function isCasePricedVariant(combinedTitle: string): boolean {
+  return /\b(\d+\s*pack|case)\b/i.test(combinedTitle);
+}
+
+/**
+ * Compute the per-selling-unit cost (what to write to ProductVariant.costPerUnit)
+ * from an invoice line.
+ */
+export function computeCostPerSellingUnit(params: {
+  combinedTitle: string;
+  caseCost: number;
+  unitsPerCase: number;
+}): number {
+  const { combinedTitle, caseCost, unitsPerCase } = params;
+  if (isCasePricedVariant(combinedTitle)) return caseCost;
+  const denom = unitsPerCase > 0 ? unitsPerCase : 1;
+  return caseCost / denom;
 }
 
 export async function createInvoiceFromParse(params: {
@@ -54,20 +62,20 @@ export async function createInvoiceFromParse(params: {
       rawParse: parsed as unknown as object,
       createdBy: createdBy ?? null,
       lines: {
+        // Legacy DB column `unitCost` now stores the per-line CASE cost from the invoice.
         create: parsed.lines.map((line) => ({
           distributorSku: line.distributorSku,
           distributorDescription: line.description,
           cases: line.cases,
           unitsPerCase: line.unitsPerCase,
           totalUnits: line.cases * line.unitsPerCase,
-          unitCost: line.unitCost != null ? new Prisma.Decimal(line.unitCost) : null,
+          unitCost: line.caseCost != null ? new Prisma.Decimal(line.caseCost) : null,
         })),
       },
     },
     include: { lines: true },
   });
 
-  // Attempt auto-match from saved mappings
   for (const line of invoice.lines) {
     const key = normalizeKey(line.distributorSku, line.distributorDescription);
     const existingMap = await prisma.distributorSkuMap.findUnique({ where: { distributorKey: key } });
@@ -127,7 +135,12 @@ export async function getVariantSuggestions(description: string, limit = 5): Pro
 export async function applyInvoice(
   invoiceId: string,
   options: { skipInventory?: boolean } = {}
-): Promise<{ appliedCount: number; skipped: number; skipInventory: boolean }> {
+): Promise<{
+  appliedCount: number;
+  skipped: number;
+  skipInventory: boolean;
+  costGuardSkips: Array<{ lineId: string; label: string; reason: string }>;
+}> {
   const skipInventory = options.skipInventory === true;
   const invoice = await prisma.receivingInvoice.findUnique({
     where: { id: invoiceId },
@@ -139,6 +152,7 @@ export async function applyInvoice(
 
   let appliedCount = 0;
   let skipped = 0;
+  const costGuardSkips: Array<{ lineId: string; label: string; reason: string }> = [];
   const reason = `Received from ${invoice.distributorName ?? 'distributor'}${invoice.invoiceNumber ? ` — invoice #${invoice.invoiceNumber}` : ''}`;
 
   for (const line of invoice.lines) {
@@ -153,6 +167,7 @@ export async function applyInvoice(
         id: true,
         productId: true,
         title: true,
+        price: true,
         product: { select: { title: true } },
       },
     });
@@ -171,31 +186,35 @@ export async function applyInvoice(
       });
     }
 
-    // Propagate unit cost to ProductVariant.costPerUnit. Invoice prints per-bottle cost;
-    // variant cost is per selling unit (often a multi-pack), so multiply by pack-size.
-    // Sanity check: if existing cost is set and the new value differs by >50%, leave it
-    // alone — that's typically OCR misreading per-pack as per-bottle (or vice versa)
-    // and would corrupt good data.
+    // The DB column `unitCost` now holds the case cost from the invoice.
     if (line.unitCost != null) {
-      const fullVariant = await prisma.productVariant.findUnique({
-        where: { id: variant.id },
-        select: { costPerUnit: true },
-      });
+      const caseCost = Number(line.unitCost);
       const combinedTitle = `${variant.product.title} ${variant.title ?? ''}`;
-      const packSize = extractPackSizeFromTitle(combinedTitle);
-      const proposed = Number(line.unitCost) * packSize;
-      const existing = fullVariant?.costPerUnit ? Number(fullVariant.costPerUnit) : null;
-      const safe =
-        existing == null || existing === 0 || Math.abs(proposed - existing) / existing <= 0.5;
-      if (safe) {
+      const isCase = isCasePricedVariant(combinedTitle);
+      const proposed = computeCostPerSellingUnit({
+        combinedTitle,
+        caseCost,
+        unitsPerCase: line.unitsPerCase,
+      });
+
+      // Plausibility guard for single-bottle variants only: if the computed cost is more
+      // than 3× the variant's retail price, the OCR almost certainly returned a per-line
+      // total or got unitsPerCase wrong. Refuse the write rather than corrupt costPerUnit.
+      const retailDollars = variant.price != null ? Number(variant.price) : null;
+      const blocked =
+        !isCase && retailDollars != null && retailDollars > 0 && proposed > retailDollars * 3;
+
+      if (blocked) {
+        const label =
+          (line.distributorSku ? `[${line.distributorSku}] ` : '') + line.distributorDescription;
+        const note = `proposed cost $${proposed.toFixed(2)} > 3× retail $${retailDollars!.toFixed(2)} — likely OCR error on caseCost or unitsPerCase`;
+        console.warn(`[receiving] cost guard skip: ${label} — ${note}`);
+        costGuardSkips.push({ lineId: line.id, label, reason: note });
+      } else {
         await prisma.productVariant.update({
           where: { id: variant.id },
           data: { costPerUnit: new Prisma.Decimal(proposed) },
         });
-      } else {
-        console.warn(
-          `[receiving] cost sanity-check skip: ${combinedTitle} (existing $${existing.toFixed(2)} → proposed $${proposed.toFixed(2)} from invoice line ${line.id})`
-        );
       }
     }
 
@@ -234,5 +253,5 @@ export async function applyInvoice(
     data: { status: 'APPLIED', appliedAt: new Date() },
   });
 
-  return { appliedCount, skipped, skipInventory };
+  return { appliedCount, skipped, skipInventory, costGuardSkips };
 }


### PR DESCRIPTION
## Summary

Replaces the per-can cost pipeline with a case-cost model that matches how we actually sell:
- Beer / seltzer / multi-pack → variant.costPerUnit = invoice case cost (no division)
- Wine / liquor / single bottle → variant.costPerUnit = invoice case cost ÷ bottles per case

## Why

Live test of the "Apply costs only" flow on Capital Reyes invoice #10093716 showed the OCR was inconsistent — sometimes returning per-can ($1.0396 for Coors Light), sometimes per-pack ($18.80 for Lone Star). The pack-size multiplier from `bfbb99fb` blindly applied to both, producing a $451 write that the >50% sanity check then silently dropped. Net effect: the receiving flow couldn't reliably populate cost data.

The deeper issue: per-can cost is a meaningless data point for our business. Customers can't buy one can of beer. Tracking and translating in two directions (case → per-can in OCR, per-can → case on apply) created two failure surfaces for no benefit.

## Changes

**Parser** (`src/lib/inventory/receiving/parser.ts`)
- Prompt now asks for `caseCost` only (per-case price as printed on invoice)
- Legacy per-bottle responses still tolerated (promoted via × unitsPerCase) for in-flight invoices

**Service** (`src/lib/inventory/receiving/service.ts`)
- New `isCasePricedVariant(title)` — matches "Pack" or "Case" in variant title
- New `computeCostPerSellingUnit({ caseCost, unitsPerCase, combinedTitle })`
- Removed `extractPackSizeFromTitle` and the >50% sanity check (no longer needed once we stop multiplying)
- Added plausibility guard: for single-bottle variants only, refuse the write if computed cost > 3× retail price. Surfaces blocked lines in `costGuardSkips` array on the apply response.

**Review UI** (`src/app/ops/inventory/receiving/[id]/page.tsx`)
- "Unit cost $" → "Case cost $"
- Shows derived selling-unit cost beside the input ("→ \$24.95 / case", "→ \$15.00 / bottle")
- Apply alert lists any cost-guard skips with reason

**reocr endpoint** (`src/app/api/admin/inventory/receiving/reocr/route.ts`) updated to match.

## Worked examples

| Variant | Invoice case cost | unitsPerCase | Detected | costPerUnit |
|---|---|---|---|---|
| Coors Light • 24 Pack | $24.95 | 24 | case | **$24.95** |
| Saint Arnold • 6 Pack | $8.60 | 6 | case | **$8.60** |
| Lone Star • 24 Pack | $18.80 | 24 | case | **$18.80** |
| Cabernet • 750ml Bottle | $180.00 | 12 | bottle | **$15.00** |
| Casamigos • 750ml Bottle | $432.00 | 12 | bottle | **$36.00** |

## Test plan

- [ ] Apply Capital Reyes invoice #10093716 (the one in the screenshot) and confirm Coors Light, Lone Star, and Saint Arnold all land at the correct case prices in `ProductVariant.costPerUnit`
- [ ] Process at least one wine/liquor invoice and confirm bottle-priced variants get the divided cost
- [ ] Process the remaining 8 historical invoices via "Apply costs only" mode and check coverage % rises in the next analytics snapshot
- [ ] Verify the cost-guard alert fires when a clearly bad OCR slips through

🤖 Generated with [Claude Code](https://claude.com/claude-code)