### PR TITLE
refactor(recommendations): extract shared lib (Phase 1A for Ops Director)

### DIFF
--- a/src/__tests__/recommendations-lifecycle.test.ts
+++ b/src/__tests__/recommendations-lifecycle.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ALL_STATUSES,
+  MARKETING_STATUSES,
+  NEXT_TRANSITIONS,
+  REASON_MIN_CHARS,
+  REASON_MODE,
+  VALID_TRANSITIONS,
+  isValidTransition,
+  type RecommendationStatus,
+} from '@/lib/recommendations/lifecycle';
+
+describe('recommendations/lifecycle', () => {
+  it('exports the full status union', () => {
+    expect(ALL_STATUSES).toEqual([
+      'open',
+      'approved',
+      'shipped',
+      'rejected',
+      'invalidated',
+      'snoozed',
+    ]);
+  });
+
+  it('marketing subset excludes snoozed', () => {
+    expect(MARKETING_STATUSES).not.toContain('snoozed');
+    expect(MARKETING_STATUSES).toHaveLength(5);
+    for (const s of MARKETING_STATUSES) {
+      expect(ALL_STATUSES).toContain(s);
+    }
+  });
+
+  describe('isValidTransition', () => {
+    it('allows open → approved/rejected/invalidated/snoozed', () => {
+      expect(isValidTransition('open', 'approved')).toBe(true);
+      expect(isValidTransition('open', 'rejected')).toBe(true);
+      expect(isValidTransition('open', 'invalidated')).toBe(true);
+      expect(isValidTransition('open', 'snoozed')).toBe(true);
+    });
+
+    it('allows approved → shipped and back to open', () => {
+      expect(isValidTransition('approved', 'shipped')).toBe(true);
+      expect(isValidTransition('approved', 'open')).toBe(true);
+      expect(isValidTransition('approved', 'rejected')).toBe(true);
+    });
+
+    it('rejects same-status no-op transitions', () => {
+      for (const s of ALL_STATUSES) {
+        expect(isValidTransition(s, s)).toBe(false);
+      }
+    });
+
+    it('blocks shipped → approved or shipped → rejected (must re-open first)', () => {
+      expect(isValidTransition('shipped', 'approved')).toBe(false);
+      expect(isValidTransition('shipped', 'rejected')).toBe(false);
+      expect(isValidTransition('shipped', 'open')).toBe(true);
+    });
+
+    it('terminal-ish statuses only transition back to open', () => {
+      for (const terminal of ['rejected', 'invalidated'] as const) {
+        for (const to of ALL_STATUSES) {
+          const expected = to === 'open';
+          expect(isValidTransition(terminal, to)).toBe(expected);
+        }
+      }
+    });
+
+    it('snoozed can re-open, reject, or invalidate', () => {
+      expect(isValidTransition('snoozed', 'open')).toBe(true);
+      expect(isValidTransition('snoozed', 'rejected')).toBe(true);
+      expect(isValidTransition('snoozed', 'invalidated')).toBe(true);
+      expect(isValidTransition('snoozed', 'approved')).toBe(false);
+    });
+  });
+
+  describe('REASON_MODE', () => {
+    it('requires a reason for dismissals (rejected, invalidated)', () => {
+      expect(REASON_MODE.rejected).toBe('required');
+      expect(REASON_MODE.invalidated).toBe('required');
+    });
+
+    it('makes the reason optional for shipped (outcome notes)', () => {
+      expect(REASON_MODE.shipped).toBe('optional');
+    });
+
+    it('skips the modal for frictionless transitions (open, approved)', () => {
+      expect(REASON_MODE.open).toBe('none');
+      expect(REASON_MODE.approved).toBe('none');
+    });
+
+    it('covers every status', () => {
+      for (const s of ALL_STATUSES) {
+        expect(REASON_MODE[s]).toBeDefined();
+      }
+    });
+
+    it('enforces a minimum length for required reasons', () => {
+      expect(REASON_MIN_CHARS).toBeGreaterThan(0);
+    });
+  });
+
+  describe('NEXT_TRANSITIONS', () => {
+    it('every offered button is in VALID_TRANSITIONS', () => {
+      for (const status of ALL_STATUSES) {
+        const offered = NEXT_TRANSITIONS[status] ?? [];
+        for (const opt of offered) {
+          expect(VALID_TRANSITIONS[status]).toContain(opt.to);
+        }
+      }
+    });
+
+    it('open offers Approve + Reject', () => {
+      const labels = NEXT_TRANSITIONS.open.map((o) => o.label);
+      expect(labels).toEqual(['Approve', 'Reject']);
+    });
+
+    it('approved offers Mark shipped + Re-open', () => {
+      const labels = NEXT_TRANSITIONS.approved.map((o) => o.label);
+      expect(labels).toEqual(['Mark shipped', 'Re-open']);
+    });
+
+    it('terminal statuses only offer Re-open', () => {
+      for (const s of ['shipped', 'rejected', 'invalidated'] as RecommendationStatus[]) {
+        const opts = NEXT_TRANSITIONS[s];
+        expect(opts).toHaveLength(1);
+        expect(opts[0]?.to).toBe('open');
+      }
+    });
+  });
+});

--- a/src/__tests__/recommendations-measurement.test.ts
+++ b/src/__tests__/recommendations-measurement.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MEASUREMENT_WINDOW_DAYS,
+  daysSinceShipped,
+  isDueForMeasurement,
+  measurementCutoff,
+} from '@/lib/recommendations/measurement';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe('recommendations/measurement', () => {
+  it('exports the 14-day window constant', () => {
+    expect(MEASUREMENT_WINDOW_DAYS).toBe(14);
+  });
+
+  describe('measurementCutoff', () => {
+    it('is exactly 14 days before now', () => {
+      const now = new Date('2026-05-20T12:00:00Z');
+      const cutoff = measurementCutoff(now);
+      const expected = new Date(now.getTime() - 14 * DAY_MS);
+      expect(cutoff.toISOString()).toBe(expected.toISOString());
+    });
+  });
+
+  describe('isDueForMeasurement', () => {
+    const now = new Date('2026-05-20T12:00:00Z');
+
+    it('false for null/undefined shippedAt', () => {
+      expect(isDueForMeasurement(null, now)).toBe(false);
+      expect(isDueForMeasurement(undefined, now)).toBe(false);
+    });
+
+    it('false when shipped less than 14 days ago', () => {
+      const shipped = new Date(now.getTime() - 13 * DAY_MS);
+      expect(isDueForMeasurement(shipped, now)).toBe(false);
+    });
+
+    it('true when shipped exactly 14 days ago', () => {
+      const shipped = new Date(now.getTime() - 14 * DAY_MS);
+      expect(isDueForMeasurement(shipped, now)).toBe(true);
+    });
+
+    it('true when shipped more than 14 days ago', () => {
+      const shipped = new Date(now.getTime() - 30 * DAY_MS);
+      expect(isDueForMeasurement(shipped, now)).toBe(true);
+    });
+
+    it('accepts ISO strings', () => {
+      const shipped = new Date(now.getTime() - 20 * DAY_MS).toISOString();
+      expect(isDueForMeasurement(shipped, now)).toBe(true);
+    });
+
+    it('returns false for unparseable input rather than throwing', () => {
+      expect(isDueForMeasurement('not-a-date', now)).toBe(false);
+    });
+  });
+
+  describe('daysSinceShipped', () => {
+    const now = new Date('2026-05-20T12:00:00Z');
+
+    it('floors fractional days', () => {
+      const shipped = new Date(now.getTime() - 3 * DAY_MS - 5 * 60 * 60 * 1000);
+      expect(daysSinceShipped(shipped, now)).toBe(3);
+    });
+
+    it('returns 0 for future-shipped (clock skew safety)', () => {
+      const shipped = new Date(now.getTime() + DAY_MS);
+      expect(daysSinceShipped(shipped, now)).toBe(0);
+    });
+
+    it('returns 0 for the moment of shipping', () => {
+      expect(daysSinceShipped(now, now)).toBe(0);
+    });
+
+    it('accepts ISO strings', () => {
+      const shipped = new Date(now.getTime() - 7 * DAY_MS).toISOString();
+      expect(daysSinceShipped(shipped, now)).toBe(7);
+    });
+  });
+});

