### PR TITLE
docs(codebase-docs): resync to current main — pick state, partners, marketing

### DIFF
--- a/codebase-docs/02-tech-stack-and-architecture.md
+++ b/codebase-docs/02-tech-stack-and-architecture.md
@@ -3,7 +3,7 @@ title: Tech Stack and Architecture
 project: PartyOn2
 doc_type: codebase-reference
 section: architecture
-last_generated: 2026-04-23
+last_generated: 2026-05-03
 tags: [partyondelivery, codebase, architecture, stack, env]
 ---
 
@@ -314,7 +314,7 @@ Grouped to match the section headers in `.env.example` at repo root. This list i
 | Script | What it does |
 |---|---|
 | `npm run dev` | Next.js dev server with Turbopack on port 3000. |
-| `npm run build` | `prisma generate` → hero-media scan → `next build`. |
+| `npm run build` | `prisma generate` → `scripts/scan-hero-media.js` → `scripts/scan-vacation-rental-hero.js` → `next build`. |
 | `npm run start` | Production Next.js server. |
 | `npm run lint` | Next.js ESLint wrapper. |
 | `npm run lint:tokens` | Custom design-token linter (`scripts/lint-design-tokens.js`). |

--- a/codebase-docs/03-routes-and-pages.md
+++ b/codebase-docs/03-routes-and-pages.md
@@ -3,7 +3,7 @@ title: Routes and Pages
 project: PartyOn2
 doc_type: codebase-reference
 section: routes
-last_generated: 2026-04-23
+last_generated: 2026-05-03
 tags: [partyondelivery, codebase, routes, api, pages]
 ---
 
@@ -93,6 +93,7 @@ Every `page.tsx` and `route.ts` discovered under `src/app/`. Paths are literal f
 | `/order/last-minute` | `src/app/order/last-minute/page.tsx` | Curated last-minute products. | — | No | Added in recent commits. |
 | `/partners` | `src/app/partners/page.tsx` | Partner program overview. | — | No | |
 | `/partners/[slug]` | `src/app/partners/[slug]/page.tsx` | Generic partner landing. | `slug` | No | iframe-embeddable. |
+| `/partners/pitch` | `src/app/partners/pitch/page.tsx` | 5-slide horizontal pitch deck for partner program. Mobile vertical-scroll fallback. | — | No | One-off; CTA → Calendly. |
 | `/partners/anderson-mill-marina-boat-club` | ... | Named partner. | — | No | |
 | `/partners/boat-babes` | ... | Named partner. | — | No | |
 | `/partners/cocktail-cowboys` | ... | Named partner. | — | No | |
@@ -267,6 +268,7 @@ v1 `/api/group-orders/*` and v2 `/api/v2/group-orders/*` are **both live** — v
 | `/api/ops/email-preview` | `.../email-preview/route.ts` | GET | Render email template. | Ops |
 | `/api/ops/email-preview/send` | `.../email-preview/send/route.ts` | POST | Send test email. | Ops |
 | `/api/ops/email-template-content` | `.../email-template-content/route.ts` | GET/PATCH | Edit template content. | Ops |
+| `/api/ops/orders/[id]/picks` | `.../orders/[id]/picks/route.ts` | GET/PUT | Persistent pick/pack state for the `/ops/orders` picker UI. Per `(orderId, itemKey)` row in `OrderItemPickState`; replaces prior per-browser localStorage so multiple devices see the same checkbox + short-by state. Added `86f58c77`. | Ops |
 
 ### Admin API namespaces — `/api/admin/*` vs `/api/v1/admin/*`
 
@@ -365,6 +367,7 @@ These are **parallel namespaces, not a migration** — neither supersedes the ot
 | `/api/v1/inventory/receiving/[id]` | `.../[id]/route.ts` | Detail. |
 | `/api/v1/inventory/receiving/[id]/apply` | `.../apply/route.ts` | Commit stock. |
 | `/api/v1/inventory/receiving/[id]/lines/[lineId]` | `.../[lineId]/route.ts` | Line edit. |
