### PR TITLE
feat(marketing): auto-sync Obsidian vault before marketing-director invocations

### DIFF
--- a/.claude/agents/marketing-director.md
+++ b/.claude/agents/marketing-director.md
@@ -36,11 +36,11 @@ You are the senior growth/marketing analyst for **Party On Delivery**, a premium
 
 ## First action every invocation
 
-0. **Sync the Obsidian vault** so it reflects the latest triage state. The browser triage queue writes to GitHub; this command pulls those changes into the local vault that Cowork reads:
+0. **Obsidian vault sync** — the project's PreToolUse hook in `.claude/settings.json` runs `npm run sync:marketing` automatically whenever the marketing-director subagent is invoked. The vault is up-to-date by the time you bootstrap. If you ever see stale data (e.g. a triaged rec that should be `accepted` still showing `proposed`), run the sync manually:
    ```bash
    npm run sync:marketing
    ```
-   Idempotent. Use `npm run sync:marketing:watch` to keep it polling every 5 min while a marketing session is active.
+   The hook fires from `Task` tool calls only; if you're invoked via a slash command or direct prompt without going through the Agent tool, sync won't auto-run.
 
 1. **Bootstrap from Obsidian** (now in sync, located at `/Users/allan/Projects/Obsidian/Obsidian/PartyOn2/Memory/Marketing/`):
    - Read the most recent 2 `Briefings/YYYY-Www.md` files (this week + last week)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "input=$(cat); subagent=$(echo \"$input\" | jq -r '.tool_input.subagent_type // \"\"'); if [ \"$subagent\" = \"marketing-director\" ]; then echo \"[marketing-sync] firing\"; cd \"$CLAUDE_PROJECT_DIR\" && npm run sync:marketing 2>&1 | tail -5 || true; fi",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds a PreToolUse hook in `.claude/settings.json` so `npm run sync:marketing` runs automatically whenever the marketing-director subagent is invoked. No more remembering to sync before opening a marketing session.

## How it works

- Hook matches all `Task` tool calls (the harness name for Agent invocations)
- Shell guard inspects `tool_input.subagent_type` and only runs sync for `marketing-director` — other agents pass through silently
- Fail-soft: sync errors don't block the agent

Pipe-tested both paths in this session before writing the JSON.

## After merge

Open `/hooks` once (or restart Claude Code session) to pick up the new `.claude/settings.json`. The settings watcher only re-scans when an existing config changes — newly-created config files aren't auto-loaded until the next session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)