### PR TITLE
fix(receiving): label cost field as 'Unit cost', show per-selling-unit value

### DIFF
--- a/src/app/ops/inventory/receiving/[id]/page.tsx
+++ b/src/app/ops/inventory/receiving/[id]/page.tsx
@@ -242,33 +242,48 @@ export default function ReceivingReviewPage({ params }: { params: Promise<{ id: 
                   <span className="text-gray-400">=</span>
                   <span className="font-bold text-gray-900">{line.totalUnits} units</span>
                   <span className="text-gray-400 ml-3">·</span>
-                  <label className="flex items-center gap-1">
-                    <span className="text-xs text-gray-500">Case cost $</span>
-                    <input
-                      type="number"
-                      min={0}
-                      step="0.01"
-                      defaultValue={line.unitCost ?? ''}
-                      placeholder="—"
-                      onBlur={(e) => {
-                        const raw = e.target.value.trim();
-                        const v = raw === '' ? null : Math.max(0, Number(raw));
-                        if (v !== line.unitCost) patchLine(line.id, { unitCost: v });
-                      }}
-                      className="w-24 px-2 py-1 border border-gray-300 rounded text-sm"
-                    />
-                  </label>
                   {(() => {
-                    if (line.unitCost == null || !line.matchedVariant) return null;
-                    const title = `${line.matchedVariant.productTitle} ${line.matchedVariant.variantTitle ?? ''}`;
-                    const isCase = /\b(\d+\s*pack|case)\b/i.test(title);
-                    const sellingUnitCost = isCase
-                      ? line.unitCost
-                      : line.unitCost / Math.max(1, line.unitsPerCase);
+                    // Selling unit (= what we actually sell, = what costPerUnit stores):
+                    //  - matched variant title contains "Pack"/"Case" → the case
+                    //  - everything else → the single bottle/can
+                    // Default to bottle for unmatched lines (most distributor invoices are
+                    // case-of-bottles).
+                    const sellingUnitIsCase = line.matchedVariant
+                      ? /\b(\d+\s*pack|case)\b/i.test(
+                          `${line.matchedVariant.productTitle} ${line.matchedVariant.variantTitle ?? ''}`
+                        )
+                      : false;
+                    const unitsPerCase = Math.max(1, line.unitsPerCase);
+                    const unitLabel = sellingUnitIsCase ? 'case' : 'bottle';
+                    const displayedUnitCost = line.unitCost == null
+                      ? ''
+                      : (sellingUnitIsCase ? line.unitCost : line.unitCost / unitsPerCase).toFixed(2);
                     return (
-                      <span className="text-xs text-gray-600">
-                        → ${sellingUnitCost.toFixed(2)} / {isCase ? 'case' : 'bottle'}
-                      </span>
+                      <>
+                        <label className="flex items-center gap-1">
+                          <span className="text-xs text-gray-500">Unit cost $</span>
+                          <input
+                            type="number"
+                            min={0}
+                            step="0.01"
+                            key={`${line.id}-${displayedUnitCost}`}
+                            defaultValue={displayedUnitCost}
+                            placeholder="—"
+                            onBlur={(e) => {
+                              const raw = e.target.value.trim();
+                              const newDisplay = raw === '' ? null : Math.max(0, Number(raw));
+                              const newStoredCost = newDisplay == null
+                                ? null
+                                : sellingUnitIsCase ? newDisplay : newDisplay * unitsPerCase;
+                              if (newStoredCost !== line.unitCost) {
+                                patchLine(line.id, { unitCost: newStoredCost });
+                              }
+                            }}
+                            className="w-24 px-2 py-1 border border-gray-300 rounded text-sm"
+                          />
+                        </label>
+                        <span className="text-xs text-gray-500">/ {unitLabel}</span>
+                      </>
                     );
                   })()}
                 </div>


### PR DESCRIPTION
Receiving review now shows per-selling-unit cost (= what gets written to ProductVariant.costPerUnit on apply) instead of the raw invoice case cost. For a case of 12 × 1L Tito's at $259.56, you now see $21.63 / bottle instead of $259.56. For a 24-pack of Coors Light at $24.95, you see $24.95 / case (unchanged). Storage and apply logic are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)