### PR TITLE
feat(marketing): rec status mirror to GitHub + 14-day measurement loop

### DIFF
--- a/src/app/admin/analytics/recommendations/page.tsx
+++ b/src/app/admin/analytics/recommendations/page.tsx
@@ -16,6 +16,15 @@ type Status = 'open' | 'approved' | 'shipped' | 'rejected' | 'invalidated';
 type RiskTier = 'autonomous' | 'recommend' | 'hard_stop';
 type EffortTier = 's' | 'm' | 'l';
 
+interface MetricSnapshot {
+  capturedAt: string;
+  snapshotDate: string;
+  revenue: number;
+  orders: number;
+  averageOrderValue: number;
+  marginCoveragePct: number | null;
+}
+
 interface Recommendation {
   id: string;
   generatedAt: string;
@@ -32,6 +41,8 @@ interface Recommendation {
   status: Status;
   shippedAt: string | null;
   notes: string | null;
+  resultMetricBefore: MetricSnapshot | null;
+  resultMetricAfter: MetricSnapshot | null;
 }
 
 const STATUS_TABS: { value: Status | 'all'; label: string }[] = [
@@ -269,6 +280,11 @@ export default function RecommendationsTriagePage(): ReactElement {
                       </div>
                     </div>
 
+                    {/* Measurement block — appears for shipped recs once before is captured */}
+                    {(rec.resultMetricBefore || rec.resultMetricAfter) && (
+                      <MeasurementBlock before={rec.resultMetricBefore} after={rec.resultMetricAfter} />
+                    )}
+
                     {/* Notes block */}
                     <div className="mt-4 pt-4 border-t border-gray-100">
                       {isEditingThisNotes ? (
@@ -344,6 +360,73 @@ function StatusBadge({ status }: { status: Status }): ReactElement {
     >
       {status}
     </span>
+  );
+}
+
+function MeasurementBlock({
+  before,
+  after,
+}: {
+  before: MetricSnapshot | null;
+  after: MetricSnapshot | null;
+}): ReactElement {
+  const fmtMoney = (n: number) => `$${n.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+  const fmtDelta = (b: number | null, a: number | null) => {
+    if (b == null || a == null || b === 0) return null;
+    const pct = ((a - b) / b) * 100;
+    const arrow = pct > 0 ? '↑' : pct < 0 ? '↓' : '—';
+    return { pct, label: `${arrow} ${Math.abs(pct).toFixed(0)}%` };
+  };
+
+  const revenueDelta = before && after ? fmtDelta(before.revenue, after.revenue) : null;
+  const ordersDelta = before && after ? fmtDelta(before.orders, after.orders) : null;
+  const aovDelta = before && after ? fmtDelta(before.averageOrderValue, after.averageOrderValue) : null;
+  const coverageDelta =
+    before && after && before.marginCoveragePct != null && after.marginCoveragePct != null
+      ? fmtDelta(before.marginCoveragePct, after.marginCoveragePct)
+      : null;
+
+  const toneClass = (d: { pct: number } | null) =>
+    d == null
+      ? 'text-gray-400'
+      : d.pct > 0
+      ? 'text-green-700'
+      : d.pct < 0
+      ? 'text-red-600'
+      : 'text-gray-600';
+
+  return (
+    <div className="mt-4 pt-4 border-t border-gray-100">
+      <div className="text-xs uppercase tracking-wider text-gray-500 font-semibold mb-2">
+        Measurement {after ? '(14 days post-ship)' : '(awaiting 14-day capture)'}
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
+        {[
+          { label: 'Revenue', before: before?.revenue, after: after?.revenue, delta: revenueDelta, fmt: fmtMoney },
+          { label: 'Orders', before: before?.orders, after: after?.orders, delta: ordersDelta, fmt: (n: number) => n.toString() },
+          { label: 'AOV', before: before?.averageOrderValue, after: after?.averageOrderValue, delta: aovDelta, fmt: fmtMoney },
+          {
+            label: 'Coverage',
+            before: before?.marginCoveragePct ?? null,
+            after: after?.marginCoveragePct ?? null,
+            delta: coverageDelta,
+            fmt: (n: number) => `${n}%`,
+          },
+        ].map((m) => (
+          <div key={m.label} className="bg-gray-50 rounded-lg p-3">
+            <div className="text-xs text-gray-500 uppercase tracking-wider mb-1">{m.label}</div>
+            <div className="text-base font-semibold text-gray-900">
+              {m.before != null ? m.fmt(m.before) : '—'}
+              {' → '}
+              {m.after != null ? m.fmt(m.after) : <span className="text-gray-400">pending</span>}
+            </div>
+            {m.delta && (
+              <div className={`text-xs font-semibold mt-0.5 ${toneClass(m.delta)}`}>{m.delta.label}</div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
   );
 }
 

--- a/src/app/api/admin/analytics/recommendations/route.ts
+++ b/src/app/api/admin/analytics/recommendations/route.ts
@@ -6,6 +6,7 @@ import {
   updateRecommendationStatus,
   type RecommendationStatus,
 } from '@/lib/analytics/recommendation-store';
+import { mirrorRecommendation } from '@/lib/analytics/recommendation-mirror';
 
 export const dynamic = 'force-dynamic';
 
@@ -54,8 +55,25 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         { status: 400 }
       );
     }
-    const updated = await updateRecommendationStatus(body.id, status as RecommendationStatus, notes);
-    return NextResponse.json({ data: updated });
+    const { updated, priorStatus } = await updateRecommendationStatus(
+      body.id,
+      status as RecommendationStatus,
+      notes
+    );
+
+    // Mirror to GitHub (fail-soft). Only mirror on actual transitions to avoid noise.
+    let mirror: { mirrored: boolean; error?: string } | undefined;
+    if (priorStatus !== status) {
+      mirror = await mirrorRecommendation(updated, {
+        date: new Date().toISOString().slice(0, 10),
+        fromStatus: priorStatus,
+        toStatus: status,
+        notes,
+        actor: 'operator',
+      });
+    }
+
+    return NextResponse.json({ data: updated, mirror });
   }
 
   // Create path: { title, body?, segment?, impactDollarsMonthly?, effortTier?, riskTier?, source? }

--- a/src/app/api/cron/measure-recommendations/route.ts
+++ b/src/app/api/cron/measure-recommendations/route.ts
@@ -1,0 +1,93 @@
+/**
+ * Measurement cron — closes the recommendation outcome loop.
+ *
+ * Runs daily. For every shipped recommendation that has a resultMetricBefore but
+ * no resultMetricAfter, and shippedAt is at least MEASUREMENT_WINDOW_DAYS ago,
+ * captures a fresh metric snapshot into resultMetricAfter and re-mirrors the file.
+ *
+ * Auth: Bearer CRON_SECRET (same as other crons).
+ *
+ * vercel.json: { "path": "/api/cron/measure-recommendations", "schedule": "0 14 * * *" }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import type { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/database/client';
+import { mirrorRecommendation } from '@/lib/analytics/recommendation-mirror';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 120;
+
+const MEASUREMENT_WINDOW_DAYS = 14;
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = request.headers.get('authorization');
+  if (auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const cutoff = new Date(Date.now() - MEASUREMENT_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+
+  const due = await prisma.recommendationItem.findMany({
+    where: {
+      status: 'shipped',
+      shippedAt: { lte: cutoff },
+      resultMetricBefore: { not: undefined },
+      resultMetricAfter: { equals: undefined },
+    },
+    take: 50,
+  });
+
+  if (due.length === 0) {
+    return NextResponse.json({ ok: true, measured: 0, note: 'no recommendations due for measurement' });
+  }
+
+  const snapshot = await prisma.analyticsSnapshot.findFirst({
+    orderBy: { date: 'desc' },
+    select: {
+      date: true,
+      revenue: true,
+      orders: true,
+      averageOrderValue: true,
+      marginData: true,
+      segmentData: true,
+    },
+  });
+
+  if (!snapshot) {
+    return NextResponse.json({ ok: false, error: 'no analytics snapshot available for measurement' }, { status: 503 });
+  }
+
+  const marginData = (snapshot.marginData ?? {}) as { coveragePct?: number; affiliateRoi?: unknown[] };
+  const segmentData = (snapshot.segmentData ?? {}) as { segments?: unknown[] };
+
+  const after: Record<string, unknown> = {
+    capturedAt: new Date().toISOString(),
+    snapshotDate: snapshot.date.toISOString().slice(0, 10),
+    revenue: Number(snapshot.revenue ?? 0),
+    orders: snapshot.orders,
+    averageOrderValue: Number(snapshot.averageOrderValue ?? 0),
+    marginCoveragePct: marginData.coveragePct ?? null,
+    affiliateRoi: marginData.affiliateRoi ?? null,
+    segments: segmentData.segments ?? null,
+  };
+
+  const measured: Array<{ id: string; title: string; mirrored: boolean }> = [];
+
+  for (const rec of due) {
+    const updated = await prisma.recommendationItem.update({
+      where: { id: rec.id },
+      data: { resultMetricAfter: after as Prisma.InputJsonValue },
+    });
+    const mirror = await mirrorRecommendation(updated, {
+      date: new Date().toISOString().slice(0, 10),
+      fromStatus: 'shipped',
+      toStatus: 'shipped',
+      notes: 'Auto-captured 14-day measurement',
+      actor: 'cron:measure-recommendations',
+    });
+    measured.push({ id: rec.id, title: rec.title, mirrored: mirror.mirrored });
+  }
+
+  return NextResponse.json({ ok: true, measured: measured.length, items: measured });
+}

--- a/src/lib/analytics/briefing-delivery.ts
+++ b/src/lib/analytics/briefing-delivery.ts
@@ -11,10 +11,7 @@ import {
   renderBriefingEmail,
   type BriefingEmailData,
 } from '@/lib/email/templates/marketing-briefing';
-
-const REPO_OWNER = process.env.GITHUB_REPO_OWNER ?? 'allan-cmyk';
-const REPO_NAME = process.env.GITHUB_REPO_NAME ?? 'PartyOn2';
-const REPO_BRANCH = process.env.GITHUB_REPO_BRANCH ?? 'main';
+import { putFileToRepo } from '@/lib/github/put-file';
 
 export interface DeliveryResult {
   email: { sent: boolean; error?: string };
@@ -98,78 +95,26 @@ function escapeHtml(s: string): string {
 /* -------------------- Commit to GitHub repo -------------------- */
 
 async function commitToRepo(p: BriefingPayload): Promise<DeliveryResult['commit']> {
-  const token = process.env.GITHUB_REPO_TOKEN;
-  if (!token) {
-    return { committed: false, error: 'GITHUB_REPO_TOKEN not configured' };
-  }
-
-  // Commit Stage A and (if present) Stage B as two separate files in one commit attempt each.
-  // We use the simple "create or update file" endpoint — fine for low volume.
-  const stageARes = await putFile(token, `docs/marketing/weekly/${p.weekLabel}.md`, p.stageA, `chore(marketing): weekly briefing ${p.weekLabel}`);
-  let stageBSha: string | undefined;
-  let stageBHtmlUrl: string | undefined;
-
-  if (p.stageB) {
-    const stageBRes = await putFile(
-      token,
-      `docs/marketing/weekly/${p.weekLabel}-director.md`,
-      p.stageB,
-      `chore(marketing): weekly briefing narrative ${p.weekLabel}`
-    );
-    if (stageBRes.error) {
-      // Stage A succeeded but Stage B failed — surface the error but consider commit "done"
-      return { committed: true, sha: stageARes.sha, url: stageARes.htmlUrl, error: `stageB: ${stageBRes.error}` };
-    }
-    stageBSha = stageBRes.sha;
-    stageBHtmlUrl = stageBRes.htmlUrl;
-  }
-
-  if (stageARes.error) {
-    return { committed: false, error: stageARes.error };
-  }
-
-  return { committed: true, sha: stageBSha ?? stageARes.sha, url: stageBHtmlUrl ?? stageARes.htmlUrl };
-}
-
-interface PutFileResult {
-  sha?: string;
-  htmlUrl?: string;
-  error?: string;
-}
-
-async function putFile(token: string, path: string, content: string, message: string): Promise<PutFileResult> {
-  const url = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/contents/${path}`;
-  const headers = {
-    Authorization: `Bearer ${token}`,
-    Accept: 'application/vnd.github+json',
-    'X-GitHub-Api-Version': '2022-11-28',
-  };
-
-  // GET to learn the existing SHA (so the PUT can update rather than reject as a duplicate path).
-  let existingSha: string | undefined;
-  const getRes = await fetch(`${url}?ref=${REPO_BRANCH}`, { headers });
-  if (getRes.ok) {
-    const body = (await getRes.json()) as { sha?: string };
-    existingSha = body.sha;
-  }
-  // 404 here is fine — file doesn't exist yet, we'll create.
-
-  const putRes = await fetch(url, {
-    method: 'PUT',
-    headers: { ...headers, 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      message,
-      content: Buffer.from(content, 'utf-8').toString('base64'),
-      branch: REPO_BRANCH,
-      ...(existingSha ? { sha: existingSha } : {}),
-    }),
+  const stageARes = await putFileToRepo({
+    path: `docs/marketing/weekly/${p.weekLabel}.md`,
+    content: p.stageA,
+    message: `chore(marketing): weekly briefing ${p.weekLabel}`,
   });
 
-  if (!putRes.ok) {
-    const body = await putRes.text();
-    return { error: `GitHub PUT ${putRes.status}: ${body.slice(0, 300)}` };
+  if (p.stageB) {
+    const stageBRes = await putFileToRepo({
+      path: `docs/marketing/weekly/${p.weekLabel}-director.md`,
+      content: p.stageB,
+      message: `chore(marketing): weekly briefing narrative ${p.weekLabel}`,
+    });
+    if (stageBRes.error && stageARes.committed) {
+      return { committed: true, sha: stageARes.sha, url: stageARes.htmlUrl, error: `stageB: ${stageBRes.error}` };
+    }
+    if (stageBRes.committed) {
+      return { committed: true, sha: stageBRes.sha, url: stageBRes.htmlUrl };
+    }
   }
 
-  const body = (await putRes.json()) as { content?: { sha?: string; html_url?: string } };
-  return { sha: body.content?.sha, htmlUrl: body.content?.html_url };
+  if (!stageARes.committed) return { committed: false, error: stageARes.error };
+  return { committed: true, sha: stageARes.sha, url: stageARes.htmlUrl };
 }

--- a/src/lib/analytics/recommendation-mirror.ts
+++ b/src/lib/analytics/recommendation-mirror.ts
@@ -1,0 +1,177 @@
+/**
+ * Recommendation mirror — renders a RecommendationItem as Obsidian-shaped markdown
+ * (frontmatter + body + Updates log) and commits to GitHub at
+ * docs/marketing/recommendations/<slug>.md.
+ *
+ * Triggered on every status change via the API POST handler. Fails soft so an
+ * unconfigured GITHUB_REPO_TOKEN doesn't block the DB update.
+ */
+
+import type { RecommendationItem } from '@prisma/client';
+import { putFileToRepo } from '@/lib/github/put-file';
+
+export interface MirrorResult {
+  mirrored: boolean;
+  path?: string;
+  url?: string;
+  error?: string;
+}
+
+/**
+ * Status change event we want to record in the Updates log.
+ */
+export interface StatusChangeEvent {
+  date: string;            // YYYY-MM-DD
+  fromStatus: string | null;
+  toStatus: string;
+  notes?: string;
+  actor?: string;          // 'operator' | 'agent' | etc.
+}
+
+/**
+ * Render a recommendation as the canonical markdown doc, optionally appending a new
+ * status-change event to the Updates log. The renderer reconstructs the full doc
+ * from the DB record + the new event each time — there's no stateful append on disk.
+ *
+ * Existing Updates entries are reconstructed from the rec's createdAt + status history
+ * we keep in DB columns where possible. Where we don't have history, we synthesize a
+ * single creation entry. The result is "good enough" — the GitHub commit history is
+ * the audit log of record.
+ */
+export function renderRecommendationMarkdown(
+  rec: RecommendationItem,
+  newEvent?: StatusChangeEvent
+): string {
+  const slug = slugifyTitle(rec.title);
+  const period = isoWeekFromDate(rec.generatedAt);
+  const datesAccepted = rec.status === 'approved' || rec.status === 'shipped' ? rec.generatedAt : null;
+  const dateExecuted = rec.status === 'shipped' ? rec.shippedAt : null;
+
+  const fm: Array<[string, string | number | null | string[]]> = [
+    ['title', JSON.stringify(rec.title)],
+    ['period_proposed', period],
+    ['date_proposed', rec.generatedAt.toISOString().slice(0, 10)],
+    ['date_accepted', datesAccepted ? datesAccepted.toISOString().slice(0, 10) : 'null'],
+    ['date_executed', dateExecuted ? dateExecuted.toISOString().slice(0, 10) : 'null'],
+    ['date_measured', 'null'],
+    ['status', mapDbStatusToObsidian(rec.status)],
+    ['risk_tier', rec.riskTier],
+    ['effort', rec.effortTier ? rec.effortTier.toUpperCase() : 'M'],
+    ['impact_dollars_monthly', rec.impactDollarsMonthly ?? 'null'],
+    ['segment', rec.segment ?? 'all'],
+    ['source', rec.source === 'auto-snapshot' ? 'snapshot-heuristic' : rec.source],
+    ['related_briefing', period],
+    ['db_id', rec.id],
+    ['tags', '[recommendation]'],
+  ];
+
+  const fmBlock = fm.map(([k, v]) => `${k}: ${v}`).join('\n');
+
+  const body = (rec.body ?? '').trim() || '_(no body provided)_';
+  const notes = (rec.notes ?? '').trim();
+
+  // Build Updates log: synthesize creation entry, plus any new event.
+  const updates: string[] = [];
+  updates.push(`- ${rec.generatedAt.toISOString().slice(0, 10)} — Created with status \`${mapDbStatusToObsidian(rec.status)}\` from source \`${rec.source}\`.`);
+  if (newEvent) {
+    const noteSuffix = newEvent.notes ? ` Notes: ${newEvent.notes}` : '';
+    const actor = newEvent.actor ?? 'operator';
+    const transition = newEvent.fromStatus
+      ? `${newEvent.fromStatus} → ${newEvent.toStatus}`
+      : `set to ${newEvent.toStatus}`;
+    updates.push(`- ${newEvent.date} — Status ${transition} (${actor}).${noteSuffix}`);
+  }
+
+  const measurementSection = (rec.resultMetricBefore || rec.resultMetricAfter)
+    ? `\n## Measurement\n\n${renderMeasurementBlock(rec)}\n`
+    : '';
+
+  return `---
+${fmBlock}
+---
+
+# ${rec.title}
+
+## What
+
+${body}
+
+${notes ? `## Notes\n\n${notes}\n\n` : ''}${measurementSection}## Updates
+
+${updates.join('\n')}
+
+---
+_Mirror file. Edited automatically by the triage queue when status changes. Source of truth is the database (id: \`${rec.id}\`). Slug: \`${slug}\`._
+`;
+}
+
+function renderMeasurementBlock(rec: RecommendationItem): string {
+  const before = rec.resultMetricBefore ? `\n\`\`\`json\n${JSON.stringify(rec.resultMetricBefore, null, 2)}\n\`\`\`` : '_(not captured)_';
+  const after = rec.resultMetricAfter ? `\n\`\`\`json\n${JSON.stringify(rec.resultMetricAfter, null, 2)}\n\`\`\`` : '_(not yet captured — typically 14 days after shipping)_';
+  return `### Before (snapshot at time of shipping)\n${before}\n\n### After\n${after}`;
+}
+
+function mapDbStatusToObsidian(s: string): string {
+  // DB statuses: open | approved | shipped | rejected | invalidated
+  // Obsidian conventional statuses: proposed | accepted | executed | measured | dismissed | superseded
+  // Map db → obsidian to match the README schema.
+  switch (s) {
+    case 'open':
+      return 'proposed';
+    case 'approved':
+      return 'accepted';
+    case 'shipped':
+      return 'executed';
+    case 'rejected':
+      return 'dismissed';
+    case 'invalidated':
+      return 'superseded';
+    default:
+      return s;
+  }
+}
+
+export function slugifyTitle(t: string): string {
+  return t
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60);
+}
+
+function isoWeekFromDate(date: Date): string {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const dayNum = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const week = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+  return `${d.getUTCFullYear()}-W${String(week).padStart(2, '0')}`;
+}
+
+/**
+ * Commit the recommendation mirror to GitHub. Path: docs/marketing/recommendations/<period>-<slug>.md
+ * Returns soft-fail result; never throws.
+ */
+export async function mirrorRecommendation(
+  rec: RecommendationItem,
+  event?: StatusChangeEvent
+): Promise<MirrorResult> {
+  try {
+    const slug = slugifyTitle(rec.title);
+    const period = isoWeekFromDate(rec.generatedAt);
+    const path = `docs/marketing/recommendations/${period}-${slug}.md`;
+    const message = event
+      ? `chore(marketing): rec "${rec.title.slice(0, 50)}" → ${event.toStatus}`
+      : `chore(marketing): mirror rec "${rec.title.slice(0, 50)}"`;
+    const content = renderRecommendationMarkdown(rec, event);
+    const result = await putFileToRepo({ path, content, message });
+    return {
+      mirrored: result.committed,
+      path,
+      url: result.htmlUrl,
+      error: result.error,
+    };
+  } catch (err) {
+    return { mirrored: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/src/lib/analytics/recommendation-store.ts
+++ b/src/lib/analytics/recommendation-store.ts
@@ -9,6 +9,7 @@
  */
 
 import { prisma } from '@/lib/database/client';
+import type { Prisma } from '@prisma/client';
 
 export type RecommendationSource = 'auto-snapshot' | 'director' | 'manual';
 export type RiskTier = 'autonomous' | 'recommend' | 'hard_stop';
@@ -104,12 +105,66 @@ export async function updateRecommendationStatus(
   status: RecommendationStatus,
   notes?: string
 ) {
-  return prisma.recommendationItem.update({
+  // Capture prior status so callers can decide whether to mirror / log a transition.
+  const prior = await prisma.recommendationItem.findUnique({
+    where: { id },
+    select: { status: true, resultMetricBefore: true },
+  });
+  const priorStatus = prior?.status ?? null;
+
+  // On status → shipped, capture a snapshot of the relevant metrics into resultMetricBefore.
+  // (No-op if already populated — preserves the original snapshot from the first ship.)
+  let resultMetricBeforeUpdate: Record<string, unknown> | undefined;
+  if (status === 'shipped' && !prior?.resultMetricBefore) {
+    try {
+      resultMetricBeforeUpdate = await captureMetricSnapshot();
+    } catch (err) {
+      console.warn('[recommendation-store] metric capture failed at ship time:', err);
+    }
+  }
+
+  const updated = await prisma.recommendationItem.update({
     where: { id },
     data: {
       status,
       ...(status === 'shipped' ? { shippedAt: new Date() } : {}),
       ...(notes ? { notes } : {}),
+      ...(resultMetricBeforeUpdate ? { resultMetricBefore: resultMetricBeforeUpdate as Prisma.InputJsonValue } : {}),
     },
   });
+
+  return { updated, priorStatus };
+}
+
+/**
+ * Capture a small JSON snapshot of the metrics we care about at ship time.
+ * Pulls from the latest AnalyticsSnapshot. Returns `null` if no snapshot exists yet.
+ */
+async function captureMetricSnapshot(): Promise<Record<string, unknown> | undefined> {
+  const snapshot = await prisma.analyticsSnapshot.findFirst({
+    orderBy: { date: 'desc' },
+    select: {
+      date: true,
+      revenue: true,
+      orders: true,
+      averageOrderValue: true,
+      marginData: true,
+      segmentData: true,
+    },
+  });
+  if (!snapshot) return undefined;
+
+  const marginData = (snapshot.marginData ?? {}) as { coveragePct?: number; affiliateRoi?: unknown[] };
+  const segmentData = (snapshot.segmentData ?? {}) as { segments?: unknown[] };
+
+  return {
+    capturedAt: new Date().toISOString(),
+    snapshotDate: snapshot.date.toISOString().slice(0, 10),
+    revenue: Number(snapshot.revenue ?? 0),
+    orders: snapshot.orders,
+    averageOrderValue: Number(snapshot.averageOrderValue ?? 0),
+    marginCoveragePct: marginData.coveragePct ?? null,
+    affiliateRoi: marginData.affiliateRoi ?? null,
+    segments: segmentData.segments ?? null,
+  };
 }

--- a/src/lib/github/put-file.ts
+++ b/src/lib/github/put-file.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared GitHub "create or update file" helper. Used by the marketing briefing
+ * delivery and the recommendation mirror. Server-side only — relies on the
+ * GITHUB_REPO_TOKEN env var.
+ *
+ * If GITHUB_REPO_TOKEN is unset, the put returns { committed: false, error } and
+ * callers fail-soft so cron / API responses stay green.
+ */
+
+const REPO_OWNER = process.env.GITHUB_REPO_OWNER ?? 'allan-cmyk';
+const REPO_NAME = process.env.GITHUB_REPO_NAME ?? 'PartyOn2';
+const REPO_BRANCH = process.env.GITHUB_REPO_BRANCH ?? 'main';
+
+export interface PutFileResult {
+  committed: boolean;
+  sha?: string;
+  htmlUrl?: string;
+  error?: string;
+}
+
+export async function putFileToRepo(params: {
+  path: string;
+  content: string;
+  message: string;
+}): Promise<PutFileResult> {
+  const token = process.env.GITHUB_REPO_TOKEN;
+  if (!token) {
+    return { committed: false, error: 'GITHUB_REPO_TOKEN not configured' };
+  }
+
+  const { path, content, message } = params;
+  const url = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/contents/${path}`;
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+
+  // GET to learn the existing SHA (so the PUT updates instead of erroring on duplicate path).
+  let existingSha: string | undefined;
+  const getRes = await fetch(`${url}?ref=${REPO_BRANCH}`, { headers });
+  if (getRes.ok) {
+    const body = (await getRes.json()) as { sha?: string };
+    existingSha = body.sha;
+  }
+  // 404 here is fine — file doesn't exist yet, we'll create.
+
+  const putRes = await fetch(url, {
+    method: 'PUT',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      message,
+      content: Buffer.from(content, 'utf-8').toString('base64'),
+      branch: REPO_BRANCH,
+      ...(existingSha ? { sha: existingSha } : {}),
+    }),
+  });
+
+  if (!putRes.ok) {
+    const body = await putRes.text();
+    return { committed: false, error: `GitHub PUT ${putRes.status}: ${body.slice(0, 300)}` };
+  }
+
+  const body = (await putRes.json()) as { content?: { sha?: string; html_url?: string } };
+  return { committed: true, sha: body.content?.sha, htmlUrl: body.content?.html_url };
+}

--- a/vercel.json
+++ b/vercel.json
@@ -29,6 +29,10 @@
       "schedule": "0 13 * * 1"
     },
     {
+      "path": "/api/cron/measure-recommendations",
+      "schedule": "0 8 * * *"
+    },
+    {
       "path": "/api/cron/group-orders-v2",
       "schedule": "0 */2 * * *"
     }


### PR DESCRIPTION
Closes the rec lifecycle that the triage queue was missing.

## What ships

- **Status sync (#1)**: every status change in the triage queue now commits a markdown mirror to `docs/marketing/recommendations/<period>-<slug>.md` via the GitHub API. Same path/Obsidian-shape as the seeded files in your local vault.
- **Measurement loop (#3)**: shipping a rec captures `resultMetricBefore` (revenue / orders / AOV / margin coverage from the latest analytics snapshot). A new daily cron at 08:00 UTC checks for shipped recs ≥14 days old and captures `resultMetricAfter` + delta. Triage UI shows the before → after deltas with color coding.
- **Helper extraction**: shared `src/lib/github/put-file.ts` so both the briefing delivery and the rec mirror use one GitHub helper.

## Test plan

- [ ] Click Approve on a rec → check that `docs/marketing/recommendations/<slug>.md` appears in the repo with status: accepted in frontmatter
- [ ] Click Mark shipped → resultMetricBefore populates in the DB; markdown shows a Measurement section with 'awaiting' for the after-side
- [ ] Manually trigger `curl -H "Authorization: Bearer $CRON_SECRET" /api/cron/measure-recommendations` after waiting 14 days (or rewinding shippedAt for testing) — resultMetricAfter populates, mirror re-commits, triage UI shows the delta

## Phase 2 (not yet)

"Approve = spawn a code session" is intentionally not built. Architectural sketch from the conversation:
- Async via cron (poll for approved + risk='autonomous' rows, kick off a session)
- Whitelist of action types per rec
- Explicit guardrails / rollback path

Wait until the lifecycle is well-exercised manually before adding autonomy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)