+| `/api/v1/inventory/variants/[id]` | `.../inventory/variants/[id]/route.ts` | PATCH — inline edits from the `/ops/inventory` page. Resolves quantity/committed/available/costPerUnit; `quantity > available > committed` write priority. |
 
 ### AI inventory & agent
 

--- a/codebase-docs/03-routes-and-pages.md
+++ b/codebase-docs/03-routes-and-pages.md
@@ -432,6 +432,7 @@ These are **parallel namespaces, not a migration** — neither supersedes the ot
 | `/api/cron/weekly-briefing` | `.../weekly-briefing/route.ts` | `0 13 * * 1` | Weekly Mon 13:00 UTC operator briefing email. |
 | `/api/cron/weekly-purchase-plan` | `.../weekly-purchase-plan/route.ts` | `0 13 * * 1` | Weekly Mon 13:00 UTC distributor purchase plan. |
 | `/api/cron/group-orders-v2` | `.../group-orders-v2/route.ts` | `0 */2 * * *` | Every 2h — locks expired `SubOrder` tabs (OPEN → LOCKED) and closes expired `GroupOrderV2` (ACTIVE → CLOSED). Added 2026-04-23. |
+| `/api/cron/measure-recommendations` | `.../measure-recommendations/route.ts` | `0 8 * * *` | Daily 08:00 UTC — captures the 14-day after-snapshot for shipped `MarketingRecommendation` rows (revenue/orders/AOV/margin coverage), then re-mirrors the markdown to GitHub. Added 2026-05-03. |
 
 ## Route groups & layouts
 

--- a/codebase-docs/05-data-model.md
+++ b/codebase-docs/05-data-model.md
@@ -3,13 +3,13 @@ title: Data Model
 project: PartyOn2
 doc_type: codebase-reference
 section: data-model
-last_generated: 2026-04-23
+last_generated: 2026-05-03
 tags: [partyondelivery, codebase, prisma, data-model, schema]
 ---
 
 # Data Model
 
-Source of truth: `prisma/schema.prisma`. Datasource is PostgreSQL (`POSTGRES_URL`, `POSTGRES_URL_NON_POOLING`). 76 models, 43 enums. Migrations live under `prisma/migrations/` (managed by Prisma CLI via `npm run db:migrate` / `db:push`).
+Source of truth: `prisma/schema.prisma`. Datasource is PostgreSQL (`POSTGRES_URL`, `POSTGRES_URL_NON_POOLING`). 77 models, 43 enums. Migrations live under `prisma/migrations/` (managed by Prisma CLI via `npm run db:migrate` / `db:push`).
 
 > _`DeliveryZone` and `TaxRate` were removed 2026-04-23. Runtime uses hardcoded TS tables in `src/lib/delivery/rates.ts` and `src/lib/tax/rates.ts`. Postgres tables `delivery_zones` and `tax_rates` remain — drop in future migration._
 >
