### PR TITLE
feat(cart/share): short-link share URLs via /s/<slug>

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2510,3 +2510,18 @@ model SyncLog {
 
   @@map("sync_log")
 }
+
+/// Short-link record for /cart/shared URLs. Customer-facing share links
+/// resolve via /s/<slug> → 302 → /cart/shared?c=...&t=...
+model CartShareLink {
+  id        String   @id @default(uuid())
+  slug      String   @unique
+  cartData  String   @map("cart_data") @db.Text  // base64 'c' payload
+  token     String   // base36 't' timestamp
+  expiresAt DateTime @map("expires_at")
+  viewCount Int      @default(0) @map("view_count")
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@index([expiresAt])
+  @@map("cart_share_links")
+}

--- a/scripts/migrate-add-cart-share-links.mjs
+++ b/scripts/migrate-add-cart-share-links.mjs
@@ -1,0 +1,55 @@
+/**
+ * Add cart_share_links table for short-link share URLs.
+ *
+ * Customer-facing share links resolve via /s/<slug> → 302 → /cart/shared?c=...&t=...
+ * Storing the encoded cart payload + token + expiration in Postgres lets us shorten
+ * the visible URL from ~110 chars to ~35 chars and survive the serverless cold-start
+ * problem the prior in-memory implementation had.
+ *
+ * Idempotent — uses CREATE TABLE IF NOT EXISTS. Safe to re-run.
+ *
+ * Usage:
+ *   set -a && source .env.local && set +a && node scripts/migrate-add-cart-share-links.mjs
+ */
+
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  console.log('=== Add cart_share_links table ===\n');
+
+  const statements = [
+    `CREATE TABLE IF NOT EXISTS "cart_share_links" (
+       "id"          TEXT PRIMARY KEY,
+       "slug"        TEXT NOT NULL UNIQUE,
+       "cart_data"   TEXT NOT NULL,
+       "token"       TEXT NOT NULL,
+       "expires_at"  TIMESTAMPTZ NOT NULL,
+       "view_count"  INTEGER NOT NULL DEFAULT 0,
+       "created_at"  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+     )`,
+    `CREATE INDEX IF NOT EXISTS "cart_share_links_expires_at_idx" ON "cart_share_links"("expires_at")`,
+  ];
+
+  for (const sql of statements) {
+    console.log(`>> ${sql.split('\n')[0].trim()}...`);
+    await prisma.$executeRawUnsafe(sql);
+  }
+
+  const cols = await prisma.$queryRawUnsafe(`
+    SELECT column_name, data_type, is_nullable
+    FROM information_schema.columns
+    WHERE table_name = 'cart_share_links'
+    ORDER BY ordinal_position
+  `);
+  console.log('\nTable structure:');
+  console.table(cols);
+
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/api/cart/share/route.ts
+++ b/src/app/api/cart/share/route.ts
@@ -1,12 +1,36 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/database/client';
 import { generateShareUrl, type SharedCartData } from '@/lib/cart/shareCart';
+
+const SLUG_ALPHABET = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+const SLUG_LENGTH = 7;
+
+function generateSlug(): string {
+  let result = '';
+  for (let i = 0; i < SLUG_LENGTH; i++) {
+    result += SLUG_ALPHABET.charAt(Math.floor(Math.random() * SLUG_ALPHABET.length));
+  }
+  return result;
+}
+
+/**
+ * Generate a unique slug, retrying on collision.
+ * 62^7 = 3.5T combinations — collisions are essentially impossible at our scale.
+ */
+async function generateUniqueSlug(): Promise<string> {
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const slug = generateSlug();
+    const existing = await prisma.cartShareLink.findUnique({ where: { slug } });
+    if (!existing) return slug;
+  }
+  throw new Error('Failed to generate unique slug after 5 attempts');
+}
 
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
     const { variants } = body;
 
