### PR TITLE
feat(affiliates): attribute /partners/<slug> visits without ?ref= (ADR M0001 P0)

### DIFF
--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { resolveRefCookieValue } from '@/middleware';
+
+function urlOf(input: string): URL {
+  return new URL(input, 'https://partyondelivery.com');
+}
+
+describe('resolveRefCookieValue', () => {
+  describe('?ref= query param', () => {
+    it('uppercases and returns the ref code', () => {
+      expect(resolveRefCookieValue(urlOf('/?ref=premier'))).toBe('PREMIER');
+      expect(resolveRefCookieValue(urlOf('/?ref=DTRBARTENDING'))).toBe('DTRBARTENDING');
+    });
+
+    it('works on any path', () => {
+      expect(resolveRefCookieValue(urlOf('/products?ref=POUR24'))).toBe('POUR24');
+    });
+  });
+
+  describe('/partners/<slug> path', () => {
+    it('uppercases the slug', () => {
+      expect(resolveRefCookieValue(urlOf('/partners/premier-party-cruises'))).toBe('PREMIER-PARTY-CRUISES');
+    });
+
+    it('captures the slug from a sub-path (e.g. /partners/<slug>/order)', () => {
+      expect(resolveRefCookieValue(urlOf('/partners/inn-cahoots/order'))).toBe('INN-CAHOOTS');
+    });
+
+    it('matches case-insensitively on the literal "/partners/" prefix', () => {
+      expect(resolveRefCookieValue(urlOf('/Partners/connected-austin'))).toBe('CONNECTED-AUSTIN');
+    });
+
+    it('lowercases the slug before re-uppercasing it (canonical form)', () => {
+      expect(resolveRefCookieValue(urlOf('/partners/Mobile-Bartenders'))).toBe('MOBILE-BARTENDERS');
+    });
+  });
+
+  describe('precedence', () => {
+    it('?ref= beats the partner path when both are present', () => {
+      expect(resolveRefCookieValue(urlOf('/partners/premier-party-cruises?ref=DTRBARTENDING'))).toBe('DTRBARTENDING');
+    });
+  });
+
+  describe('paths that should NOT set a cookie', () => {
+    it('returns null for the partner index page (no slug)', () => {
+      expect(resolveRefCookieValue(urlOf('/partners'))).toBeNull();
+      expect(resolveRefCookieValue(urlOf('/partners/'))).toBeNull();
+    });
+
+    it('returns null for /partners/pitch (sales page, not an affiliate)', () => {
+      expect(resolveRefCookieValue(urlOf('/partners/pitch'))).toBeNull();
+      expect(resolveRefCookieValue(urlOf('/partners/pitch/anything'))).toBeNull();
+    });
+
+    it('returns null for unrelated paths', () => {
+      expect(resolveRefCookieValue(urlOf('/'))).toBeNull();
+      expect(resolveRefCookieValue(urlOf('/products'))).toBeNull();
+      expect(resolveRefCookieValue(urlOf('/blog/some-post'))).toBeNull();
+    });
+
+    it('returns null when ?ref= is empty string', () => {
+      expect(resolveRefCookieValue(urlOf('/?ref='))).toBeNull();
+    });
+  });
+});