@@ -26,29 +26,30 @@ Source of truth: `prisma/schema.prisma`. Datasource is PostgreSQL (`POSTGRES_URL
 | 66 | Experiment | 865 | Fulfillment | 1768 | GroupParticipantV2 |
 | 95 | ExperimentVariant | 893 | Refund | 1793 | DraftCartItem |
 | 116 | GroupOrderItem | 948 | OrderAmendment | 1819 | PurchasedItem |
-| 136 | GroupOrder | 1002 | AIInventoryCount | 1846 | ParticipantPayment |
-| 173 | GroupParticipant | 1029 | AIInventoryQuery | 1878 | EmailTemplateContent |
-| 203 | OrderAnalytics | 1043 | InventoryPrediction | 1893 | InventoryNote |
-| 253 | GroupOrderPayment | 1076 | FeatureFlag | 1911 | ReceivingInvoice |
-| 288 | Product | 1091 | ShopifySync | 1932 | ReceivingInvoiceLine |
-| 342 | ProductVariant | 1126 | DeliveryTask | 1953 | DistributorSkuMap |
-| 396 | ProductImage | 1165 | EmailLog | 1971 | GroupDeliveryInvoice |
-| 417 | Category | 1241 | Discount | 1993 | WebhookEvent |
-| 440 | ProductCategory | 1295 | DiscountUsage | 2045 | PartnerApplication |
-| 452 | BundleComponent | 1311 | ReferralCode | 2070 | Affiliate |
-| 479 | InventoryLocation | 1329 | AutomaticDiscount | 2111 | DashboardTemplate |
-| 495 | InventoryItem | 1378 | LoyaltyTier | 2137 | AffiliateWebhookLog |
-| 527 | InventoryMovement | 1397 | CustomerLoyalty | 2156 | DashboardView |
-| 556 | LowStockAlert | 1417 | PointsTransaction | 2167 | AffiliateCommission |
-| 597 | Customer | 1446 | VercelAnalyticsEvent | 2196 | AffiliatePayout |
-| 645 | CustomerAddress | 1503 | DrinkCalculatorLead | 2217 | PayoutLineItem |
-| 676 | Cart | 1526 | DraftOrder | 2230 | MagicLinkToken |
-| 722 | CartItem | | | 2249 | AgentConversation |
+| 136 | GroupOrder | 972 | OrderItemPickState | 1846 | ParticipantPayment |
+| 173 | GroupParticipant | 1002 | AIInventoryCount | 1878 | EmailTemplateContent |
+| 203 | OrderAnalytics | 1029 | AIInventoryQuery | 1893 | InventoryNote |
+| 253 | GroupOrderPayment | 1043 | InventoryPrediction | 1911 | ReceivingInvoice |
+| 288 | Product | 1076 | FeatureFlag | 1932 | ReceivingInvoiceLine |
+| 342 | ProductVariant | 1091 | ShopifySync | 1953 | DistributorSkuMap |
+| 396 | ProductImage | 1126 | DeliveryTask | 1971 | GroupDeliveryInvoice |
+| 417 | Category | 1165 | EmailLog | 1993 | WebhookEvent |
+| 440 | ProductCategory | 1241 | Discount | 2045 | PartnerApplication |
+| 452 | BundleComponent | 1295 | DiscountUsage | 2070 | Affiliate |
+| 479 | InventoryLocation | 1311 | ReferralCode | 2111 | DashboardTemplate |
+| 495 | InventoryItem | 1329 | AutomaticDiscount | 2137 | AffiliateWebhookLog |
+| 527 | InventoryMovement | 1378 | LoyaltyTier | 2156 | DashboardView |
+| 556 | LowStockAlert | 1397 | CustomerLoyalty | 2167 | AffiliateCommission |
+| 597 | Customer | 1417 | PointsTransaction | 2196 | AffiliatePayout |
+| 645 | CustomerAddress | 1446 | VercelAnalyticsEvent | 2217 | PayoutLineItem |
+| 676 | Cart | 1503 | DrinkCalculatorLead | 2230 | MagicLinkToken |
+| 722 | CartItem | 1526 | DraftOrder | 2249 | AgentConversation |
 | | | | | 2273 | AgentProposal |
 | | | | | 2291 | McpRequestLog |
 | | | | | 2313 | BoatSchedule |
 | | | | | 2351 | ScheduleOrderMatch |
 | | | | | 2371 | SyncLog |
+
 
 ## Enums (all 43)
 
@@ -136,6 +137,7 @@ erDiagram
   Order ||--o{ OrderAmendment : amended_by
   Order ||--o| DeliveryTask : dispatched_as
   Order ||--o{ ScheduleOrderMatch : boat_matched
+  Order ||--o{ OrderItemPickState : pick_state
   DraftOrder ||--o{ DraftCartItem : items
   Affiliate ||--o{ Order : attributed
   %% DeliveryZone and TaxRate removed 2026-04-23 — runtime uses hardcoded TS tables.
@@ -232,6 +234,11 @@ erDiagram
 
 ### DeliveryTask (1126)
 - Per-order dispatch row with `DeliveryTaskStatus`. Picker/driver assignment.
+
+### OrderItemPickState (972)
+- Persistent pick/pack state for the `/ops/orders` picker UI. One row per `(orderId, itemKey)` capturing `inStock`, `packed`, `shortBy`. `itemKey` is the item title for line items, or `${itemTitle}::${bundleComponentTitle}` for bundle components.
+- Replaces prior per-browser localStorage so multiple devices/pickers share the same checkbox + short-by state on a given order. Added 2026-05-03 (commit `86f58c77`).
+- Read/written by `/api/ops/orders/[id]/picks` (GET/PUT). Deleted by cascade when the parent `Order` is deleted.
 
 ### DraftOrder (1526), DraftCartItem (1793)
 - Admin-created invoices. Token-based customer view at `/invoice/[token]`. `DraftOrderStatus` enum.

--- a/codebase-docs/06-admin-features.md
+++ b/codebase-docs/06-admin-features.md
@@ -3,7 +3,7 @@ title: Admin Features
 project: PartyOn2
 doc_type: codebase-reference
 section: admin
-last_generated: 2026-04-23
+last_generated: 2026-05-03
 tags: [partyondelivery, codebase, admin, ops, affiliate, cron, webhooks]
 ---
 
@@ -40,6 +40,7 @@ Three admin surfaces live in the app: `/admin/*` (business operator), `/ops/*` (
 | `/admin/affiliates/commissions` | `.../commissions/page.tsx` | Commission ledger. |
 | `/admin/affiliates/payouts` | `.../payouts/page.tsx` | Payouts. |
 | `/admin/affiliates/embed-generator` | `.../embed-generator/page.tsx` | Embed snippet builder. |
+| `/admin/analytics/recommendations` | `.../analytics/recommendations/page.tsx` | Marketing recommendation triage queue. Reads `MarketingRecommendation` rows surfaced by the snapshot cron + Marketing Director agent; operator moves items through `open → approved → shipped` (or `rejected` / `invalidated`). |
 
 ### `/ops/*` — warehouse / fulfilment
 
@@ -94,7 +95,7 @@ Three admin surfaces live in the app: `/admin/*` (business operator), `/ops/*` (
 
 These are **parallel namespaces, not a migration** — neither supersedes the other.
 
-- **`/api/admin/*`** is admin-UI-facing and is guarded by `ADMIN_API_KEY` / admin session. Covers: `affiliates`, `analytics`, `experiments`, `orders`, `sync`, `verify`.
+- **`/api/admin/*`** is admin-UI-facing and is guarded by `ADMIN_API_KEY` / admin session. Covers: `affiliates`, `analytics` (sub-routes: `ga4`, `gbp`, `vercel`, `internal`, `experiments`, `recommendations`), `experiments`, `orders`, `sync`, `verify`.
 - **`/api/v1/admin/*`** is ops-panel-facing. Covers: `collections`, `customers`, `dashboard`, `discounts`, `draft-orders`, `features`, `orders`, `products`, `reports`, `shortage-list`, `sync`, `unpaid-carts`. (Loyalty admin page and APIs were removed 2026-04-23.)
 - Overlap is only `orders` and `sync`; each namespace's `orders` / `sync` endpoints serve a different consumer. Do not treat either as deprecated.
 

--- a/codebase-docs/INDEX.md
+++ b/codebase-docs/INDEX.md
@@ -3,7 +3,7 @@ title: PartyOn2 Codebase Reference — Index
 project: PartyOn2
 doc_type: codebase-reference
 section: index
-last_generated: 2026-04-23
+last_generated: 2026-05-03
 tags: [partyondelivery, codebase, index, toc]
 ---
 
@@ -19,7 +19,7 @@ PartyOn2 is the Next.js 15 App Router codebase that powers [partyondelivery.com]
 | [[02-tech-stack-and-architecture]] | Exact versions, folder tree, App Router patterns, env vars, conventions. |
 | [[03-routes-and-pages]] | Exhaustive table of every page + every API route under `src/app/`. |
 | [[04-customer-journey]] | Discovery to post-purchase funnel with route-level references. |
-| [[05-data-model]] | Prisma schema — all 76 models + 43 enums, ER diagrams, relationships. |
+| [[05-data-model]] | Prisma schema — all 77 models + 43 enums, ER diagrams, relationships. |
 | [[06-admin-features]] | `/admin`, `/ops`, `/affiliate` panels, cron jobs, webhooks, integrations. |
 
 ## Quick facts
@@ -33,12 +33,12 @@ PartyOn2 is the Next.js 15 App Router codebase that powers [partyondelivery.com]
 | Database | Neon Postgres via `@prisma/client` 6.15.0 |
 | Hosting | Vercel (crons in `vercel.json`) |
 | Primary package | `party-on-delivery` v0.1.0 |
-| `page.tsx` files | **143** |
-| `route.ts` API files | **214** |
-| Prisma models | **76** |
+| `page.tsx` files | **145** |
+| `route.ts` API files | **216** |
+| Prisma models | **77** |
 | Prisma enums | **43** |
 | Blog posts in `content/blog/posts/` | **133** |
-| TS/TSX files in `src/` | **868** |
+| TS/TSX files in `src/` | **902** |
 | Approx. LOC in `src/` (TS + TSX) | **~167,379** |
 
 ## How to use this reference (for LLMs)

--- a/codebase-docs/INDEX.md
+++ b/codebase-docs/INDEX.md
@@ -34,7 +34,7 @@ PartyOn2 is the Next.js 15 App Router codebase that powers [partyondelivery.com]
 | Hosting | Vercel (crons in `vercel.json`) |
 | Primary package | `party-on-delivery` v0.1.0 |
 | `page.tsx` files | **145** |
-| `route.ts` API files | **216** |
+| `route.ts` API files | **217** |
 | Prisma models | **77** |
 | Prisma enums | **43** |
 | Blog posts in `content/blog/posts/` | **133** |


### PR DESCRIPTION
## Summary

- Resync `codebase-docs/` to current `main` after 31 commits past `ff99db99` (the prior sync). Two commits: the original resync from session start, plus a follow-up after PRs #19/#20 landed during the session.
- Live counts: **145 pages** (was 143), **217 routes** (was 214), **77 models** (was 76), 43 enums (unchanged).
- Documents new pages (`/partners/pitch`, `/admin/analytics/recommendations`), new routes (`/api/ops/orders/[id]/picks`, `/api/v1/inventory/variants/[id]`, `/api/cron/measure-recommendations`), new model (`OrderItemPickState`), and the second hero-scan script in the build (`scripts/scan-vacation-rental-hero.js`).

## What changed

- `INDEX.md` — count fields + last_generated.
- `02-tech-stack-and-architecture.md` — build script now lists both hero-scan steps.
- `03-routes-and-pages.md` — added 3 new route rows + 1 new cron row + new page row.
- `05-data-model.md` — added `OrderItemPickState` (line 972) with field details + ER diagram entry under Customers/Orders/Fulfilment.
- `06-admin-features.md` — added `/admin/analytics/recommendations` to the admin pages table; expanded `/api/admin/analytics/*` description with sub-routes (`ga4`, `gbp`, `vercel`, `internal`, `experiments`, `recommendations`).

## Test plan

- [x] Live count verify: `find src/app -name 'page.tsx' \| wc -l` → 145; `find src/app -name 'route.ts' \| wc -l` → 217; `grep -cE '^model ' prisma/schema.prisma` → 77.
- [x] `npx tsc --noEmit` — only pre-existing test-file error (group-v2-payments.test.ts:312, unchanged from prior session).
- [x] `npx next lint` — clean (only pre-existing `<img>` warnings).
- [x] `npm run test:run` — pre-existing 6 failures in group-v2-payments.test.ts (prisma mock missing groupOrderV2 — predates this branch).
- [x] Visual smoke test: `/partners/pitch` (5 slides render), `/partners/vacation-rentals` (lead capture form hero loads), `/admin/analytics/recommendations` (8 open recs in triage queue, all UI affordances present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)