### PR TITLE
fix(ghl): include dashboard_url in order webhook + persist host email/phone on Premier dashboards

### DIFF
--- a/src/app/api/cron/reconcile-orders/route.ts
+++ b/src/app/api/cron/reconcile-orders/route.ts
@@ -268,7 +268,10 @@ export async function GET(request: NextRequest) {
               })),
             },
           },
-          include: { items: true },
+          include: {
+            items: true,
+            groupOrderV2: { select: { shareCode: true } },
+          },
         });
 
         // Link order to payment

--- a/src/app/api/webhooks/create-dashboard/route.ts
+++ b/src/app/api/webhooks/create-dashboard/route.ts
@@ -67,6 +67,8 @@ export async function POST(request: NextRequest) {
   try {
     const result = await createMultiTabDashboardOrder({
       hostName: payload.customer_name,
+      hostEmail: payload.customer_email || undefined,
+      hostPhone: payload.customer_phone || undefined,
       dashboardTitle,
       deliveryDate: payload.cruise_date,
       deliveryTime,

--- a/src/lib/group-orders-v2/service.ts
+++ b/src/lib/group-orders-v2/service.ts
@@ -997,6 +997,8 @@ export async function createMultiTabDashboardOrder(
     data: {
       name: input.dashboardTitle,
       hostName: input.hostName,
+      hostEmail: input.hostEmail || null,
+      hostPhone: input.hostPhone || null,
       shareCode,
       hostClaimToken,
       partyType: input.partyType || null,

--- a/src/lib/group-orders-v2/types.ts
+++ b/src/lib/group-orders-v2/types.ts
@@ -234,6 +234,8 @@ export interface MultiTabPreset {
 
 export interface CreateMultiTabDashboardInput {
   hostName: string;
+  hostEmail?: string;
+  hostPhone?: string;
   dashboardTitle: string;
   deliveryDate: string;
   deliveryTime: string;

--- a/src/lib/inventory/services/order-service.ts
+++ b/src/lib/inventory/services/order-service.ts
@@ -38,6 +38,8 @@ export interface OrderWithItems {
   customerPhone: string | null;
   customerName: string;
   items: OrderItemWithProduct[];
+  groupOrderV2Id?: string | null;
+  groupOrderV2?: { shareCode: string } | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -477,7 +479,7 @@ export async function createOrderFromCheckout(
           session.metadata?.utmCampaign
         ),
       },
-      include: { items: true },
+      include: { items: true, groupOrderV2: { select: { shareCode: true } } },
     });
 
     // Create order items
@@ -510,7 +512,7 @@ export async function createOrderFromCheckout(
     // Get the order with items
     const orderWithItems = await tx.order.findUnique({
       where: { id: newOrder.id },
-      include: { items: true },
+      include: { items: true, groupOrderV2: { select: { shareCode: true } } },
     });
 
     return orderWithItems;
@@ -616,7 +618,7 @@ export async function createFreeOrder(
         customerName,
         affiliateId: affiliateId || undefined,
       },
-      include: { items: true },
+      include: { items: true, groupOrderV2: { select: { shareCode: true } } },
     });
 
     for (const item of cart.items) {
@@ -647,7 +649,7 @@ export async function createFreeOrder(
 
     return await tx.order.findUnique({
       where: { id: newOrder.id },
-      include: { items: true },
+      include: { items: true, groupOrderV2: { select: { shareCode: true } } },
     });
   });
 
@@ -715,7 +717,7 @@ export async function getCustomerOrders(
   const [orders, total] = await Promise.all([
     prisma.order.findMany({
       where: { customerId },
-      include: { items: true },
+      include: { items: true, groupOrderV2: { select: { shareCode: true } } },
       orderBy: { createdAt: 'desc' },
       skip,
       take: pageSize,
@@ -845,7 +847,7 @@ export async function getOrders(options: {
   const [orders, total] = await Promise.all([
     prisma.order.findMany({
       where,
-      include: { items: true },
+      include: { items: true, groupOrderV2: { select: { shareCode: true } } },
       orderBy: { createdAt: 'desc' },
       skip,
       take: pageSize,
@@ -941,7 +943,7 @@ export async function createOrderFromDraftOrder(
         customerName,
         groupOrderId: draftOrder.groupOrderId,
       },
-      include: { items: true },
+      include: { items: true, groupOrderV2: { select: { shareCode: true } } },
     });
 
     // Create order items (handle custom items that may not have real product/variant IDs)
@@ -1021,7 +1023,7 @@ export async function createOrderFromDraftOrder(
     // Get the order with items
     const orderWithItems = await tx.order.findUnique({
       where: { id: newOrder.id },
-      include: { items: true },
+      include: { items: true, groupOrderV2: { select: { shareCode: true } } },
     });
 
     return orderWithItems;

--- a/src/lib/stripe/group-v2-payments.ts
+++ b/src/lib/stripe/group-v2-payments.ts
@@ -539,7 +539,10 @@ export async function handleGroupV2PaymentCompleted(
         })),
       },
     },
-    include: { items: true },
+    include: {
+      items: true,
+      groupOrderV2: { select: { shareCode: true } },
+    },
   });
 
   // Link order to payment (acts as idempotency marker for retries)

--- a/src/lib/webhooks/ghl.ts
+++ b/src/lib/webhooks/ghl.ts
@@ -41,6 +41,10 @@ export interface GhlOrderPayload {
   deliveryType: string;
   deliveryInstructions: string;
   createdAt: string;
+  // Dashboard link for orders placed under a GroupOrderV2 (Premier cruise,
+  // partner-page dashboard, etc.). Empty string when the order has no group.
+  dashboard_url: string;
+  share_code: string;
 }
 
 /** Shape accepted by buildGhlPayload — matches OrderWithItems and raw Prisma orders */
@@ -67,6 +71,10 @@ interface OrderLike {
   deliveryType?: string;
   deliveryInstructions: string | null;
   createdAt: Date;
+  // Optional GroupOrderV2 link — when present, populates dashboard_url so the
+  // GHL SMS workflow can include the dashboard link in its template.
+  groupOrderV2Id?: string | null;
+  groupOrderV2?: { shareCode: string } | null;
 }
 
 // ──────────────────────────────────────────────
@@ -110,6 +118,10 @@ export function buildGhlPayload(order: OrderLike, orderType: string): GhlOrderPa
   const nameParts = order.customerName.trim().split(/\s+/);
   const firstName = nameParts[0] || '';
   const lastName = nameParts.slice(1).join(' ') || '';
+  const shareCode = order.groupOrderV2?.shareCode || '';
+  const dashboardUrl = shareCode
+    ? `https://partyondelivery.com/dashboard/${shareCode}`
+    : '';
 
   return {
     event: 'order.created',
@@ -139,6 +151,8 @@ export function buildGhlPayload(order: OrderLike, orderType: string): GhlOrderPa
     deliveryType: order.deliveryType || 'HOUSE',
     deliveryInstructions: order.deliveryInstructions || '',
     createdAt: order.createdAt.toISOString(),
+    dashboard_url: dashboardUrl,
+    share_code: shareCode,
   };
 }
 


### PR DESCRIPTION
## Summary

Two related GHL/Premier bugs surfaced when investigating Adrianna Aranza's booking — fixed both, plus backfilled the historical data.

### Bug 1 — `GroupOrderV2.hostEmail` / `hostPhone` not persisted

`createMultiTabDashboardOrder` never wrote `hostEmail` or `hostPhone` to the row, so 127 Premier-webhook dashboards stored empty contact info. The Premier-side `dashboard.created` SMS still worked because the email/phone go directly to GHL via webhook payload, but the DB record was broken — ops lookups, weekly-summary "host contact" lines, and any future code reading the row hit `null`.

**Fix:** thread `customer_email` and `customer_phone` from the Premier webhook payload all the way into the `prisma.groupOrderV2.create` call. Added matching optional fields to `CreateMultiTabDashboardInput`.

**Backfill:** the 119 affected records (those with an `externalBookingId` and a `SUCCESS` row in `affiliateWebhookLog`) were patched in production via an ad-hoc Prisma update script that copies the email/phone from the original webhook payload. Verified Adrianna's record now reads `hostEmail: adriannaaranza@yahoo.com`, `hostPhone: 8329976830`.

### Bug 2 — `notifyNewOrder` had no `dashboard_url`

The `order.created` webhook to GHL had no field linking back to the dashboard. When a customer paid an order placed via a Premier dashboard, GHL's "thanks for ordering" SMS workflow had no way to include the dashboard link.

**Fix:** `GhlOrderPayload` gains `dashboard_url` and `share_code`. `buildGhlPayload` reads the linked `GroupOrderV2`'s `shareCode` and constructs `https://partyondelivery.com/dashboard/<shareCode>`. All callers now load the order with `include: { items: true, groupOrderV2: { select: { shareCode: true } } }`. Non-group orders get an empty string so the GHL workflow can branch on it.

## Files

- `src/lib/group-orders-v2/types.ts` — `CreateMultiTabDashboardInput` adds optional `hostEmail`, `hostPhone`
- `src/lib/group-orders-v2/service.ts` — persist them on `prisma.groupOrderV2.create`
- `src/app/api/webhooks/create-dashboard/route.ts` — forward `customer_email` / `customer_phone` from the Premier payload
- `src/lib/webhooks/ghl.ts` — `GhlOrderPayload` + `OrderLike` get `dashboard_url`/`share_code`/`groupOrderV2`; `buildGhlPayload` populates them
- `src/lib/inventory/services/order-service.ts` — every order creation/load includes `groupOrderV2.shareCode`; `OrderWithItems` interface updated
- `src/lib/stripe/group-v2-payments.ts` — group V2 order create includes `groupOrderV2.shareCode`
- `src/app/api/cron/reconcile-orders/route.ts` — recovered group V2 orders include `groupOrderV2.shareCode`

## Operator action (GHL side)

This fix only delivers `dashboard_url` to GHL — the SMS template needs to be updated to use it. In the GHL "order.created" workflow, add `{{dashboard_url}}` to the SMS body with a guard for the empty case (e.g. an If/Else step on `share_code`) so non-group orders don't get a broken sentence.

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] On staging or prod after deploy: place a test order via a dashboard and confirm the GHL webhook receives `dashboard_url` populated
- [ ] Place a non-group test order and confirm `dashboard_url` is `""`
- [ ] Verify GHL workflow renders the SMS correctly in both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)