--- a/src/app/admin/analytics/recommendations/page.tsx
+++ b/src/app/admin/analytics/recommendations/page.tsx
@@ -7,53 +7,33 @@
  * Sourced by the snapshot cron (auto-snapshot heuristics) and the Marketing
  * Director agent (director). Operator moves items through:
  *   open → approved → shipped (or rejected / invalidated)
+ *
+ * Card rendering is delegated to the shared RecommendationCard component so
+ * Operations / SEO / Finance queues can reuse it (per Ops Director Phase 1A).
  */
 
 import { useEffect, useState, ReactElement, useCallback } from 'react';
 import Link from 'next/link';
+import { RecommendationCard } from '@/components/admin/RecommendationCard';
+import {
+  MARKETING_STATUSES,
+  REASON_MIN_CHARS,
+  REASON_MODE,
+  type RecommendationStatus,
+} from '@/lib/recommendations/lifecycle';
+import type { RecommendationCardData } from '@/lib/recommendations/card-types';
 
-type Status = 'open' | 'approved' | 'shipped' | 'rejected' | 'invalidated';
+type Status = RecommendationStatus;
 type Domain = 'marketing' | 'seo';
 type DomainFilter = Domain | 'all';
-type RiskTier = 'autonomous' | 'recommend' | 'hard_stop';
-type EffortTier = 's' | 'm' | 'l';
 
-interface MetricSnapshot {
-  capturedAt: string;
-  snapshotDate: string;
-  revenue: number;
-  orders: number;
-  averageOrderValue: number;
-  marginCoveragePct: number | null;
-}
-
-interface Recommendation {
-  id: string;
-  generatedAt: string;
-  source: string;
-  domain: Domain;
-  title: string;
-  body: string | null;
-  segment: string | null;
-  metric: string | null;
-  currentValue: string | null;
-  targetValue: string | null;
-  impactDollarsMonthly: number | null;
-  effortTier: EffortTier | null;
-  riskTier: RiskTier;
-  status: Status;
-  shippedAt: string | null;
-  notes: string | null;
-  resultMetricBefore: MetricSnapshot | null;
-  resultMetricAfter: MetricSnapshot | null;
-}
+type Recommendation = RecommendationCardData & { domain: Domain };
 
 const STATUS_TABS: { value: Status | 'all'; label: string }[] = [
-  { value: 'open', label: 'Open' },
-  { value: 'approved', label: 'Approved' },
-  { value: 'shipped', label: 'Shipped' },
-  { value: 'rejected', label: 'Rejected' },
-  { value: 'invalidated', label: 'Invalidated' },
+  ...MARKETING_STATUSES.map((s) => ({
+    value: s,
+    label: s.charAt(0).toUpperCase() + s.slice(1),
+  })),
   { value: 'all', label: 'All' },
 ];
 
@@ -62,30 +42,6 @@ const DOMAIN_TABS: { value: DomainFilter; label: string }[] = [
   { value: 'seo', label: 'SEO' },
   { value: 'all', label: 'All' },
 ];