-    // Validate input
     if (!variants || !Array.isArray(variants) || variants.length === 0) {
       return NextResponse.json(
         { error: 'Cart must contain at least one item' },
@@ -14,46 +38,55 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Validate each variant
     for (const variant of variants) {
       if (!variant.id || typeof variant.id !== 'string') {
-        return NextResponse.json(
-          { error: 'Invalid variant ID' },
-          { status: 400 }
-        );
+        return NextResponse.json({ error: 'Invalid variant ID' }, { status: 400 });
       }
       if (!variant.quantity || typeof variant.quantity !== 'number' || variant.quantity <= 0) {
-        return NextResponse.json(
-          { error: 'Invalid quantity' },
-          { status: 400 }
-        );
+        return NextResponse.json({ error: 'Invalid quantity' }, { status: 400 });
       }
     }
 
-    // Create shared cart data
     const cartData: SharedCartData = {
       variants,
       timestamp: Date.now(),
-      expiresAt: Date.now() + (60 * 24 * 60 * 60 * 1000), // 60 days from now
+      expiresAt: Date.now() + 60 * 24 * 60 * 60 * 1000, // 60 days
     };
 
-    // Get base URL from request
     const baseUrl = `${request.nextUrl.protocol}//${request.nextUrl.host}`;
 
-    // Generate compressed shareable URL with parameters
-    const shareUrl = generateShareUrl(cartData, baseUrl);
+    // Generate the long URL once so we can extract the encoded c + t params,
+    // then persist them under a short slug.
+    const longUrl = generateShareUrl(cartData, baseUrl);
+    const longParams = new URL(longUrl).searchParams;
+    const c = longParams.get('c');
+    const t = longParams.get('t');
+
+    if (!c || !t) {
+      // Should never happen, but fall back to the long URL rather than crash.
+      return NextResponse.json({ success: true, shareUrl: longUrl, expiresAt: cartData.expiresAt });
+    }
+
+    const slug = await generateUniqueSlug();
+
+    await prisma.cartShareLink.create({
+      data: {
+        slug,
+        cartData: c,
+        token: t,
+        expiresAt: new Date(cartData.expiresAt!),
+      },
+    });
+
+    const shareUrl = `${baseUrl}/s/${slug}`;
 
     return NextResponse.json({
       success: true,
       shareUrl,
       expiresAt: cartData.expiresAt,
     });
-
   } catch (error) {
     console.error('Error creating shared cart:', error);
-    return NextResponse.json(
-      { error: 'Failed to create shared cart' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Failed to create shared cart' }, { status: 500 });
   }
 }

--- a/src/app/s/[slug]/route.ts
+++ b/src/app/s/[slug]/route.ts
@@ -1,0 +1,45 @@
+/**
+ * Short-link redirect for shared carts.
+ *
+ *   GET /s/<slug>  →  302  →  /cart/shared?c=<cartData>&t=<token>
+ *
+ * The /cart/shared page handles the existing parse + add-to-cart flow.
+ * We only persist the encoded c + t pair on the POST side; this route just
+ * recovers them and bumps the view count.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/database/client';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+
+  // Slug is 7 chars from [a-zA-Z0-9]; reject anything else without hitting DB.
+  if (!slug || !/^[A-Za-z0-9]{4,16}$/.test(slug)) {
+    return NextResponse.redirect(new URL('/?cart-share-invalid=1', request.url), 302);
+  }
+
+  const link = await prisma.cartShareLink.findUnique({ where: { slug } });
+
+  if (!link) {
+    return NextResponse.redirect(new URL('/?cart-share-not-found=1', request.url), 302);
+  }
+
+  if (link.expiresAt.getTime() < Date.now()) {
+    return NextResponse.redirect(new URL('/?cart-share-expired=1', request.url), 302);
+  }
+
+  // Bump view count, fire-and-forget — don't block the redirect on it.
+  prisma.cartShareLink
+    .update({ where: { slug }, data: { viewCount: { increment: 1 } } })
+    .catch((err) => console.error('Failed to increment cart-share view count:', err));
+
+  const target = new URL('/cart/shared', request.url);
+  target.searchParams.set('c', link.cartData);
+  target.searchParams.set('t', link.token);
+
+  return NextResponse.redirect(target, 302);
+}


### PR DESCRIPTION
## Summary

Share URLs were ~110 characters and looked spammy in iMessage / SMS:

> https://partyondelivery.com/cart/shared?c=YzFlNDA3MjEt...&t=teojnx

Now they're ~35 characters:

> https://partyondelivery.com/s/aB3xK9p

## How it works

- **POST `/api/cart/share`** generates a 7-char base62 slug, persists the encoded `c + t` payload + `expiresAt` in a new `cart_share_links` table, and returns `/s/<slug>` instead of the inlined long URL.
- **GET `/s/<slug>`** looks up the slug, bumps `view_count`, and 302-redirects to `/cart/shared?c=...&t=...`. The existing receiver flow is untouched, so any in-flight long URLs that were already sent keep working — no backfill needed.

7-char base62 = 3.5T combinations. Slug-collision retry is built in but won't realistically fire.

## Migration

Purely additive — `CREATE TABLE IF NOT EXISTS cart_share_links`. Already applied to prod via `scripts/migrate-add-cart-share-links.mjs` (idempotent).

## Test plan

- [ ] Add an item to cart → click "Share Cart" → resulting URL is `https://partyondelivery.com/s/<7-char>` (~35 chars total).
- [ ] Open the short URL in incognito → 302 redirects to `/cart/shared?c=...&t=...` → cart loads with the right item.
- [ ] Send an old long URL (from before this change) — still works.
- [ ] Bad slug like `/s/zzzzzz` redirects to `/?cart-share-not-found=1`.
- [ ] DB row's `view_count` increments after the recipient opens the short URL.