--- a/src/lib/affiliates/commission-engine.ts
+++ b/src/lib/affiliates/commission-engine.ts
@@ -198,8 +198,16 @@ export async function linkOrderToAffiliate(
   },
   affiliateCode: string
 ) {
+  // Match by Affiliate.code (from ?ref=<code>) OR by Affiliate.partnerSlug
+  // (from /partners/<slug> visits — middleware uppercases the slug into ref_code).
+  // Per ADR M0001: partner-page visits without an explicit ?ref= now attribute too.
   const affiliate = await prisma.affiliate.findFirst({
-    where: { code: { equals: affiliateCode, mode: 'insensitive' } },
+    where: {
+      OR: [
+        { code: { equals: affiliateCode, mode: 'insensitive' } },
+        { partnerSlug: affiliateCode.toLowerCase() },
+      ],
+    },
   });
 
   if (!affiliate || affiliate.status !== 'ACTIVE') {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,7 +3,8 @@ import { NextRequest, NextResponse } from 'next/server';
 /**
  * Middleware:
  * 1. Enforce canonical non-www domain
- * 2. Set affiliate attribution cookie from ?ref= param
+ * 2. Set affiliate attribution cookie from ?ref= param OR /partners/<slug> path
+ *    (per ADR M0001: partner-page visits must attribute even without ?ref=)
  */
 export function middleware(request: NextRequest) {
   const { hostname } = request.nextUrl;
@@ -30,22 +31,48 @@ export function middleware(request: NextRequest) {
 
   const response = NextResponse.next();
 
-  const cookieOptions = {
-    httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
-    sameSite: 'lax' as const,
-    maxAge: 60 * 60 * 24 * 30, // 30 days
-    path: '/',
-  };
-
-  // Set affiliate attribution cookie from ?ref= query param (last-touch, 30 days)
-  const refCode = request.nextUrl.searchParams.get('ref');
-  if (refCode) {
-    response.cookies.set('ref_code', refCode.toUpperCase(), cookieOptions);
+  const cookieValue = resolveRefCookieValue(request.nextUrl);
+  if (cookieValue) {
+    response.cookies.set('ref_code', cookieValue, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 60 * 60 * 24 * 30, // 30 days
+      path: '/',
+    });
   }
 
-
   return response;
+}
+
+/**
+ * Resolve the ref_code cookie value from a request URL.
+ *
+ * Precedence (last-touch wins, but explicit ?ref= beats path inference):
+ * 1. ?ref=<code> query param — uppercased.
+ * 2. /partners/<slug>[/...] path — slug uppercased.
+ *
+ * Returns null when neither applies (so callers leave any existing cookie alone).
+ *
+ * The cookie value may be either an Affiliate.code (from ?ref=) or a partnerSlug
+ * (from /partners/<slug>). linkOrderToAffiliate at checkout matches either form.
+ *
+ * Excluded paths: /partners/pitch is the prospective-partner sales page, not an
+ * affiliate. Treating it as one would set a junk cookie that downstream lookups
+ * would just discard, but we'd rather not pollute the cookie at all.
+ */
+export function resolveRefCookieValue(url: URL | { searchParams: URLSearchParams; pathname: string }): string | null {
+  const refParam = url.searchParams.get('ref');
+  if (refParam) return refParam.toUpperCase();
+
+  const partnerMatch = url.pathname.match(/^\/partners\/([^/]+)/i);
+  if (partnerMatch) {
+    const slug = partnerMatch[1].toLowerCase();
+    if (slug === 'pitch') return null;
+    return slug.toUpperCase();
+  }
+
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes the largest affiliate revenue-attribution leak identified in marketing ADR M0001. Visitors landing on `/partners/<slug>` directly (from email, business cards, AI search results, organic) previously got no `ref_code` cookie because [src/middleware.ts](src/middleware.ts) only wrote the cookie when the URL had a `?ref=` query param. At checkout, `Order.affiliateId` stayed null and the order was invisible to `getAffiliateRoi` — producing artificially negative ROI for partners with strong direct-link traffic.

## Changes

- **`src/middleware.ts`** — when path matches `/partners/<slug>` and there's no `?ref=`, set `ref_code` cookie to the slug (uppercased). Explicit `?ref=` still takes precedence (last-touch beats path inference). `/partners/pitch` (the prospect sales page) is excluded so it doesn't set a junk cookie. Logic is extracted into a pure `resolveRefCookieValue()` function for unit testability.
- **`src/lib/affiliates/commission-engine.ts`** — `linkOrderToAffiliate` now matches by `Affiliate.code` OR `Affiliate.partnerSlug`, so a slug-form cookie value resolves at checkout. Single one-line OR clause; no other call sites needed changes (single chokepoint — also covers Stripe webhooks and group-v2-payments).
- **`src/__tests__/middleware.test.ts`** — 11 unit tests covering `?ref=` uppercasing, `/partners/<slug>` capture (root + sub-path + case-insensitive prefix), precedence (`?ref=` wins), and excluded paths.

## Decision: no DB lookup in middleware

Considered three implementation options:
1. Static slug→code map in middleware — requires updating on every new affiliate
2. Edge-compatible Prisma (`@neondatabase/serverless` + driver adapter) — heavy infra change for one feature
3. **Set cookie to slug as-is, resolve at checkout** ✅

Picked option 3 because `linkOrderToAffiliate` is the single chokepoint for all affiliate attribution (checkout API, Stripe webhooks, group-v2 payments) and already does a DB lookup; the `OR` clause makes it work for both forms without any new infrastructure or staleness risk.

## Out of scope

- `Customer.firstTouchAffiliateId` for repeat-customer LTV (M0001 follow-up, separate PR)
- Director-agent guardrail on ROI sign — already shipped in [PR #24](https://github.com/allan-cmyk/PartyOn2/pull/24)
- PREMIER group-dashboard sub-order audit — closed read-only this session, no bug found, sub-orders all carry `affiliateId` correctly

## Test plan

- [x] `npx vitest run src/__tests__/middleware.test.ts` — 11/11 pass
- [x] `npx tsc --noEmit` clean (excluding one pre-existing unrelated error)
- [x] `npx next lint` clean on changed files
- [ ] After deploy: visit `https://partyondelivery.com/partners/premier-party-cruises` in a fresh browser
- [ ] Verify `ref_code` cookie is set to `PREMIER-PARTY-CRUISES` (DevTools → Application → Cookies)
- [ ] Add a product, complete an order
- [ ] Verify `Order.affiliateId` is set to PREMIER's id in the DB
- [ ] Repeat with `?ref=PREMIER` URL → cookie value should be `PREMIER` (not slug form)
- [ ] Repeat with `/partners/premier-party-cruises?ref=DTRBARTENDING` → cookie should be `DTRBARTENDING` (`?ref=` wins)
- [ ] Visit `/partners/pitch` → no `ref_code` cookie set
- [ ] Run `npx tsx scripts/admin/snapshot-recommendations.ts` (or wait for the nightly cron) and verify the next affiliate-roi rollup includes the new attributions

🤖 Generated with [Claude Code](https://claude.com/claude-code)