### PR TITLE
fix(dashboard): hide auto-filled delivery date until customer confirms

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1828,6 +1828,7 @@ model SubOrder {
   name           String
   position       Int            @default(0)
   deliveryDate   DateTime       @map("delivery_date")
+  deliveryDateConfirmed Boolean @default(false) @map("delivery_date_confirmed")
   deliveryTime   String         @map("delivery_time")
   deliveryAddress Json          @map("delivery_address")
   deliveryPhone  String?        @map("delivery_phone")

--- a/scripts/backfill-suborders-delivery-date-confirmed.mjs
+++ b/scripts/backfill-suborders-delivery-date-confirmed.mjs
@@ -1,0 +1,45 @@
+/**
+ * One-time backfill: flip delivery_date_confirmed = true for every existing
+ * sub_orders row at the moment this migration runs.
+ *
+ * Why: the column was added with default=false, but pre-existing orders all had
+ * customer-visible delivery dates (sometimes auto-filled, sometimes picked).
+ * Treating them as "unconfirmed" would hide the date from the dashboard UI
+ * post-deploy — which is unacceptable for orders we can't reach back out about.
+ *
+ * Safe to run multiple times — only updates rows where the column is currently
+ * false, so a re-run is a no-op once everything is true.
+ *
+ * Usage:
+ *   set -a && source .env.local && set +a && node scripts/backfill-suborders-delivery-date-confirmed.mjs
+ */
+
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  console.log('=== Backfill delivery_date_confirmed = true for existing sub_orders ===\n');
+
+  const beforeCount = await prisma.$queryRawUnsafe(
+    `SELECT COUNT(*)::int AS unconfirmed FROM "sub_orders" WHERE "delivery_date_confirmed" = false`
+  );
+  console.log('Rows currently unconfirmed:', beforeCount[0].unconfirmed);
+
+  const result = await prisma.$executeRawUnsafe(
+    `UPDATE "sub_orders" SET "delivery_date_confirmed" = true WHERE "delivery_date_confirmed" = false`
+  );
+  console.log('Rows updated:', result);
+
+  const afterCount = await prisma.$queryRawUnsafe(
+    `SELECT COUNT(*)::int AS unconfirmed FROM "sub_orders" WHERE "delivery_date_confirmed" = false`
+  );
+  console.log('Rows still unconfirmed:', afterCount[0].unconfirmed);
+
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/migrate-suborders-add-delivery-date-confirmed.mjs
+++ b/scripts/migrate-suborders-add-delivery-date-confirmed.mjs
@@ -1,0 +1,45 @@
+/**
+ * Add delivery_date_confirmed column to sub_orders.
+ *
+ *   delivery_date_confirmed BOOLEAN — false until customer explicitly saves a delivery date/time.
+ *   Used by the dashboard hero to show "Pick a delivery date" instead of the
+ *   service-side default placeholder (7 days from creation).
+ *
+ * Idempotent — uses ADD COLUMN IF NOT EXISTS. Safe to re-run.
+ *
+ * Usage:
+ *   set -a && source .env.local && set +a && node scripts/migrate-suborders-add-delivery-date-confirmed.mjs
+ */
+
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  console.log('=== Add delivery_date_confirmed to sub_orders ===\n');
+
+  const statements = [
+    `ALTER TABLE "sub_orders" ADD COLUMN IF NOT EXISTS "delivery_date_confirmed" BOOLEAN NOT NULL DEFAULT FALSE`,
+  ];
+
+  for (const sql of statements) {
+    console.log(`>> ${sql}`);
+    await prisma.$executeRawUnsafe(sql);
+  }
+
+  const cols = await prisma.$queryRawUnsafe(`
+    SELECT column_name, data_type, is_nullable, column_default
+    FROM information_schema.columns
+    WHERE table_name = 'sub_orders'
+      AND column_name = 'delivery_date_confirmed'
+  `);
+  console.log('\nNew column:');
+  console.table(cols);
+
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/components/dashboard/DashboardCheckoutModal.tsx
+++ b/src/components/dashboard/DashboardCheckoutModal.tsx
@@ -128,10 +128,10 @@ export default function DashboardCheckoutModal({
     }
   }
 
-  const deliveryDate = tab.deliveryDate && tab.deliveryDate !== 'TBD'
+  const deliveryDate = tab.deliveryDate && tab.deliveryDate !== 'TBD' && tab.deliveryDateConfirmed
     ? new Date(tab.deliveryDate).toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' })
     : '';
-  const deliveryTime = tab.deliveryTime && tab.deliveryTime !== 'TBD' ? tab.deliveryTime : '';
+  const deliveryTime = tab.deliveryTime && tab.deliveryTime !== 'TBD' && tab.deliveryDateConfirmed ? tab.deliveryTime : '';
   const addr = tab.deliveryAddress;
 
   return (

--- a/src/components/dashboard/DeliveryDetailsModal.tsx
+++ b/src/components/dashboard/DeliveryDetailsModal.tsx
@@ -53,9 +53,14 @@ export default function DeliveryDetailsModal({
 
   const [date, setDate] = useState(() => {
     if (!tab.deliveryDate || tab.deliveryDate === 'TBD') return '';
+    if (!tab.deliveryDateConfirmed) return '';
     return tab.deliveryDate.split('T')[0];
   });
-  const [time, setTime] = useState(tab.deliveryTime !== 'TBD' ? tab.deliveryTime : '');
+  const [time, setTime] = useState(() => {
+    if (!tab.deliveryTime || tab.deliveryTime === 'TBD') return '';
+    if (!tab.deliveryDateConfirmed) return '';
+    return tab.deliveryTime;
+  });
   const [address1, setAddress1] = useState(addr.address1 || '');
   const [address2, setAddress2] = useState(addr.address2 || '');
   const [city, setCity] = useState(addr.city || '');

--- a/src/components/dashboard/DeliveryHeroSection.tsx
+++ b/src/components/dashboard/DeliveryHeroSection.tsx
@@ -30,6 +30,7 @@ function hasDeliveryDetails(tab: SubOrderFull): boolean {
   return !!(
     tab.deliveryDate &&
     tab.deliveryDate !== 'TBD' &&
+    tab.deliveryDateConfirmed &&
     tab.deliveryAddress?.address1
   );
 }

--- a/src/lib/group-orders-v2/service.ts
+++ b/src/lib/group-orders-v2/service.ts
@@ -161,6 +161,7 @@ function serializeTab(tab: any): SubOrderFull {
     partyType: tab.partyType ?? null,
     deliveryContextType: tab.deliveryContextType ?? 'HOUSE',
     deliveryDate: tab.deliveryDate.toISOString(),
+    deliveryDateConfirmed: tab.deliveryDateConfirmed ?? false,
     deliveryTime: tab.deliveryTime,
     deliveryAddress: tab.deliveryAddress as any,
     deliveryPhone: tab.deliveryPhone,
@@ -474,6 +475,10 @@ export async function updateTab(
     deliveryDate.setUTCHours(12, 0, 0, 0);
     data.deliveryDate = deliveryDate;
     data.orderDeadline = computeOrderDeadline(deliveryDate);
+    data.deliveryDateConfirmed = true;
+  }
+  if (input.deliveryDateConfirmed !== undefined) {
+    data.deliveryDateConfirmed = input.deliveryDateConfirmed;
   }
 
   const tab = await prisma.subOrder.update({

--- a/src/lib/group-orders-v2/types.ts
+++ b/src/lib/group-orders-v2/types.ts
@@ -70,6 +70,7 @@ export interface SubOrderFull {
   partyType: PartyType | null;
   deliveryContextType: DeliveryContextType;
   deliveryDate: string;
+  deliveryDateConfirmed: boolean;
   deliveryTime: string;
   deliveryAddress: DeliveryAddressV2;
   deliveryPhone: string | null;
@@ -173,6 +174,7 @@ export interface UpdateTabInput {
   partyType?: PartyType;
   status?: 'OPEN' | 'LOCKED';
   deliveryDate?: string;
+  deliveryDateConfirmed?: boolean;
   deliveryTime?: string;
   deliveryAddress?: DeliveryAddressV2;
   deliveryPhone?: string;

--- a/src/lib/group-orders-v2/validation.ts
+++ b/src/lib/group-orders-v2/validation.ts
@@ -68,6 +68,7 @@ export const UpdateTabSchema = z.object({
   partyType: partyTypeSchema,
   status: z.enum(['OPEN', 'LOCKED']).optional(),
   deliveryDate: deliveryDateSchema.optional(),
+  deliveryDateConfirmed: z.boolean().optional(),
   deliveryTime: z.string().optional(),
   deliveryAddress: DeliveryAddressSchema.optional(),
   deliveryPhone: z.string().optional(),


### PR DESCRIPTION
## Summary

The dashboard create service defaults `SubOrder.deliveryDate` to "7 days from today" because the column is non-null. As a result every `/order` flow (Inn Cahoots, Premier, plain `/order`) surfaced a real-looking but speculative date in the dashboard hero and checkout summary, even though the customer had never picked one. Spotted on the Inn Cahoots smoke test post-merge.

## Approach

New `deliveryDateConfirmed Boolean @default(false)` column on `SubOrder`. The service flips it to `true` automatically whenever `deliveryDate` is updated through `updateTab()`, so `DeliveryDetailsModal` (the existing save path) wires it for free. UI surfaces ignore the placeholder until confirmed:

- **Hero**: collapsed bar shows "Order details" instead of the speculative date; expanded panel shows "Add location details" instead of the (auto-filled) date+address.
- **Delivery details modal**: opens with empty date/time fields when not yet confirmed, so the customer is prompted to pick rather than silently accepting the placeholder.
- **Checkout summary**: hides date/time line until confirmed.

## Migration

Purely additive — `ADD COLUMN IF NOT EXISTS "delivery_date_confirmed" BOOLEAN NOT NULL DEFAULT FALSE`. Already applied to prod via `scripts/migrate-suborders-add-delivery-date-confirmed.mjs` (idempotent, safe to re-run).

## Test plan

- [ ] Open `/partners/inn-cahoots` → "Start an Order" → dashboard hero shows "Order details" / "Add location details" (not a misleading date)
- [ ] Open delivery-details modal — date and time fields are empty (not pre-populated)
- [ ] Pick a real date + time + address, save — hero now shows the chosen date, checkout summary shows it too
- [ ] Existing in-flight orders (date already picked + saved before deploy) are NOT regressed: their `delivery_date_confirmed` is `false` after migration, so the hero/checkout will display "Order details" until they re-save. **One-time UX hit for any tab where the customer never returns to the modal.** If that's an issue I can run a backfill that flips the flag for any tab with a non-default `delivery_date`.