### PR TITLE
fix(inventory): subtract already-packed qty at fulfillment (Phase 1A re-spin)

### DIFF
--- a/src/__tests__/fulfill-inventory-pack-aware.test.ts
+++ b/src/__tests__/fulfill-inventory-pack-aware.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for the pack-aware fulfillment math in fulfillInventoryForOrder.
+ *
+ * The actual function is DB-bound (Prisma transactions), so these tests
+ * cover the pure subtraction logic — the same formula the function applies
+ * per item. If a real-DB integration test ever lands, it should assert
+ * end-to-end on the same scenarios.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { unitsOffShelf } from '@/lib/inventory/services/pick-inventory-service';
+
+function computeRemainingFulfillQty(args: {
+  pickState: { packed: boolean; shortBy: number } | undefined;
+  packBaseQty: number; // qty used at pack time (item.quantity, or item.qty * bc.qty)
+  fulfillQty: number; // qty being fulfilled (effectiveQty after refunds)
+}): number {
+  const { pickState, packBaseQty, fulfillQty } = args;
+  const alreadyPacked = pickState ? unitsOffShelf(pickState, packBaseQty) : 0;
+  return Math.max(0, fulfillQty - alreadyPacked);
+}
+
+describe('fulfillInventoryForOrder — pack-aware subtraction', () => {
+  it('un-packed line: fulfills the full effective quantity', () => {
+    expect(
+      computeRemainingFulfillQty({
+        pickState: undefined,
+        packBaseQty: 10,
+        fulfillQty: 10,
+      }),
+    ).toBe(10);
+
+    expect(
+      computeRemainingFulfillQty({
+        pickState: { packed: false, shortBy: 0 },
+        packBaseQty: 10,
+        fulfillQty: 10,
+      }),
+    ).toBe(10);
+  });
+
+  it('fully-packed line: fulfillment is a no-op (avoids double-decrement)', () => {
+    expect(
+      computeRemainingFulfillQty({
+        pickState: { packed: true, shortBy: 0 },
+        packBaseQty: 10,
+        fulfillQty: 10,
+      }),
+    ).toBe(0);
+  });
+
+  it('packed with shortage: fulfillment skips because remaining shortBy never left the shelf', () => {
+    // Packed 8 of 10 (2 short). Pack-time decremented 8.
+    // Fulfillment shouldn't decrement the 2 that were never off the shelf — those stay.
+    expect(
+      computeRemainingFulfillQty({
+        pickState: { packed: true, shortBy: 2 },
+        packBaseQty: 10,
+        fulfillQty: 10,
+      }),
+    ).toBe(2);
+  });
+
+  it('refunded before delivery: fulfillment uses effective qty, floors negatives', () => {
+    // Order had qty=10. 3 refunded after pack. effectiveQty=7. But pack moved 10 units.
+    // floor(7 - 10) = 0. Refund-side flow handles the over-decrement separately.
+    expect(
+      computeRemainingFulfillQty({
+        pickState: { packed: true, shortBy: 0 },
+        packBaseQty: 10,
+        fulfillQty: 7,
+      }),
+    ).toBe(0);
+  });
+
+  it('idempotent: calling fulfillment twice on a packed order still decrements 0 the second time', () => {
+    // First fulfillment leaves pick state untouched (packed: true). Second call
+    // sees the same packed state → still skips.
+    const first = computeRemainingFulfillQty({
+      pickState: { packed: true, shortBy: 0 },
+      packBaseQty: 10,
+      fulfillQty: 10,
+    });
+    const second = computeRemainingFulfillQty({
+      pickState: { packed: true, shortBy: 0 },
+      packBaseQty: 10,
+      fulfillQty: 10,
+    });
+    expect(first).toBe(0);
+    expect(second).toBe(0);
+  });
+
+  it('bundle component scenario: packBaseQty multiplies parent × component qty', () => {
+    // Bundle with 2 parents, each containing 3 of this component → packBaseQty = 6.
+    // Operator packed all 6 with no short. fulfillQty also 6 (no refunds).
+    expect(
+      computeRemainingFulfillQty({
+        pickState: { packed: true, shortBy: 0 },
+        packBaseQty: 6,
+        fulfillQty: 6,
+      }),
+    ).toBe(0);
+
+    // Same bundle, operator was 1 short on the component.
+    expect(
+      computeRemainingFulfillQty({
+        pickState: { packed: true, shortBy: 1 },
+        packBaseQty: 6,
+        fulfillQty: 6,
+      }),
+    ).toBe(1);
+  });
+});

--- a/src/lib/inventory/services/order-service.ts
+++ b/src/lib/inventory/services/order-service.ts
@@ -10,6 +10,7 @@ import { CartWithItems } from './cart-service';
 import type { DraftOrderWithTotal, DraftOrderItem } from '@/lib/draft-orders/types';
 import { snapshotItemCost, finalizeOrderMargin } from '@/lib/analytics/margin-service';
 import { classifySegment } from '@/lib/analytics/segment-classifier';
