### PR TITLE
feat(seo): add domain discriminator to RecommendationItem (Phase 1 PR 1/N)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2468,11 +2468,12 @@ model ScheduleOrderMatch {
 model RecommendationItem {
   id                    String    @id @default(uuid())
   generatedAt           DateTime  @default(now()) @map("generated_at")
-  source                String    // 'auto-snapshot' | 'director' | 'manual'
+  source                String    // 'auto-snapshot' | 'director' | 'manual' | 'seo-director'
+  domain                String    @default("marketing") // 'marketing' | 'seo' — see ADR S0001 in Memory/SEO/Decisions/
   title                 String
   body                  String?   @db.Text
   segment               String?   // bach | wedding | corporate | boat | kegs | general | null (cross-segment)
-  metric                String?   // e.g. 'conversion-by-page:/weddings'
+  metric                String?   // e.g. 'conversion-by-page:/weddings' or 'gsc-position:/weddings'
   currentValue          String?   @map("current_value")
   targetValue           String?   @map("target_value")
   impactDollarsMonthly  Int?      @map("impact_dollars_monthly")
@@ -2490,6 +2491,7 @@ model RecommendationItem {
   @@index([generatedAt])
   @@index([segment])
   @@index([title, segment])
+  @@index([domain, status])
   @@map("recommendation_items")
 }
 

--- a/scripts/migrate-recommendation-items-add-domain.mjs
+++ b/scripts/migrate-recommendation-items-add-domain.mjs
@@ -1,0 +1,69 @@
+/**
+ * Add `domain` column to recommendation_items.
+ *
+ *   domain TEXT NOT NULL DEFAULT 'marketing' — discriminates Marketing vs. SEO recs in the
+ *   shared queue. Per ADR S0001 (Memory/SEO/Decisions/) we extend the existing table
+ *   rather than create a parallel SeoRecommendation model.
+ *
+ * Also adds a partial index on (domain, status) for the queue-filter query path:
+ * `WHERE domain = 'seo' AND status IN ('open','approved')` is the SEO Director's
+ * primary read pattern.
+ *
+ * Idempotent — uses ADD COLUMN IF NOT EXISTS and CREATE INDEX IF NOT EXISTS.
+ * Safe to re-run.
+ *
+ * Usage:
+ *   set -a && source .env.local && set +a && node scripts/migrate-recommendation-items-add-domain.mjs
+ */
+
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  console.log('=== Add `domain` to recommendation_items ===\n');
+
+  const statements = [
+    `ALTER TABLE "recommendation_items" ADD COLUMN IF NOT EXISTS "domain" TEXT NOT NULL DEFAULT 'marketing'`,
+    `CREATE INDEX IF NOT EXISTS "recommendation_items_domain_status_idx" ON "recommendation_items" ("domain", "status")`,
+  ];
+
+  for (const sql of statements) {
+    console.log(`>> ${sql}`);
+    await prisma.$executeRawUnsafe(sql);
+  }
+
+  const cols = await prisma.$queryRawUnsafe(`
+    SELECT column_name, data_type, is_nullable, column_default
+    FROM information_schema.columns
+    WHERE table_name = 'recommendation_items'
+      AND column_name = 'domain'
+  `);
+  console.log('\nNew column:');
+  console.table(cols);
+
+  const indexes = await prisma.$queryRawUnsafe(`
+    SELECT indexname, indexdef
+    FROM pg_indexes
+    WHERE tablename = 'recommendation_items'
+      AND indexname = 'recommendation_items_domain_status_idx'
+  `);
+  console.log('\nNew index:');
+  console.table(indexes);
+
+  const counts = await prisma.$queryRawUnsafe(`
+    SELECT domain, COUNT(*)::int AS rows
+    FROM recommendation_items
+    GROUP BY domain
+    ORDER BY domain
+  `);
+  console.log('\nRow counts by domain (existing rows backfilled by DEFAULT):');
+  console.table(counts);
+
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/admin/analytics/recommendations/page.tsx
+++ b/src/app/admin/analytics/recommendations/page.tsx
@@ -13,6 +13,8 @@ import { useEffect, useState, ReactElement, useCallback } from 'react';
 import Link from 'next/link';
 
 type Status = 'open' | 'approved' | 'shipped' | 'rejected' | 'invalidated';
+type Domain = 'marketing' | 'seo';
+type DomainFilter = Domain | 'all';
 type RiskTier = 'autonomous' | 'recommend' | 'hard_stop';
 type EffortTier = 's' | 'm' | 'l';
 
@@ -29,6 +31,7 @@ interface Recommendation {
   id: string;
   generatedAt: string;
   source: string;
+  domain: Domain;
   title: string;
   body: string | null;
   segment: string | null;
@@ -51,6 +54,12 @@ const STATUS_TABS: { value: Status | 'all'; label: string }[] = [
   { value: 'shipped', label: 'Shipped' },
   { value: 'rejected', label: 'Rejected' },
   { value: 'invalidated', label: 'Invalidated' },
+  { value: 'all', label: 'All' },
+];
+
+const DOMAIN_TABS: { value: DomainFilter; label: string }[] = [
+  { value: 'marketing', label: 'Marketing' },
+  { value: 'seo', label: 'SEO' },
   { value: 'all', label: 'All' },
 ];
 
@@ -81,6 +90,7 @@ const REASON_MIN_CHARS = 10;
 export default function RecommendationsTriagePage(): ReactElement {
   const [recs, setRecs] = useState<Recommendation[]>([]);
   const [filter, setFilter] = useState<Status | 'all'>('open');
+  const [domainFilter, setDomainFilter] = useState<DomainFilter>('marketing');
   const [isLoading, setIsLoading] = useState(true);
   const [savingId, setSavingId] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
@@ -93,6 +103,7 @@ export default function RecommendationsTriagePage(): ReactElement {
     try {
       const params = new URLSearchParams();
       if (filter !== 'all') params.set('status', filter);
+      if (domainFilter !== 'all') params.set('domain', domainFilter);
       params.set('limit', '200');
       const res = await fetch(`/api/admin/analytics/recommendations?${params.toString()}`);
       if (res.ok) {
@@ -104,7 +115,7 @@ export default function RecommendationsTriagePage(): ReactElement {
     } finally {
       setIsLoading(false);
     }
-  }, [filter]);
+  }, [filter, domainFilter]);
 
   useEffect(() => {
     fetchRecs();
@@ -195,6 +206,26 @@ export default function RecommendationsTriagePage(): ReactElement {
           </button>
         </div>
 
+        {/* Domain tabs */}
+        <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-3 mb-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-xs uppercase tracking-wider text-gray-500 font-medium mr-1">Domain</span>
+            {DOMAIN_TABS.map((d) => (
+              <button
+                key={d.value}
+                onClick={() => setDomainFilter(d.value)}
+                className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors ${
+                  domainFilter === d.value
+                    ? 'bg-brand-blue text-white'
+                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                }`}
+              >
+                {d.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
         {/* Status tabs */}
         <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-3 mb-6">
           <div className="flex flex-wrap gap-2">
@@ -230,9 +261,15 @@ export default function RecommendationsTriagePage(): ReactElement {
         ) : recs.length === 0 ? (
           <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-12 text-center">
             <p className="text-gray-500 text-sm">No recommendations match this filter.</p>
-            {filter === 'open' && (
+            {filter === 'open' && domainFilter === 'marketing' && (
               <p className="text-gray-400 text-xs mt-2">
-                The agent will populate this queue on the next weekly briefing run.
+                The Marketing Director will populate this queue on the next weekly briefing run.
+              </p>
+            )}
+            {filter === 'open' && domainFilter === 'seo' && (
+              <p className="text-gray-400 text-xs mt-2">
+                The SEO Director Phase 1 snapshot pipeline isn&apos;t live yet. SEO recs will start
+                appearing here once <code className="px-1 bg-gray-100 rounded">/api/cron/seo-snapshot</code> ships.
               </p>
             )}
           </div>
@@ -253,13 +290,30 @@ export default function RecommendationsTriagePage(): ReactElement {
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2 mb-1.5 flex-wrap">
                           <StatusBadge status={rec.status} />
+                          {domainFilter === 'all' && rec.domain && (
+                            <span
+                              className={`px-2 py-0.5 text-xs rounded-full font-medium ${
+                                rec.domain === 'seo'
+                                  ? 'bg-emerald-100 text-emerald-800'
+                                  : 'bg-indigo-100 text-indigo-800'
+                              }`}
+                            >
+                              {rec.domain === 'seo' ? 'SEO' : 'Marketing'}
+                            </span>
+                          )}
                           {rec.segment && (
                             <span className="px-2 py-0.5 text-xs rounded-full bg-gray-100 text-gray-700 font-medium">
                               {rec.segment}
                             </span>
                           )}
                           <span className="text-xs text-gray-400">
-                            {rec.source === 'director' ? 'Director' : rec.source === 'auto-snapshot' ? 'Heuristic' : 'Manual'}
+                            {rec.source === 'seo-director'
+                              ? 'SEO Director'
+                              : rec.source === 'director'
+                                ? 'Director'
+                                : rec.source === 'auto-snapshot'
+                                  ? 'Heuristic'
+                                  : 'Manual'}
                             {' · '}
                             {new Date(rec.generatedAt).toLocaleDateString()}
                           </span>

--- a/src/app/api/admin/analytics/recommendations/route.ts
+++ b/src/app/api/admin/analytics/recommendations/route.ts
@@ -5,19 +5,25 @@ import {
   persistRecommendations,
   updateRecommendationStatus,
   type RecommendationStatus,
+  type RecommendationDomain,
 } from '@/lib/analytics/recommendation-store';
 import { mirrorRecommendation } from '@/lib/analytics/recommendation-mirror';
 
 export const dynamic = 'force-dynamic';
 
 const STATUSES: RecommendationStatus[] = ['open', 'approved', 'shipped', 'rejected', 'invalidated'];
+const DOMAINS: RecommendationDomain[] = ['marketing', 'seo'];
 
 /**
- * GET  /api/admin/analytics/recommendations?status=open&segment=wedding&limit=50
+ * GET  /api/admin/analytics/recommendations?status=open&segment=wedding&domain=marketing&limit=50
  * POST /api/admin/analytics/recommendations  body: { id, status, notes? }
+ *                                          | body: { title, domain?, ..., source? }
  *
  * Lists Director-generated and heuristic recommendations from the persistent queue,
  * and lets ops move them through the open → approved → shipped (or rejected) workflow.
+ *
+ * `domain` defaults to `marketing` on POST when omitted (back-compat with Marketing
+ * Director callers that predate the discriminator). SEO Director must pass `domain: "seo"`.
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const auth = await requireOpsAuth();
@@ -26,6 +32,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   const sp = request.nextUrl.searchParams;
   const statusParam = sp.get('status');
   const segment = sp.get('segment') ?? undefined;
+  const domainParam = sp.get('domain');
   const limit = Math.min(500, Math.max(1, parseInt(sp.get('limit') ?? '100', 10)));
 
   let status: RecommendationStatus | RecommendationStatus[] | undefined;
@@ -35,7 +42,14 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     status = valid.length === 1 ? valid[0] : valid;
   }
 
-  const data = await listRecommendations({ status, segment, limit });
+  let domain: RecommendationDomain | RecommendationDomain[] | undefined;
+  if (domainParam) {
+    const requested = domainParam.split(',').map((s) => s.trim()) as RecommendationDomain[];
+    const valid = requested.filter((d): d is RecommendationDomain => DOMAINS.includes(d));
+    domain = valid.length === 1 ? valid[0] : valid.length > 1 ? valid : undefined;
+  }
+
+  const data = await listRecommendations({ status, segment, domain, limit });
   return NextResponse.json({ data });
 }
 
@@ -76,12 +90,19 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ data: updated, mirror });
   }
 
-  // Create path: { title, body?, segment?, impactDollarsMonthly?, effortTier?, riskTier?, source? }
+  // Create path: { title, body?, domain?, segment?, impactDollarsMonthly?, effortTier?, riskTier?, source? }
   if (typeof body?.title === 'string') {
+    const domain: RecommendationDomain | undefined = DOMAINS.includes(body.domain)
+      ? body.domain
+      : undefined;
+    const validSources = ['director', 'manual', 'seo-director'] as const;
+    const source = validSources.includes(body.source) ? body.source : 'manual';
+
     const result = await persistRecommendations(
       [{
         title: body.title,
         body: typeof body.body === 'string' ? body.body : undefined,
+        domain,
         segment: typeof body.segment === 'string' ? body.segment : undefined,
         metric: typeof body.metric === 'string' ? body.metric : undefined,
         impactDollarsMonthly:
@@ -91,7 +112,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
           ? body.riskTier
           : undefined,
       }],
-      body.source === 'director' || body.source === 'manual' ? body.source : 'manual'
+      source
     );
     return NextResponse.json({ data: result });
   }

--- a/src/lib/analytics/recommendation-store.ts
+++ b/src/lib/analytics/recommendation-store.ts
@@ -11,13 +11,15 @@
 import { prisma } from '@/lib/database/client';
 import type { Prisma } from '@prisma/client';
 
-export type RecommendationSource = 'auto-snapshot' | 'director' | 'manual';
+export type RecommendationSource = 'auto-snapshot' | 'director' | 'manual' | 'seo-director';
 export type RiskTier = 'autonomous' | 'recommend' | 'hard_stop';
 export type RecommendationStatus = 'open' | 'approved' | 'shipped' | 'rejected' | 'invalidated';
+export type RecommendationDomain = 'marketing' | 'seo';
 
 export interface RecommendationInput {
   title: string;
   body?: string;
+  domain?: RecommendationDomain;
   segment?: string | null;
   metric?: string;
   currentValue?: string;
@@ -45,10 +47,13 @@ export async function persistRecommendations(
   let skippedExisting = 0;
 
   for (const rec of recs) {
+    const domain: RecommendationDomain = rec.domain ?? (source === 'seo-director' ? 'seo' : 'marketing');
+
     const existing = await prisma.recommendationItem.findFirst({
       where: {
         title: rec.title,
         segment: rec.segment ?? null,
+        domain,
         status: { in: ['open', 'approved'] },
       },
       select: { id: true },
@@ -62,6 +67,7 @@ export async function persistRecommendations(
     await prisma.recommendationItem.create({
       data: {
         source,
+        domain,
         title: rec.title,
         body: rec.body ?? null,
         segment: rec.segment ?? null,
@@ -82,16 +88,21 @@ export async function persistRecommendations(
 export async function listRecommendations(opts?: {
   status?: RecommendationStatus | RecommendationStatus[];
   segment?: string;
+  domain?: RecommendationDomain | RecommendationDomain[];
   limit?: number;
 }) {
   const where: {
     status?: RecommendationStatus | { in: RecommendationStatus[] };
     segment?: string;
+    domain?: RecommendationDomain | { in: RecommendationDomain[] };
   } = {};
   if (opts?.status) {
     where.status = Array.isArray(opts.status) ? { in: opts.status } : opts.status;
   }
   if (opts?.segment) where.segment = opts.segment;
+  if (opts?.domain) {
+    where.domain = Array.isArray(opts.domain) ? { in: opts.domain } : opts.domain;
+  }
 
   return prisma.recommendationItem.findMany({
     where,


### PR DESCRIPTION
## Summary

First Phase 1 PR for the SEO Director — extends the existing `RecommendationItem` queue with a `domain` field so SEO recs share the table with Marketing recs. Per [ADR S0001](https://github.com/allan-cmyk/PartyOn2/pull/28) (in `Memory/SEO/Decisions/` in the Obsidian vault), one shared queue beats two parallel models.

- **Schema:** `domain TEXT NOT NULL DEFAULT 'marketing'` on `recommendation_items` + partial index `[domain, status]` for the queue-filter query path.
- **Migration:** raw SQL via `scripts/migrate-recommendation-items-add-domain.mjs` (per the schema-drift memory note — additive migrations go through `scripts/migrate-*.mjs`, not Prisma migrate). Idempotent (`ADD COLUMN IF NOT EXISTS`). Existing rows backfilled to `'marketing'` by the column default.
- **API:** `/api/admin/analytics/recommendations` GET accepts `?domain=marketing|seo` (or both when omitted). POST accepts a `domain` field on the create path. New `seo-director` source value.
- **UI:** Domain filter row above the existing status tabs (Marketing | SEO | All). Domain badge on each rec card when viewing All. SEO empty-state explains the Phase 1 snapshot pipeline isn't live yet.

## Operator action: run the migration before deploy

```bash
set -a && source .env.local && set +a && \
  node scripts/migrate-recommendation-items-add-domain.mjs
```

The script prints the new column + index + a row-count-by-domain breakdown so you can confirm the backfill worked. Idempotent — safe to re-run.

## What this PR does NOT include (deferred to subsequent Phase 1 PRs)

- `seo-semrush-snapshot` Playwright implementation
- `/api/cron/seo-snapshot` + `/api/cron/seo-briefing`
- `/api/admin/seo/*` endpoints
- Measurement cron extension for SEO success metrics
- Vault sync `npm run sync:seo`

## Test plan

- [ ] **Run the migration locally** (command above), confirm output shows the new column with default `'marketing'` and the new index
- [ ] **Pull the branch in dev** (`npm run dev`), open `/admin/analytics/recommendations`, confirm:
  - Domain filter row renders above status tabs, defaulting to **Marketing**
  - Switching to **SEO** shows the empty-state with the Phase 1 message
  - Switching to **All** renders both kinds with a colored domain badge on each card
  - Existing Marketing recs still appear identically (no regressions)
- [ ] **Smoke-test the API**:
  ```bash
  # Should return only marketing rows
  curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/recommendations?domain=marketing&limit=5' | jq '.data[].domain'
  # Should return only seo rows (likely empty until SEO Director Phase 1 ships)
  curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/analytics/recommendations?domain=seo&limit=5'
  # Create a test SEO rec
  curl -s -H "Cookie: $OPS_COOKIE" -X POST 'http://localhost:3000/api/admin/analytics/recommendations' \
    -H 'Content-Type: application/json' \
    -d '{"title":"Phase 1 smoke test","domain":"seo","source":"seo-director","riskTier":"recommend"}'
  ```
- [ ] **Verify pre-existing tests still pass:** `npx tsc --noEmit` clean (one unrelated Stripe test fixture error in `src/__tests__/group-v2-payments.test.ts` already on main); `npx next lint` clean on all four touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)