### PR TITLE
fix(group-orders): expiresAt extends past delivery date for long-lead bookings

### DIFF
--- a/src/lib/group-orders-v2/service.ts
+++ b/src/lib/group-orders-v2/service.ts
@@ -239,6 +239,10 @@ export async function createGroupOrder(
     attempts++;
   }
 
+  const tabDeliveryDates = input.tabs
+    .map(tab => new Date(tab.deliveryDate ?? ''))
+    .filter(d => !isNaN(d.getTime()));
+
   const group = await prisma.groupOrderV2.create({
     data: {
       name: input.name,
@@ -247,7 +251,7 @@ export async function createGroupOrder(
       hostPhone: input.hostPhone || null,
       hostCustomerId: input.hostCustomerId || null,
       shareCode,
-      expiresAt: defaultExpiresAt(),
+      expiresAt: defaultExpiresAt(tabDeliveryDates),
       tabs: {
         create: input.tabs.map((tab, idx) => {
           const deliveryDate = new Date(tab.deliveryDate ?? '');
@@ -940,7 +944,7 @@ export async function createDashboardOrder(
       affiliateId: input.affiliateId || null,
       source: input.source || 'DIRECT',
       isLastMinute: input.isLastMinute ?? false,
-      expiresAt: defaultExpiresAt(),
+      expiresAt: defaultExpiresAt(deliveryDate),
       tabs: {
         create: {
           name: input.tabName || 'Location 1',
@@ -1007,7 +1011,7 @@ export async function createMultiTabDashboardOrder(
       partyType: input.partyType || null,
       affiliateId: input.affiliateId,
       source: input.source || 'PARTNER_PAGE',
-      expiresAt: defaultExpiresAt(),
+      expiresAt: defaultExpiresAt(deliveryDate),
       tabs: {
         create: input.tabs.map((tab, idx) => {
           const address = tab.deliveryAddress

--- a/src/lib/group-orders-v2/utils.ts
+++ b/src/lib/group-orders-v2/utils.ts
@@ -36,12 +36,28 @@ export function isSunday(date: Date): boolean {
 }
 
 /**
- * Default expiration: 30 days from now
+ * Default expiration window.
+ *
+ * Without a delivery date, falls back to 30 days from now. With a delivery date
+ * (or list of dates — e.g. multi-tab orders), extends to `bufferDays` past the
+ * latest delivery, with a floor of 30 days from now. This prevents long-lead
+ * bookings (e.g. boat cruises booked >30 days out) from auto-closing before
+ * the actual delivery date.
  */
-export function defaultExpiresAt(): Date {
-  const d = new Date();
-  d.setDate(d.getDate() + 30);
-  return d;
+export function defaultExpiresAt(deliveryDate?: Date | Date[], bufferDays = 7): Date {
+  const floor = new Date();
+  floor.setDate(floor.getDate() + 30);
+
+  if (!deliveryDate) return floor;
+
+  const dates = Array.isArray(deliveryDate) ? deliveryDate : [deliveryDate];
+  if (dates.length === 0) return floor;
+
+  const latest = dates.reduce((max, d) => (d > max ? d : max));
+  const fromDelivery = new Date(latest);
+  fromDelivery.setDate(fromDelivery.getDate() + bufferDays);
+
+  return fromDelivery > floor ? fromDelivery : floor;
 }
 
 /**


### PR DESCRIPTION
## Summary

Long-lead group order bookings (boat cruises, weddings booked >30 days out) were auto-closing 30 days after creation — even when delivery was still weeks away — locking customers out of their own group order.

**Root cause:** `defaultExpiresAt()` always returned `now + 30 days`, ignoring the actual delivery date.

**Fix:** `defaultExpiresAt()` now optionally takes a delivery date (or list of dates) and returns `max(now + 30 days, latest delivery + 7 days)`. Updated all 3 call sites in `service.ts`:
- `createGroupOrder` — uses latest of `input.tabs[*].deliveryDate`
- single-tab webhook creator — uses `deliveryDate`
- `createMultiTabDashboardOrder` — uses `deliveryDate`

No-arg behavior preserved (returns 30-day floor) so any other caller can't break.

## Customer impact
Surfaced via a Premier Party Cruises customer (Sam, on behalf of Shilpa Chopra's Saturday cruise). I've already manually reopened that group. A separate sweep found **108 other CLOSED groups with delivery still in the future** that need backfilling — tracked separately, not in this PR.

## Test plan
- [ ] After deploy, confirm any new long-lead booking (e.g. >30 days out) has `expiresAt` set past its delivery date
- [ ] Confirm short-lead bookings still get the 30-day floor (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)