+import { unitsOffShelf } from './pick-inventory-service';
 
 /**
  * Order with all relations
@@ -198,6 +199,10 @@ async function fulfillVariantInventory(
  * Fulfill inventory for an entire order.
  * Decrements both inventoryQuantity and committedQuantity for each item,
  * floored at 0. Called when an order's fulfillmentStatus changes to DELIVERED.
+ *
+ * Subtracts units that were already moved off the shelf at pack time
+ * (via pick-inventory-service). Without this, packed-then-delivered orders
+ * would double-decrement.
  */
 export async function fulfillInventoryForOrder(orderId: string): Promise<void> {
   const order = await prisma.order.findUnique({
@@ -207,12 +212,14 @@ export async function fulfillInventoryForOrder(orderId: string): Promise<void> {
         include: {
           product: {
             select: {
+              title: true,
               isBundle: true,
               bundleComponents: {
                 select: {
                   componentProductId: true,
                   componentVariantId: true,
                   quantity: true,
+                  componentProduct: { select: { title: true } },
                 },
               },
             },
@@ -224,14 +231,30 @@ export async function fulfillInventoryForOrder(orderId: string): Promise<void> {
 
   if (!order) return;
 
+  const pickStateRows = await prisma.orderItemPickState.findMany({
+    where: { orderId },
+    select: { itemKey: true, packed: true, shortBy: true },
+  });
+  const pickStates = new Map(pickStateRows.map((r) => [r.itemKey, r]));
+
   await prisma.$transaction(async (tx: TransactionClient) => {
     for (const item of order.items) {
       const effectiveQty = item.quantity - item.refundedQuantity;
       if (effectiveQty <= 0) continue;
 
+      const parentKey = item.title || item.product.title;
+
       if (item.product.isBundle && item.product.bundleComponents.length > 0) {
         for (const component of item.product.bundleComponents) {
           const fulfillQty = component.quantity * effectiveQty;
+
+          const bcKey = `${parentKey}::${component.componentProduct.title}`;
+          const bcPick = pickStates.get(bcKey);
+          const alreadyPacked = bcPick
+            ? unitsOffShelf(bcPick, item.quantity * component.quantity)
+            : 0;
+          const remainingQty = Math.max(0, fulfillQty - alreadyPacked);
+          if (remainingQty <= 0) continue;
 
           let componentVariant;
           if (component.componentVariantId) {
@@ -247,17 +270,22 @@ export async function fulfillInventoryForOrder(orderId: string): Promise<void> {
           }
 
           if (componentVariant) {
-            await fulfillVariantInventory(tx, componentVariant, fulfillQty, order.orderNumber, orderId, true);
+            await fulfillVariantInventory(tx, componentVariant, remainingQty, order.orderNumber, orderId, true);
           }
         }
       } else {
+        const linePick = pickStates.get(parentKey);
+        const alreadyPacked = linePick ? unitsOffShelf(linePick, item.quantity) : 0;
+        const remainingQty = Math.max(0, effectiveQty - alreadyPacked);
+        if (remainingQty <= 0) continue;
+
         const variant = await tx.productVariant.findUnique({
           where: { id: item.variantId },
           select: { id: true, inventoryQuantity: true, committedQuantity: true, trackInventory: true },
         });
 
         if (variant) {
-          await fulfillVariantInventory(tx, variant, effectiveQty, order.orderNumber, orderId, false);
+          await fulfillVariantInventory(tx, variant, remainingQty, order.orderNumber, orderId, false);
         }
       }
     }


### PR DESCRIPTION
## Why this PR exists

Re-spin of [#40](https://github.com/allan-cmyk/PartyOn2/pull/40) against `main`. #40 was stacked on #38; both merged within ~20 seconds, so GitHub's auto-retarget didn't fire and #40's diff merged into the stale stacked branch instead of `main`. This PR re-applies that exact diff against today's `main`.

**This is currently a live correctness gap.** [#38](https://github.com/allan-cmyk/PartyOn2/pull/38) (pack-time decrement) is live on prod, but the fulfillment-side fix is not. Any order that gets packed AND then marked DELIVERED will double-decrement stock until this lands.

## Summary

Same as #40 — `fulfillInventoryForOrder` now loads `OrderItemPickState` rows once up front and subtracts already-packed units from the fulfillment decrement, floored at 0.

## Behavior matrix

| State at DELIVERED | Decrement at fulfillment |
|---|---|
| Un-packed | Full `effectiveQty` (unchanged from before #38) |
| Fully packed, no short | 0 (pack already moved it) |
| Packed with `shortBy: N` | `N` units (the short ones never left the shelf) |
| Packed, then partially refunded | Floored at 0; refund flow reconciles its own side |
| DELIVERED webhook fires twice | Second call decrements 0 (now idempotent for packed orders) |

## Test plan

Automated:
- [x] `src/__tests__/fulfill-inventory-pack-aware.test.ts` — 6 tests covering each row of the matrix.
- [x] `npx tsc --noEmit` clean on touched files.
- [x] `npx next lint` clean.

Manual smoke (recommended before merge):
- [ ] Pack all lines on a real order, then mark DELIVERED. Stock should NOT drop further; no new `inventory_movements` rows beyond the `pack` entries.
- [ ] Order with one un-packed line and one packed line. DELIVERED should only decrement the un-packed line.
- [ ] Packed line with `shortBy: 2`, then DELIVERED → two units decrement at delivery.

## Merge urgency

Recommend merging promptly — every packed+delivered order between now and merge will over-decrement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)