### PR TITLE
fix(cart/share): stop wrapping UUIDs in fake Shopify GIDs

### DIFF
--- a/src/lib/cart/shareCart.ts
+++ b/src/lib/cart/shareCart.ts
@@ -42,15 +42,19 @@ function extractVariantId(gid: string): string {
 }
 
 /**
- * Reconstruct Shopify GID from numeric ID
+ * Reconstruct a variant identifier the cart API can resolve.
+ *
+ * Cart now stores local UUIDs (post-Shopify-cart migration) but legacy share
+ * URLs may contain numeric Shopify variant IDs. /api/v1/products/variant/[id]
+ * accepts both formats natively, so:
+ *   - full gid:// → pass through unchanged
+ *   - purely numeric → wrap as legacy Shopify GID (preserves old share links)
+ *   - anything else (UUID, etc.) → pass through unchanged
  */
 function reconstructGid(id: string): string {
-  // If already a full GID, return as-is
-  if (id.startsWith('gid://')) {
-    return id;
-  }
-  // Otherwise, reconstruct from numeric ID
-  return `gid://shopify/ProductVariant/${id}`;
+  if (id.startsWith('gid://')) return id;
+  if (/^\d+$/.test(id)) return `gid://shopify/ProductVariant/${id}`;
+  return id;
 }
 
 /**


### PR DESCRIPTION
## Summary

Share cart was broken for any cart created through the modern flow (search → product page → add to cart). The recipient saw "Failed to add items to your cart."

**Root cause**: post-Shopify-cart migration, the storefront cart stores variants as local Postgres UUIDs. Cart.tsx and MobileCart.tsx pass `node.merchandise.id` (a UUID) into the share payload. On the receive side, `reconstructGid` was unconditionally wrapping every non-`gid://` id as `gid://shopify/ProductVariant/<id>`. For a UUID this produces a fake GID; the variant lookup at `/api/v1/products/variant/[id]` then strips the `gid://shopify/ProductVariant/` prefix and queries `where: { shopifyId: <uuid> }`, which never matches → 404 → addToCart throws → recipient sees the error screen.

Confirmed against prod: `GET /api/v1/products/variant/<uuid>` returns the variant; `GET /api/v1/products/variant/gid%3A%2F%2Fshopify%2FProductVariant%2F<uuid>` returns `{"error":"Variant not found"}`.

**Fix**: only wrap purely-numeric ids (preserves any legacy share URLs that contained Shopify variant IDs); pass UUIDs through unchanged.

## Bonus

Any UUID-share-URLs already in the wild (links customers shared but couldn't open) will start working as soon as this deploys — the fix is purely on the receive side. No backfill or URL regeneration needed.

## Test plan

- [ ] After deploy, open the failing URL the user reported: `https://partyondelivery.com/cart/shared?c=YzFlNDA3MjEtN2U1MC00MWQ1LTk4NjItNmE2ZmExMDliNTNkLDE&t=teojnx` — should add the Pearl Snap 6-pack to cart and redirect home.
- [ ] Fresh flow: search a product on homepage → add to cart → click "Share Cart" → open the URL in incognito → cart loads with the same item.
- [ ] Legacy: confirm a numeric-id share URL (if any pre-Shopify-cart-migration link is around) still works.