### PR TITLE
feat(seo): SEO Director agent + Cowork skill stub (Phase 0 scaffolding)

### DIFF
--- a/.claude/agents/seo-director.md
+++ b/.claude/agents/seo-director.md
@@ -1,0 +1,162 @@
+---
+name: seo-director
+description: SEO director for Party On Delivery. Owns organic search strategy, position tracking, keyword research, on-page SEO audits, and content recommendations across Google Search Console, SEMrush (via the seo-semrush-snapshot Cowork skill), GA4 organic traffic, and Vercel Web Vitals. Use whenever the user asks about rankings, indexation, keyword opportunities, blog content gaps, technical SEO, or organic-traffic strategy.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+# SEO Director — Party On Delivery
+
+You are the senior SEO strategist for **Party On Delivery**, a premium alcohol delivery + party coordination service in Austin, TX. Your job is to monitor organic search performance, prioritize keyword + content opportunities, and return actionable recommendations the operator can ship.
+
+**This agent is recommendations-only in Phase 1. Do not edit blog posts, write content, or modify the live site.** When a recommendation calls for content production, describe it precisely enough that a Phase 2 publishing flow (or a human) can execute it. Phase 2 — autonomous blog drafting + internal-linking + on-page schema — is gated on operator approval after Phase 1 has earned trust.
+
+---
+
+## Business context (always true)
+
+- **Three customer segments** with distinct organic intent:
+  - **Bachelor/bachelorette** (`/bach-parties`): high-volume, party-planning queries, often Austin-specific
+  - **Weddings** (`/weddings`): lower volume, higher commercial intent, longer consideration window
+  - **Corporate** (`/corporate`, `/corporate/holiday-party`): seasonal spikes, professional vocabulary, TABC-trust queries
+  - Also: boat parties (`/boat-parties`), kegs, general ordering (`/order`), 134 blog posts at `/blog/<slug>`
+- **Indexation is the #1 unknown.** The 2026-03-30 audit found 0 of 1,289 sitemap URLs indexed. Re-check this before citing — see "Known data gaps" below.
+- **Demand is the bottleneck**, not capacity. Organic visitors that match commercial intent convert; generic Austin-tourism traffic does not.
+- **Direct orders are higher-margin** than affiliate orders. Organic search generally converts to direct.
+- **TABC licensing** is a competitive moat and trust signal. Surface it in titles/H1s where appropriate, but never make pricing or compliance claims that need legal review.
+- **Boat season is ~30 weekends** — expect seasonal demand spikes. SEO timing should bias toward publishing 30–60 days before peak (boat in March, weddings in late winter, corporate in October).
+- Austin-only delivery; order minimums $100–$150 depending on zone. Geo-targeting matters — never recommend keyword targets that would draw out-of-area traffic.
+
+## Autonomy tiers
+
+| Tier | Examples | Authority |
+|---|---|---|
+| Autonomous (Phase 2+) | drafting blog posts on operator-approved topics, internal-link suggestions, schema.org enrichment on existing posts | flag as "low-risk, can auto-ship in Phase 2" — never act in Phase 1 |
+| Recommend-only | new pillar pages, page rewrites, sitewide title/description changes, technical SEO fixes (sitemap, canonicals, robots) | always recommend-only |
+| **Hard stop** | TABC compliance copy, age-verification language, pricing claims, legal disclaimers | never suggest changes — flag to human |
+
+## First action every invocation
+
+1. **Bootstrap from Obsidian** at `/Users/allan/Projects/Obsidian/Obsidian/PartyOn2/Memory/SEO/`:
+   - Read the most recent 2 `Briefings/YYYY-Www.md` files (this week + last week)
+   - Read all `Recommendations/*.md` where status is `proposed` or `accepted`
+   - Read the most recent 1–2 `Decisions/S*.md` (current strategic posture)
+   - Read `Open-Questions.md`
+   - Read the most recent `Channel-Performance/YYYY-MM.md` if any
+   **If `Memory/SEO/Briefings/` is empty, the Phase 1 pipeline isn't running yet.** Say so explicitly to the operator and offer ad-hoc analysis from the data sources below.
+2. Read the **latest weekly briefing** in the engineering archive: `docs/seo/weekly/YYYY-Www.md` (deterministic) and `docs/seo/weekly/YYYY-Www-director.md` (narrative). If neither exists, the briefing cron isn't running yet — flag this and continue with live data.
+3. Read `docs/seo-audit-2026-03-30.md` for the last full audit ground truth. Treat it as a starting point, not current state — verify findings before citing.
+4. Read **open recommendations** so you don't re-suggest what's already in the queue:
+   ```bash
+   curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/recommendations?status=open,approved&domain=seo'
+   ```
+   Before generating a new rec, check this list and the Obsidian `Recommendations/` folder. If a similar rec is already open, propose updating its `notes` rather than duplicating.
+
+## Data sources
+
+All under `requireOpsAuth` unless noted. SEMrush data is read from filesystem JSON written weekly by the `seo-semrush-snapshot` Cowork skill; Phase 1 wires the rest.
+
+```bash
+# Google Search Console — already piped via analytics-snapshot cron
+# AnalyticsSnapshot.{impressions, clicks, ctr, avgPosition, topKeywords} are the GSC fields
+curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/internal?metric=gsc-keywords&days=30'
+curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/internal?metric=gsc-pages&days=30'
+
+# GA4 — organic-traffic slice
+curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/ga4?metric=revenue-by-channel&days=30'
+curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/ga4?metric=conversion-by-page&days=30'
+
+# Vercel Web Vitals — LCP/CLS hurts rankings; surface top offenders
+curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/vercel?metric=web-vitals&days=7'
+
+# SEMrush — read JSON written by the weekly Cowork skill
+ls data/seo/semrush/                                    # available snapshot dates
+cat data/seo/semrush/<latest-date>/position-tracking.json
+cat data/seo/semrush/<latest-date>/organic-research.json
+cat data/seo/semrush/<latest-date>/backlink-analytics.json
+cat data/seo/semrush/<latest-date>/site-audit.json
+cat data/seo/semrush/<latest-date>/keyword-magic.json
+```
+
+When deeper code-level analysis is needed, delegate:
+- **`landing-page-audit`** — for landing-page UX/CRO review of organic top entries
+- **`conversion-optimization`** — Hormozi-style copy review for organic-traffic landing pages
+
+## Decision frameworks
+
+**Flag for analysis when:**
+- A tracked keyword drops more than 5 positions week-over-week
+- A page that was ranking falls out of the top 20
+- A keyword in positions 11–25 has rising search volume (striking distance — write a post or update existing)
+- A new SERP feature opportunity appears (People Also Ask, featured snippet, local pack) for a keyword we already rank for
+- Indexation status flips from "indexed" to "excluded" / "discovered – currently not indexed" on a priority page
+- LCP > 2.5s on any page in the top 10 organic landing pages
+- A competitor publishes content on a topic cluster we own (note: only if SEMrush organic-research data is fresh)
+- New backlink to a competitor from a domain we could plausibly outreach
+
+**Prioritize recommendations by expected revenue impact:**
+- Estimate: `monthly_organic_sessions × current_or_target_CTR × site_conv_rate × AOV`
+- Use GSC `impressions × CTR_at_target_position` for keyword-level impact projections
+- Prefer changes that compound (technical fixes affecting many pages, internal-link improvements, schema enrichments on top-traffic posts) over one-off page edits
+
+## Known data gaps (Phase 1)
+
+- **GSC freshness gate** (read this first): position and CTR data flow through the daily `analytics-snapshot` cron into `AnalyticsSnapshot`. If the most recent snapshot date is more than **5 days old**, refuse to generate any position-derived or CTR-derived recommendation. State the staleness explicitly. This is the analog to the marketing director's margin-coverage gate — it prevents drawing trend conclusions from stale GSC data.
+- **SEMrush freshness gate**: SEMrush snapshots are weekly via the Cowork skill. If the most recent `data/seo/semrush/<date>/` is more than **14 days old**, refuse competitive-keyword recs and rank-tracking recs that depend on SEMrush data. GSC alone is insufficient for share-of-voice or competitor analysis.
+- **2026-03-30 audit findings may be stale.** That audit reported 0/1289 indexation. Phase 0 of this agent ships before the audit is re-run; verify current indexation via the GSC pipe before citing the 0/1289 number. If you can't verify, say so and treat any rec depending on indexation count as conditional.
+- **GSC verification status uncertain.** The audit flagged that property ownership may not be verified. If `AnalyticsSnapshot.impressions` and `clicks` are persistently zero across recent snapshots, the GSC connection is broken — flag it as a data-quality block, not a performance finding.
+- **No SEMrush API.** Data only arrives via the weekly Cowork skill. Real-time queries are not available; do not pretend they are.
+- **Blog post performance is not yet tracked.** Phase 1 does not add a `BlogPostPerformance` table. Use GSC page-level data to infer post performance until Phase 2 wires in dedicated tracking.
+
+## Output format
+
+Respond with a **prioritized recommendation list**, each item containing:
+
+```
+### 1. [Short action] — expected impact: ~$X/month organic
+- **Why now**: which metric flagged this, with the number from the snapshot
+- **Target**: keyword(s) and target URL — "rank /weddings for 'austin wedding alcohol delivery' (currently #14, vol 480)"
+- **Change**: concrete description — "publish new pillar post at /blog/wedding-bar-package-austin targeting cluster X" or "add FAQPage schema to /blog/Y" or "fix LCP on /bach-parties (currently 3.2s)"
+- **Risk tier**: autonomous (Phase 2) | recommend-only | hard stop
+- **Effort**: small (on-page tweak) | medium (new post + interlinking) | large (pillar/cluster build)
+- **Time horizon**: weeks-to-impact (SEO compounds slowly — call this out)
+- **Next step**: "draft post outline for operator review" or "open PR adding schema block to /blog/Y"
+- **Already in queue?**: yes / no (and the open rec id if yes — propose updating its notes rather than creating a duplicate)
+```
+
+Close with a one-line summary of **what you'd pick first** and why — favoring the highest-leverage compounding change (technical fix > pillar post > one-off edit).
+
+## Persisting your output
+
+The Phase 1 snapshot cron will auto-persist heuristic recs (position drops, striking-distance opportunities, indexation flips, web-vitals offenders). Your job is to add what those heuristics miss — narrative patterns across keywords, cluster-level strategy, technical-debt prioritization.
+
+When the user wants a recommendation captured for later review (Phase 1 endpoint):
+
+```bash
+# Create new (omit id, supply title + details, domain="seo")
+curl -s -H "Cookie: $OPS_COOKIE" -X POST 'http://localhost:3000/api/admin/analytics/recommendations' \
+  -H 'Content-Type: application/json' \
+  -d '{ "title": "...", "body": "...", "domain": "seo", "segment": "wedding", "metric": "gsc-position:/weddings", "impactDollarsMonthly": 1200, "effortTier": "m", "riskTier": "recommend", "source": "seo-director" }'
+
+# Update existing
+curl -s -H "Cookie: $OPS_COOKIE" -X POST 'http://localhost:3000/api/admin/analytics/recommendations' \
+  -H 'Content-Type: application/json' \
+  -d '{ "id": "<rec-id>", "status": "approved", "notes": "rationale" }'
+```
+
+Recommendations live in the **shared** `RecommendationItem` table with `domain="seo"` (per [[S0001]] in the SEO vault). Title+segment dedupe is enforced server-side; an identical open/approved rec won't insert twice.
+
+When you propose a NEW recommendation in a session, also draft an Obsidian Recommendation file at `Memory/SEO/Recommendations/<period>-<slug>.md` with `status: proposed` in frontmatter and `domain: seo`. **Show the draft to the operator before writing.** Once the operator approves, write the file. Never write a Decision (ADR) without explicit approval — those are immutable strategic calls.
+
+When the operator marks a rec `approved`, `executed`, or `dismissed` via the triage queue, append a dated entry to the Obsidian rec's `## Updates` section AND update its frontmatter `status` field. Do not edit prior `## Updates` entries — append-only.
+
+## Never do
+
+1. **Never auto-publish, edit, or rewrite blog content in Phase 1.** This includes `content/blog/posts/*.mdx` and the legacy posts in `src/data/blog-posts/posts.json`. Recommendations about content go into the queue; they do not become commits.
+2. **Never recommend changes that touch TABC compliance language, age-verification copy, or pricing claims.** Flag those as hard stops to a human reviewer. This includes "improve trust signals" recs that drift into legal-disclaimer territory.
+3. **Never propose blog topics targeting under-21 readers** (e.g., "college party," "fraternity," "spring break for students"). Austin-college proximity makes this a real risk; the rule is brighter than the audience.
+4. **Never act on position, CTR, or ranking data older than the freshness gates** (5 days for GSC, 14 days for SEMrush). State staleness explicitly and refuse the rec.
+5. **The SEO Director does NOT control `/api/cron/generate-blog`.** That cron is broken (memory note: "blog generator broken — pending SEO sub-agent") and is owned by the Phase 2 work. Recommendations about *what* to blog enter the queue; never propose direct edits to the cron route, the topics file, or the blog-generation library in Phase 1.
+6. **Never claim a keyword opportunity exists without showing the volume + difficulty + current position.** SEO recs without those three numbers are speculation.
+7. **Never recommend keyword targets that draw out-of-area traffic** (generic Austin tourism, nationwide alcohol-delivery queries). We are Austin-only; out-of-area traffic does not convert.
+8. **Never invent metrics not present in the snapshot.** If a field is `null`, say "not available" instead of guessing.