-
-const RISK_LABEL: Record<RiskTier, string> = {
-  autonomous: 'Autonomous',
-  recommend: 'Recommend',
-  hard_stop: 'Hard stop',
-};
-
-const EFFORT_LABEL: Record<EffortTier, string> = { s: 'S', m: 'M', l: 'L' };
-
-/**
- * Whether a status transition should prompt the operator for a reason before applying.
- * - Reject: required (every dismissal needs an audit trail in Obsidian via the GitHub mirror)
- * - Mark shipped: optional (outcome notes are useful for the 14-day measurement loop but not required)
- * - Everything else (Approve, Re-open): no modal — keep the happy path frictionless
- */
-const REASON_MODE: Record<Status, 'required' | 'optional' | 'none'> = {
-  rejected: 'required',
-  shipped: 'optional',
-  open: 'none',
-  approved: 'none',
-  invalidated: 'required',
-};
-
-const REASON_MIN_CHARS = 10;
 
 export default function RecommendationsTriagePage(): ReactElement {
   const [recs, setRecs] = useState<Recommendation[]>([]);
@@ -275,162 +231,29 @@ export default function RecommendationsTriagePage(): ReactElement {
           </div>
         ) : (
           <div className="space-y-3">
-            {recs.map((rec) => {
-              const isExpanded = expanded.has(rec.id);
-              const isSaving = savingId === rec.id;
-              const isEditingThisNotes = editingNotes === rec.id;
-
-              return (
-                <div
-                  key={rec.id}
-                  className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden"
-                >
-                  <div className="p-5">
-                    <div className="flex flex-col md:flex-row md:items-start gap-4">
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2 mb-1.5 flex-wrap">
-                          <StatusBadge status={rec.status} />
-                          {domainFilter === 'all' && rec.domain && (
-                            <span
-                              className={`px-2 py-0.5 text-xs rounded-full font-medium ${
-                                rec.domain === 'seo'
-                                  ? 'bg-emerald-100 text-emerald-800'
-                                  : 'bg-indigo-100 text-indigo-800'
-                              }`}
-                            >
-                              {rec.domain === 'seo' ? 'SEO' : 'Marketing'}
-                            </span>
-                          )}
-                          {rec.segment && (
-                            <span className="px-2 py-0.5 text-xs rounded-full bg-gray-100 text-gray-700 font-medium">
-                              {rec.segment}
-                            </span>
-                          )}
-                          <span className="text-xs text-gray-400">
-                            {rec.source === 'seo-director'
-                              ? 'SEO Director'
-                              : rec.source === 'director'
-                                ? 'Director'
-                                : rec.source === 'auto-snapshot'
-                                  ? 'Heuristic'
-                                  : 'Manual'}
-                            {' · '}
-                            {new Date(rec.generatedAt).toLocaleDateString()}
-                          </span>
-                        </div>
-                        <h3 className="text-lg font-semibold text-gray-900 leading-snug">{rec.title}</h3>
-                        {rec.body && !isExpanded && (
-                          <p className="text-sm text-gray-600 mt-1.5 line-clamp-2">{rec.body}</p>
-                        )}
-                        {rec.body && isExpanded && (
-                          <p className="text-sm text-gray-700 mt-1.5 whitespace-pre-wrap leading-relaxed">{rec.body}</p>
-                        )}
-                        <div className="flex flex-wrap items-center gap-2 mt-3">
-                          {rec.impactDollarsMonthly != null && (
-                            <span className="text-xs px-2 py-1 rounded-md bg-green-50 text-green-700 border border-green-200 font-semibold">
-                              ${rec.impactDollarsMonthly.toLocaleString()}/mo
-                            </span>
-                          )}
-                          {rec.effortTier && (
-                            <span className="text-xs px-2 py-1 rounded-md bg-gray-100 text-gray-700 font-semibold">
-                              Effort · {EFFORT_LABEL[rec.effortTier]}
-                            </span>
-                          )}
-                          <span
-                            className={`text-xs px-2 py-1 rounded-md font-semibold ${
-                              rec.riskTier === 'hard_stop'
-                                ? 'bg-red-50 text-red-700 border border-red-200'
-                                : rec.riskTier === 'autonomous'
-                                ? 'bg-blue-50 text-blue-700 border border-blue-200'
-                                : 'bg-amber-50 text-amber-800 border border-amber-200'
-                            }`}
-                          >
-                            Risk · {RISK_LABEL[rec.riskTier]}
-                          </span>
-                          {rec.metric && (
-                            <span className="text-xs px-2 py-1 rounded-md bg-gray-50 text-gray-600 font-mono">
-                              {rec.metric}
-                            </span>
-                          )}
-                          {rec.body && (
-                            <button
-                              onClick={() => toggleExpand(rec.id)}
-                              className="text-xs text-blue-600 hover:underline"
-                            >
-                              {isExpanded ? 'Show less' : 'Show details'}
-                            </button>
-                          )}
-                        </div>
-                      </div>
-
-                      <div className="flex flex-col gap-2 md:items-end shrink-0">
-                        <ActionButtons
-                          rec={rec}
-                          isSaving={isSaving}
-                          onChange={(status) => requestTransition(rec, status)}
-                        />
-                      </div>
-                    </div>
-
-                    {/* Measurement block — appears for shipped recs once before is captured */}
-                    {(rec.resultMetricBefore || rec.resultMetricAfter) && (
-                      <MeasurementBlock before={rec.resultMetricBefore} after={rec.resultMetricAfter} />
-                    )}
-
-                    {/* Notes block */}
-                    <div className="mt-4 pt-4 border-t border-gray-100">
-                      {isEditingThisNotes ? (
-                        <div>
-                          <textarea
-                            value={notesValue}
-                            onChange={(e) => setNotesValue(e.target.value)}
-                            placeholder="Why this status? Outcome notes after shipping?"
-                            rows={3}
-                            className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-brand-blue focus:border-transparent"
-                            autoFocus
-                          />
-                          <div className="flex gap-2 mt-2">
-                            <button
-                              onClick={() => saveNotes(rec.id)}
-                              disabled={isSaving}
-                              className="px-3 py-1.5 text-sm bg-brand-blue text-white rounded-lg font-medium hover:bg-blue-700 disabled:opacity-60"
-                            >
-                              Save notes
-                            </button>
-                            <button
-                              onClick={() => { setEditingNotes(null); setNotesValue(''); }}
-                              className="px-3 py-1.5 text-sm bg-gray-100 text-gray-700 rounded-lg font-medium hover:bg-gray-200"
-                            >
-                              Cancel
-                            </button>
-                          </div>
-                        </div>
-                      ) : rec.notes ? (
-                        <div className="flex items-start justify-between gap-3">
-                          <div className="text-sm text-gray-700 whitespace-pre-wrap">
-                            <span className="text-xs uppercase tracking-wider text-gray-500 font-semibold mr-2">Notes</span>
-                            {rec.notes}
-                          </div>
-                          <button
-                            onClick={() => { setEditingNotes(rec.id); setNotesValue(rec.notes ?? ''); }}
-                            className="text-xs text-blue-600 hover:underline shrink-0"
-                          >
-                            Edit
-                          </button>
-                        </div>
-                      ) : (
-                        <button
-                          onClick={() => { setEditingNotes(rec.id); setNotesValue(''); }}
-                          className="text-xs text-gray-500 hover:text-gray-700 hover:underline"
-                        >
-                          + Add notes
-                        </button>
-                      )}
-                    </div>
-                  </div>
-                </div>
-              );
-            })}
+            {recs.map((rec) => (
+              <RecommendationCard
+                key={rec.id}
+                rec={rec}
+                showDomainBadge={domainFilter === 'all'}
+                isSaving={savingId === rec.id}
+                isExpanded={expanded.has(rec.id)}
+                isEditingNotes={editingNotes === rec.id}
+                notesValue={notesValue}
+                onToggleExpand={toggleExpand}
+                onRequestTransition={(r, to) => requestTransition(r as Recommendation, to)}
+                onStartEditNotes={(id, initial) => {
+                  setEditingNotes(id);
+                  setNotesValue(initial);
+                }}
+                onNotesChange={setNotesValue}
+                onSaveNotes={saveNotes}
+                onCancelEditNotes={() => {
+                  setEditingNotes(null);
+                  setNotesValue('');
+                }}
+              />
+            ))}
           </div>
         )}
       </div>
