### PR TITLE
fix(receiving): trust PPC column for sellable-units-per-case

### DIFF
--- a/src/app/api/admin/inventory/receiving/reocr/route.ts
+++ b/src/app/api/admin/inventory/receiving/reocr/route.ts
@@ -15,10 +15,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/database/client';
 import { parseInvoiceImage, type ParsedInvoiceLine } from '@/lib/inventory/receiving/parser';
-import {
-  isCasePricedVariant,
-  computeCostPerSellingUnit,
-} from '@/lib/inventory/receiving/service';
+import { computeCostPerSellingUnit } from '@/lib/inventory/receiving/service';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 300;
@@ -70,7 +67,6 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       label: string;
       action: 'updated' | 'no-match' | 'no-cost' | 'no-variant' | 'cost-guard-skip';
       caseCost: number | null;          // case cost from OCR
-      isCasePriced: boolean | null;      // selling-unit detection
       sellingUnitCost: number | null;    // what we'd write to costPerUnit
       variantId: string | null;
       variantLabel: string | null;
@@ -111,7 +107,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       if (!reocrLine) {
         invSummary.perLine.push({
           lineId: dbLine.id, label, action: 'no-match',
-          caseCost: null, isCasePriced: null, sellingUnitCost: null,
+          caseCost: null, sellingUnitCost: null,
           variantId: dbLine.matchedVariantId, variantLabel: null,
           previousVariantCost: null, retailDollars: null,
         });
@@ -121,7 +117,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       if (reocrLine.caseCost == null) {
         invSummary.perLine.push({
           lineId: dbLine.id, label, action: 'no-cost',
-          caseCost: null, isCasePriced: null, sellingUnitCost: null,
+          caseCost: null, sellingUnitCost: null,
           variantId: dbLine.matchedVariantId, variantLabel: null,
           previousVariantCost: null, retailDollars: null,
         });
@@ -142,12 +138,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         : null;
       const previousVariantCost = variant?.costPerUnit ? Number(variant.costPerUnit) : null;
       const retailDollars = variant?.price != null ? Number(variant.price) : null;
-      const combinedTitle = variant ? `${variant.product.title} ${variant.title ?? ''}` : '';
-      const isCase = variant ? isCasePricedVariant(combinedTitle) : null;
       const sellingUnitCost = variant
         ? Number(
             computeCostPerSellingUnit({
-              combinedTitle,
               caseCost: reocrLine.caseCost,
               unitsPerCase: reocrLine.unitsPerCase,
             }).toFixed(4)
@@ -163,10 +156,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         totalLineUpdates++;
       }
 
-      // Plausibility guard for single-bottle variants only.
+      // Plausibility guard: refuse the write if proposed selling-unit cost > 3× retail.
       const blocked =
         variant != null &&
-        isCase === false &&
         retailDollars != null &&
         retailDollars > 0 &&
         sellingUnitCost != null &&
@@ -189,7 +181,6 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         label,
         action: !variant ? 'no-variant' : blocked ? 'cost-guard-skip' : 'updated',
         caseCost: reocrLine.caseCost,
-        isCasePriced: isCase,
         sellingUnitCost,
         variantId: dbLine.matchedVariantId,
         variantLabel,

--- a/src/app/ops/inventory/receiving/[id]/page.tsx
+++ b/src/app/ops/inventory/receiving/[id]/page.tsx
@@ -243,21 +243,14 @@ export default function ReceivingReviewPage({ params }: { params: Promise<{ id: 
                   <span className="font-bold text-gray-900">{line.totalUnits} units</span>
                   <span className="text-gray-400 ml-3">·</span>
                   {(() => {
-                    // Selling unit (= what we actually sell, = what costPerUnit stores):
-                    //  - matched variant title contains "Pack"/"Case" → the case
-                    //  - everything else → the single bottle/can
-                    // Default to bottle for unmatched lines (most distributor invoices are
-                    // case-of-bottles).
-                    const sellingUnitIsCase = line.matchedVariant
-                      ? /\b(\d+\s*pack|case)\b/i.test(
-                          `${line.matchedVariant.productTitle} ${line.matchedVariant.variantTitle ?? ''}`
-                        )
-                      : false;
+                    // Selling-unit cost = caseCost / unitsPerCase. The parser sets
+                    // unitsPerCase to PPC (sellable units per case) when available; for
+                    // straight single-bottle cases it falls back to PACK / bottles-per-case.
+                    // The operator can correct unitsPerCase above if the OCR got it wrong.
                     const unitsPerCase = Math.max(1, line.unitsPerCase);
-                    const unitLabel = sellingUnitIsCase ? 'case' : 'bottle';
                     const displayedUnitCost = line.unitCost == null
                       ? ''
-                      : (sellingUnitIsCase ? line.unitCost : line.unitCost / unitsPerCase).toFixed(2);
+                      : (line.unitCost / unitsPerCase).toFixed(2);
                     return (
                       <>
                         <label className="flex items-center gap-1">
@@ -274,7 +267,7 @@ export default function ReceivingReviewPage({ params }: { params: Promise<{ id: 
                               const newDisplay = raw === '' ? null : Math.max(0, Number(raw));
                               const newStoredCost = newDisplay == null
                                 ? null
-                                : sellingUnitIsCase ? newDisplay : newDisplay * unitsPerCase;
+                                : newDisplay * unitsPerCase;
                               if (newStoredCost !== line.unitCost) {
                                 patchLine(line.id, { unitCost: newStoredCost });
                               }
@@ -282,7 +275,6 @@ export default function ReceivingReviewPage({ params }: { params: Promise<{ id: 
                             className="w-24 px-2 py-1 border border-gray-300 rounded text-sm"
                           />
                         </label>
-                        <span className="text-xs text-gray-500">/ {unitLabel}</span>
                       </>
                     );
                   })()}

--- a/src/lib/inventory/receiving/parser.ts
+++ b/src/lib/inventory/receiving/parser.ts
@@ -45,7 +45,15 @@ Rules:
 - One object per physical line on the invoice. Do NOT aggregate.
 - "cases" is the quantity column. If only singles are listed, set cases = quantity and unitsPerCase = 1.
 - Ignore totals, subtotals, tax, fees, freight, deposit lines.
-- For pack notation like "12/750", "24/12OZ", "6/4/12OZ": unitsPerCase is the FIRST number (12, 24, 24 respectively — the total individual containers per case).
+- "unitsPerCase" = number of SELLABLE UNITS per case (= what shows up in inventory after receiving). Source priority:
+  1. If the invoice has a "PPC" (Parts/Pieces Per Case) column, that IS unitsPerCase. Use it.
+  2. Otherwise use the "PACK" column when present (typical for invoices with single-bottle/can items).
+  3. As a last resort, infer from pack notation in the description: "12/750ML" → 12 bottles per case; "24/12OZ" with single cans → 24; for variety packs like "6/4/12OZ" → 6 (six four-packs per case).
+- Important examples to disambiguate:
+  - Wine "12/750ML" sold as bottles: unitsPerCase = 12
+  - Liquor "6/750ML" sold as bottles: unitsPerCase = 6
+  - Cutwater variety "24/12OZ 6/4" sold as four-packs: unitsPerCase = 6 (PPC column will say 6)
+  - Beer like "Coors Light 24-pack" sold as the 24-pack: PPC column will say 1
 - If the photo is blurry or you cannot read a field, use null.
 
 Cost rules:

--- a/src/lib/inventory/receiving/service.ts
+++ b/src/lib/inventory/receiving/service.ts
@@ -17,28 +17,18 @@ function normalizeKey(sku: string | null, description: string): string {
 }
 
 /**
- * A variant is "case-priced" when its selling unit is the full distributor case —
- * e.g. a "24 Pack" of beer or a pre-built "Mixed Case" of wine. For these,
- * variant.costPerUnit equals the invoice case cost directly (no division).
- *
- * Single-bottle variants (wine, liquor, single 750ml/1.75L) are bottle-priced —
- * costPerUnit equals invoice case cost ÷ bottles per case.
- */
-export function isCasePricedVariant(combinedTitle: string): boolean {
-  return /\b(\d+\s*pack|case)\b/i.test(combinedTitle);
-}
-
-/**
  * Compute the per-selling-unit cost (what to write to ProductVariant.costPerUnit)
- * from an invoice line.
+ * from an invoice line. Always divides — the parser is responsible for setting
+ * unitsPerCase to the number of SELLABLE units per case (PPC column when present,
+ * else PACK column). For a Coors Light 24-pack sold as the 24-pack, PPC=1 and
+ * caseCost/1 = caseCost. For a Cutwater variety pack with 6 four-packs per case,
+ * PPC=6 and caseCost/6 = per-four-pack cost.
  */
 export function computeCostPerSellingUnit(params: {
-  combinedTitle: string;
   caseCost: number;
   unitsPerCase: number;
 }): number {
-  const { combinedTitle, caseCost, unitsPerCase } = params;
-  if (isCasePricedVariant(combinedTitle)) return caseCost;
+  const { caseCost, unitsPerCase } = params;
   const denom = unitsPerCase > 0 ? unitsPerCase : 1;
   return caseCost / denom;
 }
@@ -186,23 +176,22 @@ export async function applyInvoice(
       });
     }
 
-    // The DB column `unitCost` now holds the case cost from the invoice.
+    // The DB column `unitCost` holds the case cost from the invoice.
+    // Selling-unit cost is always caseCost / unitsPerCase — the parser is responsible
+    // for setting unitsPerCase to the number of sellable units per case (PPC column).
     if (line.unitCost != null) {
       const caseCost = Number(line.unitCost);
-      const combinedTitle = `${variant.product.title} ${variant.title ?? ''}`;
-      const isCase = isCasePricedVariant(combinedTitle);
       const proposed = computeCostPerSellingUnit({
-        combinedTitle,
         caseCost,
         unitsPerCase: line.unitsPerCase,
       });
 
-      // Plausibility guard for single-bottle variants only: if the computed cost is more
-      // than 3× the variant's retail price, the OCR almost certainly returned a per-line
-      // total or got unitsPerCase wrong. Refuse the write rather than corrupt costPerUnit.
+      // Plausibility guard: if the proposed selling-unit cost is more than 3× the
+      // variant's retail price, the OCR almost certainly got caseCost or unitsPerCase
+      // wrong. Refuse the write rather than corrupt costPerUnit.
       const retailDollars = variant.price != null ? Number(variant.price) : null;
       const blocked =
-        !isCase && retailDollars != null && retailDollars > 0 && proposed > retailDollars * 3;
+        retailDollars != null && retailDollars > 0 && proposed > retailDollars * 3;
 
       if (blocked) {
         const label =


### PR DESCRIPTION
Drops the title-based 'is this case-priced?' heuristic in favor of always dividing caseCost by unitsPerCase, where unitsPerCase comes from the invoice's PPC column (or PACK fallback). Correctly handles variety packs (Cutwater 6/4) which the title heuristic was getting wrong.

Worked examples:
- Austin 85 Whiskey (RNDC, PACK=6): $143.94 case → **$23.99/bottle**
- Cutwater Margarita variety (Brown, PPC=6): caseCost / 6 → **per-4-pack**
- Coors Light 24-pack (Brown, PPC=1): $24.95 → **$24.95/case** (unchanged)
- Cabernet 750ml (PPC=12): $180 → **$15/bottle** (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)