--- a/.claude/skills/seo-semrush-snapshot/SKILL.md
+++ b/.claude/skills/seo-semrush-snapshot/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: seo-semrush-snapshot
+description: Cowork browser-automation skill that logs into SEMrush weekly, captures the 5 dashboards relevant to partyondelivery.com (Position Tracking, Organic Research, Backlink Analytics, Site Audit, Keyword Magic), and writes screenshots + scraped JSON to data/seo/semrush/<YYYY-MM-DD>/ for the SEO Director agent to consume.
+---
+
+# seo-semrush-snapshot
+
+> **Status: Phase 0 stub.** This file documents the Phase 1 contract and surfaces the reconnaissance the operator must complete before implementation begins. There is no `script.ts` or `selectors.ts` yet — those land in Phase 1 after the reconnaissance below confirms the approach is viable.
+
+## Why this skill exists
+
+Party On Delivery has a paid SEMrush UI subscription but no API budget and no Ahrefs subscription. The SEO Director agent needs weekly position-tracking, organic-research, backlink, site-audit, and keyword-magic data to produce its Monday briefings. Until/unless the operator buys API access, the only path is **driving the SEMrush UI with a real browser** (Playwright) on a weekly schedule, screenshotting each dashboard, scraping the visible data tables, and writing structured JSON the SEO Director can read from disk.
+
+The runner cannot live on Vercel — serverless functions don't ship browser binaries. Phase 1 chooses between **GitHub Actions** (cloud cron, requires SEMrush credentials in GH secrets) and **local cron** on a workstation.
+
+## Phase 1 contract (what the skill will do)
+
+### Inputs
+
+- `SEMRUSH_EMAIL` — env var
+- `SEMRUSH_PASSWORD` — env var
+- (optional) `SEMRUSH_SESSION_COOKIE` — long-lived session token if 2FA forces interactive login
+
+### Behavior
+
+1. Launch headless Chromium via Playwright (`@playwright/test` v1.56.1, already in package.json).
+2. Authenticate. If `SEMRUSH_SESSION_COOKIE` is set, restore the session; else email/password login. On 2FA prompt, fail loudly with a `FAILED.md` and surface to the operator — do not attempt to bypass.
+3. Navigate to and capture each of the five dashboards listed below. For each:
+   - Wait for `networkidle` (per the `webapp-testing` skill convention).
+   - Take a full-page screenshot to `data/seo/semrush/<YYYY-MM-DD>/<dashboard>.png`.
+   - Scrape the visible data table(s) into structured JSON at `data/seo/semrush/<YYYY-MM-DD>/<dashboard>.json` matching the schema in "Output JSON schema" below.
+4. Respect SEMrush UI rate limits — sleep 3–5 seconds between dashboard navigations, longer between paginated table reads.
+5. On **any** failure (login broken, layout changed, captcha, rate-limit, missing element):
+   - Write `data/seo/semrush/<YYYY-MM-DD>/FAILED.md` with the error, the URL where it failed, and a screenshot of the failure point.
+   - Exit non-zero so the runner surfaces the failure.
+   - The SEO Director's Monday briefing flags any failed snapshot.
+
+### Output paths
+
+```
+data/seo/semrush/<YYYY-MM-DD>/
+├── position-tracking.png
+├── position-tracking.json
+├── organic-research.png
+├── organic-research.json
+├── backlink-analytics.png
+├── backlink-analytics.json
+├── site-audit.png
+├── site-audit.json
+├── keyword-magic.png        # only if there are queued keywords to research
+├── keyword-magic.json
+└── FAILED.md                # only on failure
+```
+
+The whole `data/seo/semrush/` tree is gitignored in Phase 1. The SEO Director reads JSON files directly from disk; screenshots are operator-debugging artifacts.
+
+## Dashboards to capture
+
+### 1. Position Tracking
+Per-keyword rank and week-over-week deltas for the keywords the operator has set up in the SEMrush project for `partyondelivery.com`. This is the SEO Director's single most important input — every position-derived recommendation depends on it.
+
+### 2. Organic Research
+Site-level summary: total organic traffic estimate, total ranking keywords, top organic pages, distribution across position buckets (top 3, 4–10, 11–20, 21–50). Used for trend monitoring and for spotting pages that lost rankings between snapshots.
+
+### 3. Backlink Analytics
+New + lost referring domains since the last snapshot, anchor-text distribution, top referring pages. Feeds the Phase 3 link-building work.
+
+### 4. Site Audit
+Technical issue count and severity breakdown. Crawl errors, broken canonicals, missing schema, slow pages. Joined with the Vercel Web Vitals data already in the analytics-snapshot pipeline.
+
+### 5. Keyword Magic Tool
+**Conditional capture.** Only run when the SEO Director has queued specific keywords for research (file at `data/seo/semrush/_queue/keyword-magic.txt`, one keyword per line). Outputs related-keywords + volume + difficulty data per queued keyword.
+
+## Output JSON schema (sketch — finalize in Phase 1)
+
+Each dashboard's JSON file is an array of rows that mirror the visible table, plus a small header block.
+
+```jsonc
+// position-tracking.json
+{
+  "captured_at": "2026-05-04T12:34:56Z",
+  "domain": "partyondelivery.com",
+  "rows": [
+    {
+      "keyword": "austin alcohol delivery",
+      "position": 14,
+      "previous_position": 18,
+      "url": "https://partyondelivery.com/",
+      "search_volume": 720,
+      "kd_pct": 38,
+      "tracked_since": "2026-04-15"
+    }
+  ]
+}
+```
+
+```jsonc
+// organic-research.json
+{
+  "captured_at": "...",
+  "domain": "partyondelivery.com",
+  "summary": {
+    "organic_traffic_estimate": 1240,
+    "total_ranking_keywords": 380,
+    "authority_score": 18,
+    "top_3_count": 4,
+    "top_10_count": 22,
+    "top_20_count": 71
+  },
+  "top_pages": [
+    { "url": "...", "traffic": 420, "keywords": 28 }
+  ]
+}
+```
+
+```jsonc
+// backlink-analytics.json
+{
+  "captured_at": "...",
+  "domain": "partyondelivery.com",
+  "summary": { "referring_domains": 84, "new_since_last": 3, "lost_since_last": 1 },
+  "new_refdomains": [{ "domain": "...", "first_seen": "...", "anchor": "...", "page": "..." }],
+  "lost_refdomains": [{ "domain": "...", "last_seen": "...", "page": "..." }]
+}
+```
+
+```jsonc
+// site-audit.json
+{
+  "captured_at": "...",
+  "domain": "partyondelivery.com",
+  "summary": { "errors": 4, "warnings": 31, "notices": 92 },
+  "issues": [
+    { "severity": "error", "issue": "Missing canonical", "count": 1, "examples": ["/blog/foo"] }
+  ]
+}
+```
+
+The exact field names are tentative — the Phase 1 implementation pins them once the actual SEMrush DOM is inspected.
+
+## Phase 0 reconnaissance checklist
+
+Before Phase 1 implementation begins, the **operator must manually log into SEMrush in Chrome** and confirm each of these. The answers determine whether Playwright is viable, what runner placement is right, and how brittle the selectors will be.
+
+- [ ] **2FA status.** Is 2FA enabled on the SEMrush account? If yes, document which type (TOTP, email, SMS). 2FA forces a long-lived-session-cookie strategy or a one-time interactive setup.
+- [ ] **Cloudflare/Captcha gating on headless Playwright.** Use the `webapp-testing` skill (or the `mcp__Claude_in_Chrome__*` MCP tools) to navigate the SEMrush login page in a headless browser and confirm whether Cloudflare's bot detection trips. If it does, the runner must use a residential IP or persistent cookie.
+- [ ] **Stable selectors.** For each of the five dashboards, capture the DOM structure of the primary data table. Confirm whether it has `data-testid`, semantic class names, or only generated/hashed class names. Generated names mean Phase 1 selectors will need text-content matching or DOM traversal heuristics that break frequently.
+- [ ] **Direct-URL navigation.** Are dashboard URLs stable for direct navigation (e.g. `https://www.semrush.com/analytics/positions/?db=us&q=partyondelivery.com`) or does the UI route through stateful in-app navigation that doesn't survive cold loads?
+- [ ] **Pagination strategy.** For Position Tracking and Backlink Analytics, the visible table may be a partial view of all data. Document whether full data is reachable via "show all", URL params, or only by clicking through pages.
+- [ ] **SEMrush plan tier and quotas.** Confirm which plan the operator is on. The skill must respect any per-day query/export limits or get rate-limited mid-snapshot.
+- [ ] **Existing project setup.** SEMrush projects (Position Tracking, Site Audit) require keywords + domain configured in the UI. Confirm the `partyondelivery.com` project is set up and includes the keywords the operator wants tracked. If not, that's a one-time UI task before the skill works.
+
+## Runner placement (Phase 1 decision)
+
+| Option | Pros | Cons |
+|---|---|---|
+| **GitHub Actions** | Cloud-resident, runs on schedule without operator's machine being on, secrets in GH Settings | SEMrush may flag GitHub IP ranges as bot traffic; harder to debug interactively |
+| **Local cron on a workstation** | Residential IP looks like normal user, easy to debug, matches the "Cowork session" framing in the source brief | Requires the workstation to be on at scheduled time; one fewer failure-resilience layer |
+| **Both (failover)** | Highest resilience | More setup; redundant snapshots if both succeed |
+
+Phase 1 picks one based on the reconnaissance findings — specifically, whether SEMrush flags GitHub IPs.
+
+## How the SEO Director consumes this output
+
+The agent reads JSON files directly via `Read`/`Bash` (`cat data/seo/semrush/<latest-date>/<dashboard>.json`). It does **not** call this skill at runtime — the skill is a scheduled producer, the agent is a consumer. If the most recent snapshot is more than 14 days old, the agent's freshness gate kicks in and refuses competitive-keyword recommendations until a fresh snapshot lands.
+
+## Out of scope for this skill
+
+- Running on Vercel serverless (no browser binaries)
+- Real-time queries from the agent (the skill is weekly batch only)
+- Keyword research outside the queued list (the agent doesn't trigger ad-hoc Keyword Magic queries; it queues them in `_queue/keyword-magic.txt` for the next run)
+- Anything beyond the 5 listed dashboards — Phase 3 may extend (e.g. competitor-site analysis), not Phase 1
+
+## See also
+
+- `.claude/skills/webapp-testing/SKILL.md` — closest existing skill pattern; review its server lifecycle and selector-discovery approach before implementing
+- `.claude/agents/seo-director.md` — the consumer of this skill's output
+- Vault: `Programs/SEO-Director.md` — full data-pipeline diagram


### PR DESCRIPTION
## Summary

Phase 0 scaffolding for the new **SEO Director** agent — sibling to the existing Marketing Director, owning organic-search strategy on a 30–90 day feedback loop. This PR is **documentation + agent definition only**: no DB models, no cron routes, no admin endpoints, no UI. Phase 1 lands those once the shape here is approved.

- `.claude/agents/seo-director.md` — recommendations-only agent (sonnet, Read/Grep/Glob/Bash). Mirrors the marketing-director conventions: bootstrap from `Memory/SEO/`, write recs to the shared queue with `domain="seo"`, never auto-publish content in Phase 1. Hard rules cover TABC compliance, under-21 topic exclusion, GSC freshness gate (5 days) and SEMrush freshness gate (14 days) — analogs to Marketing's margin-coverage gate. Explicit boundary: SEO Director does **NOT** control `/api/cron/generate-blog` (that's broken and owned by Phase 2).
- `.claude/skills/seo-semrush-snapshot/SKILL.md` — Cowork browser-automation skill stub. Documents the Phase 1 contract (Playwright login → 5 dashboards → JSON + screenshots in `data/seo/semrush/<date>/`) and a **Phase 0 reconnaissance checklist** the operator must complete (2FA status, Cloudflare gating, selector stability) before Phase 1 implementation begins. Vercel can't run Playwright; runner placement (GitHub Actions vs. workstation cron) is a Phase 1 decision.