@@ -534,144 +357,6 @@ function TransitionModal({
           </button>
         </div>
       </div>
-    </div>
-  );
-}
-
-function StatusBadge({ status }: { status: Status }): ReactElement {
-  const styles: Record<Status, string> = {
-    open: 'bg-amber-50 text-amber-800 border-amber-200',
-    approved: 'bg-blue-50 text-blue-700 border-blue-200',
-    shipped: 'bg-green-50 text-green-700 border-green-200',
-    rejected: 'bg-gray-100 text-gray-600 border-gray-200',
-    invalidated: 'bg-gray-100 text-gray-500 border-gray-200',
-  };
-  return (
-    <span
-      className={`text-xs px-2 py-0.5 rounded-full border font-semibold uppercase tracking-wider ${styles[status]}`}
-    >
-      {status}
-    </span>
-  );
-}
-
-function MeasurementBlock({
-  before,
-  after,
-}: {
-  before: MetricSnapshot | null;
-  after: MetricSnapshot | null;
-}): ReactElement {
-  const fmtMoney = (n: number) => `$${n.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
-  const fmtDelta = (b: number | null, a: number | null) => {
-    if (b == null || a == null || b === 0) return null;
-    const pct = ((a - b) / b) * 100;
-    const arrow = pct > 0 ? '↑' : pct < 0 ? '↓' : '—';
-    return { pct, label: `${arrow} ${Math.abs(pct).toFixed(0)}%` };
-  };
-
-  const revenueDelta = before && after ? fmtDelta(before.revenue, after.revenue) : null;
-  const ordersDelta = before && after ? fmtDelta(before.orders, after.orders) : null;
-  const aovDelta = before && after ? fmtDelta(before.averageOrderValue, after.averageOrderValue) : null;
-  const coverageDelta =
-    before && after && before.marginCoveragePct != null && after.marginCoveragePct != null
-      ? fmtDelta(before.marginCoveragePct, after.marginCoveragePct)
-      : null;
-
-  const toneClass = (d: { pct: number } | null) =>
-    d == null
-      ? 'text-gray-400'
-      : d.pct > 0
-      ? 'text-green-700'
-      : d.pct < 0
-      ? 'text-red-600'
-      : 'text-gray-600';
-
-  return (
-    <div className="mt-4 pt-4 border-t border-gray-100">
-      <div className="text-xs uppercase tracking-wider text-gray-500 font-semibold mb-2">
-        Measurement {after ? '(14 days post-ship)' : '(awaiting 14-day capture)'}
-      </div>
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
-        {[
-          { label: 'Revenue', before: before?.revenue, after: after?.revenue, delta: revenueDelta, fmt: fmtMoney },
-          { label: 'Orders', before: before?.orders, after: after?.orders, delta: ordersDelta, fmt: (n: number) => n.toString() },
-          { label: 'AOV', before: before?.averageOrderValue, after: after?.averageOrderValue, delta: aovDelta, fmt: fmtMoney },
-          {
-            label: 'Coverage',
-            before: before?.marginCoveragePct ?? null,
-            after: after?.marginCoveragePct ?? null,
-            delta: coverageDelta,
-            fmt: (n: number) => `${n}%`,
-          },
-        ].map((m) => (
-          <div key={m.label} className="bg-gray-50 rounded-lg p-3">
-            <div className="text-xs text-gray-500 uppercase tracking-wider mb-1">{m.label}</div>
-            <div className="text-base font-semibold text-gray-900">
-              {m.before != null ? m.fmt(m.before) : '—'}
-              {' → '}
-              {m.after != null ? m.fmt(m.after) : <span className="text-gray-400">pending</span>}
-            </div>
-            {m.delta && (
-              <div className={`text-xs font-semibold mt-0.5 ${toneClass(m.delta)}`}>{m.delta.label}</div>
-            )}
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function ActionButtons({
-  rec,
-  isSaving,
-  onChange,
-}: {
-  rec: Recommendation;
-  isSaving: boolean;
-  onChange: (status: Status) => void;
-}): ReactElement {
-  const transitions: Record<Status, Array<{ to: Status; label: string; tone: 'primary' | 'neutral' | 'danger' }>> = {
-    open: [
-      { to: 'approved', label: 'Approve', tone: 'primary' },
-      { to: 'rejected', label: 'Reject', tone: 'neutral' },
-    ],
-    approved: [
-      { to: 'shipped', label: 'Mark shipped', tone: 'primary' },
-      { to: 'open', label: 'Re-open', tone: 'neutral' },
-    ],
-    shipped: [
-      { to: 'open', label: 'Re-open', tone: 'neutral' },
-    ],
-    rejected: [
-      { to: 'open', label: 'Re-open', tone: 'neutral' },
-    ],
-    invalidated: [
-      { to: 'open', label: 'Re-open', tone: 'neutral' },
-    ],
-  };
-
-  const opts = transitions[rec.status];
-  return (
-    <div className="flex gap-2 flex-wrap md:justify-end">
-      {opts.map((opt) => {
-        const cls =
-          opt.tone === 'primary'
-            ? 'bg-brand-blue text-white hover:bg-blue-700'
-            : opt.tone === 'danger'
-            ? 'bg-red-600 text-white hover:bg-red-700'
-            : 'bg-white text-gray-700 border border-gray-200 hover:bg-gray-50';
-        return (
-          <button
-            key={opt.to}
-            onClick={() => onChange(opt.to)}
-            disabled={isSaving}
-            className={`px-3 py-1.5 text-sm font-semibold rounded-lg transition-colors disabled:opacity-50 ${cls}`}
-          >
-            {isSaving ? '…' : opt.label}
-          </button>
-        );
-      })}
     </div>
   );
 }

--- a/src/app/api/cron/measure-recommendations/route.ts
+++ b/src/app/api/cron/measure-recommendations/route.ts
@@ -14,11 +14,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import type { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/database/client';
 import { mirrorRecommendation } from '@/lib/analytics/recommendation-mirror';
+import { measurementCutoff } from '@/lib/recommendations/measurement';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 120;
-
-const MEASUREMENT_WINDOW_DAYS = 14;
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const auth = request.headers.get('authorization');
@@ -26,7 +25,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const cutoff = new Date(Date.now() - MEASUREMENT_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+  const cutoff = measurementCutoff();
 
   const due = await prisma.recommendationItem.findMany({
     where: {

--- a/src/components/admin/RecommendationCard.tsx
+++ b/src/components/admin/RecommendationCard.tsx
@@ -1,0 +1,322 @@
+'use client';
+
+/**
+ * Shared RecommendationCard — renders one row of the triage queue.
+ *
+ * Marketing uses this today (advisory recs, no inline action). Operations
+ * (Phase 1B/1C) will pass `onExecuteAction` so the card sprouts an inline
+ * action button derived from `rec.actionPayload`.
+ *
+ * Stateless — all UI state (expanded, editing notes) is lifted to the page.
+ */
+
+import { ReactElement } from 'react';
+import { NEXT_TRANSITIONS, type RecommendationStatus } from '@/lib/recommendations/lifecycle';
+import type {
+  MetricSnapshot,
+  RecommendationCardData,
+  RecommendationCardProps,
+} from '@/lib/recommendations/card-types';
+import type { RiskTier, EffortTier } from '@/lib/recommendations/lifecycle';
+
+const RISK_LABEL: Record<RiskTier, string> = {
+  autonomous: 'Autonomous',
+  recommend: 'Recommend',
+  hard_stop: 'Hard stop',
+};
+
+const EFFORT_LABEL: Record<EffortTier, string> = { s: 'S', m: 'M', l: 'L' };
+
+function sourceLabel(source: string): string {
+  if (source === 'seo-director') return 'SEO Director';
+  if (source === 'director') return 'Director';
+  if (source === 'auto-snapshot') return 'Heuristic';
+  return 'Manual';
+}
+
+export function RecommendationCard({
+  rec,
+  showDomainBadge = false,
+  isSaving = false,
+  isExpanded = false,
+  isEditingNotes = false,
+  notesValue = '',
+  onToggleExpand,
+  onRequestTransition,
+  onStartEditNotes,
+  onNotesChange,
+  onSaveNotes,
+  onCancelEditNotes,
+  onExecuteAction,
+}: RecommendationCardProps): ReactElement {
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+      <div className="p-5">
+        <div className="flex flex-col md:flex-row md:items-start gap-4">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-1.5 flex-wrap">
+              <StatusBadge status={rec.status} />
+              {showDomainBadge && rec.domain && (
+                <span
+                  className={`px-2 py-0.5 text-xs rounded-full font-medium ${
+                    rec.domain === 'seo'
+                      ? 'bg-emerald-100 text-emerald-800'
+                      : 'bg-indigo-100 text-indigo-800'
+                  }`}
+                >
+                  {rec.domain === 'seo' ? 'SEO' : 'Marketing'}
+                </span>
+              )}
+              {rec.segment && (
+                <span className="px-2 py-0.5 text-xs rounded-full bg-gray-100 text-gray-700 font-medium">
+                  {rec.segment}
+                </span>
+              )}
+              <span className="text-xs text-gray-400">
+                {sourceLabel(rec.source)}
+                {' · '}
+                {new Date(rec.generatedAt).toLocaleDateString()}
+              </span>
+            </div>
+            <h3 className="text-lg font-semibold text-gray-900 leading-snug">{rec.title}</h3>
+            {rec.body && !isExpanded && (
+              <p className="text-sm text-gray-600 mt-1.5 line-clamp-2">{rec.body}</p>
+            )}
+            {rec.body && isExpanded && (
+              <p className="text-sm text-gray-700 mt-1.5 whitespace-pre-wrap leading-relaxed">{rec.body}</p>
+            )}
+            <div className="flex flex-wrap items-center gap-2 mt-3">
+              {rec.impactDollarsMonthly != null && (
+                <span className="text-xs px-2 py-1 rounded-md bg-green-50 text-green-700 border border-green-200 font-semibold">
+                  ${rec.impactDollarsMonthly.toLocaleString()}/mo
+                </span>
+              )}
+              {rec.effortTier && (
+                <span className="text-xs px-2 py-1 rounded-md bg-gray-100 text-gray-700 font-semibold">
+                  Effort · {EFFORT_LABEL[rec.effortTier]}
+                </span>
+              )}
+              <span
+                className={`text-xs px-2 py-1 rounded-md font-semibold ${
+                  rec.riskTier === 'hard_stop'
+                    ? 'bg-red-50 text-red-700 border border-red-200'
+                    : rec.riskTier === 'autonomous'
+                    ? 'bg-blue-50 text-blue-700 border border-blue-200'
+                    : 'bg-amber-50 text-amber-800 border border-amber-200'
+                }`}
+              >
+                Risk · {RISK_LABEL[rec.riskTier]}
+              </span>
+              {rec.metric && (
+                <span className="text-xs px-2 py-1 rounded-md bg-gray-50 text-gray-600 font-mono">
+                  {rec.metric}
+                </span>
+              )}
+              {rec.body && onToggleExpand && (
+                <button
+                  onClick={() => onToggleExpand(rec.id)}
+                  className="text-xs text-blue-600 hover:underline"
+                >
+                  {isExpanded ? 'Show less' : 'Show details'}
+                </button>
+              )}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2 md:items-end shrink-0">
+            <ActionButtons
+              rec={rec}
+              isSaving={isSaving}
+              onChange={(status) => onRequestTransition?.(rec, status)}
+              onExecuteAction={onExecuteAction}
+            />
+          </div>
+        </div>
+
+        {(rec.resultMetricBefore || rec.resultMetricAfter) && (
+          <MeasurementBlock before={rec.resultMetricBefore} after={rec.resultMetricAfter} />
+        )}
+
+        <div className="mt-4 pt-4 border-t border-gray-100">
+          {isEditingNotes ? (
+            <div>
+              <textarea
+                value={notesValue}
+                onChange={(e) => onNotesChange?.(e.target.value)}
+                placeholder="Why this status? Outcome notes after shipping?"
+                rows={3}
+                className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-brand-blue focus:border-transparent"
+                autoFocus
+              />
+              <div className="flex gap-2 mt-2">
+                <button
+                  onClick={() => onSaveNotes?.(rec.id)}
+                  disabled={isSaving}
+                  className="px-3 py-1.5 text-sm bg-brand-blue text-white rounded-lg font-medium hover:bg-blue-700 disabled:opacity-60"
+                >
+                  Save notes
+                </button>
+                <button
+                  onClick={() => onCancelEditNotes?.()}
+                  className="px-3 py-1.5 text-sm bg-gray-100 text-gray-700 rounded-lg font-medium hover:bg-gray-200"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : rec.notes ? (
+            <div className="flex items-start justify-between gap-3">
+              <div className="text-sm text-gray-700 whitespace-pre-wrap">
+                <span className="text-xs uppercase tracking-wider text-gray-500 font-semibold mr-2">Notes</span>
+                {rec.notes}
+              </div>
+              <button
+                onClick={() => onStartEditNotes?.(rec.id, rec.notes ?? '')}
+                className="text-xs text-blue-600 hover:underline shrink-0"
+              >
+                Edit
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={() => onStartEditNotes?.(rec.id, '')}
+              className="text-xs text-gray-500 hover:text-gray-700 hover:underline"
+            >
+              + Add notes
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function StatusBadge({ status }: { status: RecommendationStatus }): ReactElement {
+  const styles: Record<RecommendationStatus, string> = {
+    open: 'bg-amber-50 text-amber-800 border-amber-200',
+    approved: 'bg-blue-50 text-blue-700 border-blue-200',
+    shipped: 'bg-green-50 text-green-700 border-green-200',
+    rejected: 'bg-gray-100 text-gray-600 border-gray-200',
+    invalidated: 'bg-gray-100 text-gray-500 border-gray-200',
+    snoozed: 'bg-slate-100 text-slate-600 border-slate-200',
+  };
+  return (
+    <span
+      className={`text-xs px-2 py-0.5 rounded-full border font-semibold uppercase tracking-wider ${styles[status]}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+function MeasurementBlock({
+  before,
+  after,
+}: {
+  before: MetricSnapshot | null;
+  after: MetricSnapshot | null;
+}): ReactElement {
+  const fmtMoney = (n: number) => `$${n.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+  const fmtDelta = (b: number | null, a: number | null) => {
+    if (b == null || a == null || b === 0) return null;
+    const pct = ((a - b) / b) * 100;
+    const arrow = pct > 0 ? '↑' : pct < 0 ? '↓' : '—';
+    return { pct, label: `${arrow} ${Math.abs(pct).toFixed(0)}%` };
+  };
+
+  const revenueDelta = before && after ? fmtDelta(before.revenue, after.revenue) : null;
+  const ordersDelta = before && after ? fmtDelta(before.orders, after.orders) : null;
+  const aovDelta = before && after ? fmtDelta(before.averageOrderValue, after.averageOrderValue) : null;
+  const coverageDelta =
+    before && after && before.marginCoveragePct != null && after.marginCoveragePct != null
+      ? fmtDelta(before.marginCoveragePct, after.marginCoveragePct)
+      : null;
+
+  const toneClass = (d: { pct: number } | null) =>
+    d == null
+      ? 'text-gray-400'
+      : d.pct > 0
+      ? 'text-green-700'
+      : d.pct < 0
+      ? 'text-red-600'
+      : 'text-gray-600';
+
+  return (
+    <div className="mt-4 pt-4 border-t border-gray-100">
+      <div className="text-xs uppercase tracking-wider text-gray-500 font-semibold mb-2">
+        Measurement {after ? '(14 days post-ship)' : '(awaiting 14-day capture)'}
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
+        {[
+          { label: 'Revenue', before: before?.revenue, after: after?.revenue, delta: revenueDelta, fmt: fmtMoney },
+          { label: 'Orders', before: before?.orders, after: after?.orders, delta: ordersDelta, fmt: (n: number) => n.toString() },
+          { label: 'AOV', before: before?.averageOrderValue, after: after?.averageOrderValue, delta: aovDelta, fmt: fmtMoney },
+          {
+            label: 'Coverage',
+            before: before?.marginCoveragePct ?? null,
+            after: after?.marginCoveragePct ?? null,
+            delta: coverageDelta,
+            fmt: (n: number) => `${n}%`,
+          },
+        ].map((m) => (
+          <div key={m.label} className="bg-gray-50 rounded-lg p-3">
+            <div className="text-xs text-gray-500 uppercase tracking-wider mb-1">{m.label}</div>
+            <div className="text-base font-semibold text-gray-900">
+              {m.before != null ? m.fmt(m.before) : '—'}
+              {' → '}
+              {m.after != null ? m.fmt(m.after) : <span className="text-gray-400">pending</span>}
+            </div>
+            {m.delta && (
+              <div className={`text-xs font-semibold mt-0.5 ${toneClass(m.delta)}`}>{m.delta.label}</div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ActionButtons({
+  rec,
+  isSaving,
+  onChange,
+  onExecuteAction,
+}: {
+  rec: RecommendationCardData;
+  isSaving: boolean;
+  onChange: (status: RecommendationStatus) => void;
+  onExecuteAction?: (rec: RecommendationCardData) => void;
+}): ReactElement {
+  const opts = NEXT_TRANSITIONS[rec.status] ?? [];
+  return (
+    <div className="flex gap-2 flex-wrap md:justify-end">
+      {rec.actionPayload && onExecuteAction && (
+        <button
+          onClick={() => onExecuteAction(rec)}
+          disabled={isSaving}
+          className="px-3 py-1.5 text-sm font-semibold rounded-lg transition-colors disabled:opacity-50 bg-brand-yellow text-gray-900 hover:bg-yellow-400"
+        >
+          {rec.actionPayload.label ?? 'Run action'}
+        </button>
+      )}
+      {opts.map((opt) => {
+        const cls =
+          opt.tone === 'primary'
+            ? 'bg-brand-blue text-white hover:bg-blue-700'
+            : opt.tone === 'danger'
+            ? 'bg-red-600 text-white hover:bg-red-700'
+            : 'bg-white text-gray-700 border border-gray-200 hover:bg-gray-50';
+        return (
+          <button
+            key={opt.to}
+            onClick={() => onChange(opt.to)}
+            disabled={isSaving}
+            className={`px-3 py-1.5 text-sm font-semibold rounded-lg transition-colors disabled:opacity-50 ${cls}`}
+          >
+            {isSaving ? '…' : opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/analytics/recommendation-store.ts
+++ b/src/lib/analytics/recommendation-store.ts
@@ -10,10 +10,20 @@
 
 import { prisma } from '@/lib/database/client';
 import type { Prisma } from '@prisma/client';
+import type {
+  RecommendationStatus as SharedStatus,
+  RiskTier as SharedRiskTier,
+  EffortTier,
+} from '@/lib/recommendations/lifecycle';
 
 export type RecommendationSource = 'auto-snapshot' | 'director' | 'manual' | 'seo-director';
-export type RiskTier = 'autonomous' | 'recommend' | 'hard_stop';
-export type RecommendationStatus = 'open' | 'approved' | 'shipped' | 'rejected' | 'invalidated';
+export type RiskTier = SharedRiskTier;
+/**
+ * Marketing API surface — currently a strict subset of the shared lifecycle
+ * (no `snoozed`). Kept narrow so existing callers/validators behave exactly
+ * as before. Ops will widen to the shared union in a later phase.
+ */
+export type RecommendationStatus = Exclude<SharedStatus, 'snoozed'>;
 export type RecommendationDomain = 'marketing' | 'seo';
 
 export interface RecommendationInput {
@@ -25,7 +35,7 @@ export interface RecommendationInput {
   currentValue?: string;
   targetValue?: string;
   impactDollarsMonthly?: number;
-  effortTier?: 's' | 'm' | 'l';
+  effortTier?: EffortTier;
   riskTier?: RiskTier;
 }
 

--- a/src/lib/recommendations/card-types.ts
+++ b/src/lib/recommendations/card-types.ts
@@ -1,0 +1,102 @@
+/**
+ * Shared types for the RecommendationCard UI.
+ *
+ * Marketing recs are advisory (actionPayload is always null) — operator
+ * reads, decides, ships outside the queue. Operations recs (Phase 1B/1C)
+ * will carry an ActionPayload describing an inline button: re-pack a cooler,
+ * adjust inventory, etc.
+ */
+
+import type { RecommendationStatus, RiskTier, EffortTier } from './lifecycle';
+
+/**
+ * Domain identifier. Open string so adding `ops`, `finance`, `cs` doesn't
+ * require touching this file each time a new director comes online.
+ */
+export type RecommendationDomainId = 'marketing' | 'seo' | 'ops' | 'finance' | 'cs' | string;
+
+/**
+ * Visual severity hint. Distinct from RiskTier (which gates autonomy) —
+ * severity is "how loud should this card look in the queue".
+ */
+export type Severity = 'low' | 'medium' | 'high' | 'critical';
+
+export interface Evidence {
+  metric?: string | null;
+  currentValue?: string | null;
+  targetValue?: string | null;
+  impactDollarsMonthly?: number | null;
+  segment?: string | null;
+}
+
+/**
+ * Describes an inline action the operator can trigger from the card.
+ * Marketing recs leave this null. Operations recs carry e.g.
+ * { kind: 'repack-cooler', params: { coolerId: '...', items: [...] } }.
+ * The card component renders a button when present; the click handler is
+ * passed in from the page via RecommendationCardProps.onExecuteAction.
+ */
+export interface ActionPayload {
+  kind: string;
+  label?: string;
+  params: Record<string, unknown>;
+}
+
+export interface MetricSnapshot {
+  capturedAt: string;
+  snapshotDate: string;
+  revenue: number;
+  orders: number;
+  averageOrderValue: number;
+  marginCoveragePct: number | null;
+}
+
+/**
+ * The shape the card renders. Compatible with the API GET response —
+ * page-level types should extend this rather than duplicating fields.
+ */
+export interface RecommendationCardData {
+  id: string;
+  domain: RecommendationDomainId;
+  source: string;
+  generatedAt: string;
+  title: string;
+  body: string | null;
+  segment: string | null;
+  metric: string | null;
+  currentValue: string | null;
+  targetValue: string | null;
+  impactDollarsMonthly: number | null;
+  effortTier: EffortTier | null;
+  riskTier: RiskTier;
+  status: RecommendationStatus;
+  shippedAt: string | null;
+  notes: string | null;
+  resultMetricBefore: MetricSnapshot | null;
+  resultMetricAfter: MetricSnapshot | null;
+  /** Null for advisory (Marketing) recs; populated for actionable (Ops) recs. */
+  actionPayload?: ActionPayload | null;
+  /** Optional severity hint. Marketing today doesn't set this. */
+  severity?: Severity;
+}
+
+export interface RecommendationCardProps {
+  rec: RecommendationCardData;
+  /**
+   * When true, the domain badge is rendered (used when the queue is showing
+   * mixed-domain results). Marketing-only view hides it.
+   */
+  showDomainBadge?: boolean;
+  isSaving?: boolean;
+  isExpanded?: boolean;
+  isEditingNotes?: boolean;
+  notesValue?: string;
+  onToggleExpand?: (id: string) => void;
+  onRequestTransition?: (rec: RecommendationCardData, to: RecommendationStatus) => void;
+  onStartEditNotes?: (id: string, initial: string) => void;
+  onNotesChange?: (value: string) => void;
+  onSaveNotes?: (id: string) => void;
+  onCancelEditNotes?: () => void;
+  /** Reserved for Phase 1B/1C — Marketing today never invokes this. */
+  onExecuteAction?: (rec: RecommendationCardData) => void;
+}

--- a/src/lib/recommendations/lifecycle.ts
+++ b/src/lib/recommendations/lifecycle.ts
@@ -1,0 +1,117 @@
+/**
+ * Recommendation lifecycle — shared status state machine.
+ *
+ * Used by Marketing today; will be reused by Operations, SEO, Finance, CS.
+ * Domain-specific code decides which subset of statuses it actually exposes
+ * (e.g. Marketing currently ignores `snoozed`). The state machine itself is
+ * domain-agnostic.
+ *
+ * Transitions:
+ *   open ─→ approved ─→ shipped ─→ (measured via resultMetricAfter)
+ *     │        │           │
+ *     │        └────────── re-open ─┐
+ *     ├──→ rejected ───── re-open ──┤
+ *     ├──→ invalidated ── re-open ──┤
+ *     └──→ snoozed ───── re-open ───┘
+ */
+
+export type RecommendationStatus =
+  | 'open'
+  | 'approved'
+  | 'shipped'
+  | 'rejected'
+  | 'invalidated'
+  | 'snoozed';
+
+export type RiskTier = 'autonomous' | 'recommend' | 'hard_stop';
+export type EffortTier = 's' | 'm' | 'l';
+
+export const ALL_STATUSES: RecommendationStatus[] = [
+  'open',
+  'approved',
+  'shipped',
+  'rejected',
+  'invalidated',
+  'snoozed',
+];
+
+/**
+ * Statuses currently used by the Marketing Director queue. Operations Director
+ * (Phase 1B/1C) may opt into the full set.
+ */
+export const MARKETING_STATUSES: RecommendationStatus[] = [
+  'open',
+  'approved',
+  'shipped',
+  'rejected',
+  'invalidated',
+];
+
+/**
+ * What you can transition TO from each status.
+ */
+export const VALID_TRANSITIONS: Record<RecommendationStatus, RecommendationStatus[]> = {
+  open: ['approved', 'rejected', 'invalidated', 'snoozed'],
+  approved: ['shipped', 'open', 'rejected'],
+  shipped: ['open'],
+  rejected: ['open'],
+  invalidated: ['open'],
+  snoozed: ['open', 'rejected', 'invalidated'],
+};
+
+export function isValidTransition(
+  from: RecommendationStatus,
+  to: RecommendationStatus
+): boolean {
+  if (from === to) return false;
+  return VALID_TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+/**
+ * Whether a status transition should prompt the operator for a reason.
+ * - required: dismissals need an audit trail (mirrored to Obsidian).
+ * - optional: outcome notes are useful but not enforced.
+ * - none: keep the happy path frictionless.
+ */
+export const REASON_MODE: Record<RecommendationStatus, 'required' | 'optional' | 'none'> = {
+  rejected: 'required',
+  invalidated: 'required',
+  shipped: 'optional',
+  snoozed: 'optional',
+  open: 'none',
+  approved: 'none',
+};
+
+export const REASON_MIN_CHARS = 10;
+
+export type TransitionTone = 'primary' | 'neutral' | 'danger';
+
+export interface TransitionOption {
+  to: RecommendationStatus;
+  label: string;
+  tone: TransitionTone;
+}
+
+/**
+ * Buttons offered for each current status in the triage UI. Subset of
+ * VALID_TRANSITIONS — some valid transitions don't need a top-level button
+ * (e.g. open→snoozed is wired through a separate "Snooze" action when Ops
+ * needs it).
+ */
+export const NEXT_TRANSITIONS: Record<RecommendationStatus, TransitionOption[]> = {
+  open: [
+    { to: 'approved', label: 'Approve', tone: 'primary' },
+    { to: 'rejected', label: 'Reject', tone: 'neutral' },
+  ],
+  approved: [
+    { to: 'shipped', label: 'Mark shipped', tone: 'primary' },
+    { to: 'open', label: 'Re-open', tone: 'neutral' },
+  ],
+  shipped: [{ to: 'open', label: 'Re-open', tone: 'neutral' }],
+  rejected: [{ to: 'open', label: 'Re-open', tone: 'neutral' }],
+  invalidated: [{ to: 'open', label: 'Re-open', tone: 'neutral' }],
+  snoozed: [
+    { to: 'open', label: 'Re-open', tone: 'neutral' },
+    { to: 'rejected', label: 'Reject', tone: 'neutral' },
+  ],
+};

--- a/src/lib/recommendations/measurement.ts
+++ b/src/lib/recommendations/measurement.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared measurement window math.
+ *
+ * A recommendation is "due for measurement" once it's been shipped for
+ * MEASUREMENT_WINDOW_DAYS — the cron route then captures a fresh metric
+ * snapshot into resultMetricAfter. Marketing today; reused by Operations,
+ * Finance, and any other domain that ships rec-driven changes.
+ *
+ * Pure functions — no DB, no I/O. The marketing cron route owns "what
+ * to capture" (revenue/AOV/coverage); this module owns "when to capture".
+ */
+
+export const MEASUREMENT_WINDOW_DAYS = 14;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Recommendations shipped at or before this cutoff are due for measurement.
+ */
+export function measurementCutoff(now: Date = new Date()): Date {
+  return new Date(now.getTime() - MEASUREMENT_WINDOW_DAYS * MS_PER_DAY);
+}
+
+/**
+ * True when a shipped rec has crossed the measurement window. Returns false
+ * for null/undefined shippedAt so callers don't need to null-check.
+ */
+export function isDueForMeasurement(
+  shippedAt: Date | string | null | undefined,
+  now: Date = new Date()
+): boolean {
+  if (!shippedAt) return false;
+  const shipped = typeof shippedAt === 'string' ? new Date(shippedAt) : shippedAt;
+  if (Number.isNaN(shipped.getTime())) return false;
+  return shipped.getTime() <= measurementCutoff(now).getTime();
+}
+
+/**
+ * Whole days between shippedAt and now. Floors at 0 — never negative.
+ */
+export function daysSinceShipped(
+  shippedAt: Date | string,
+  now: Date = new Date()
+): number {
+  const shipped = typeof shippedAt === 'string' ? new Date(shippedAt) : shippedAt;
+  const diff = now.getTime() - shipped.getTime();
+  if (diff <= 0) return 0;
+  return Math.floor(diff / MS_PER_DAY);
+}


### PR DESCRIPTION
## Summary

Extracts the domain-agnostic parts of the Marketing recommendation pipeline into a new shared library so Operations, SEO, Finance, and CS directors can reuse them. **Pure refactor — no behavior change.**

This is the second step in the Operations Director Phase 1 sequence (the first was pack-aware inventory at fulfillment, PR #41). See `docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md` §5b ("Extract the shared layer") and §7 (Phase 1A).

## What's new

**`src/lib/recommendations/`** — shared, domain-agnostic modules:

| File | LOC | What it owns |
|------|-----|--------------|
| `lifecycle.ts` | 117 | Status union (`open|approved|shipped|rejected|invalidated|snoozed`), valid transitions, REASON_MODE, NEXT_TRANSITIONS, RiskTier, EffortTier. Marketing exposes a 5-status subset (`MARKETING_STATUSES`) so its UI/API behavior is unchanged — `snoozed` is reserved for Ops. |
| `measurement.ts` | 49 | `MEASUREMENT_WINDOW_DAYS` + pure helpers `measurementCutoff()`, `isDueForMeasurement()`, `daysSinceShipped()`. |
| `card-types.ts` | 102 | `Severity`, `Evidence`, `ActionPayload`, `MetricSnapshot`, `RecommendationCardData`, `RecommendationCardProps`. `actionPayload` is `null` for Marketing (advisory); reserved for actionable Ops recs. |

**`src/components/admin/RecommendationCard.tsx`** (322 LOC) — extracted from the triage page. Renders an advisory card today; accepts `onExecuteAction` + `rec.actionPayload` so Phase 1B/1C can sprout an inline action button without changing the file again.

## Refactored Marketing files

| File | Before | After | Δ |
|------|--------|-------|---|
| `src/app/admin/analytics/recommendations/page.tsx` | 677 | 362 | **−315** |
| `src/lib/analytics/recommendation-store.ts` | 181 | 191 | +10 (extra import/type comments) |
| `src/app/api/cron/measure-recommendations/route.ts` | 93 | 92 | −1 |
| `src/lib/analytics/recommendations.ts` | 323 | 323 | unchanged — pure heuristics, no domain-agnostic surface to extract |
| `src/lib/analytics/snapshot-recommendations.ts` | 108 | 108 | unchanged — Marketing-specific heuristics |
| `src/lib/analytics/recommendation-mirror.ts` | 177 | 177 | unchanged — Marketing-specific Obsidian/GitHub mirror |
| `src/app/api/admin/analytics/recommendations/route.ts` | 124 | 124 | unchanged — domain types still flow through `recommendation-store` |

Marketing-specific bits stay in `src/lib/analytics/`:
- heuristic generators (`recommendations.ts`, `snapshot-recommendations.ts`)
- the Obsidian/GitHub mirror at `docs/marketing/recommendations/…` (`recommendation-mirror.ts`)
- the metric snapshot shape (revenue/AOV/coverage)
- API validators (still restrict to the Marketing status subset)

## Out of scope

- No `OperationsRecommendation` model (Phase 1B)
- No unified `/admin/recommendations` queue with filter chips (Phase 1C)
- No schema changes — `MarketingRecommendation` / `RecommendationItem` is untouched (per `memory/prisma_schema_drift.md`, additive migrations need raw SQL + a separate PR)
- No CSS/styling changes on the card or page
- No `vercel.json` cron schedule changes

## Test plan

- [x] `npx tsc --noEmit` — clean for new files; pre-existing schema-drift errors (`cartShareLink`, `CustomerDetails`) are unchanged from main
- [x] `npx next lint` — clean for new files
- [x] `npm run test:run` — 29 new tests pass (17 lifecycle + 12 measurement); all 90 previously-passing tests still pass. The 6 `group-v2-payments` failures are pre-existing on main (Prisma mock issue) and unrelated to this PR
- [ ] Manual: load `/admin/analytics/recommendations` and confirm the page renders unchanged (Marketing tabs, Domain tabs, card layout, status badges, measurement block, notes editor, transition modal)
- [ ] Manual: verify Marketing Monday briefing email payload code path still pulls open recs the same way (`listRecommendations({ status: ['open', 'approved'], limit: 25 })` in `/api/cron/weekly-briefing/route.ts` — unchanged)
- [ ] Manual: smoke the 14-day measurement cron locally and confirm it still writes `resultMetricAfter` and re-mirrors

## Unblocks

- Phase 1B — Ops scaffolding (`OperationsRecommendation` model or extension of `RecommendationItem` with an `ops` domain + `actionPayload` JSON column)
- Phase 1C — Unified `/admin/recommendations` queue with domain filter chips

🤖 Generated with [Claude Code](https://claude.com/claude-code)