### PR TITLE
feat(inventory): decrement stock on pack (pre-Phase-1 for Ops Director)

### DIFF
--- a/src/__tests__/pick-inventory-service.test.ts
+++ b/src/__tests__/pick-inventory-service.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Pick Inventory Service — pure transition logic tests.
+ *
+ * Covers each row of the pack/unpack/short-adjust truth table in
+ * docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md §7.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  computePickInventoryChange,
+  unitsOffShelf,
+} from '@/lib/inventory/services/pick-inventory-service';
+
+describe('unitsOffShelf', () => {
+  it('returns 0 when not packed', () => {
+    expect(unitsOffShelf({ packed: false, shortBy: 0 }, 10)).toBe(0);
+    expect(unitsOffShelf({ packed: false, shortBy: 4 }, 10)).toBe(0);
+  });
+
+  it('returns orderQty - shortBy when packed', () => {
+    expect(unitsOffShelf({ packed: true, shortBy: 0 }, 10)).toBe(10);
+    expect(unitsOffShelf({ packed: true, shortBy: 3 }, 10)).toBe(7);
+  });
+
+  it('floors at 0 when shortBy exceeds orderQty', () => {
+    expect(unitsOffShelf({ packed: true, shortBy: 99 }, 10)).toBe(0);
+  });
+});
+
+describe('computePickInventoryChange', () => {
+  it('packed false → true, full quantity → decrement reason=pack', () => {
+    const change = computePickInventoryChange(
+      { packed: false, shortBy: 0 },
+      { packed: true, shortBy: 0 },
+      10,
+    );
+    expect(change).toEqual({ delta: 10, reason: 'pack' });
+  });
+
+  it('packed false → true with shortBy → decrement minus shortBy, reason=pack', () => {
+    const change = computePickInventoryChange(
+      { packed: false, shortBy: 0 },
+      { packed: true, shortBy: 2 },
+      10,
+    );
+    expect(change).toEqual({ delta: 8, reason: 'pack' });
+  });
+
+  it('packed true → false → increment back, reason=unpack', () => {
+    const change = computePickInventoryChange(
+      { packed: true, shortBy: 0 },
+      { packed: false, shortBy: 0 },
+      10,
+    );
+    expect(change).toEqual({ delta: -10, reason: 'unpack' });
+  });
+
+  it('packed true → false preserves shortBy in increment, reason=unpack', () => {
+    const change = computePickInventoryChange(
+      { packed: true, shortBy: 3 },
+      { packed: false, shortBy: 3 },
+      10,
+    );
+    expect(change).toEqual({ delta: -7, reason: 'unpack' });
+  });
+
+  it('shortBy increases while packed → increment back, reason=pack-short-adjust', () => {
+    // Was packed with 0 short; operator now marks 2 short → those 2 units were never off the shelf
+    const change = computePickInventoryChange(
+      { packed: true, shortBy: 0 },
+      { packed: true, shortBy: 2 },
+      10,
+    );
+    expect(change).toEqual({ delta: -2, reason: 'pack-short-adjust' });
+  });
+
+  it('shortBy decreases while packed → further decrement, reason=pack-short-adjust', () => {
+    const change = computePickInventoryChange(
+      { packed: true, shortBy: 3 },
+      { packed: true, shortBy: 1 },
+      10,
+    );
+    expect(change).toEqual({ delta: 2, reason: 'pack-short-adjust' });
+  });
+
+  it('packed unchanged AND shortBy unchanged → null (idempotent)', () => {
+    expect(
+      computePickInventoryChange(
+        { packed: false, shortBy: 0 },
+        { packed: false, shortBy: 0 },
+        10,
+      ),
+    ).toBeNull();
+
+    expect(
+      computePickInventoryChange(
+        { packed: true, shortBy: 2 },
+        { packed: true, shortBy: 2 },
+        10,
+      ),
+    ).toBeNull();
+  });
+
+  it('packed false → true with shortBy >= orderQty → no decrement (all short)', () => {
+    expect(
+      computePickInventoryChange(
+        { packed: false, shortBy: 0 },
+        { packed: true, shortBy: 10 },
+        10,
+      ),
+    ).toBeNull();
+  });
+
+  it('handles orderQty=0 cleanly (zero-quantity rows produce no movement)', () => {
+    expect(
+      computePickInventoryChange(
+        { packed: false, shortBy: 0 },
+        { packed: true, shortBy: 0 },
+        0,
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/app/api/ops/orders/[id]/picks/route.ts
+++ b/src/app/api/ops/orders/[id]/picks/route.ts
@@ -17,6 +17,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { prisma } from '@/lib/database/client';
 import { requireOpsAuth } from '@/lib/auth/ops-session';
+import { applyPickInventoryTransition } from '@/lib/inventory/services/pick-inventory-service';
 
 const PutBodySchema = z.object({
   itemKey: z.string().min(1).max(500),
@@ -81,21 +82,42 @@ export async function PUT(
 
   const { itemKey, inStock, packed, shortBy } = parsed.data;
 
-  const row = await prisma.orderItemPickState.upsert({
-    where: { orderId_itemKey: { orderId, itemKey } },
-    create: {
-      orderId,
-      itemKey,
-      inStock: inStock ?? false,
-      packed: packed ?? false,
-      shortBy: shortBy ?? 0,
-    },
-    update: {
-      ...(inStock !== undefined ? { inStock } : {}),
-      ...(packed !== undefined ? { packed } : {}),
-      ...(shortBy !== undefined ? { shortBy } : {}),
-    },
-    select: { itemKey: true, inStock: true, packed: true, shortBy: true },
+  // Pack-state transitions move physical inventory. Read the prior row, upsert
+  // the new state, and apply any inventory delta in one transaction so the
+  // two stay in lockstep. Idempotent: a repeat PUT with the same payload
+  // computes a zero delta and skips the InventoryMovement.
+  const row = await prisma.$transaction(async (tx) => {
+    const existing = await tx.orderItemPickState.findUnique({
+      where: { orderId_itemKey: { orderId, itemKey } },
+      select: { packed: true, shortBy: true },
+    });
+
+    const prev = existing ?? { packed: false, shortBy: 0 };
+    const next = {
+      packed: packed ?? prev.packed,
+      shortBy: shortBy ?? prev.shortBy,
+    };
+
+    const upserted = await tx.orderItemPickState.upsert({
+      where: { orderId_itemKey: { orderId, itemKey } },
+      create: {
+        orderId,
+        itemKey,
+        inStock: inStock ?? false,
+        packed: packed ?? false,
+        shortBy: shortBy ?? 0,
+      },
+      update: {
+        ...(inStock !== undefined ? { inStock } : {}),
+        ...(packed !== undefined ? { packed } : {}),
+        ...(shortBy !== undefined ? { shortBy } : {}),
+      },
+      select: { itemKey: true, inStock: true, packed: true, shortBy: true },
+    });
+
+    await applyPickInventoryTransition(tx, { orderId, itemKey, prev, next });
+
+    return upserted;
   });
 
   return NextResponse.json({ ok: true, state: row });

--- a/src/lib/inventory/services/pick-inventory-service.ts
+++ b/src/lib/inventory/services/pick-inventory-service.ts
@@ -1,0 +1,238 @@
+/**
+ * Pick Inventory Service
+ *
+ * Couples ops/orders pack actions to physical inventory. When an operator
+ * toggles `packed` on a pick row (or adjusts `shortBy` while already packed),
+ * we move units off the shelf — decrementing both `inventoryQuantity` and
+ * `committedQuantity` on the relevant ProductVariant and writing an
+ * `InventoryMovement` row for the audit trail.
+ *
+ * Pre-Phase-1 for the Ops Director (see
+ * docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md §7).
+ *
+ * NOTE on coordination with `fulfillInventoryForOrder`: once pack-time
+ * decrements ship, marking an order DELIVERED via the existing fulfillment
+ * path would double-decrement units that were already packed. Reconciling
+ * the fulfillment path is Phase 1A and intentionally NOT in this PR. The
+ * Ops Director's drift signal #2 surfaces pre-deploy packed orders for
+ * one-click reconciliation.
+ */
+
+import { prisma } from '@/lib/database/client';
+
+type TransactionClient = Omit<
+  typeof prisma,
+  '$connect' | '$disconnect' | '$on' | '$transaction' | '$use' | '$extends'
+>;
+
+export interface PickStateLike {
+  packed: boolean;
+  shortBy: number;
+}
+
+export type PickInventoryReason = 'pack' | 'unpack' | 'pack-short-adjust';
+
+/**
+ * Units physically off the shelf for a given pick state.
+ * packed=false → 0. packed=true → max(0, orderQty - shortBy).
+ */
+export function unitsOffShelf(state: PickStateLike, orderQty: number): number {
+  if (!state.packed) return 0;
+  return Math.max(0, orderQty - state.shortBy);
+}
+
+/**
+ * Inventory delta for a pick-state transition.
+ * Positive = units leaving the shelf (decrement). Negative = units returning.
+ * Null = no movement required (idempotent re-saves, or only `inStock` changed).
+ */
+export function computePickInventoryChange(
+  prev: PickStateLike,
+  next: PickStateLike,
+  orderQty: number,
+): { delta: number; reason: PickInventoryReason } | null {
+  const delta = unitsOffShelf(next, orderQty) - unitsOffShelf(prev, orderQty);
+  if (delta === 0) return null;
+
+  let reason: PickInventoryReason;
+  if (!prev.packed && next.packed) reason = 'pack';
+  else if (prev.packed && !next.packed) reason = 'unpack';
+  else reason = 'pack-short-adjust';
+
+  return { delta, reason };
+}
+
+export interface ResolvedPickTarget {
+  variantId: string;
+  trackInventory: boolean;
+  orderQty: number;
+}
+
+/**
+ * Map an `(orderId, itemKey)` pair from the picker UI to the variant whose
+ * stock should move. itemKey is either an OrderItem title (line item) or
+ * `${itemTitle}::${bcTitle}` (bundle component).
+ *
+ * Returns null when the key doesn't map cleanly to a single tracked variant:
+ *   - Bundle parent rows (the components carry their own pick rows).
+ *   - Custom/placeholder items whose variant doesn't exist.
+ *   - Variants flagged `trackInventory: false`.
+ *
+ * Edge case: multiple OrderItems sharing a title. The cart deduplicates by
+ * (productId, variantId) so this is exceedingly rare; we take the first
+ * match and log a warning. Ops Director drift signal #2 will catch any drift.
+ */
+export async function resolvePickInventoryTarget(
+  tx: TransactionClient,
+  orderId: string,
+  itemKey: string,
+): Promise<ResolvedPickTarget | null> {
+  const items = await tx.orderItem.findMany({
+    where: { orderId },
+    select: {
+      id: true,
+      title: true,
+      variantId: true,
+      quantity: true,
+      product: {
+        select: {
+          title: true,
+          isBundle: true,
+          bundleComponents: {
+            select: {
+              componentProductId: true,
+              componentVariantId: true,
+              quantity: true,
+              componentProduct: { select: { title: true } },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const sepIdx = itemKey.indexOf('::');
+  if (sepIdx >= 0) {
+    const parentTitle = itemKey.slice(0, sepIdx);
+    const bcTitle = itemKey.slice(sepIdx + 2);
+
+    const parents = items.filter(
+      (it) => it.title === parentTitle || it.product.title === parentTitle,
+    );
+    if (parents.length === 0) return null;
+    if (parents.length > 1) {
+      console.warn(
+        `[pickInventory] Multiple OrderItems match bundle parent "${parentTitle}" on order ${orderId}; using first.`,
+      );
+    }
+    const parent = parents[0];
+    if (!parent.product.isBundle) return null;
+
+    const bc = parent.product.bundleComponents.find(
+      (c) => c.componentProduct.title === bcTitle,
+    );
+    if (!bc) return null;
+
+    let variantId = bc.componentVariantId;
+    if (!variantId) {
+      const fallback = await tx.productVariant.findFirst({
+        where: { productId: bc.componentProductId },
+        select: { id: true },
+      });
+      variantId = fallback?.id ?? null;
+    }
+    if (!variantId) return null;
+
+    const variant = await tx.productVariant.findUnique({
+      where: { id: variantId },
+      select: { trackInventory: true },
+    });
+    if (!variant) return null;
+
+    return {
+      variantId,
+      trackInventory: variant.trackInventory,
+      orderQty: parent.quantity * bc.quantity,
+    };
+  }
+
+  const matches = items.filter(
+    (it) => it.title === itemKey || it.product.title === itemKey,
+  );
+  if (matches.length === 0) return null;
+  if (matches.length > 1) {
+    console.warn(
+      `[pickInventory] Multiple OrderItems match "${itemKey}" on order ${orderId}; using first.`,
+    );
+  }
+  const match = matches[0];
+  if (match.product.isBundle) return null;
+
+  const variant = await tx.productVariant.findUnique({
+    where: { id: match.variantId },
+    select: { trackInventory: true },
+  });
+  if (!variant) return null;
+
+  return {
+    variantId: match.variantId,
+    trackInventory: variant.trackInventory,
+    orderQty: match.quantity,
+  };
+}
+
+/**
+ * Apply a pick-state transition to inventory inside an existing transaction.
+ * Caller must already have upserted (or planned to upsert) the
+ * OrderItemPickState row. Both ops succeed or fail together.
+ *
+ * Skips silently when the itemKey doesn't resolve to a tracked variant.
+ */
+export async function applyPickInventoryTransition(
+  tx: TransactionClient,
+  args: {
+    orderId: string;
+    itemKey: string;
+    prev: PickStateLike;
+    next: PickStateLike;
+  },
+): Promise<void> {
+  const { orderId, itemKey, prev, next } = args;
+
+  if (prev.packed === next.packed && prev.shortBy === next.shortBy) {
+    return;
+  }
+
+  const target = await resolvePickInventoryTarget(tx, orderId, itemKey);
+  if (!target || !target.trackInventory) return;
+
+  const change = computePickInventoryChange(prev, next, target.orderQty);
+  if (!change) return;
+
+  const variant = await tx.productVariant.findUnique({
+    where: { id: target.variantId },
+    select: { id: true, inventoryQuantity: true, committedQuantity: true },
+  });
+  if (!variant) return;
+
+  const newInventory = Math.max(0, variant.inventoryQuantity - change.delta);
+  const newCommitted = Math.max(0, variant.committedQuantity - change.delta);
+
+  await tx.productVariant.update({
+    where: { id: variant.id },
+    data: { inventoryQuantity: newInventory, committedQuantity: newCommitted },
+  });
+
+  await tx.inventoryMovement.create({
+    data: {
+      variantId: variant.id,
+      type: 'ADJUSTMENT',
+      quantity: -change.delta,
+      previousQuantity: variant.inventoryQuantity,
+      newQuantity: newInventory,
+      reason: change.reason,
+      referenceId: orderId,
+      referenceType: 'Order',
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Couples the ops/orders picker's `packed` checkbox to physical inventory. When an operator toggles `packed` (or adjusts `shortBy` while already packed), the same PUT that upserts `OrderItemPickState` now also:

- Decrements `inventoryQuantity` AND `committedQuantity` on the resolved variant by `(orderQty − shortBy)` (floored at 0).
- Writes an `InventoryMovement` audit row with `type: ADJUSTMENT` and `reason: 'pack' | 'unpack' | 'pack-short-adjust'`.
- Runs in a single Prisma transaction with the pick-state upsert — both succeed or both fail.

Pre-Phase-1 for the Ops Director — see `docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md` §7.

## Transition truth table

| `packed` | `shortBy` change | Delta | Reason |
|---|---|---|---|
| false → true | — | `-(orderQty − shortBy)` | `pack` |
| true → false | — | `+(orderQty − shortBy)` | `unpack` |
| true → true | yes | `±delta` | `pack-short-adjust` |
| unchanged & unchanged | no | 0 (skipped) | — |

Idempotent — a repeat PUT with the same payload computes a zero delta and skips the movement write.

## What's skipped (silently)

- Bundle parent rows: components carry their own pick rows, so the parent toggle is informational. Components decrement their own component-variant by `(parentQty × componentQty − shortBy)`.
- `productVariantId` resolves to a placeholder/missing variant (custom items).
- Variants with `trackInventory: false`.
- Multiple `OrderItem` rows sharing a title (rare — cart deduplicates by variant): logs a warning and uses the first match. Drift gets caught by Ops Director signal #2.

## No backfill — by design

Per the brief §7 and §11 (resolved decision: "no backfill"): existing packed-but-not-decremented orders are NOT retroactively reconciled here. The Ops Director's drift signal #2 (Phase 1B) will surface them as one-click recommendations.

## Coordination note

Once this ships, marking an order `DELIVERED` via the existing admin/bulk-fulfill path would double-decrement units that were already packed. That's intentionally NOT addressed here — adjusting `fulfillInventoryForOrder` is Phase 1A and lands in a separate PR. Flagged in the service file's docstring.

## Test plan

Automated (this PR):
- [x] `src/__tests__/pick-inventory-service.test.ts` — 12 unit tests covering each row of the truth table, including idempotent re-saves and the `shortBy ≥ orderQty` edge case.
- [x] `npx tsc --noEmit` clean on the new files.
- [x] `npx next lint` clean on the new files.

Manual smoke (recommended before merge):
- [ ] Pack a single line item on a real order → variant `inventoryQuantity` and `committedQuantity` both drop by qty; `inventory_movements` row written with `reason: 'pack'`.
- [ ] Unpack the same line → both counters return; movement row with `reason: 'unpack'`.
- [ ] Set `shortBy: 2` on an already-packed row of qty 10 → both counters increase by 2; movement row with `reason: 'pack-short-adjust'`.
- [ ] PUT the same payload twice → second call produces no second movement row.
- [ ] Bundle item: toggle a component row → only that component's variant moves; the bundle parent row toggle is a no-op for inventory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)