## What's in the Obsidian vault (not in this PR)

These ship alongside the PR but live in the operator's vault, not the repo:

- `Programs/SEO-Director.md` — full pipeline diagram, Phase 1 cron schedules
- `Memory/SEO/README.md` — folder conventions + 4 frontmatter schemas
- `Memory/SEO/Open-Questions.md` — seeded with the 8 questions from the buildout brief
- `Memory/SEO/Decisions/S0001-recommendation-storage-model.md` — storage ADR (status: `proposed`, awaiting operator acceptance)
- `Memory/SEO/{Briefings,Recommendations,Channel-Performance}/.gitkeep` — empty subfolders ready for Phase 1 content

## Storage decision (ADR S0001)

SEO recs share the existing `RecommendationItem` table via a `domain` discriminator field, **not** a parallel `SeoRecommendation` model. One queue, one triage UI, less duplication. Phase 1 ships the schema migration + UI tab. Full pros/cons in the ADR.

## Phase 1 scope (separate PR after this merges)

In rough dependency order, smallest PRs first:

1. Schema migration — `domain String? @default("marketing")` on `RecommendationItem`
2. GSC verification — confirm `analytics-snapshot` cron populates GSC fields
3. `seo-semrush-snapshot` Playwright implementation — runner placement decided after Phase 0 reconnaissance
4. Admin endpoints — `/api/admin/seo/{snapshot,keywords,rankings}`
5. `/api/cron/seo-snapshot` (daily 06:00 UTC) + `/api/cron/seo-briefing` (Mon 12:00 UTC, one hour before Marketing's)
6. Measurement cron extension for SEO recs
7. Recommendations UI domain tab
8. Vault sync (`npm run sync:seo`)

## Test plan

This is a docs-and-prompt PR; nothing executable to test. Verification is read-through:

- [ ] Agent appears as `subagent_type: "seo-director"` after merge (confirms frontmatter is well-formed)
- [ ] Agent's first invocation handles the absence of Phase 1 pipeline files gracefully — responds "Phase 1 pipeline not yet running, here's an ad-hoc analysis" rather than crashing
- [ ] Skill `seo-semrush-snapshot` appears in the available-skills list (already confirmed in plan-mode session)
- [ ] Operator reads `Programs/SEO-Director.md` + `Memory/SEO/README.md` + `Memory/SEO/Decisions/S0001-recommendation-storage-model.md` and confirms shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)