### PR TITLE
feat(operations): drift detectors + snapshot cron (Phase 1B)

### DIFF
--- a/docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md
+++ b/docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md
@@ -1,0 +1,375 @@
+# Operations Director Agent — Buildout Brief
+
+**Drop this entire file into a new Claude Code session.** It is self-contained — the new session will have no memory of the conversation that produced it.
+
+**Goal of the new session:** Build the Operations Director agent for Party On Delivery and ship it through Phase 1 (inventory-accuracy monitor + reconciliation workflow with inline actions).
+
+---
+
+## 1. Context — why this agent exists
+
+Party On Delivery (premium alcohol + party coordination delivery, Austin TX) is being reorganized around an "agentic org structure" — director-level Claude agents that own a functional area, surface decisions to the operator (Allan), and execute routine work autonomously. The Marketing Director shipped first (`.claude/agents/marketing-director.md`) and proved the pattern: nightly snapshot → DB → triage queue UI → email briefing → 14-day measurement → Obsidian memory loop with ADRs. The Operations Director is the second director and reuses that pattern.
+
+The original 6-director scope (Apr 18, 2026) listed three Operations sub-agents: order verification, inventory, fulfillment. **Phase 1 collapses these into a single Operations Director** — separate sub-agents will only get spun out if the prompt grows unwieldy. The full plan, the architectural reasoning behind making SEO a sibling rather than a Marketing sub-agent, and the broader org-chart vision live in [SEO-DIRECTOR-AGENT-BUILDOUT.md](./SEO-DIRECTOR-AGENT-BUILDOUT.md) §1 — read that first if you need org context.
+
+---
+
+## 2. The Phase-1 thesis
+
+The inventory **system** is solid (three-tier model In Stock / Committed / Available, AI-parsed inventory notes, full receiving pipeline, pick-state tracking). The **data inside it drifts** because reality and the ledger update on different clocks.
+
+**Phase 1 is a divergence detector + reconciliation workflow, not new inventory features.** The Director surfaces drift signals to the operator's triage queue. Each rec card has **inline action buttons** that perform the fix via existing API endpoints — the operator doesn't have to tab over to another screen to act.
+
+Phase 1 scope deliberately excludes anything that requires data we don't yet collect (driver telemetry, customer complaints, vendor SLAs that haven't been formalized). Those land in Phase 2+.
+
+---
+
+## 3. Scope
+
+### In scope (Phase 1 — own these outcomes)
+
+- **Inventory drift detection** across all 9 signals listed in §6
+- **Reconciliation workflow** — every flagged drift has an inline action that fixes it via existing endpoints
+- **Cycle count discipline** — surface the top-N velocity SKUs that haven't been physically counted recently, route the operator to the existing "add note" modal pre-filled with the SKU
+- **Pre-fulfillment shortage prevention** — extend the existing Monday purchase plan into a daily look-ahead that flags shortages on already-paid orders specifically
+- **Daily ops snapshot** — `OperationsSnapshot` row capturing inventory accuracy %, drift events, urgent shortages, cost-coverage gap, receiving lag stats
+- **Monday operator briefing email** — top drift events of the week, cycle-count list for this week, any dangling drafts
+- **Cost-coverage push** — surface high-velocity variants missing `costPerUnit` so margin attribution can become trustworthy (currently ~4% per the saved memory note)
+- **Draft order quality flags** — drafts where items are out of stock, delivery zone/date impossible, address fails validation, total below zone minimum, payer phone/email malformed (advisory only in Phase 1; don't block creation)
+
+### Out of scope (Phase 1)
+
+- Auto-applying AI-parsed inventory notes (still operator-confirmed)
+- Auto-triggering physical counts (recommends, doesn't force)
+- Vendor performance scoring (Phase 2 — collect data first)
+- Driver/route fulfillment SLA (no driver telemetry yet)
+- Customer complaints / refund reconciliation (Customer Success Director territory)
+- Pricing/margin decisions (Finance Director territory)
+- New product additions (`/products` skill stays operator-driven)
+
+### Deliverables for the operator
+
+Mirror the Marketing Director cadence so surfaces feel familiar:
+
+- **Triage queue** at `/admin/operations/recommendations` (or merged with existing recs UI) — recs with severity, evidence, and **inline action buttons**
+- **Daily 07:30 UTC ops-snapshot** + **hourly drift cron** for time-sensitive signals
+- **Monday 13:30 UTC briefing email** (right after Marketing's 13:00) — top drift events, cycle-count list, dangling drafts, cost-coverage progress
+- **`/admin/operations` dashboard page** — one-page health view (inventory accuracy %, urgent shortages, cost coverage %, drift events trend)
+
+---
+
+## 4. Available data sources — already piped in, DO NOT rebuild
+
+Everything Phase 1 needs already exists. The Director consumes; it does not lay new pipe.
+
+### Database models (`prisma/schema.prisma`)
+
+| Model | Used for |
+|---|---|
+| `Product`, `ProductVariant` | Catalog. `costPerUnit` field is the cost-coverage target. |
+| `InventoryItem` (line 571) | Per-location stock. `inventoryQuantity`, `committedQuantity`. |
+| `InventoryMovement` (line 603) | Audit trail of every adjustment. |
+| `InventoryLocation` (line 555) | Locations (warehouse, etc.). |
+| `InventoryNote` (line 1983) | The "add note" modal payload. Status `pending → processed | dismissed`. |
+| `ReceivingInvoice` (line 2001) + `ReceivingInvoiceLine` (line 2022) | The "receive shipment" modal payload. Status `PENDING_REVIEW → APPLIED | CANCELLED`. |
+| `Order`, `OrderItem` | Paid orders + line items, including `unitCost` / `totalCost` / `Order.marginAmount`. |
+| `OrderItemPickState` (added `86f58c77`) | Per-order pick/pack state (`inStock`, `packed`, `shortBy`). |
+| `DraftOrder`, `DraftOrderItem` | Invoices before payment — Phase 1 quality flags target these. |
+| `GroupOrderV2`, `SubOrder`, `DraftCartItem` | Universal dashboard orders — paid-order forecasts must include these. |
+| `InventoryPrediction` (line 1165) | Existing predictions; check whether the Director should consume or replace. |
+
+### Existing API endpoints (use these in inline actions)
+
+- `GET /api/v1/inventory` (filters: `low_stock`, `out_of_stock`)
+- `POST /api/v1/inventory` `{ operation: "adjust", productId, quantity, reason }` — physical-count-style adjustments
+- `POST /api/v1/inventory/notes` — submit a note
+- `POST /api/v1/inventory/notes/[id]/apply` — apply a parsed note
+- `GET/POST /api/v1/inventory/receiving` — list / start receiving invoice
+- `POST /api/v1/inventory/receiving/[id]/apply` — apply a receiving invoice (likely path; verify exact route)
+- `GET/PUT /api/ops/orders/[id]/picks` — read/update pick state
+- `PATCH /api/v1/inventory/variants/[id]` — variant edit (cost entry, etc.)
+
+### Existing scripts to call or extend
+
+- `scripts/ops/check-inventory.mjs` — query stock for a variant
+- `scripts/ops/adjust-inventory.mjs` — apply manual adjustment with reason
+- `scripts/ops/low-stock.mjs` — current low-stock list
+- `scripts/ops/upcoming-orders.mjs` — paid demand window
+- `scripts/ops/purchase-plan.mjs` — Monday weekly plan (already automated via Vercel cron)
+- `scripts/ops/enter-cogs.mjs` — interactive cost entry (the cost-coverage rec links here)
+- `scripts/ops/match-invoice-costs.mjs` — match receiving invoice lines to cost-per-unit
+
+### Existing UI surfaces
+
+- `/ops/inventory` — main inventory page (the "add note" + "receive shipment" modals live here)
+- `/ops/inventory/count` — counting workflow page
+- `/ops/inventory/receiving/[id]` — receiving invoice detail
+- `/ops/inventory/receiving/new` — start a new receiving
+- `/ops/inventory/predictions` — InventoryPrediction surface
+
+The Director's inline actions should **deep-link into these existing pages with query-param prefills** rather than creating new ones.
+
+### Existing skills
+
+- `/inventory` skill (`.claude/skills/inventory/SKILL.md`) — operator-driven CLI for stock/adjust/plan
+- `/ops` skill (`.claude/skills/ops/SKILL.md`) — orders, customers, dashboards
+- `/weekly-summary` skill — printable Friday checklist
+
+The Operations Director uses these surfaces but doesn't replace them — they remain operator-invoked tools.
+
+---
+
+## 5. Architectural calls
+
+### a) Recommendation model — parallel, not unified
+
+There is already a `MarketingRecommendation` model. **Add a parallel `OperationsRecommendation` model** rather than unifying into a single `Recommendation` table. Reasons:
+
+- Ops recs need fields Marketing recs don't (`targetEntityType`, `targetEntityId`, `actionPayload`, `severity`)
+- Forcing a unified schema bloats Marketing for fields it never uses
+- Future directors (SEO, Finance, CS) follow the same pattern — own table, shared library
+
+### b) Extract the shared layer to `src/lib/recommendations/`
+
+- `src/lib/recommendations/lifecycle.ts` — status state machine (`open → approved → shipped → measured` + `rejected | invalidated`)
+- `src/lib/recommendations/measurement.ts` — 14-day after-snapshot logic (refactor of `src/app/api/cron/measure-recommendations/route.ts`)
+- `src/lib/recommendations/card-types.ts` — TS types for severity, evidence, action payloads
+- `src/components/admin/RecommendationCard.tsx` — shared component, accepts `domain` prop and renders the right inline actions
+
+Refactor the existing Marketing pipeline to consume these shared helpers (small refactor, no behavior change).
+
+### c) Inline-action contract
+
+Every Ops rec card has:
+
+```ts
+type OperationsRecommendation = {
+  id: string;
+  title: string;                  // plain-English issue
+  severity: 'urgent' | 'high' | 'normal';
+  evidence: {
+    metricName: string;
+    metricValue: string | number;
+    sourceLinks: { label: string; href: string }[];   // links to source records
+  }[];
+  targetEntityType: 'productVariant' | 'order' | 'draftOrder' | 'inventoryNote' | 'receivingInvoice' | 'vendor';
+  targetEntityId: string;
+  suggestedAction: {
+    label: string;                  // button text
+    kind: 'navigate' | 'apiCall';
+    payload:
+      | { kind: 'navigate'; href: string }   // deep-link with prefill
+      | { kind: 'apiCall'; method: string; path: string; body: Record<string, unknown> };
+  };
+  status: 'open' | 'approved' | 'shipped' | 'measured' | 'rejected' | 'invalidated' | 'snoozed';
+  snoozeUntil: Date | null;
+  dismissReason: string | null;
+  // ... lifecycle dates, source, related entities
+};
+```
+
+Inline `apiCall` actions hit existing endpoints; inline `navigate` actions deep-link to existing UI with query-param prefills (e.g. `/ops/inventory?openNoteFor=variantId&prefill=Counted+N+units`).
+
+### d) Snooze + dismiss with reason feed back into heuristics
+
+The drift detectors should read recent dismissals when scoring. If the operator dismisses "Repeated shorts on variant Z" three times in a row with reason "intentional buffer," the heuristic stops flagging that variant. This is built in from day one — not a Phase-2 addition — because noise tolerance is what makes or breaks a triage queue.
+
+---
+
+## 6. The 9 drift signals + inline actions
+
+These are what the Phase-1 Director scans for. Thresholds are starting points; tune from operator feedback.
+
+| # | Drift signal | Detection logic | Severity | Inline action |
+|---|---|---|---|---|
+| 1 | **Receiving lag** | `ReceivingInvoice.status = PENDING_REVIEW` AND `createdAt < now() - 24h` | high | "Open receiving" → `/ops/inventory/receiving/[id]` |
+| 2 | **Pick-state ↔ inventory lag** | `OrderItemPickState.packed = true` for orders fulfilled ≥24h ago, but inventory `committedQuantity` hasn't decremented to match | high | "Reconcile pick → inventory for order Y" — apiCall that decrements committed and increments movements |
+| 3 | **Repeated shorts on same SKU** | Same `productVariantId` shorted (`OrderItemPickState.shortBy > 0`) on ≥2 distinct orders in last 7d | high | "Mark for count" → opens `/ops/inventory?openNoteFor=variantId` |
+| 4 | **Negative available** | `committedQuantity > inventoryQuantity` for any variant | urgent | "Adjust in-stock by N (after physical count)" — opens count modal |
+| 5 | **Velocity anomaly** | Variant sold ≥N/week trailing-30d, then 0 sales for 14d, no `Product.status` change | normal | "Audit variant — possible mis-mapping" → opens variant edit page |
+| 6 | **AI-note backlog** | `InventoryNote.status = pending` AND `createdAt < now() - 24h` | high | "Review and apply" → `/ops/inventory?openNote=noteId` |
+| 7 | **Variant mismapping suspect** | Variant A has sales, sister variant B (same product, similar SKU pattern) has growing committed without sales | normal | "Audit variant binding" → opens variant comparison view |
+| 8 | **Cost-coverage gap** | Variant has ≥5 units sold in 30d but `ProductVariant.costPerUnit IS NULL` | normal | "Enter cost" → opens cost-entry modal pre-filled with variantId |
+| 9 | **Cycle count overdue** | Top-20-by-unit-volume variant **over the trailing 14 days** has no `InventoryNote` (type: count) AND no `InventoryMovement` with reason like 'count' in ≥7d | normal | "Mark counted" → opens "add note" modal pre-filled |
+
+### Pre-fulfillment shortage signal (separate, runs hourly)
+
+For every variant in any **PAID** upcoming order in the next 14 days: if `inventoryQuantity - committedQuantity < 0`, raise an **urgent** rec. Inline action: deep-link to the purchase plan filtered to that variant. (This complements the existing Monday plan by catching shortages between Monday runs.)
+
+---
+
+## 7. Phased build
+
+### Phase 0 — Setup (Day 1)
+
+- Create `.claude/agents/operations-director.md` mirroring `marketing-director.md` frontmatter.
+- Create empty Obsidian memory shell at `Memory/Operations/` mirroring `Memory/Marketing/` (folders: `Briefings`, `Recommendations`, `Decisions`, `Channel-Performance`, `Open-Questions.md`, `README.md`).
+- Read these reference files in order:
+  1. `.claude/agents/marketing-director.md` — agent file template
+  2. `~/Projects/Obsidian/Obsidian/PartyOn2/Programs/Marketing-Director.md` — program doc template
+  3. `~/Projects/Obsidian/Obsidian/PartyOn2/Memory/Marketing/README.md` — memory conventions
+  4. `src/app/api/cron/analytics-snapshot/route.ts` — daily snapshot pattern
+  5. `src/app/api/cron/measure-recommendations/route.ts` — 14-day measurement
+  6. `src/app/admin/analytics/recommendations/` — triage queue UI
+  7. `src/lib/inventory/services/inventory-service.ts` — inventory mutations
+  8. `prisma/schema.prisma` lines 555–620, 1165–1200, 1983–2080 — inventory + notes + receiving models
+
+### Pre-Phase-1 — Pack-to-inventory wiring (Day 2, separate small PR)
+
+**Why this is a prereq, not part of the Director:** The Director's value depends on inventory being roughly accurate at any given moment. Today, packing an order doesn't decrement stock. That gap is the single biggest source of drift. Close it before the Director ships, so the Director isn't fighting a constantly-growing backlog of "packed but not decremented" orders.
+
+**What changes:**
+
+- In `src/app/api/ops/orders/[id]/picks/route.ts` PUT handler: when `packed` flips from `false → true`, after the `OrderItemPickState` upsert, call `decrementOnFulfillment` (or equivalent) for that line item. Decrement amount is `(originalQty - shortBy)`. Wrap both writes in a Prisma transaction so a failure in either rolls back both.
+- Reverse case: when `packed` flips from `true → false` (operator unpacks), increment back by the same amount. Same transaction pattern.
+- Edge case: `shortBy` changes while `packed` is already true — adjust the delta accordingly. (Example: was packed with `shortBy: 0`, operator updates to `shortBy: 2`. Inventory needs to come back up by 2 because those units never actually left.)
+- Audit trail: write an `InventoryMovement` row with `reason: 'pack'` and a reference to the order + item key. Reuses the existing audit table, no schema change.
+- **No backfill** (operator-decided 2026-05-07). Wiring takes effect from the deploy date forward. Existing packed-but-not-decremented orders surface as recs after Phase 1B ships via signal #2; operator closes each via inline action. Reasons: (a) backfill scripts that touch inventory go wrong silently; (b) one-click reconciliation via the rec card doubles as the first real test of the inline-action workflow; (c) operator stays in the loop on every fix.
+
+**Why a separate PR:** This is a real transactional state change with rollback semantics. It deserves its own review, its own test coverage, and its own deploy. Mixing it into the Director PRs muddies the diff and increases blast radius.
+
+**Drift signal #2 stays in Phase 1B** — it becomes a safety net for orders that predate this wiring, for any future bugs, and for edge cases (e.g., dashboard group orders where the picker UI may differ).
+
+### Phase 1A — Shared lib refactor (Days 2–3, small PR)
+
+- Extract `src/lib/recommendations/{lifecycle,measurement,card-types}.ts`
+- Extract `src/components/admin/RecommendationCard.tsx`
+- Refactor existing Marketing pipeline to consume the shared helpers
+- No behavior change — pure refactor. Verify Marketing's Monday email still sends and the existing triage queue still works.
+
+### Phase 1B — Ops scaffolding (Days 4–6)
+
+- Add `OperationsRecommendation` and `OperationsSnapshot` models to `prisma/schema.prisma`
+- **Important:** per saved memory note "Prisma schema drift — avoid db push", use raw SQL `CREATE TABLE IF NOT EXISTS` for additive migrations on production. Confirm migration path with operator before pushing.
+- Build `src/lib/operations/recommendations.ts` — heuristic generators (one function per signal)
+- Build `src/app/api/cron/operations-snapshot/route.ts` — daily 07:30 UTC, runs all 9 detectors, writes `OperationsSnapshot`, upserts `OperationsRecommendation` rows
+- Build `src/app/api/cron/operations-drift-hourly/route.ts` — hourly fast loop on signals 1, 2, 6 (time-sensitive) + pre-fulfillment shortage
+- Wire crons in `vercel.json`
+
+### Phase 1C — Triage queue UI (Days 7–9)
+
+- Build `src/app/admin/operations/recommendations/page.tsx` (or extend `/admin/analytics/recommendations` with a domain filter)
+- Build `src/app/api/admin/operations/recommendations/route.ts` (GET list, PATCH status, POST execute action)
+- Inline-action handler: routes `apiCall` payloads through existing inventory/order endpoints, never directly mutates DB from this path
+- "Snooze 7d" + "Dismiss with reason" controls feed `OperationsRecommendation.dismissReason` back into heuristic scoring
+
+### Phase 1D — Briefing + dashboard (Days 10–11)
+
+- Build `src/lib/email/templates/operations-briefing.ts` mirroring `marketing-briefing.ts`
+- Build `src/lib/operations/briefing-payload.ts` — assembles top drift events, cycle-count list, dangling drafts, cost-coverage progress
+- Build `src/app/api/cron/operations-briefing/route.ts` — Monday 13:30 UTC
+- Build `src/app/admin/operations/page.tsx` — one-page health dashboard
+
+### Phase 1E — Agent surface (Days 12–13)
+
+- Build `.claude/agents/operations-director.md` properly — Sonnet, Read/Grep/Glob/Bash tools (mirror Marketing Director's tool list), prompt that instructs the agent to read the daily snapshot + active recs + active drift signals on every invocation
+- Add Obsidian sync for `Memory/Operations/` mirroring the Marketing pattern (PR #20 / #22 from Marketing's history)
+- Write `Programs/Operations-Director.md` in the Obsidian vault
+
+**Exit criterion for Phase 1:** Operator reads the Monday Operations briefing for 2 consecutive weeks, acts on ≥3 inline actions per week, and inventory accuracy (measured by adjustment-volume-after-count) improves.
+
+### Phase 2 — Auto-apply + draft validation (Quarter 2)
+
+- High-confidence AI-parsed inventory notes auto-apply (with operator notification, undoable)
+- Pre-creation draft order validation (block save with errors, warn on warnings)
+- Vendor reliability scoring (after 90 days of receiving data)
+
+### Phase 3 — Fulfillment intelligence (when driver telemetry exists)
+
+- On-time delivery tracking
+- Route suggestion
+- Driver dispatch
+
+---
+
+## 8. Files this build will likely touch
+
+```
+.claude/agents/operations-director.md                     [NEW]
+prisma/schema.prisma                                      [+OperationsRecommendation, +OperationsSnapshot]
+src/lib/recommendations/lifecycle.ts                      [NEW — shared]
+src/lib/recommendations/measurement.ts                    [NEW — shared, refactored from cron]
+src/lib/recommendations/card-types.ts                     [NEW — shared types]
+src/components/admin/RecommendationCard.tsx               [NEW — shared component]
+src/lib/operations/recommendations.ts                     [NEW — 9 detectors + pre-fulfillment]
+src/lib/operations/briefing-payload.ts                    [NEW]
+src/lib/operations/heuristic-scoring.ts                   [NEW — reads dismiss history, suppresses noise]
+src/lib/email/templates/operations-briefing.ts            [NEW]
+src/app/api/cron/operations-snapshot/route.ts             [NEW]
+src/app/api/cron/operations-drift-hourly/route.ts         [NEW]
+src/app/api/cron/operations-briefing/route.ts             [NEW]
+src/app/api/cron/measure-recommendations/route.ts         [REFACTOR — generic over domain]
+src/app/api/admin/operations/recommendations/route.ts     [NEW]
+src/app/api/admin/operations/snapshot/route.ts            [NEW]
+src/app/admin/operations/page.tsx                         [NEW — health dashboard]
+src/app/admin/operations/recommendations/page.tsx         [NEW]
+src/app/admin/analytics/recommendations/                  [REFACTOR — uses shared component]
+src/app/ops/inventory/page.tsx                            [+ query-param prefill handling for inline actions]
+vercel.json                                               [+ 3 new cron schedules]
+
+# Obsidian vault (manual creates, not in repo)
+PartyOn2/Programs/Operations-Director.md
+PartyOn2/Memory/Operations/README.md
+PartyOn2/Memory/Operations/Open-Questions.md
+PartyOn2/Memory/Operations/Briefings/
+PartyOn2/Memory/Operations/Recommendations/
+PartyOn2/Memory/Operations/Decisions/
+PartyOn2/Memory/Operations/Channel-Performance/
+```
+
+---
+
+## 9. First-session checklist (drop-into-new-session steps)
+
+1. Read this entire doc.
+2. Read the 8 reference files in §7 Phase 0 (especially the Marketing Director vault doc — it's the template).
+3. Confirm the listed inventory APIs all exist and respond (`GET /api/v1/inventory`, `POST /api/v1/inventory/notes`, `GET /api/v1/inventory/receiving`, `GET/PUT /api/ops/orders/[id]/picks`).
+4. **Open Phase 1A as its own PR first** — the shared-lib refactor. No new directors yet, no new models. Just: extract shared lifecycle/measurement/card-types/component from the existing Marketing pipeline, prove Marketing still works unchanged.
+5. After Phase 1A merges, open Phase 1B as a second PR — schema + heuristic generators + crons. No UI yet.
+6. After Phase 1B merges, open Phase 1C — UI + inline actions.
+7. After Phase 1C merges, open Phase 1D — briefing email + dashboard.
+8. After Phase 1D merges, open Phase 1E — agent file + Obsidian wiring + program doc.
+
+Five small PRs, not one big one. Each merges independently, each is reviewable.
+
+---
+
+## 10. Hard rules (apply throughout)
+
+- **Phase 1 never auto-mutates inventory.** Every action requires an operator click on a rec card. Inline buttons hit APIs the operator already uses today; the Director just routes them.
+- **Receiving lag SLA is 24 hours**, not 4. Don't fire false positives on same-day-evening invoice processing.
+- **Cycle counts use the existing "add note" modal** — do not build a parallel count workflow. Inline actions deep-link to `/ops/inventory` with query-param prefill.
+- **Per saved memory: avoid `prisma db push`.** Use raw SQL `CREATE TABLE IF NOT EXISTS` for additive migrations on production. Confirm migration path with operator.
+- **Group order manifest names** — when surfacing draft-quality issues for orders with `groupOrderV2Id`, always show the manifest name (`GroupOrderV2.name`), not just `Order.customerName`. Use `scripts/ops/_group-label.mjs:resolveGroupLabel()`. (Per saved memory.)
+- **Demand source for shortage detection: PAID orders only**, mirroring the existing weekly purchase plan. No drafts, no dashboards. (Per saved memory.)
+- **Variants ARE the case** — for any quantity logic, treat the variant as the unit. No split-case ordering. (Per saved memory.)
+- **Snooze + dismiss-with-reason MUST feed back into heuristic scoring** from day one. Noise tolerance is what makes triage queues trustworthy.
+- **No `any` type, files <500 lines, components <200 lines, functions <50 lines** (per project CLAUDE.md).
+- **Use existing design system classes** for any admin UI (`.btn-primary`, `.card`, `.input-premium`, etc. — see project CLAUDE.md design-system section).
+
+---
+
+## 11. Resolved decisions (operator-confirmed 2026-05-07)
+
+1. **Triage UI placement → ONE QUEUE WITH FILTER CHIPS.** Extend `/admin/analytics/recommendations` (or a renamed equivalent like `/admin/recommendations`) with filter chips at the top: `All | Marketing | Operations | SEO | …`. Shared `RecommendationCard` component renders each domain's card style. Scales to all future directors without proliferating URLs.
+2. **Pick-state ↔ inventory closing → CURRENTLY DECOUPLED, GAP IS UNINTENTIONAL.** Confirmed in code: `src/app/api/ops/orders/[id]/picks/route.ts:84-99` only writes to `OrderItemPickState`, doesn't touch `inventoryQuantity` or `committedQuantity`. The `decrementOnFulfillment` function in `src/lib/inventory/services/order-service.ts:157` exists but isn't called from the picker. **Decision: wire packing → inventory decrement as a separate small PR BEFORE Phase 1B.** See "Pre-Phase-1: pack-to-inventory wiring" in §7. Drift signal #2 stays in scope as a backfill detector for orders that predate the wiring + edge cases.
+3. **Cycle count velocity window → TRAILING 14 DAYS.** Counts are fast and the operator does them in the morning. Two-week window keeps the cycle-count list responsive to current movers (boat season, weekend bach demand spikes) without the noise of one-off party orders.
+4. **Receiving-lag clock → `createdAt` (upload time), 24h SLA.** Reliable measure; doesn't depend on the operator filling `invoiceDate` correctly. Revisit if the broader pipeline needs visibility.
+5. **Notification for urgent recs → EMAIL-ONLY for Phase 1.** Same channel as Marketing Director (Monday briefing surfaces them). Add SMS/Slack push in Phase 1.5 once the heuristic is tuned and "urgent" is reliably urgent.
+6. **Action audit trail → LOG ON THE REC.** Add `OperationsRecommendation.actionLog` (JSON array). Each entry: `{ timestamp, actionLabel, result: 'success' | 'error', errorMessage?, relatedMovementId? }`. Reconstructs "Director recommended → operator clicked → outcome" in one place; powers the 14-day measurement loop and heuristic tuning.
+
+---
+
+## 12. Success metrics (set baselines in Phase 0, measure quarterly)
+
+- **Inventory accuracy %** — proxy: `(adjustments_within_50_units_of_zero / total_count_adjustments)` for a rolling 30-day window. Counts that confirm the ledger was right ≈ accurate; counts that move stock by ±N units measure how wrong it was. Lower-is-better drift volume.
+- **Drift-event volume** — count of `OperationsRecommendation` rows opened per week, by signal type. Should trend down as systemic issues get fixed.
+- **Time-to-action on urgent recs** — median minutes from rec creation to inline-action click for `severity = urgent`. Target <60 min during business hours.
+- **Cost coverage %** — `(variants_with_costPerUnit_set / variants_sold_in_30d) * 100`. Target Phase-1 exit: ≥30% (from ~4% baseline).
+- **Receiving lag p50 / p90** — hours between distributor invoice date and `ReceivingInvoice.status = APPLIED`.
+- **Pre-fulfillment shortage rate** — `(orders_with_short_at_pick_time / orders_fulfilled)` per week. Target: <2%.
+- **Cycle counts completed per week** — directly measurable via `InventoryNote` rows tagged as counts in the 7-day window.
+
+---
+
+That's everything a fresh session needs. The Operations Director mirrors the Marketing Director's pattern, anchors Phase 1 on inventory accuracy (the operator's #1 pain), uses inline actions to make ops work transactional rather than advisory, and sets up the shared `src/lib/recommendations/` layer that all subsequent directors (Finance, CS, Product) will reuse.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2495,6 +2495,58 @@ model RecommendationItem {
   @@map("recommendation_items")
 }
 
+/// Operations Director recommendation queue (Phase 1B). Parallel to
+/// RecommendationItem (Marketing/SEO) — see docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md
+/// §5a for why this is a separate model rather than a unified table.
+///
+/// dedupeKey = signalKind + ':' + targetEntityId — prevents an open detector
+/// from creating duplicate rows on repeat snapshot runs.
+model OperationsRecommendation {
+  id               String    @id @default(cuid())
+  signalKind       String    @map("signal_kind")
+  severity         String    // 'urgent' | 'high' | 'normal'
+  title            String
+  evidence         Json      // Evidence[]
+  targetEntityType String    @map("target_entity_type")
+  targetEntityId   String    @map("target_entity_id")
+  actionPayload    Json      @map("action_payload")
+  status           String    @default("open")
+  snoozeUntil      DateTime? @map("snooze_until")
+  dismissReason    String?   @map("dismiss_reason") @db.Text
+  actionLog        Json      @default("[]") @map("action_log")
+  source           String    @default("auto-snapshot")
+  shippedAt        DateTime? @map("shipped_at")
+  measuredAt       DateTime? @map("measured_at")
+  measurementResult Json?    @map("measurement_result")
+  dedupeKey        String    @unique @map("dedupe_key")
+  createdAt        DateTime  @default(now()) @map("created_at")
+  updatedAt        DateTime  @updatedAt @map("updated_at")
+
+  @@index([status])
+  @@index([severity, status])
+  @@index([signalKind, status])
+  @@map("operations_recommendations")
+}
+
+/// Daily ops snapshot — one row per cron run. Powers the dashboard trend
+/// charts and the Monday briefing. See docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md §12.
+model OperationsSnapshot {
+  id                          String   @id @default(cuid())
+  capturedAt                  DateTime @default(now()) @map("captured_at")
+  inventoryAccuracyPct        Float?   @map("inventory_accuracy_pct")
+  driftEventsTotal            Int      @map("drift_events_total")
+  driftEventsBySignal         Json     @map("drift_events_by_signal")
+  urgentShortagesCount        Int      @map("urgent_shortages_count")
+  costCoveragePct             Float    @map("cost_coverage_pct")
+  receivingLagP50Hours        Float?   @map("receiving_lag_p50_hours")
+  receivingLagP90Hours        Float?   @map("receiving_lag_p90_hours")
+  cycleCountsCompletedLast7d  Int      @map("cycle_counts_completed_last_7d")
+  paidOrders14dShortageCount  Int      @map("paid_orders_14d_shortage_count")
+
+  @@index([capturedAt])
+  @@map("operations_snapshots")
+}
+
 model SyncLog {
   id                Int       @id @default(autoincrement())
   startedAt         DateTime  @default(now()) @map("started_at")

--- a/scripts/apply-operations-schema.ts
+++ b/scripts/apply-operations-schema.ts
@@ -1,0 +1,100 @@
+/**
+ * One-shot DDL applier for the Operations Director Phase 1B tables.
+ *
+ * Adds:
+ *   - operations_recommendations: drift detector queue with dedupe + action log
+ *   - operations_snapshots: daily ops snapshot for the briefing + trend charts
+ *
+ * Why raw SQL: per memory note "Prisma schema drift", schema.prisma has
+ * columns deleted that still hold prod data. `prisma db push` would clobber
+ * those. Additive migrations go through this script.
+ *
+ * Usage:
+ *   DATABASE_URL=<prod> npx tsx scripts/apply-operations-schema.ts
+ *
+ * Idempotent — safe to run multiple times.
+ */
+
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const STATEMENTS: Array<[string, string]> = [
+  [
+    'operations_recommendations table',
+    `CREATE TABLE IF NOT EXISTS operations_recommendations (
+      id TEXT PRIMARY KEY,
+      signal_kind TEXT NOT NULL,
+      severity TEXT NOT NULL,
+      title TEXT NOT NULL,
+      evidence JSONB NOT NULL,
+      target_entity_type TEXT NOT NULL,
+      target_entity_id TEXT NOT NULL,
+      action_payload JSONB NOT NULL,
+      status TEXT NOT NULL DEFAULT 'open',
+      snooze_until TIMESTAMP(3),
+      dismiss_reason TEXT,
+      action_log JSONB NOT NULL DEFAULT '[]',
+      source TEXT NOT NULL DEFAULT 'auto-snapshot',
+      shipped_at TIMESTAMP(3),
+      measured_at TIMESTAMP(3),
+      measurement_result JSONB,
+      dedupe_key TEXT NOT NULL,
+      created_at TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )`,
+  ],
+  [
+    'operations_recommendations dedupe_key uniq',
+    'CREATE UNIQUE INDEX IF NOT EXISTS operations_recommendations_dedupe_key_key ON operations_recommendations(dedupe_key)',
+  ],
+  [
+    'operations_recommendations status_idx',
+    'CREATE INDEX IF NOT EXISTS operations_recommendations_status_idx ON operations_recommendations(status)',
+  ],
+  [
+    'operations_recommendations severity_status_idx',
+    'CREATE INDEX IF NOT EXISTS operations_recommendations_severity_status_idx ON operations_recommendations(severity, status)',
+  ],
+  [
+    'operations_recommendations signal_kind_status_idx',
+    'CREATE INDEX IF NOT EXISTS operations_recommendations_signal_kind_status_idx ON operations_recommendations(signal_kind, status)',
+  ],
+  [
+    'operations_snapshots table',
+    `CREATE TABLE IF NOT EXISTS operations_snapshots (
+      id TEXT PRIMARY KEY,
+      captured_at TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      inventory_accuracy_pct DOUBLE PRECISION,
+      drift_events_total INTEGER NOT NULL,
+      drift_events_by_signal JSONB NOT NULL,
+      urgent_shortages_count INTEGER NOT NULL,
+      cost_coverage_pct DOUBLE PRECISION NOT NULL,
+      receiving_lag_p50_hours DOUBLE PRECISION,
+      receiving_lag_p90_hours DOUBLE PRECISION,
+      cycle_counts_completed_last_7d INTEGER NOT NULL,
+      paid_orders_14d_shortage_count INTEGER NOT NULL
+    )`,
+  ],
+  [
+    'operations_snapshots captured_at_idx',
+    'CREATE INDEX IF NOT EXISTS operations_snapshots_captured_at_idx ON operations_snapshots(captured_at)',
+  ],
+];
+
+async function main(): Promise<void> {
+  console.log('[apply-operations-schema] applying additive DDL…');
+  for (const [label, sql] of STATEMENTS) {
+    process.stdout.write(`  • ${label.padEnd(54)} `);
+    await prisma.$executeRawUnsafe(sql);
+    console.log('OK');
+  }
+  console.log('[apply-operations-schema] done. Safe to deploy now.');
+}
+
+main()
+  .catch((err) => {
+    console.error('[apply-operations-schema] FAILED:', err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/__tests__/recommendations-lifecycle.test.ts
+++ b/src/__tests__/recommendations-lifecycle.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ALL_STATUSES,
+  MARKETING_STATUSES,
+  NEXT_TRANSITIONS,
+  REASON_MIN_CHARS,
+  REASON_MODE,
+  VALID_TRANSITIONS,
+  isValidTransition,
+  type RecommendationStatus,
+} from '@/lib/recommendations/lifecycle';
+
+describe('recommendations/lifecycle', () => {
+  it('exports the full status union', () => {
+    expect(ALL_STATUSES).toEqual([
+      'open',
+      'approved',
+      'shipped',
+      'rejected',
+      'invalidated',
+      'snoozed',
+    ]);
+  });
+
+  it('marketing subset excludes snoozed', () => {
+    expect(MARKETING_STATUSES).not.toContain('snoozed');
+    expect(MARKETING_STATUSES).toHaveLength(5);
+    for (const s of MARKETING_STATUSES) {
+      expect(ALL_STATUSES).toContain(s);
+    }
+  });
+
+  describe('isValidTransition', () => {
+    it('allows open → approved/rejected/invalidated/snoozed', () => {
+      expect(isValidTransition('open', 'approved')).toBe(true);
+      expect(isValidTransition('open', 'rejected')).toBe(true);
+      expect(isValidTransition('open', 'invalidated')).toBe(true);
+      expect(isValidTransition('open', 'snoozed')).toBe(true);
+    });
+
+    it('allows approved → shipped and back to open', () => {
+      expect(isValidTransition('approved', 'shipped')).toBe(true);
+      expect(isValidTransition('approved', 'open')).toBe(true);
+      expect(isValidTransition('approved', 'rejected')).toBe(true);
+    });
+
+    it('rejects same-status no-op transitions', () => {
+      for (const s of ALL_STATUSES) {
+        expect(isValidTransition(s, s)).toBe(false);
+      }
+    });
+
+    it('blocks shipped → approved or shipped → rejected (must re-open first)', () => {
+      expect(isValidTransition('shipped', 'approved')).toBe(false);
+      expect(isValidTransition('shipped', 'rejected')).toBe(false);
+      expect(isValidTransition('shipped', 'open')).toBe(true);
+    });
+
+    it('terminal-ish statuses only transition back to open', () => {
+      for (const terminal of ['rejected', 'invalidated'] as const) {
+        for (const to of ALL_STATUSES) {
+          const expected = to === 'open';
+          expect(isValidTransition(terminal, to)).toBe(expected);
+        }
+      }
+    });
+
+    it('snoozed can re-open, reject, or invalidate', () => {
+      expect(isValidTransition('snoozed', 'open')).toBe(true);
+      expect(isValidTransition('snoozed', 'rejected')).toBe(true);
+      expect(isValidTransition('snoozed', 'invalidated')).toBe(true);
+      expect(isValidTransition('snoozed', 'approved')).toBe(false);
+    });
+  });
+
+  describe('REASON_MODE', () => {
+    it('requires a reason for dismissals (rejected, invalidated)', () => {
+      expect(REASON_MODE.rejected).toBe('required');
+      expect(REASON_MODE.invalidated).toBe('required');
+    });
+
+    it('makes the reason optional for shipped (outcome notes)', () => {
+      expect(REASON_MODE.shipped).toBe('optional');
+    });
+
+    it('skips the modal for frictionless transitions (open, approved)', () => {
+      expect(REASON_MODE.open).toBe('none');
+      expect(REASON_MODE.approved).toBe('none');
+    });
+
+    it('covers every status', () => {
+      for (const s of ALL_STATUSES) {
+        expect(REASON_MODE[s]).toBeDefined();
+      }
+    });
+
+    it('enforces a minimum length for required reasons', () => {
+      expect(REASON_MIN_CHARS).toBeGreaterThan(0);
+    });
+  });
+
+  describe('NEXT_TRANSITIONS', () => {
+    it('every offered button is in VALID_TRANSITIONS', () => {
+      for (const status of ALL_STATUSES) {
+        const offered = NEXT_TRANSITIONS[status] ?? [];
+        for (const opt of offered) {
+          expect(VALID_TRANSITIONS[status]).toContain(opt.to);
+        }
+      }
+    });
+
+    it('open offers Approve + Reject', () => {
+      const labels = NEXT_TRANSITIONS.open.map((o) => o.label);
+      expect(labels).toEqual(['Approve', 'Reject']);
+    });
+
+    it('approved offers Mark shipped + Re-open', () => {
+      const labels = NEXT_TRANSITIONS.approved.map((o) => o.label);
+      expect(labels).toEqual(['Mark shipped', 'Re-open']);
+    });
+
+    it('terminal statuses only offer Re-open', () => {
+      for (const s of ['shipped', 'rejected', 'invalidated'] as RecommendationStatus[]) {
+        const opts = NEXT_TRANSITIONS[s];
+        expect(opts).toHaveLength(1);
+        expect(opts[0]?.to).toBe('open');
+      }
+    });
+  });
+});

--- a/src/__tests__/recommendations-measurement.test.ts
+++ b/src/__tests__/recommendations-measurement.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MEASUREMENT_WINDOW_DAYS,
+  daysSinceShipped,
+  isDueForMeasurement,
+  measurementCutoff,
+} from '@/lib/recommendations/measurement';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe('recommendations/measurement', () => {
+  it('exports the 14-day window constant', () => {
+    expect(MEASUREMENT_WINDOW_DAYS).toBe(14);
+  });
+
+  describe('measurementCutoff', () => {
+    it('is exactly 14 days before now', () => {
+      const now = new Date('2026-05-20T12:00:00Z');
+      const cutoff = measurementCutoff(now);
+      const expected = new Date(now.getTime() - 14 * DAY_MS);
+      expect(cutoff.toISOString()).toBe(expected.toISOString());
+    });
+  });
+
+  describe('isDueForMeasurement', () => {
+    const now = new Date('2026-05-20T12:00:00Z');
+
+    it('false for null/undefined shippedAt', () => {
+      expect(isDueForMeasurement(null, now)).toBe(false);
+      expect(isDueForMeasurement(undefined, now)).toBe(false);
+    });
+
+    it('false when shipped less than 14 days ago', () => {
+      const shipped = new Date(now.getTime() - 13 * DAY_MS);
+      expect(isDueForMeasurement(shipped, now)).toBe(false);
+    });
+
+    it('true when shipped exactly 14 days ago', () => {
+      const shipped = new Date(now.getTime() - 14 * DAY_MS);
+      expect(isDueForMeasurement(shipped, now)).toBe(true);
+    });
+
+    it('true when shipped more than 14 days ago', () => {
+      const shipped = new Date(now.getTime() - 30 * DAY_MS);
+      expect(isDueForMeasurement(shipped, now)).toBe(true);
+    });
+
+    it('accepts ISO strings', () => {
+      const shipped = new Date(now.getTime() - 20 * DAY_MS).toISOString();
+      expect(isDueForMeasurement(shipped, now)).toBe(true);
+    });
+
+    it('returns false for unparseable input rather than throwing', () => {
+      expect(isDueForMeasurement('not-a-date', now)).toBe(false);
+    });
+  });
+
+  describe('daysSinceShipped', () => {
+    const now = new Date('2026-05-20T12:00:00Z');
+
+    it('floors fractional days', () => {
+      const shipped = new Date(now.getTime() - 3 * DAY_MS - 5 * 60 * 60 * 1000);
+      expect(daysSinceShipped(shipped, now)).toBe(3);
+    });
+
+    it('returns 0 for future-shipped (clock skew safety)', () => {
+      const shipped = new Date(now.getTime() + DAY_MS);
+      expect(daysSinceShipped(shipped, now)).toBe(0);
+    });
+
+    it('returns 0 for the moment of shipping', () => {
+      expect(daysSinceShipped(now, now)).toBe(0);
+    });
+
+    it('accepts ISO strings', () => {
+      const shipped = new Date(now.getTime() - 7 * DAY_MS).toISOString();
+      expect(daysSinceShipped(shipped, now)).toBe(7);
+    });
+  });
+});

--- a/src/app/admin/analytics/recommendations/page.tsx
+++ b/src/app/admin/analytics/recommendations/page.tsx
@@ -7,53 +7,33 @@
  * Sourced by the snapshot cron (auto-snapshot heuristics) and the Marketing
  * Director agent (director). Operator moves items through:
  *   open → approved → shipped (or rejected / invalidated)
+ *
+ * Card rendering is delegated to the shared RecommendationCard component so
+ * Operations / SEO / Finance queues can reuse it (per Ops Director Phase 1A).
  */
 
 import { useEffect, useState, ReactElement, useCallback } from 'react';
 import Link from 'next/link';
+import { RecommendationCard } from '@/components/admin/RecommendationCard';
+import {
+  MARKETING_STATUSES,
+  REASON_MIN_CHARS,
+  REASON_MODE,
+  type RecommendationStatus,
+} from '@/lib/recommendations/lifecycle';
+import type { RecommendationCardData } from '@/lib/recommendations/card-types';
 
-type Status = 'open' | 'approved' | 'shipped' | 'rejected' | 'invalidated';
+type Status = RecommendationStatus;
 type Domain = 'marketing' | 'seo';
 type DomainFilter = Domain | 'all';
-type RiskTier = 'autonomous' | 'recommend' | 'hard_stop';
-type EffortTier = 's' | 'm' | 'l';
 
-interface MetricSnapshot {
-  capturedAt: string;
-  snapshotDate: string;
-  revenue: number;
-  orders: number;
-  averageOrderValue: number;
-  marginCoveragePct: number | null;
-}
-
-interface Recommendation {
-  id: string;
-  generatedAt: string;
-  source: string;
-  domain: Domain;
-  title: string;
-  body: string | null;
-  segment: string | null;
-  metric: string | null;
-  currentValue: string | null;
-  targetValue: string | null;
-  impactDollarsMonthly: number | null;
-  effortTier: EffortTier | null;
-  riskTier: RiskTier;
-  status: Status;
-  shippedAt: string | null;
-  notes: string | null;
-  resultMetricBefore: MetricSnapshot | null;
-  resultMetricAfter: MetricSnapshot | null;
-}
+type Recommendation = RecommendationCardData & { domain: Domain };
 
 const STATUS_TABS: { value: Status | 'all'; label: string }[] = [
-  { value: 'open', label: 'Open' },
-  { value: 'approved', label: 'Approved' },
-  { value: 'shipped', label: 'Shipped' },
-  { value: 'rejected', label: 'Rejected' },
-  { value: 'invalidated', label: 'Invalidated' },
+  ...MARKETING_STATUSES.map((s) => ({
+    value: s,
+    label: s.charAt(0).toUpperCase() + s.slice(1),
+  })),
   { value: 'all', label: 'All' },
 ];
 
@@ -62,30 +42,6 @@ const DOMAIN_TABS: { value: DomainFilter; label: string }[] = [
   { value: 'seo', label: 'SEO' },
   { value: 'all', label: 'All' },
 ];
-
-const RISK_LABEL: Record<RiskTier, string> = {
-  autonomous: 'Autonomous',
-  recommend: 'Recommend',
-  hard_stop: 'Hard stop',
-};
-
-const EFFORT_LABEL: Record<EffortTier, string> = { s: 'S', m: 'M', l: 'L' };
-
-/**
- * Whether a status transition should prompt the operator for a reason before applying.
- * - Reject: required (every dismissal needs an audit trail in Obsidian via the GitHub mirror)
- * - Mark shipped: optional (outcome notes are useful for the 14-day measurement loop but not required)
- * - Everything else (Approve, Re-open): no modal — keep the happy path frictionless
- */
-const REASON_MODE: Record<Status, 'required' | 'optional' | 'none'> = {
-  rejected: 'required',
-  shipped: 'optional',
-  open: 'none',
-  approved: 'none',
-  invalidated: 'required',
-};
-
-const REASON_MIN_CHARS = 10;
 
 export default function RecommendationsTriagePage(): ReactElement {
   const [recs, setRecs] = useState<Recommendation[]>([]);
@@ -275,162 +231,29 @@ export default function RecommendationsTriagePage(): ReactElement {
           </div>
         ) : (
           <div className="space-y-3">
-            {recs.map((rec) => {
-              const isExpanded = expanded.has(rec.id);
-              const isSaving = savingId === rec.id;
-              const isEditingThisNotes = editingNotes === rec.id;
-
-              return (
-                <div
-                  key={rec.id}
-                  className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden"
-                >
-                  <div className="p-5">
-                    <div className="flex flex-col md:flex-row md:items-start gap-4">
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2 mb-1.5 flex-wrap">
-                          <StatusBadge status={rec.status} />
-                          {domainFilter === 'all' && rec.domain && (
-                            <span
-                              className={`px-2 py-0.5 text-xs rounded-full font-medium ${
-                                rec.domain === 'seo'
-                                  ? 'bg-emerald-100 text-emerald-800'
-                                  : 'bg-indigo-100 text-indigo-800'
-                              }`}
-                            >
-                              {rec.domain === 'seo' ? 'SEO' : 'Marketing'}
-                            </span>
-                          )}
-                          {rec.segment && (
-                            <span className="px-2 py-0.5 text-xs rounded-full bg-gray-100 text-gray-700 font-medium">
-                              {rec.segment}
-                            </span>
-                          )}
-                          <span className="text-xs text-gray-400">
-                            {rec.source === 'seo-director'
-                              ? 'SEO Director'
-                              : rec.source === 'director'
-                                ? 'Director'
-                                : rec.source === 'auto-snapshot'
-                                  ? 'Heuristic'
-                                  : 'Manual'}
-                            {' · '}
-                            {new Date(rec.generatedAt).toLocaleDateString()}
-                          </span>
-                        </div>
-                        <h3 className="text-lg font-semibold text-gray-900 leading-snug">{rec.title}</h3>
-                        {rec.body && !isExpanded && (
-                          <p className="text-sm text-gray-600 mt-1.5 line-clamp-2">{rec.body}</p>
-                        )}
-                        {rec.body && isExpanded && (
-                          <p className="text-sm text-gray-700 mt-1.5 whitespace-pre-wrap leading-relaxed">{rec.body}</p>
-                        )}
-                        <div className="flex flex-wrap items-center gap-2 mt-3">
-                          {rec.impactDollarsMonthly != null && (
-                            <span className="text-xs px-2 py-1 rounded-md bg-green-50 text-green-700 border border-green-200 font-semibold">
-                              ${rec.impactDollarsMonthly.toLocaleString()}/mo
-                            </span>
-                          )}
-                          {rec.effortTier && (
-                            <span className="text-xs px-2 py-1 rounded-md bg-gray-100 text-gray-700 font-semibold">
-                              Effort · {EFFORT_LABEL[rec.effortTier]}
-                            </span>
-                          )}
-                          <span
-                            className={`text-xs px-2 py-1 rounded-md font-semibold ${
-                              rec.riskTier === 'hard_stop'
-                                ? 'bg-red-50 text-red-700 border border-red-200'
-                                : rec.riskTier === 'autonomous'
-                                ? 'bg-blue-50 text-blue-700 border border-blue-200'
-                                : 'bg-amber-50 text-amber-800 border border-amber-200'
-                            }`}
-                          >
-                            Risk · {RISK_LABEL[rec.riskTier]}
-                          </span>
-                          {rec.metric && (
-                            <span className="text-xs px-2 py-1 rounded-md bg-gray-50 text-gray-600 font-mono">
-                              {rec.metric}
-                            </span>
-                          )}
-                          {rec.body && (
-                            <button
-                              onClick={() => toggleExpand(rec.id)}
-                              className="text-xs text-blue-600 hover:underline"
-                            >
-                              {isExpanded ? 'Show less' : 'Show details'}
-                            </button>
-                          )}
-                        </div>
-                      </div>
-
-                      <div className="flex flex-col gap-2 md:items-end shrink-0">
-                        <ActionButtons
-                          rec={rec}
-                          isSaving={isSaving}
-                          onChange={(status) => requestTransition(rec, status)}
-                        />
-                      </div>
-                    </div>
-
-                    {/* Measurement block — appears for shipped recs once before is captured */}
-                    {(rec.resultMetricBefore || rec.resultMetricAfter) && (
-                      <MeasurementBlock before={rec.resultMetricBefore} after={rec.resultMetricAfter} />
-                    )}
-
-                    {/* Notes block */}
-                    <div className="mt-4 pt-4 border-t border-gray-100">
-                      {isEditingThisNotes ? (
-                        <div>
-                          <textarea
-                            value={notesValue}
-                            onChange={(e) => setNotesValue(e.target.value)}
-                            placeholder="Why this status? Outcome notes after shipping?"
-                            rows={3}
-                            className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-brand-blue focus:border-transparent"
-                            autoFocus
-                          />
-                          <div className="flex gap-2 mt-2">
-                            <button
-                              onClick={() => saveNotes(rec.id)}
-                              disabled={isSaving}
-                              className="px-3 py-1.5 text-sm bg-brand-blue text-white rounded-lg font-medium hover:bg-blue-700 disabled:opacity-60"
-                            >
-                              Save notes
-                            </button>
-                            <button
-                              onClick={() => { setEditingNotes(null); setNotesValue(''); }}
-                              className="px-3 py-1.5 text-sm bg-gray-100 text-gray-700 rounded-lg font-medium hover:bg-gray-200"
-                            >
-                              Cancel
-                            </button>
-                          </div>
-                        </div>
-                      ) : rec.notes ? (
-                        <div className="flex items-start justify-between gap-3">
-                          <div className="text-sm text-gray-700 whitespace-pre-wrap">
-                            <span className="text-xs uppercase tracking-wider text-gray-500 font-semibold mr-2">Notes</span>
-                            {rec.notes}
-                          </div>
-                          <button
-                            onClick={() => { setEditingNotes(rec.id); setNotesValue(rec.notes ?? ''); }}
-                            className="text-xs text-blue-600 hover:underline shrink-0"
-                          >
-                            Edit
-                          </button>
-                        </div>
-                      ) : (
-                        <button
-                          onClick={() => { setEditingNotes(rec.id); setNotesValue(''); }}
-                          className="text-xs text-gray-500 hover:text-gray-700 hover:underline"
-                        >
-                          + Add notes
-                        </button>
-                      )}
-                    </div>
-                  </div>
-                </div>
-              );
-            })}
+            {recs.map((rec) => (
+              <RecommendationCard
+                key={rec.id}
+                rec={rec}
+                showDomainBadge={domainFilter === 'all'}
+                isSaving={savingId === rec.id}
+                isExpanded={expanded.has(rec.id)}
+                isEditingNotes={editingNotes === rec.id}
+                notesValue={notesValue}
+                onToggleExpand={toggleExpand}
+                onRequestTransition={(r, to) => requestTransition(r as Recommendation, to)}
+                onStartEditNotes={(id, initial) => {
+                  setEditingNotes(id);
+                  setNotesValue(initial);
+                }}
+                onNotesChange={setNotesValue}
+                onSaveNotes={saveNotes}
+                onCancelEditNotes={() => {
+                  setEditingNotes(null);
+                  setNotesValue('');
+                }}
+              />
+            ))}
           </div>
         )}
       </div>
@@ -534,144 +357,6 @@ function TransitionModal({
           </button>
         </div>
       </div>
-    </div>
-  );
-}
-
-function StatusBadge({ status }: { status: Status }): ReactElement {
-  const styles: Record<Status, string> = {
-    open: 'bg-amber-50 text-amber-800 border-amber-200',
-    approved: 'bg-blue-50 text-blue-700 border-blue-200',
-    shipped: 'bg-green-50 text-green-700 border-green-200',
-    rejected: 'bg-gray-100 text-gray-600 border-gray-200',
-    invalidated: 'bg-gray-100 text-gray-500 border-gray-200',
-  };
-  return (
-    <span
-      className={`text-xs px-2 py-0.5 rounded-full border font-semibold uppercase tracking-wider ${styles[status]}`}
-    >
-      {status}
-    </span>
-  );
-}
-
-function MeasurementBlock({
-  before,
-  after,
-}: {
-  before: MetricSnapshot | null;
-  after: MetricSnapshot | null;
-}): ReactElement {
-  const fmtMoney = (n: number) => `$${n.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
-  const fmtDelta = (b: number | null, a: number | null) => {
-    if (b == null || a == null || b === 0) return null;
-    const pct = ((a - b) / b) * 100;
-    const arrow = pct > 0 ? '↑' : pct < 0 ? '↓' : '—';
-    return { pct, label: `${arrow} ${Math.abs(pct).toFixed(0)}%` };
-  };
-
-  const revenueDelta = before && after ? fmtDelta(before.revenue, after.revenue) : null;
-  const ordersDelta = before && after ? fmtDelta(before.orders, after.orders) : null;
-  const aovDelta = before && after ? fmtDelta(before.averageOrderValue, after.averageOrderValue) : null;
-  const coverageDelta =
-    before && after && before.marginCoveragePct != null && after.marginCoveragePct != null
-      ? fmtDelta(before.marginCoveragePct, after.marginCoveragePct)
-      : null;
-
-  const toneClass = (d: { pct: number } | null) =>
-    d == null
-      ? 'text-gray-400'
-      : d.pct > 0
-      ? 'text-green-700'
-      : d.pct < 0
-      ? 'text-red-600'
-      : 'text-gray-600';
-
-  return (
-    <div className="mt-4 pt-4 border-t border-gray-100">
-      <div className="text-xs uppercase tracking-wider text-gray-500 font-semibold mb-2">
-        Measurement {after ? '(14 days post-ship)' : '(awaiting 14-day capture)'}
-      </div>
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
-        {[
-          { label: 'Revenue', before: before?.revenue, after: after?.revenue, delta: revenueDelta, fmt: fmtMoney },
-          { label: 'Orders', before: before?.orders, after: after?.orders, delta: ordersDelta, fmt: (n: number) => n.toString() },
-          { label: 'AOV', before: before?.averageOrderValue, after: after?.averageOrderValue, delta: aovDelta, fmt: fmtMoney },
-          {
-            label: 'Coverage',
-            before: before?.marginCoveragePct ?? null,
-            after: after?.marginCoveragePct ?? null,
-            delta: coverageDelta,
-            fmt: (n: number) => `${n}%`,
-          },
-        ].map((m) => (
-          <div key={m.label} className="bg-gray-50 rounded-lg p-3">
-            <div className="text-xs text-gray-500 uppercase tracking-wider mb-1">{m.label}</div>
-            <div className="text-base font-semibold text-gray-900">
-              {m.before != null ? m.fmt(m.before) : '—'}
-              {' → '}
-              {m.after != null ? m.fmt(m.after) : <span className="text-gray-400">pending</span>}
-            </div>
-            {m.delta && (
-              <div className={`text-xs font-semibold mt-0.5 ${toneClass(m.delta)}`}>{m.delta.label}</div>
-            )}
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function ActionButtons({
-  rec,
-  isSaving,
-  onChange,
-}: {
-  rec: Recommendation;
-  isSaving: boolean;
-  onChange: (status: Status) => void;
-}): ReactElement {
-  const transitions: Record<Status, Array<{ to: Status; label: string; tone: 'primary' | 'neutral' | 'danger' }>> = {
-    open: [
-      { to: 'approved', label: 'Approve', tone: 'primary' },
-      { to: 'rejected', label: 'Reject', tone: 'neutral' },
-    ],
-    approved: [
-      { to: 'shipped', label: 'Mark shipped', tone: 'primary' },
-      { to: 'open', label: 'Re-open', tone: 'neutral' },
-    ],
-    shipped: [
-      { to: 'open', label: 'Re-open', tone: 'neutral' },
-    ],
-    rejected: [
-      { to: 'open', label: 'Re-open', tone: 'neutral' },
-    ],
-    invalidated: [
-      { to: 'open', label: 'Re-open', tone: 'neutral' },
-    ],
-  };
-
-  const opts = transitions[rec.status];
-  return (
-    <div className="flex gap-2 flex-wrap md:justify-end">
-      {opts.map((opt) => {
-        const cls =
-          opt.tone === 'primary'
-            ? 'bg-brand-blue text-white hover:bg-blue-700'
-            : opt.tone === 'danger'
-            ? 'bg-red-600 text-white hover:bg-red-700'
-            : 'bg-white text-gray-700 border border-gray-200 hover:bg-gray-50';
-        return (
-          <button
-            key={opt.to}
-            onClick={() => onChange(opt.to)}
-            disabled={isSaving}
-            className={`px-3 py-1.5 text-sm font-semibold rounded-lg transition-colors disabled:opacity-50 ${cls}`}
-          >
-            {isSaving ? '…' : opt.label}
-          </button>
-        );
-      })}
     </div>
   );
 }

--- a/src/app/api/cron/measure-operations-recommendations/route.ts
+++ b/src/app/api/cron/measure-operations-recommendations/route.ts
@@ -1,0 +1,93 @@
+/**
+ * Measurement loop for OperationsRecommendation.
+ *
+ * Parallel to the Marketing measure-recommendations cron: shares the 14-day
+ * window (measurementCutoff from the shared lib) but the "result" we capture
+ * is different — for ops recs, "did the underlying drift signal recur in the
+ * 14 days after ship?" That answer drives the heuristic-tuning feedback loop.
+ *
+ * For each shipped rec older than 14 days that hasn't been measured yet:
+ *   1. Re-run the matching detector
+ *   2. Check whether the same dedupeKey appears in the new proposals
+ *   3. Write measurement_result + stamp measuredAt
+ *
+ * Auth: Bearer CRON_SECRET.
+ *
+ * vercel.json: { "path": "/api/cron/measure-operations-recommendations", "schedule": "0 8 * * *" }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import type { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/database/client';
+import { measurementCutoff } from '@/lib/recommendations/measurement';
+import { ALL_DETECTORS } from '@/lib/operations/recommendations';
+import { buildDedupeKey, type SignalKind } from '@/lib/operations/types';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 120;
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = request.headers.get('authorization');
+  if (auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const cutoff = measurementCutoff();
+  const due = await prisma.operationsRecommendation.findMany({
+    where: {
+      status: 'shipped',
+      shippedAt: { lte: cutoff },
+      measuredAt: null,
+    },
+    take: 100,
+  });
+
+  if (due.length === 0) {
+    return NextResponse.json({ ok: true, measured: 0, note: 'no operations recs due for measurement' });
+  }
+
+  // Group by signalKind so each detector runs at most once.
+  const byKind = new Map<SignalKind, typeof due>();
+  for (const rec of due) {
+    const kind = rec.signalKind as SignalKind;
+    const arr = byKind.get(kind) ?? [];
+    arr.push(rec);
+    byKind.set(kind, arr);
+  }
+
+  const now = new Date();
+  const recurringDedupeKeys = new Set<string>();
+  for (const [kind, recs] of byKind) {
+    const detector = ALL_DETECTORS.find(([k]) => k === kind)?.[1];
+    if (!detector) {
+      // Unknown signal kind — mark these as not-recurring (best we can do).
+      for (const r of recs) recurringDedupeKeys.delete(r.dedupeKey);
+      continue;
+    }
+    const proposals = await detector(now);
+    for (const p of proposals) {
+      const key = buildDedupeKey(p.signalKind, p.targetEntityId);
+      recurringDedupeKeys.add(key);
+    }
+  }
+
+  const measured: Array<{ id: string; signalKind: string; recurred: boolean }> = [];
+  for (const rec of due) {
+    const recurred = recurringDedupeKeys.has(rec.dedupeKey);
+    const result = {
+      capturedAt: now.toISOString(),
+      recurred,
+      windowDays: 14,
+    };
+    await prisma.operationsRecommendation.update({
+      where: { id: rec.id },
+      data: {
+        measuredAt: now,
+        measurementResult: result as unknown as Prisma.InputJsonValue,
+      },
+    });
+    measured.push({ id: rec.id, signalKind: rec.signalKind, recurred });
+  }
+
+  return NextResponse.json({ ok: true, measured: measured.length, items: measured });
+}

--- a/src/app/api/cron/measure-recommendations/route.ts
+++ b/src/app/api/cron/measure-recommendations/route.ts
@@ -14,11 +14,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import type { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/database/client';
 import { mirrorRecommendation } from '@/lib/analytics/recommendation-mirror';
+import { measurementCutoff } from '@/lib/recommendations/measurement';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 120;
-
-const MEASUREMENT_WINDOW_DAYS = 14;
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const auth = request.headers.get('authorization');
@@ -26,7 +25,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const cutoff = new Date(Date.now() - MEASUREMENT_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+  const cutoff = measurementCutoff();
 
   const due = await prisma.recommendationItem.findMany({
     where: {

--- a/src/app/api/cron/operations-drift-hourly/route.ts
+++ b/src/app/api/cron/operations-drift-hourly/route.ts
@@ -1,0 +1,50 @@
+/**
+ * Hourly Operations drift cron.
+ *
+ * Runs the time-sensitive subset of detectors every hour:
+ *   - receiving-lag, pick-inventory-lag, ai-note-backlog, pre-fulfillment-shortage
+ *
+ * Same upsert flow as the daily snapshot, just no snapshot row. Keeps the
+ * triage queue fresh between Monday plan runs and lets urgent shortages
+ * surface within an hour of a paid order landing.
+ *
+ * Auth: Bearer CRON_SECRET.
+ *
+ * vercel.json: { "path": "/api/cron/operations-drift-hourly", "schedule": "0 * * * *" }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { generateHourly } from '@/lib/operations/recommendations';
+import { upsertRecommendations } from '@/lib/operations/recommendation-store';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 120;
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = request.headers.get('authorization');
+  if (auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const now = new Date();
+  try {
+    const result = await generateHourly(now);
+    const summary = await upsertRecommendations(result.proposals);
+    return NextResponse.json({
+      ok: true,
+      detectors: {
+        bySignal: result.bySignal,
+        proposals: result.proposals.length,
+        suppressedSnoozed: result.suppressedSnoozed,
+        suppressedKnockdown: result.suppressedKnockdown,
+      },
+      upsert: summary,
+    });
+  } catch (err) {
+    console.error('[operations-drift-hourly] failed:', err);
+    return NextResponse.json(
+      { ok: false, error: err instanceof Error ? err.message : String(err) },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/cron/operations-snapshot/route.ts
+++ b/src/app/api/cron/operations-snapshot/route.ts
@@ -1,0 +1,101 @@
+/**
+ * Daily Operations snapshot cron.
+ *
+ * Runs at 07:30 UTC, right after the Marketing snapshot. Computes the
+ * OperationsSnapshot metrics row, runs all 10 drift detectors, and upserts
+ * the resulting OperationsRecommendation rows (dedupe + suppression handled
+ * by the orchestrator).
+ *
+ * Auth: Bearer CRON_SECRET (matches the rest of the cron family).
+ *
+ * vercel.json: { "path": "/api/cron/operations-snapshot", "schedule": "30 7 * * *" }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/database/client';
+import { generateAll } from '@/lib/operations/recommendations';
+import { upsertRecommendations } from '@/lib/operations/recommendation-store';
+import {
+  computeCostCoveragePct,
+  computeCycleCountsCompletedLast7d,
+  computeInventoryAccuracyPct,
+  computePaidOrders14dShortageCount,
+  computeReceivingLagPercentiles,
+} from '@/lib/operations/snapshot';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 300;
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = request.headers.get('authorization');
+  if (auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const now = new Date();
+  const errors: string[] = [];
+  const safe = async <T>(label: string, fn: () => Promise<T>): Promise<T | null> => {
+    try {
+      return await fn();
+    } catch (err) {
+      console.error(`[operations-snapshot] ${label} failed:`, err);
+      errors.push(`${label}: ${err instanceof Error ? err.message : String(err)}`);
+      return null;
+    }
+  };
+
+  const [accuracy, coverage, lag, shortageCount, cycleCounts, generated] = await Promise.all([
+    safe('metrics.accuracy', () => computeInventoryAccuracyPct(now)),
+    safe('metrics.coverage', () => computeCostCoveragePct(now)),
+    safe('metrics.receiving-lag', () => computeReceivingLagPercentiles(now)),
+    safe('metrics.shortage', () => computePaidOrders14dShortageCount(now)),
+    safe('metrics.cycle-counts', () => computeCycleCountsCompletedLast7d(now)),
+    safe('detectors', () => generateAll(now)),
+  ]);
+
+  const driftTotal = generated?.proposals.length ?? 0;
+  const urgentShortages = (generated?.proposals ?? []).filter(
+    (r) => r.signalKind === 'pre-fulfillment-shortage'
+  ).length;
+
+  const snapshot = await safe('snapshot.write', () =>
+    prisma.operationsSnapshot.create({
+      data: {
+        capturedAt: now,
+        inventoryAccuracyPct: accuracy,
+        driftEventsTotal: driftTotal,
+        driftEventsBySignal: generated?.bySignal ?? {},
+        urgentShortagesCount: urgentShortages,
+        costCoveragePct: coverage ?? 0,
+        receivingLagP50Hours: lag?.p50 ?? null,
+        receivingLagP90Hours: lag?.p90 ?? null,
+        cycleCountsCompletedLast7d: cycleCounts ?? 0,
+        paidOrders14dShortageCount: shortageCount ?? 0,
+      },
+    })
+  );
+
+  const upsertSummary = generated
+    ? await safe('store.upsert', () => upsertRecommendations(generated.proposals))
+    : null;
+
+  return NextResponse.json({
+    ok: true,
+    snapshotId: snapshot?.id ?? null,
+    metrics: {
+      inventoryAccuracyPct: accuracy,
+      costCoveragePct: coverage,
+      receivingLag: lag,
+      paidOrders14dShortageCount: shortageCount,
+      cycleCountsCompletedLast7d: cycleCounts,
+    },
+    detectors: {
+      bySignal: generated?.bySignal ?? {},
+      proposals: driftTotal,
+      suppressedSnoozed: generated?.suppressedSnoozed ?? 0,
+      suppressedKnockdown: generated?.suppressedKnockdown ?? 0,
+    },
+    upsert: upsertSummary ?? { created: 0, updated: 0, skipped: 0 },
+    errors: errors.length ? errors : undefined,
+  });
+}

--- a/src/components/admin/RecommendationCard.tsx
+++ b/src/components/admin/RecommendationCard.tsx
@@ -1,0 +1,322 @@
+'use client';
+
+/**
+ * Shared RecommendationCard — renders one row of the triage queue.
+ *
+ * Marketing uses this today (advisory recs, no inline action). Operations
+ * (Phase 1B/1C) will pass `onExecuteAction` so the card sprouts an inline
+ * action button derived from `rec.actionPayload`.
+ *
+ * Stateless — all UI state (expanded, editing notes) is lifted to the page.
+ */
+
+import { ReactElement } from 'react';
+import { NEXT_TRANSITIONS, type RecommendationStatus } from '@/lib/recommendations/lifecycle';
+import type {
+  MetricSnapshot,
+  RecommendationCardData,
+  RecommendationCardProps,
+} from '@/lib/recommendations/card-types';
+import type { RiskTier, EffortTier } from '@/lib/recommendations/lifecycle';
+
+const RISK_LABEL: Record<RiskTier, string> = {
+  autonomous: 'Autonomous',
+  recommend: 'Recommend',
+  hard_stop: 'Hard stop',
+};
+
+const EFFORT_LABEL: Record<EffortTier, string> = { s: 'S', m: 'M', l: 'L' };
+
+function sourceLabel(source: string): string {
+  if (source === 'seo-director') return 'SEO Director';
+  if (source === 'director') return 'Director';
+  if (source === 'auto-snapshot') return 'Heuristic';
+  return 'Manual';
+}
+
+export function RecommendationCard({
+  rec,
+  showDomainBadge = false,
+  isSaving = false,
+  isExpanded = false,
+  isEditingNotes = false,
+  notesValue = '',
+  onToggleExpand,
+  onRequestTransition,
+  onStartEditNotes,
+  onNotesChange,
+  onSaveNotes,
+  onCancelEditNotes,
+  onExecuteAction,
+}: RecommendationCardProps): ReactElement {
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+      <div className="p-5">
+        <div className="flex flex-col md:flex-row md:items-start gap-4">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-1.5 flex-wrap">
+              <StatusBadge status={rec.status} />
+              {showDomainBadge && rec.domain && (
+                <span
+                  className={`px-2 py-0.5 text-xs rounded-full font-medium ${
+                    rec.domain === 'seo'
+                      ? 'bg-emerald-100 text-emerald-800'
+                      : 'bg-indigo-100 text-indigo-800'
+                  }`}
+                >
+                  {rec.domain === 'seo' ? 'SEO' : 'Marketing'}
+                </span>
+              )}
+              {rec.segment && (
+                <span className="px-2 py-0.5 text-xs rounded-full bg-gray-100 text-gray-700 font-medium">
+                  {rec.segment}
+                </span>
+              )}
+              <span className="text-xs text-gray-400">
+                {sourceLabel(rec.source)}
+                {' · '}
+                {new Date(rec.generatedAt).toLocaleDateString()}
+              </span>
+            </div>
+            <h3 className="text-lg font-semibold text-gray-900 leading-snug">{rec.title}</h3>
+            {rec.body && !isExpanded && (
+              <p className="text-sm text-gray-600 mt-1.5 line-clamp-2">{rec.body}</p>
+            )}
+            {rec.body && isExpanded && (
+              <p className="text-sm text-gray-700 mt-1.5 whitespace-pre-wrap leading-relaxed">{rec.body}</p>
+            )}
+            <div className="flex flex-wrap items-center gap-2 mt-3">
+              {rec.impactDollarsMonthly != null && (
+                <span className="text-xs px-2 py-1 rounded-md bg-green-50 text-green-700 border border-green-200 font-semibold">
+                  ${rec.impactDollarsMonthly.toLocaleString()}/mo
+                </span>
+              )}
+              {rec.effortTier && (
+                <span className="text-xs px-2 py-1 rounded-md bg-gray-100 text-gray-700 font-semibold">
+                  Effort · {EFFORT_LABEL[rec.effortTier]}
+                </span>
+              )}
+              <span
+                className={`text-xs px-2 py-1 rounded-md font-semibold ${
+                  rec.riskTier === 'hard_stop'
+                    ? 'bg-red-50 text-red-700 border border-red-200'
+                    : rec.riskTier === 'autonomous'
+                    ? 'bg-blue-50 text-blue-700 border border-blue-200'
+                    : 'bg-amber-50 text-amber-800 border border-amber-200'
+                }`}
+              >
+                Risk · {RISK_LABEL[rec.riskTier]}
+              </span>
+              {rec.metric && (
+                <span className="text-xs px-2 py-1 rounded-md bg-gray-50 text-gray-600 font-mono">
+                  {rec.metric}
+                </span>
+              )}
+              {rec.body && onToggleExpand && (
+                <button
+                  onClick={() => onToggleExpand(rec.id)}
+                  className="text-xs text-blue-600 hover:underline"
+                >
+                  {isExpanded ? 'Show less' : 'Show details'}
+                </button>
+              )}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2 md:items-end shrink-0">
+            <ActionButtons
+              rec={rec}
+              isSaving={isSaving}
+              onChange={(status) => onRequestTransition?.(rec, status)}
+              onExecuteAction={onExecuteAction}
+            />
+          </div>
+        </div>
+
+        {(rec.resultMetricBefore || rec.resultMetricAfter) && (
+          <MeasurementBlock before={rec.resultMetricBefore} after={rec.resultMetricAfter} />
+        )}
+
+        <div className="mt-4 pt-4 border-t border-gray-100">
+          {isEditingNotes ? (
+            <div>
+              <textarea
+                value={notesValue}
+                onChange={(e) => onNotesChange?.(e.target.value)}
+                placeholder="Why this status? Outcome notes after shipping?"
+                rows={3}
+                className="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-brand-blue focus:border-transparent"
+                autoFocus
+              />
+              <div className="flex gap-2 mt-2">
+                <button
+                  onClick={() => onSaveNotes?.(rec.id)}
+                  disabled={isSaving}
+                  className="px-3 py-1.5 text-sm bg-brand-blue text-white rounded-lg font-medium hover:bg-blue-700 disabled:opacity-60"
+                >
+                  Save notes
+                </button>
+                <button
+                  onClick={() => onCancelEditNotes?.()}
+                  className="px-3 py-1.5 text-sm bg-gray-100 text-gray-700 rounded-lg font-medium hover:bg-gray-200"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : rec.notes ? (
+            <div className="flex items-start justify-between gap-3">
+              <div className="text-sm text-gray-700 whitespace-pre-wrap">
+                <span className="text-xs uppercase tracking-wider text-gray-500 font-semibold mr-2">Notes</span>
+                {rec.notes}
+              </div>
+              <button
+                onClick={() => onStartEditNotes?.(rec.id, rec.notes ?? '')}
+                className="text-xs text-blue-600 hover:underline shrink-0"
+              >
+                Edit
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={() => onStartEditNotes?.(rec.id, '')}
+              className="text-xs text-gray-500 hover:text-gray-700 hover:underline"
+            >
+              + Add notes
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function StatusBadge({ status }: { status: RecommendationStatus }): ReactElement {
+  const styles: Record<RecommendationStatus, string> = {
+    open: 'bg-amber-50 text-amber-800 border-amber-200',
+    approved: 'bg-blue-50 text-blue-700 border-blue-200',
+    shipped: 'bg-green-50 text-green-700 border-green-200',
+    rejected: 'bg-gray-100 text-gray-600 border-gray-200',
+    invalidated: 'bg-gray-100 text-gray-500 border-gray-200',
+    snoozed: 'bg-slate-100 text-slate-600 border-slate-200',
+  };
+  return (
+    <span
+      className={`text-xs px-2 py-0.5 rounded-full border font-semibold uppercase tracking-wider ${styles[status]}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+function MeasurementBlock({
+  before,
+  after,
+}: {
+  before: MetricSnapshot | null;
+  after: MetricSnapshot | null;
+}): ReactElement {
+  const fmtMoney = (n: number) => `$${n.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+  const fmtDelta = (b: number | null, a: number | null) => {
+    if (b == null || a == null || b === 0) return null;
+    const pct = ((a - b) / b) * 100;
+    const arrow = pct > 0 ? '↑' : pct < 0 ? '↓' : '—';
+    return { pct, label: `${arrow} ${Math.abs(pct).toFixed(0)}%` };
+  };
+
+  const revenueDelta = before && after ? fmtDelta(before.revenue, after.revenue) : null;
+  const ordersDelta = before && after ? fmtDelta(before.orders, after.orders) : null;
+  const aovDelta = before && after ? fmtDelta(before.averageOrderValue, after.averageOrderValue) : null;
+  const coverageDelta =
+    before && after && before.marginCoveragePct != null && after.marginCoveragePct != null
+      ? fmtDelta(before.marginCoveragePct, after.marginCoveragePct)
+      : null;
+
+  const toneClass = (d: { pct: number } | null) =>
+    d == null
+      ? 'text-gray-400'
+      : d.pct > 0
+      ? 'text-green-700'
+      : d.pct < 0
+      ? 'text-red-600'
+      : 'text-gray-600';
+
+  return (
+    <div className="mt-4 pt-4 border-t border-gray-100">
+      <div className="text-xs uppercase tracking-wider text-gray-500 font-semibold mb-2">
+        Measurement {after ? '(14 days post-ship)' : '(awaiting 14-day capture)'}
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
+        {[
+          { label: 'Revenue', before: before?.revenue, after: after?.revenue, delta: revenueDelta, fmt: fmtMoney },
+          { label: 'Orders', before: before?.orders, after: after?.orders, delta: ordersDelta, fmt: (n: number) => n.toString() },
+          { label: 'AOV', before: before?.averageOrderValue, after: after?.averageOrderValue, delta: aovDelta, fmt: fmtMoney },
+          {
+            label: 'Coverage',
+            before: before?.marginCoveragePct ?? null,
+            after: after?.marginCoveragePct ?? null,
+            delta: coverageDelta,
+            fmt: (n: number) => `${n}%`,
+          },
+        ].map((m) => (
+          <div key={m.label} className="bg-gray-50 rounded-lg p-3">
+            <div className="text-xs text-gray-500 uppercase tracking-wider mb-1">{m.label}</div>
+            <div className="text-base font-semibold text-gray-900">
+              {m.before != null ? m.fmt(m.before) : '—'}
+              {' → '}
+              {m.after != null ? m.fmt(m.after) : <span className="text-gray-400">pending</span>}
+            </div>
+            {m.delta && (
+              <div className={`text-xs font-semibold mt-0.5 ${toneClass(m.delta)}`}>{m.delta.label}</div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ActionButtons({
+  rec,
+  isSaving,
+  onChange,
+  onExecuteAction,
+}: {
+  rec: RecommendationCardData;
+  isSaving: boolean;
+  onChange: (status: RecommendationStatus) => void;
+  onExecuteAction?: (rec: RecommendationCardData) => void;
+}): ReactElement {
+  const opts = NEXT_TRANSITIONS[rec.status] ?? [];
+  return (
+    <div className="flex gap-2 flex-wrap md:justify-end">
+      {rec.actionPayload && onExecuteAction && (
+        <button
+          onClick={() => onExecuteAction(rec)}
+          disabled={isSaving}
+          className="px-3 py-1.5 text-sm font-semibold rounded-lg transition-colors disabled:opacity-50 bg-brand-yellow text-gray-900 hover:bg-yellow-400"
+        >
+          {rec.actionPayload.label ?? 'Run action'}
+        </button>
+      )}
+      {opts.map((opt) => {
+        const cls =
+          opt.tone === 'primary'
+            ? 'bg-brand-blue text-white hover:bg-blue-700'
+            : opt.tone === 'danger'
+            ? 'bg-red-600 text-white hover:bg-red-700'
+            : 'bg-white text-gray-700 border border-gray-200 hover:bg-gray-50';
+        return (
+          <button
+            key={opt.to}
+            onClick={() => onChange(opt.to)}
+            disabled={isSaving}
+            className={`px-3 py-1.5 text-sm font-semibold rounded-lg transition-colors disabled:opacity-50 ${cls}`}
+          >
+            {isSaving ? '…' : opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/analytics/recommendation-store.ts
+++ b/src/lib/analytics/recommendation-store.ts
@@ -10,10 +10,20 @@
 
 import { prisma } from '@/lib/database/client';
 import type { Prisma } from '@prisma/client';
+import type {
+  RecommendationStatus as SharedStatus,
+  RiskTier as SharedRiskTier,
+  EffortTier,
+} from '@/lib/recommendations/lifecycle';
 
 export type RecommendationSource = 'auto-snapshot' | 'director' | 'manual' | 'seo-director';
-export type RiskTier = 'autonomous' | 'recommend' | 'hard_stop';
-export type RecommendationStatus = 'open' | 'approved' | 'shipped' | 'rejected' | 'invalidated';
+export type RiskTier = SharedRiskTier;
+/**
+ * Marketing API surface — currently a strict subset of the shared lifecycle
+ * (no `snoozed`). Kept narrow so existing callers/validators behave exactly
+ * as before. Ops will widen to the shared union in a later phase.
+ */
+export type RecommendationStatus = Exclude<SharedStatus, 'snoozed'>;
 export type RecommendationDomain = 'marketing' | 'seo';
 
 export interface RecommendationInput {
@@ -25,7 +35,7 @@ export interface RecommendationInput {
   currentValue?: string;
   targetValue?: string;
   impactDollarsMonthly?: number;
-  effortTier?: 's' | 'm' | 'l';
+  effortTier?: EffortTier;
   riskTier?: RiskTier;
 }
 

--- a/src/lib/operations/__tests__/detectors-batch-a.test.ts
+++ b/src/lib/operations/__tests__/detectors-batch-a.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Detector tests — signals 1-5.
+ *
+ * Each detector has:
+ *   (a) generates the rec when conditions are met
+ *   (b) returns [] when conditions are not met
+ *   (c) populates evidence[] with metric + source link
+ *   (d) populates actionPayload with a valid navigate/apiCall
+ *
+ * The orchestrator handles dedupe (in upsertRecommendations) and suppression
+ * (in applySuppression) — those are covered in recommendation-store.test.ts
+ * and recommendations.test.ts respectively, not duplicated per detector.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const prismaMock = vi.hoisted(() => ({
+  receivingInvoice: { findMany: vi.fn() },
+  orderItemPickState: { findMany: vi.fn() },
+  inventoryMovement: { findFirst: vi.fn() },
+  order: { findUnique: vi.fn() },
+  $queryRawUnsafe: vi.fn(),
+}));
+
+vi.mock('@/lib/database/client', () => ({ prisma: prismaMock }));
+
+import {
+  detectReceivingLag,
+  detectPickInventoryLag,
+  detectRepeatedShorts,
+  detectNegativeAvailable,
+  detectVelocityAnomaly,
+} from '../detectors';
+
+beforeEach(() => {
+  for (const m of Object.values(prismaMock)) {
+    if (typeof m === 'function') (m as ReturnType<typeof vi.fn>).mockReset();
+    else for (const fn of Object.values(m)) (fn as ReturnType<typeof vi.fn>).mockReset();
+  }
+});
+
+// ─── Signal #1: receiving-lag ──────────────────────────────────────────
+
+describe('detectReceivingLag', () => {
+  const now = new Date('2026-05-13T10:00:00Z');
+
+  it('flags invoices PENDING_REVIEW for ≥24h', async () => {
+    prismaMock.receivingInvoice.findMany.mockResolvedValue([
+      { id: 'inv_1', distributorName: 'RNDC', invoiceNumber: 'A123', createdAt: new Date('2026-05-12T08:00:00Z') },
+    ]);
+    const recs = await detectReceivingLag(now);
+    expect(recs).toHaveLength(1);
+    expect(recs[0].signalKind).toBe('receiving-lag');
+    expect(recs[0].severity).toBe('high');
+    expect(recs[0].targetEntityId).toBe('inv_1');
+  });
+
+  it('returns [] when no invoices match', async () => {
+    prismaMock.receivingInvoice.findMany.mockResolvedValue([]);
+    expect(await detectReceivingLag(now)).toEqual([]);
+  });
+
+  it('populates evidence with hours_pending + source link', async () => {
+    prismaMock.receivingInvoice.findMany.mockResolvedValue([
+      { id: 'inv_2', distributorName: null, invoiceNumber: null, createdAt: new Date('2026-05-12T00:00:00Z') },
+    ]);
+    const [rec] = await detectReceivingLag(now);
+    expect(rec.evidence[0].metricName).toBe('hours_pending');
+    expect(rec.evidence[0].metricValue).toBe(34);
+    expect(rec.evidence[0].sourceLinks?.[0].href).toBe('/ops/inventory/receiving/inv_2');
+  });
+
+  it('builds a navigate actionPayload pointing to the invoice', async () => {
+    prismaMock.receivingInvoice.findMany.mockResolvedValue([
+      { id: 'inv_3', distributorName: 'Spec', invoiceNumber: 'B-9', createdAt: new Date('2026-05-12T00:00:00Z') },
+    ]);
+    const [rec] = await detectReceivingLag(now);
+    expect(rec.actionPayload.kind).toBe('navigate');
+    expect(rec.actionPayload.params).toEqual({ href: '/ops/inventory/receiving/inv_3' });
+  });
+});
+
+// ─── Signal #2: pick-inventory-lag ────────────────────────────────────
+
+describe('detectPickInventoryLag', () => {
+  const now = new Date('2026-05-13T10:00:00Z');
+
+  it('flags packed pick states ≥24h old with no matching movement', async () => {
+    prismaMock.orderItemPickState.findMany.mockResolvedValue([
+      { orderId: 'o1', itemKey: 'k1', shortBy: 0, updatedAt: new Date('2026-05-10T00:00:00Z') },
+    ]);
+    prismaMock.inventoryMovement.findFirst.mockResolvedValue(null);
+    prismaMock.order.findUnique.mockResolvedValue({ orderNumber: 42, customerName: 'Jane', groupOrderV2: null });
+    const recs = await detectPickInventoryLag(now);
+    expect(recs).toHaveLength(1);
+    expect(recs[0].signalKind).toBe('pick-inventory-lag');
+    expect(recs[0].targetEntityId).toBe('o1');
+  });
+
+  it('skips orders that already have a pack movement', async () => {
+    prismaMock.orderItemPickState.findMany.mockResolvedValue([
+      { orderId: 'o2', itemKey: 'k', shortBy: 0, updatedAt: new Date('2026-05-10T00:00:00Z') },
+    ]);
+    prismaMock.inventoryMovement.findFirst.mockResolvedValue({ id: 'mv_1' });
+    expect(await detectPickInventoryLag(now)).toEqual([]);
+  });
+
+  it('uses manifest name when groupOrderV2 is set', async () => {
+    prismaMock.orderItemPickState.findMany.mockResolvedValue([
+      { orderId: 'o3', itemKey: 'k', shortBy: 0, updatedAt: new Date('2026-05-10T00:00:00Z') },
+    ]);
+    prismaMock.inventoryMovement.findFirst.mockResolvedValue(null);
+    prismaMock.order.findUnique.mockResolvedValue({
+      orderNumber: 99,
+      customerName: 'Maria Mercado',
+      groupOrderV2: { name: 'Cynthia Cruz Drink Delivery!', hostName: 'Diana', shareCode: 'X' },
+    });
+    const [rec] = await detectPickInventoryLag(now);
+    expect(rec.title).toContain('Cynthia Cruz');
+    expect(rec.title).toContain('paid by Maria Mercado');
+  });
+
+  it('uses apiCall actionPayload for reconciliation', async () => {
+    prismaMock.orderItemPickState.findMany.mockResolvedValue([
+      { orderId: 'o4', itemKey: 'k', shortBy: 0, updatedAt: new Date('2026-05-10T00:00:00Z') },
+    ]);
+    prismaMock.inventoryMovement.findFirst.mockResolvedValue(null);
+    prismaMock.order.findUnique.mockResolvedValue({ orderNumber: 1, customerName: 'X', groupOrderV2: null });
+    const [rec] = await detectPickInventoryLag(now);
+    expect(rec.actionPayload.kind).toBe('apiCall');
+    expect((rec.actionPayload.params as { body: { orderId: string } }).body.orderId).toBe('o4');
+  });
+});
+
+// ─── Signal #3: repeated-shorts ───────────────────────────────────────
+
+describe('detectRepeatedShorts', () => {
+  it('flags variants short on ≥2 orders in last 7d', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([
+      { variant_id: 'v1', title: 'Modelo 12pk', orders: BigInt(3), total_short: BigInt(8) },
+    ]);
+    const recs = await detectRepeatedShorts();
+    expect(recs).toHaveLength(1);
+    expect(recs[0].targetEntityType).toBe('productVariant');
+    expect(recs[0].targetEntityId).toBe('v1');
+  });
+
+  it('returns [] when no shorts qualify', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([]);
+    expect(await detectRepeatedShorts()).toEqual([]);
+  });
+
+  it('populates evidence with orders_shorted_7d + total_units_short', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([
+      { variant_id: 'v1', title: 'X', orders: BigInt(2), total_short: BigInt(4) },
+    ]);
+    const [rec] = await detectRepeatedShorts();
+    const names = rec.evidence.map((e) => e.metricName);
+    expect(names).toContain('orders_shorted_7d');
+    expect(names).toContain('total_units_short');
+  });
+
+  it('builds a navigate action prefilled for the count modal', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([
+      { variant_id: 'v9', title: 'X', orders: BigInt(2), total_short: BigInt(4) },
+    ]);
+    const [rec] = await detectRepeatedShorts();
+    expect(rec.actionPayload.kind).toBe('navigate');
+    expect((rec.actionPayload.params as { href: string }).href).toContain('openNoteFor=v9');
+  });
+});
+
+// ─── Signal #4: negative-available ────────────────────────────────────
+
+describe('detectNegativeAvailable', () => {
+  it('flags variants where committed > on-hand', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([
+      { id: 'v1', title: '750ml', product_title: 'Tito', inventory_quantity: 5, committed_quantity: 12 },
+    ]);
+    const recs = await detectNegativeAvailable();
+    expect(recs).toHaveLength(1);
+    expect(recs[0].severity).toBe('urgent');
+  });
+
+  it('returns [] when no variants in deficit', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([]);
+    expect(await detectNegativeAvailable()).toEqual([]);
+  });
+
+  it('reports the deficit in title + evidence', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([
+      { id: 'v1', title: 'Default', product_title: 'X', inventory_quantity: 0, committed_quantity: 7 },
+    ]);
+    const [rec] = await detectNegativeAvailable();
+    expect(rec.title).toContain('7');
+    const deficit = rec.evidence.find((e) => e.metricName === 'deficit');
+    expect(deficit?.metricValue).toBe(7);
+  });
+
+  it('builds a navigate action pointing to count modal', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([
+      { id: 'v2', title: 'X', product_title: 'Y', inventory_quantity: 1, committed_quantity: 3 },
+    ]);
+    const [rec] = await detectNegativeAvailable();
+    expect(rec.actionPayload.kind).toBe('navigate');
+    expect((rec.actionPayload.params as { href: string }).href).toContain('openNoteFor=v2');
+  });
+});
+
+// ─── Signal #5: velocity-anomaly ──────────────────────────────────────
+
+describe('detectVelocityAnomaly', () => {
+  it('flags variants that sold ≥4 in 30d then 0 in last 14d', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([
+      { variant_id: 'v1', title: 'X', product_title: 'Y', units_30d: BigInt(12), units_last_14d: BigInt(0) },
+    ]);
+    const recs = await detectVelocityAnomaly();
+    expect(recs).toHaveLength(1);
+    expect(recs[0].signalKind).toBe('velocity-anomaly');
+    expect(recs[0].severity).toBe('normal');
+  });
+
+  it('returns [] when SQL returns nothing', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([]);
+    expect(await detectVelocityAnomaly()).toEqual([]);
+  });
+
+  it('evidence carries units_30d AND units_last_14d', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([
+      { variant_id: 'v1', title: 'X', product_title: 'Y', units_30d: BigInt(10), units_last_14d: BigInt(0) },
+    ]);
+    const [rec] = await detectVelocityAnomaly();
+    const names = rec.evidence.map((e) => e.metricName);
+    expect(names).toContain('units_30d');
+    expect(names).toContain('units_last_14d');
+  });
+
+  it('navigate action opens variant page', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([
+      { variant_id: 'v3', title: 'X', product_title: 'Y', units_30d: BigInt(10), units_last_14d: BigInt(0) },
+    ]);
+    const [rec] = await detectVelocityAnomaly();
+    expect((rec.actionPayload.params as { href: string }).href).toContain('variantId=v3');
+  });
+});

--- a/src/lib/operations/__tests__/detectors-batch-b.test.ts
+++ b/src/lib/operations/__tests__/detectors-batch-b.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Detector tests — signals 6-10. Same 4-case shape as batch A.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const prismaMock = vi.hoisted(() => ({
+  inventoryNote: { findMany: vi.fn() },
+  inventoryMovement: { findFirst: vi.fn() },
+  $queryRawUnsafe: vi.fn(),
+}));
+
+vi.mock('@/lib/database/client', () => ({ prisma: prismaMock }));
+
+import {
+  detectAiNoteBacklog,
+  detectVariantMismapping,
+  detectCostCoverageGap,
+  detectCycleCountOverdue,
+  detectPreFulfillmentShortage,
+} from '../detectors';
+
+beforeEach(() => {
+  for (const m of Object.values(prismaMock)) {
+    if (typeof m === 'function') (m as ReturnType<typeof vi.fn>).mockReset();
+    else for (const fn of Object.values(m)) (fn as ReturnType<typeof vi.fn>).mockReset();
+  }
+});
+
+// ─── Signal #6: ai-note-backlog ───────────────────────────────────────
+
+describe('detectAiNoteBacklog', () => {
+  const now = new Date('2026-05-13T10:00:00Z');
+
+  it('flags inventory notes pending ≥24h', async () => {
+    prismaMock.inventoryNote.findMany.mockResolvedValue([
+      { id: 'n1', content: 'Counted 12 Modelos', createdAt: new Date('2026-05-12T00:00:00Z') },
+    ]);
+    const recs = await detectAiNoteBacklog(now);
+    expect(recs).toHaveLength(1);
+    expect(recs[0].targetEntityType).toBe('inventoryNote');
+    expect(recs[0].targetEntityId).toBe('n1');
+  });
+
+  it('returns [] when no pending notes', async () => {
+    prismaMock.inventoryNote.findMany.mockResolvedValue([]);
+    expect(await detectAiNoteBacklog(now)).toEqual([]);
+  });
+
+  it('previews long content (≤70 chars)', async () => {
+    const long = 'x'.repeat(200);
+    prismaMock.inventoryNote.findMany.mockResolvedValue([
+      { id: 'n1', content: long, createdAt: new Date('2026-05-12T00:00:00Z') },
+    ]);
+    const [rec] = await detectAiNoteBacklog(now);
+    expect(rec.title.includes('…')).toBe(true);
+  });
+
+  it('navigate action points to /ops/inventory?openNote=…', async () => {
+    prismaMock.inventoryNote.findMany.mockResolvedValue([
+      { id: 'n2', content: 'short', createdAt: new Date('2026-05-12T00:00:00Z') },
+    ]);
+    const [rec] = await detectAiNoteBacklog(now);
+    expect((rec.actionPayload.params as { href: string }).href).toContain('openNote=n2');
+  });
+});
+
+// ─── Signal #7: variant-mismapping ────────────────────────────────────
+
+describe('detectVariantMismapping', () => {
+  it('flags variants with committed but no sales when sibling sells', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([
+      {
+        product_id: 'p1', product_title: 'Tito',
+        suspect_variant_id: 'v_susp', suspect_title: '750ml', suspect_committed: 8,
+        sibling_variant_id: 'v_sib', sibling_title: '1L', sibling_units_30d: BigInt(20),
+      },
+    ]);
+    const recs = await detectVariantMismapping();
+    expect(recs).toHaveLength(1);
+    expect(recs[0].targetEntityId).toBe('v_susp');
+  });
+
+  it('returns [] when no candidates', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([]);
+    expect(await detectVariantMismapping()).toEqual([]);
+  });
+
+  it('dedupes when multiple siblings reference the same suspect', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([
+      { product_id: 'p', product_title: 'X', suspect_variant_id: 'A', suspect_title: 'a', suspect_committed: 5, sibling_variant_id: 'B', sibling_title: 'b', sibling_units_30d: BigInt(10) },
+      { product_id: 'p', product_title: 'X', suspect_variant_id: 'A', suspect_title: 'a', suspect_committed: 5, sibling_variant_id: 'C', sibling_title: 'c', sibling_units_30d: BigInt(7) },
+    ]);
+    const recs = await detectVariantMismapping();
+    expect(recs).toHaveLength(1);
+  });
+
+  it('action links to both suspect + sibling for comparison', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([
+      { product_id: 'p', product_title: 'X', suspect_variant_id: 'A', suspect_title: 'a', suspect_committed: 5, sibling_variant_id: 'B', sibling_title: 'b', sibling_units_30d: BigInt(10) },
+    ]);
+    const [rec] = await detectVariantMismapping();
+    expect((rec.actionPayload.params as { href: string }).href).toContain('sibling=B');
+  });
+});
+
+// ─── Signal #8: cost-coverage-gap ─────────────────────────────────────
+
+describe('detectCostCoverageGap', () => {
+  it('flags high-velocity variants with no cost', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([
+      { variant_id: 'v1', title: 'X', product_title: 'Y', units_30d: BigInt(50) },
+    ]);
+    const recs = await detectCostCoverageGap();
+    expect(recs).toHaveLength(1);
+    expect(recs[0].signalKind).toBe('cost-coverage-gap');
+  });
+
+  it('returns [] when no qualifying variants', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([]);
+    expect(await detectCostCoverageGap()).toEqual([]);
+  });
+
+  it('evidence carries units_30d', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([
+      { variant_id: 'v1', title: 'X', product_title: 'Y', units_30d: BigInt(50) },
+    ]);
+    const [rec] = await detectCostCoverageGap();
+    const units = rec.evidence.find((e) => e.metricName === 'units_30d');
+    expect(units?.metricValue).toBe(50);
+  });
+
+  it('navigate action opens variant with editCost flag', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([
+      { variant_id: 'v8', title: 'X', product_title: 'Y', units_30d: BigInt(50) },
+    ]);
+    const [rec] = await detectCostCoverageGap();
+    expect((rec.actionPayload.params as { href: string }).href).toContain('editCost=1');
+  });
+});
+
+// ─── Signal #9: cycle-count-overdue ───────────────────────────────────
+
+describe('detectCycleCountOverdue', () => {
+  it('flags top-N variants without a recent count', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([
+      { variant_id: 'v1', title: 'X', product_title: 'Y', units_14d: BigInt(40) },
+    ]);
+    prismaMock.inventoryMovement.findFirst.mockResolvedValue(null);
+    const recs = await detectCycleCountOverdue();
+    expect(recs).toHaveLength(1);
+    expect(recs[0].signalKind).toBe('cycle-count-overdue');
+  });
+
+  it('skips variants already counted in last 7d', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([
+      { variant_id: 'v1', title: 'X', product_title: 'Y', units_14d: BigInt(40) },
+    ]);
+    prismaMock.inventoryMovement.findFirst.mockResolvedValue({ id: 'mv_1' });
+    expect(await detectCycleCountOverdue()).toEqual([]);
+  });
+
+  it('evidence carries units_14d', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([
+      { variant_id: 'v1', title: 'X', product_title: 'Y', units_14d: BigInt(25) },
+    ]);
+    prismaMock.inventoryMovement.findFirst.mockResolvedValue(null);
+    const [rec] = await detectCycleCountOverdue();
+    expect(rec.evidence.find((e) => e.metricName === 'units_14d')?.metricValue).toBe(25);
+  });
+
+  it('navigate action prefills count modal', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([
+      { variant_id: 'v9', title: 'X', product_title: 'Y', units_14d: BigInt(40) },
+    ]);
+    prismaMock.inventoryMovement.findFirst.mockResolvedValue(null);
+    const [rec] = await detectCycleCountOverdue();
+    expect((rec.actionPayload.params as { href: string }).href).toContain('openNoteFor=v9');
+  });
+});
+
+// ─── Pre-fulfillment shortage ─────────────────────────────────────────
+
+describe('detectPreFulfillmentShortage', () => {
+  it('flags any variant with available<0 inside paid 14d window', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([
+      {
+        variant_id: 'v1', title: 'X', product_title: 'Y',
+        demand: BigInt(20), available: -5,
+        earliest: new Date('2026-05-15T12:00:00Z'),
+      },
+    ]);
+    const recs = await detectPreFulfillmentShortage();
+    expect(recs).toHaveLength(1);
+    expect(recs[0].severity).toBe('urgent');
+  });
+
+  it('returns [] when nothing is short', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([]);
+    expect(await detectPreFulfillmentShortage()).toEqual([]);
+  });
+
+  it('reports earliest_delivery + paid_demand_14d + available', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([
+      {
+        variant_id: 'v1', title: 'X', product_title: 'Y',
+        demand: BigInt(30), available: -10,
+        earliest: new Date('2026-05-15T12:00:00Z'),
+      },
+    ]);
+    const [rec] = await detectPreFulfillmentShortage();
+    const names = rec.evidence.map((e) => e.metricName);
+    expect(names).toContain('paid_demand_14d');
+    expect(names).toContain('available');
+    expect(names).toContain('earliest_delivery');
+  });
+
+  it('navigate action deep-links to purchase plan filtered to variant', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([
+      {
+        variant_id: 'v9', title: 'X', product_title: 'Y',
+        demand: BigInt(30), available: -10,
+        earliest: new Date('2026-05-15T12:00:00Z'),
+      },
+    ]);
+    const [rec] = await detectPreFulfillmentShortage();
+    expect((rec.actionPayload.params as { href: string }).href).toContain('variantId=v9');
+    expect((rec.actionPayload.params as { href: string }).href).toContain('plan=1');
+  });
+});

--- a/src/lib/operations/__tests__/recommendation-store.test.ts
+++ b/src/lib/operations/__tests__/recommendation-store.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const prismaMock = vi.hoisted(() => ({
+  operationsRecommendation: {
+    findUnique: vi.fn(),
+    findFirst: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  },
+  $transaction: vi.fn(),
+}));
+
+vi.mock('@/lib/database/client', () => ({ prisma: prismaMock }));
+
+import {
+  upsertRecommendations,
+  markStatus,
+  appendActionLog,
+  findRecentResolved,
+  getActiveByDedupeKey,
+} from '../recommendation-store';
+import type { OperationsRecommendationInput } from '../types';
+
+function sampleInput(overrides: Partial<OperationsRecommendationInput> = {}): OperationsRecommendationInput {
+  return {
+    signalKind: 'receiving-lag',
+    severity: 'high',
+    title: 'Invoice INV-1 stuck',
+    evidence: [{ metricName: 'hours_pending', metricValue: 30 }],
+    targetEntityType: 'receivingInvoice',
+    targetEntityId: 'inv_1',
+    actionPayload: { kind: 'navigate', params: { href: '/ops/inventory/receiving/inv_1' } },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  prismaMock.operationsRecommendation.findUnique.mockReset();
+  prismaMock.operationsRecommendation.findFirst.mockReset();
+  prismaMock.operationsRecommendation.create.mockReset();
+  prismaMock.operationsRecommendation.update.mockReset();
+  prismaMock.$transaction.mockReset();
+  prismaMock.$transaction.mockImplementation(async (cb: (tx: typeof prismaMock) => Promise<unknown>) =>
+    cb(prismaMock)
+  );
+});
+
+describe('upsertRecommendations', () => {
+  it('creates a new rec when no dedupe match exists', async () => {
+    prismaMock.operationsRecommendation.findUnique.mockResolvedValue(null);
+    const summary = await upsertRecommendations([sampleInput()]);
+    expect(summary).toEqual({ created: 1, updated: 0, skipped: 0 });
+    expect(prismaMock.operationsRecommendation.create).toHaveBeenCalledOnce();
+    const args = prismaMock.operationsRecommendation.create.mock.calls[0][0] as { data: { dedupeKey: string } };
+    expect(args.data.dedupeKey).toBe('receiving-lag:inv_1');
+  });
+
+  it('updates an existing open rec (refresh evidence)', async () => {
+    prismaMock.operationsRecommendation.findUnique.mockResolvedValue({
+      id: 'rec_1', status: 'open', severity: 'normal',
+    });
+    const summary = await upsertRecommendations([sampleInput({ severity: 'high' })]);
+    expect(summary).toEqual({ created: 0, updated: 1, skipped: 0 });
+    const updateArgs = prismaMock.operationsRecommendation.update.mock.calls[0][0] as { data: { severity: string } };
+    expect(updateArgs.data.severity).toBe('high'); // bumped up
+  });
+
+  it("doesn't lower severity on existing open rec", async () => {
+    prismaMock.operationsRecommendation.findUnique.mockResolvedValue({
+      id: 'rec_1', status: 'open', severity: 'urgent',
+    });
+    await upsertRecommendations([sampleInput({ severity: 'normal' })]);
+    const updateArgs = prismaMock.operationsRecommendation.update.mock.calls[0][0] as { data: { severity: string } };
+    expect(updateArgs.data.severity).toBe('urgent'); // preserved
+  });
+
+  it('skips when an existing rec is already shipped/rejected/snoozed', async () => {
+    prismaMock.operationsRecommendation.findUnique.mockResolvedValue({
+      id: 'rec_1', status: 'rejected', severity: 'high',
+    });
+    const summary = await upsertRecommendations([sampleInput()]);
+    expect(summary).toEqual({ created: 0, updated: 0, skipped: 1 });
+    expect(prismaMock.operationsRecommendation.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('markStatus', () => {
+  it('transitions open → approved', async () => {
+    prismaMock.operationsRecommendation.findUnique.mockResolvedValue({ status: 'open' });
+    prismaMock.operationsRecommendation.update.mockResolvedValue({ id: 'r', status: 'approved' });
+    await markStatus('r', 'approved');
+    const args = prismaMock.operationsRecommendation.update.mock.calls[0][0] as { data: { status: string } };
+    expect(args.data.status).toBe('approved');
+  });
+
+  it('stamps shippedAt on transition to shipped', async () => {
+    prismaMock.operationsRecommendation.findUnique.mockResolvedValue({ status: 'approved' });
+    prismaMock.operationsRecommendation.update.mockResolvedValue({ id: 'r' });
+    await markStatus('r', 'shipped');
+    const args = prismaMock.operationsRecommendation.update.mock.calls[0][0] as { data: { shippedAt?: Date } };
+    expect(args.data.shippedAt).toBeInstanceOf(Date);
+  });
+
+  it('rejects invalid transitions (shipped → snoozed)', async () => {
+    prismaMock.operationsRecommendation.findUnique.mockResolvedValue({ status: 'shipped' });
+    await expect(markStatus('r', 'snoozed')).rejects.toThrow(/Invalid transition/);
+  });
+
+  it('clears dismissReason + snoozeUntil on re-open', async () => {
+    prismaMock.operationsRecommendation.findUnique.mockResolvedValue({ status: 'rejected' });
+    prismaMock.operationsRecommendation.update.mockResolvedValue({});
+    await markStatus('r', 'open');
+    const args = prismaMock.operationsRecommendation.update.mock.calls[0][0] as { data: { dismissReason: null; snoozeUntil: null } };
+    expect(args.data.dismissReason).toBeNull();
+    expect(args.data.snoozeUntil).toBeNull();
+  });
+});
+
+describe('appendActionLog', () => {
+  it('appends atomically inside a transaction', async () => {
+    prismaMock.operationsRecommendation.findUnique.mockResolvedValue({ actionLog: [] });
+    prismaMock.operationsRecommendation.update.mockResolvedValue({});
+    await appendActionLog('r', {
+      timestamp: '2026-05-13T10:00:00Z',
+      actionLabel: 'Reconcile pick → inventory',
+      result: 'success',
+    });
+    expect(prismaMock.$transaction).toHaveBeenCalledOnce();
+    const args = prismaMock.operationsRecommendation.update.mock.calls[0][0] as {
+      data: { actionLog: Array<{ actionLabel: string }> };
+    };
+    expect(args.data.actionLog).toHaveLength(1);
+    expect(args.data.actionLog[0].actionLabel).toBe('Reconcile pick → inventory');
+  });
+
+  it('preserves prior log entries', async () => {
+    prismaMock.operationsRecommendation.findUnique.mockResolvedValue({
+      actionLog: [{ timestamp: 't1', actionLabel: 'prior', result: 'success' }],
+    });
+    prismaMock.operationsRecommendation.update.mockResolvedValue({});
+    await appendActionLog('r', { timestamp: 't2', actionLabel: 'next', result: 'error', errorMessage: 'x' });
+    const args = prismaMock.operationsRecommendation.update.mock.calls[0][0] as {
+      data: { actionLog: Array<{ actionLabel: string }> };
+    };
+    expect(args.data.actionLog.map((e) => e.actionLabel)).toEqual(['prior', 'next']);
+  });
+});
+
+describe('findRecentResolved / getActiveByDedupeKey', () => {
+  it('findRecentResolved queries snoozed/rejected/invalidated', async () => {
+    prismaMock.operationsRecommendation.findFirst.mockResolvedValue(null);
+    await findRecentResolved('k', 30);
+    const args = prismaMock.operationsRecommendation.findFirst.mock.calls[0][0] as {
+      where: { status: { in: string[] } };
+    };
+    expect(args.where.status.in).toEqual(['snoozed', 'rejected', 'invalidated']);
+  });
+
+  it('getActiveByDedupeKey looks up by unique dedupeKey', async () => {
+    prismaMock.operationsRecommendation.findUnique.mockResolvedValue({ id: 'r' });
+    const result = await getActiveByDedupeKey('receiving-lag:inv_1');
+    expect(result).toEqual({ id: 'r' });
+  });
+});

--- a/src/lib/operations/__tests__/recommendations.test.ts
+++ b/src/lib/operations/__tests__/recommendations.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Orchestrator tests — focused on the snooze/dismiss suppression rule, which
+ * is THE behavior that keeps the queue trustworthy (§5d). Per-detector
+ * behavior lives in detectors-*.test.ts.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const prismaMock = vi.hoisted(() => ({
+  operationsRecommendation: { findFirst: vi.fn() },
+}));
+
+vi.mock('@/lib/database/client', () => ({ prisma: prismaMock }));
+
+import { applySuppression } from '../recommendations';
+import type { OperationsRecommendationInput } from '../types';
+
+function rec(overrides: Partial<OperationsRecommendationInput> = {}): OperationsRecommendationInput {
+  return {
+    signalKind: 'receiving-lag',
+    severity: 'high',
+    title: 't',
+    evidence: [{ metricName: 'm', metricValue: 1 }],
+    targetEntityType: 'receivingInvoice',
+    targetEntityId: 'inv_1',
+    actionPayload: { kind: 'navigate', params: { href: '/x' } },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  prismaMock.operationsRecommendation.findFirst.mockReset();
+});
+
+describe('applySuppression', () => {
+  it('passes recs through when no recent resolution exists', async () => {
+    prismaMock.operationsRecommendation.findFirst.mockResolvedValue(null);
+    const out = await applySuppression([rec()]);
+    expect(out.kept).toHaveLength(1);
+    expect(out.suppressedSnoozed).toBe(0);
+    expect(out.suppressedKnockdown).toBe(0);
+  });
+
+  it('drops recs whose snoozeUntil is in the future', async () => {
+    const now = new Date('2026-05-13T10:00:00Z');
+    prismaMock.operationsRecommendation.findFirst.mockResolvedValue({
+      status: 'snoozed',
+      snoozeUntil: new Date('2026-05-20T00:00:00Z'),
+    });
+    const out = await applySuppression([rec()], now);
+    expect(out.kept).toHaveLength(0);
+    expect(out.suppressedSnoozed).toBe(1);
+  });
+
+  it('surfaces recs whose snoozeUntil has passed', async () => {
+    const now = new Date('2026-05-13T10:00:00Z');
+    prismaMock.operationsRecommendation.findFirst.mockResolvedValue({
+      status: 'snoozed',
+      snoozeUntil: new Date('2026-05-10T00:00:00Z'),
+    });
+    const out = await applySuppression([rec()], now);
+    expect(out.kept).toHaveLength(1);
+    expect(out.suppressedSnoozed).toBe(0);
+  });
+
+  it('knocks severity down one tier when recently rejected', async () => {
+    prismaMock.operationsRecommendation.findFirst.mockResolvedValue({
+      status: 'rejected',
+      snoozeUntil: null,
+      dismissReason: 'intentional buffer',
+    });
+    const out = await applySuppression([rec({ severity: 'urgent' })]);
+    expect(out.kept).toHaveLength(1);
+    expect(out.kept[0].severity).toBe('high');
+    expect(out.suppressedKnockdown).toBe(1);
+  });
+
+  it('also knocks down when recently invalidated', async () => {
+    prismaMock.operationsRecommendation.findFirst.mockResolvedValue({
+      status: 'invalidated',
+      snoozeUntil: null,
+    });
+    const out = await applySuppression([rec({ severity: 'high' })]);
+    expect(out.kept[0].severity).toBe('normal');
+    expect(out.suppressedKnockdown).toBe(1);
+  });
+
+  it("doesn't lower below normal — normal stays normal", async () => {
+    prismaMock.operationsRecommendation.findFirst.mockResolvedValue({
+      status: 'rejected',
+      snoozeUntil: null,
+    });
+    const out = await applySuppression([rec({ severity: 'normal' })]);
+    expect(out.kept[0].severity).toBe('normal');
+  });
+});

--- a/src/lib/operations/__tests__/snapshot.test.ts
+++ b/src/lib/operations/__tests__/snapshot.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const prismaMock = vi.hoisted(() => ({
+  inventoryMovement: { findMany: vi.fn(), count: vi.fn() },
+  orderItem: { findMany: vi.fn() },
+  productVariant: { count: vi.fn() },
+  receivingInvoice: { findMany: vi.fn() },
+  inventoryNote: { count: vi.fn() },
+  $queryRawUnsafe: vi.fn(),
+}));
+
+vi.mock('@/lib/database/client', () => ({ prisma: prismaMock }));
+
+import {
+  computeCostCoveragePct,
+  computeCycleCountsCompletedLast7d,
+  computeInventoryAccuracyPct,
+  computePaidOrders14dShortageCount,
+  computeReceivingLagPercentiles,
+} from '../snapshot';
+
+beforeEach(() => {
+  for (const m of Object.values(prismaMock)) {
+    if (typeof m === 'function') (m as ReturnType<typeof vi.fn>).mockReset();
+    else for (const fn of Object.values(m)) (fn as ReturnType<typeof vi.fn>).mockReset();
+  }
+});
+
+describe('computeInventoryAccuracyPct', () => {
+  it('returns null when no counts exist', async () => {
+    prismaMock.inventoryMovement.findMany.mockResolvedValue([]);
+    expect(await computeInventoryAccuracyPct()).toBeNull();
+  });
+
+  it('returns 100 when all counts confirmed (|delta|≤50)', async () => {
+    prismaMock.inventoryMovement.findMany.mockResolvedValue([
+      { quantity: 0 },
+      { quantity: 10 },
+      { quantity: -42 },
+    ]);
+    expect(await computeInventoryAccuracyPct()).toBe(100);
+  });
+
+  it('mixes small and large deltas correctly', async () => {
+    prismaMock.inventoryMovement.findMany.mockResolvedValue([
+      { quantity: 0 }, // within
+      { quantity: 200 }, // outside
+      { quantity: -300 }, // outside
+      { quantity: 5 }, // within
+    ]);
+    expect(await computeInventoryAccuracyPct()).toBe(50);
+  });
+});
+
+describe('computeCostCoveragePct', () => {
+  it('returns 0 when nothing sold', async () => {
+    prismaMock.orderItem.findMany.mockResolvedValue([]);
+    expect(await computeCostCoveragePct()).toBe(0);
+  });
+
+  it('returns coverage% when some variants have cost set', async () => {
+    prismaMock.orderItem.findMany.mockResolvedValue([
+      { variantId: 'a' },
+      { variantId: 'b' },
+      { variantId: 'c' },
+      { variantId: 'd' },
+    ]);
+    prismaMock.productVariant.count.mockResolvedValue(1);
+    expect(await computeCostCoveragePct()).toBe(25);
+  });
+});
+
+describe('computeReceivingLagPercentiles', () => {
+  it('returns null/null when <2 samples', async () => {
+    prismaMock.receivingInvoice.findMany.mockResolvedValue([
+      { createdAt: new Date('2026-01-01T00:00:00Z'), appliedAt: new Date('2026-01-01T05:00:00Z') },
+    ]);
+    expect(await computeReceivingLagPercentiles()).toEqual({ p50: null, p90: null });
+  });
+
+  it('computes nearest-rank percentiles in hours', async () => {
+    const base = new Date('2026-01-01T00:00:00Z').getTime();
+    const samples = [1, 2, 3, 4, 100].map((h) => ({
+      createdAt: new Date(base),
+      appliedAt: new Date(base + h * 3600 * 1000),
+    }));
+    prismaMock.receivingInvoice.findMany.mockResolvedValue(samples);
+    const { p50, p90 } = await computeReceivingLagPercentiles();
+    expect(p50).toBe(3);
+    expect(p90).toBe(100);
+  });
+});
+
+describe('computePaidOrders14dShortageCount', () => {
+  it('returns the raw SQL count', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([{ count: BigInt(7) }]);
+    expect(await computePaidOrders14dShortageCount()).toBe(7);
+  });
+
+  it('handles empty result rows', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([]);
+    expect(await computePaidOrders14dShortageCount()).toBe(0);
+  });
+});
+
+describe('computeCycleCountsCompletedLast7d', () => {
+  it('sums processed notes + count movements', async () => {
+    prismaMock.inventoryNote.count.mockResolvedValue(3);
+    prismaMock.inventoryMovement.count.mockResolvedValue(5);
+    expect(await computeCycleCountsCompletedLast7d()).toBe(8);
+  });
+});

--- a/src/lib/operations/__tests__/types.test.ts
+++ b/src/lib/operations/__tests__/types.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildDedupeKey,
+  isHigherSeverity,
+  knockDownSeverity,
+} from '../types';
+
+describe('operations/types', () => {
+  describe('buildDedupeKey', () => {
+    it('joins signalKind + targetEntityId with a colon', () => {
+      expect(buildDedupeKey('receiving-lag', 'inv_123')).toBe('receiving-lag:inv_123');
+    });
+
+    it('treats different targetEntityIds as distinct keys', () => {
+      expect(buildDedupeKey('repeated-shorts', 'v1')).not.toBe(
+        buildDedupeKey('repeated-shorts', 'v2')
+      );
+    });
+  });
+
+  describe('isHigherSeverity', () => {
+    it('urgent > high > normal', () => {
+      expect(isHigherSeverity('urgent', 'high')).toBe(true);
+      expect(isHigherSeverity('high', 'normal')).toBe(true);
+      expect(isHigherSeverity('urgent', 'normal')).toBe(true);
+    });
+
+    it('returns false for equal severities', () => {
+      expect(isHigherSeverity('high', 'high')).toBe(false);
+      expect(isHigherSeverity('urgent', 'urgent')).toBe(false);
+    });
+
+    it('returns false when a is lower', () => {
+      expect(isHigherSeverity('normal', 'high')).toBe(false);
+      expect(isHigherSeverity('high', 'urgent')).toBe(false);
+    });
+  });
+
+  describe('knockDownSeverity', () => {
+    it('urgent → high', () => {
+      expect(knockDownSeverity('urgent')).toBe('high');
+    });
+    it('high → normal', () => {
+      expect(knockDownSeverity('high')).toBe('normal');
+    });
+    it('normal stays normal', () => {
+      expect(knockDownSeverity('normal')).toBe('normal');
+    });
+  });
+});

--- a/src/lib/operations/detector-helpers.ts
+++ b/src/lib/operations/detector-helpers.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared helpers used by the drift detectors.
+ *
+ * Group-label resolution mirrors `scripts/ops/_group-label.mjs:resolveGroupLabel`
+ * — kept in TS here so the cron route doesn't depend on the .mjs script.
+ * If you change the strip suffixes here, mirror the change in the .mjs.
+ */
+
+import { prisma } from '@/lib/database/client';
+
+export const HOUR_MS = 60 * 60 * 1000;
+export const DAY_MS = 24 * HOUR_MS;
+
+const SUFFIX_PATTERNS: RegExp[] = [
+  / Drink Delivery!?$/i,
+  / Bach Drink Delivery!?$/i,
+  / Cruise Drink Delivery!?$/i,
+  /'s Party$/i,
+  /'s Cruise$/i,
+];
+
+const PLACEHOLDER_HOST_NAMES = new Set(['party host', 'host', 'unknown', '']);
+
+function stripSuffix(name: string | null | undefined): string | null {
+  if (!name) return null;
+  let trimmed = name.trim();
+  for (const re of SUFFIX_PATTERNS) trimmed = trimmed.replace(re, '').trim();
+  return trimmed.length ? trimmed : null;
+}
+
+export interface OrderLabel {
+  customerName: string;
+  manifestName: string | null;
+  payerDiffers: boolean;
+}
+
+export async function resolveOrderLabel(orderId: string): Promise<OrderLabel> {
+  const order = await prisma.order.findUnique({
+    where: { id: orderId },
+    select: {
+      customerName: true,
+      groupOrderV2: { select: { name: true, hostName: true, shareCode: true } },
+    },
+  });
+  if (!order) return { customerName: '(unknown)', manifestName: null, payerDiffers: false };
+  const customerName = order.customerName ?? '(unknown)';
+  if (!order.groupOrderV2) return { customerName, manifestName: null, payerDiffers: false };
+  const stripped = stripSuffix(order.groupOrderV2.name);
+  const hostName = order.groupOrderV2.hostName?.trim() ?? '';
+  const hostIsPlaceholder = PLACEHOLDER_HOST_NAMES.has(hostName.toLowerCase());
+  const manifestName = stripped ?? (hostIsPlaceholder ? null : hostName) ?? null;
+  const norm = (s: string) => s.toLowerCase().replace(/\s+/g, ' ').trim();
+  const payerDiffers =
+    !!manifestName &&
+    norm(customerName) !== norm(manifestName) &&
+    !norm(manifestName).includes(norm(customerName)) &&
+    !norm(customerName).includes(norm(manifestName));
+  return { customerName, manifestName, payerDiffers };
+}
+
+export function formatGroupLabel(opts: OrderLabel): string {
+  if (opts.manifestName && opts.payerDiffers) return `${opts.manifestName} (paid by ${opts.customerName})`;
+  return opts.manifestName ?? opts.customerName;
+}

--- a/src/lib/operations/detectors.ts
+++ b/src/lib/operations/detectors.ts
@@ -1,0 +1,22 @@
+/**
+ * Drift-signal detector barrel — see detectors/signals-a.ts and signals-b.ts
+ * for the actual implementations. Re-exported here so callers can
+ * `import { detectXxx } from '@/lib/operations/detectors'` without caring
+ * which batch a signal belongs to.
+ */
+
+export {
+  detectReceivingLag,
+  detectPickInventoryLag,
+  detectRepeatedShorts,
+  detectNegativeAvailable,
+  detectVelocityAnomaly,
+} from './detectors/signals-a';
+
+export {
+  detectAiNoteBacklog,
+  detectVariantMismapping,
+  detectCostCoverageGap,
+  detectCycleCountOverdue,
+  detectPreFulfillmentShortage,
+} from './detectors/signals-b';

--- a/src/lib/operations/detectors/signals-a.ts
+++ b/src/lib/operations/detectors/signals-a.ts
@@ -1,0 +1,228 @@
+/**
+ * Drift-signal detectors — batch A (signals 1-5).
+ *
+ *  1. receiving-lag           ReceivingInvoice.status='PENDING_REVIEW' AND createdAt < now-24h
+ *  2. pick-inventory-lag      OrderItemPickState.packed=true, ≥24h old, no matching pack movement
+ *  3. repeated-shorts         Same variantId shorted on ≥2 distinct orders in last 7d
+ *  4. negative-available      committedQuantity > inventoryQuantity for any variant
+ *  5. velocity-anomaly        Variant ≥4 units in 30d, then 0 in last 14d, parent ACTIVE
+ *
+ * See docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md §6 for the full spec.
+ */
+
+import { prisma } from '@/lib/database/client';
+import type { OperationsRecommendationInput } from '../types';
+import { DAY_MS, HOUR_MS, formatGroupLabel, resolveOrderLabel } from '../detector-helpers';
+
+/** Signal #1: receiving invoices stuck in PENDING_REVIEW for ≥24 hours. */
+export async function detectReceivingLag(now: Date = new Date()): Promise<OperationsRecommendationInput[]> {
+  const cutoff = new Date(now.getTime() - 24 * HOUR_MS);
+  const stuck = await prisma.receivingInvoice.findMany({
+    where: { status: 'PENDING_REVIEW', createdAt: { lt: cutoff } },
+    select: { id: true, distributorName: true, invoiceNumber: true, createdAt: true },
+  });
+  return stuck.map((inv) => {
+    const hours = Math.round((now.getTime() - inv.createdAt.getTime()) / HOUR_MS);
+    const distributor = inv.distributorName ?? 'Unknown distributor';
+    return {
+      signalKind: 'receiving-lag' as const,
+      severity: 'high' as const,
+      title: `Receiving invoice ${inv.invoiceNumber ?? '(unnumbered)'} stuck in PENDING_REVIEW (${hours}h, ${distributor})`,
+      evidence: [
+        {
+          metricName: 'hours_pending',
+          metricValue: hours,
+          sourceLinks: [{ label: 'Open receiving invoice', href: `/ops/inventory/receiving/${inv.id}` }],
+        },
+        { note: `Distributor: ${distributor}` },
+      ],
+      targetEntityType: 'receivingInvoice' as const,
+      targetEntityId: inv.id,
+      actionPayload: {
+        kind: 'navigate',
+        label: 'Open receiving',
+        params: { href: `/ops/inventory/receiving/${inv.id}` },
+      },
+    };
+  });
+}
+
+/**
+ * Signal #2: packed ≥24h ago but inventory hasn't decremented. After the
+ * pre-Phase-1 wiring, every packed order also writes an InventoryMovement row
+ * with reason starting with 'pack'. So "lag" = packed pick state exists ≥24h
+ * old AND no movement row with reference to this order. Catches backfill +
+ * any future bugs.
+ */
+export async function detectPickInventoryLag(now: Date = new Date()): Promise<OperationsRecommendationInput[]> {
+  const cutoff = new Date(now.getTime() - 24 * HOUR_MS);
+  const picks = await prisma.orderItemPickState.findMany({
+    where: { packed: true, updatedAt: { lt: cutoff } },
+    select: { orderId: true, itemKey: true, shortBy: true, updatedAt: true },
+    take: 500,
+  });
+  const byOrder = new Map<string, { count: number; oldest: Date }>();
+  for (const p of picks) {
+    const cur = byOrder.get(p.orderId);
+    if (!cur) byOrder.set(p.orderId, { count: 1, oldest: p.updatedAt });
+    else {
+      cur.count += 1;
+      if (p.updatedAt < cur.oldest) cur.oldest = p.updatedAt;
+    }
+  }
+  const recs: OperationsRecommendationInput[] = [];
+  for (const [orderId, agg] of byOrder.entries()) {
+    const moved = await prisma.inventoryMovement.findFirst({
+      where: { referenceId: orderId, reason: { contains: 'pack', mode: 'insensitive' } },
+      select: { id: true },
+    });
+    if (moved) continue;
+    const label = await resolveOrderLabel(orderId);
+    const order = await prisma.order.findUnique({
+      where: { id: orderId },
+      select: { orderNumber: true },
+    });
+    const hours = Math.round((now.getTime() - agg.oldest.getTime()) / HOUR_MS);
+    recs.push({
+      signalKind: 'pick-inventory-lag',
+      severity: 'high',
+      title: `Order #${order?.orderNumber ?? orderId.slice(0, 8)} (${formatGroupLabel(label)}) — packed ${hours}h ago, inventory not decremented`,
+      evidence: [
+        { metricName: 'packed_lines', metricValue: agg.count },
+        { metricName: 'hours_since_pack', metricValue: hours },
+        { note: `Manifest: ${formatGroupLabel(label)}`, sourceLinks: [{ label: 'Open order', href: `/ops/orders/${orderId}` }] },
+      ],
+      targetEntityType: 'order',
+      targetEntityId: orderId,
+      actionPayload: {
+        kind: 'apiCall',
+        label: 'Reconcile pick → inventory',
+        params: { method: 'POST', path: `/api/admin/operations/recommendations/reconcile-pack`, body: { orderId } },
+      },
+    });
+  }
+  return recs;
+}
+
+/** Signal #3: same variant shorted on ≥2 distinct orders in last 7 days. */
+export async function detectRepeatedShorts(now: Date = new Date()): Promise<OperationsRecommendationInput[]> {
+  const cutoff = new Date(now.getTime() - 7 * DAY_MS);
+  const rows = await prisma.$queryRawUnsafe<Array<{ variant_id: string; title: string; orders: bigint; total_short: bigint }>>(
+    `SELECT oi.variant_id AS variant_id,
+            MIN(oi.title) AS title,
+            COUNT(DISTINCT pks.order_id)::bigint AS orders,
+            SUM(pks.short_by)::bigint AS total_short
+       FROM order_item_pick_states pks
+       JOIN orders o ON o.id = pks.order_id
+       JOIN order_items oi ON oi.order_id = pks.order_id AND oi.title = pks.item_key
+      WHERE pks.short_by > 0
+        AND pks.updated_at >= $1::timestamp
+        AND o.financial_status = 'PAID'
+      GROUP BY oi.variant_id
+     HAVING COUNT(DISTINCT pks.order_id) >= 2`,
+    cutoff
+  );
+  return rows.map((r) => ({
+    signalKind: 'repeated-shorts' as const,
+    severity: 'high' as const,
+    title: `${r.title}: short on ${Number(r.orders)} orders this week (${Number(r.total_short)} units short total)`,
+    evidence: [
+      { metricName: 'orders_shorted_7d', metricValue: Number(r.orders) },
+      { metricName: 'total_units_short', metricValue: Number(r.total_short) },
+      { note: 'Likely ledger drift — physical count recommended', sourceLinks: [{ label: 'Open variant in ops', href: `/ops/inventory?variantId=${r.variant_id}` }] },
+    ],
+    targetEntityType: 'productVariant' as const,
+    targetEntityId: r.variant_id,
+    actionPayload: {
+      kind: 'navigate',
+      label: 'Mark for count',
+      params: { href: `/ops/inventory?openNoteFor=${r.variant_id}&prefill=Repeated+shorts+this+week+%E2%80%94+counted` },
+    },
+  }));
+}
+
+/** Signal #4: variants with committed > on-hand. Urgent — math is broken. */
+export async function detectNegativeAvailable(): Promise<OperationsRecommendationInput[]> {
+  const rows = await prisma.$queryRawUnsafe<
+    Array<{ id: string; title: string; product_title: string; inventory_quantity: number; committed_quantity: number }>
+  >(
+    `SELECT v.id AS id, v.title AS title, p.title AS product_title,
+            v.inventory_quantity, v.committed_quantity
+       FROM product_variants v
+       JOIN products p ON p.id = v.product_id
+      WHERE v.track_inventory = TRUE
+        AND v.committed_quantity > v.inventory_quantity
+      LIMIT 200`
+  );
+  return rows.map((r) => {
+    const deficit = r.committed_quantity - r.inventory_quantity;
+    const display = `${r.product_title}${r.title && r.title !== 'Default' ? ` (${r.title})` : ''}`;
+    return {
+      signalKind: 'negative-available' as const,
+      severity: 'urgent' as const,
+      title: `${display}: ${deficit} units committed but not on hand (in-stock ${r.inventory_quantity}, committed ${r.committed_quantity})`,
+      evidence: [
+        { metricName: 'in_stock', metricValue: r.inventory_quantity },
+        { metricName: 'committed', metricValue: r.committed_quantity },
+        { metricName: 'deficit', metricValue: deficit, sourceLinks: [{ label: 'Open variant', href: `/ops/inventory?variantId=${r.id}` }] },
+      ],
+      targetEntityType: 'productVariant' as const,
+      targetEntityId: r.id,
+      actionPayload: {
+        kind: 'navigate',
+        label: 'Count + adjust',
+        params: { href: `/ops/inventory?openNoteFor=${r.id}&prefill=Counted+%5BN%5D+units+%28negative+available+detected%29` },
+      },
+    };
+  });
+}
+
+/**
+ * Signal #5: variant sold steadily in last 30d, then went silent for 14d, no
+ * status change on the parent product. "Steadily" = ≥4 units in 30d.
+ */
+export async function detectVelocityAnomaly(now: Date = new Date()): Promise<OperationsRecommendationInput[]> {
+  const start30 = new Date(now.getTime() - 30 * DAY_MS);
+  const start14 = new Date(now.getTime() - 14 * DAY_MS);
+  const rows = await prisma.$queryRawUnsafe<
+    Array<{ variant_id: string; title: string; product_title: string; units_30d: bigint; units_last_14d: bigint }>
+  >(
+    `WITH v_sales AS (
+       SELECT oi.variant_id, SUM(oi.quantity)::bigint AS units_30d,
+              SUM(CASE WHEN o.created_at >= $1::timestamp THEN oi.quantity ELSE 0 END)::bigint AS units_last_14d
+         FROM order_items oi
+         JOIN orders o ON o.id = oi.order_id
+        WHERE o.financial_status = 'PAID'
+          AND o.created_at >= $2::timestamp
+        GROUP BY oi.variant_id
+     )
+     SELECT v_sales.variant_id, v.title AS title, p.title AS product_title,
+            v_sales.units_30d, v_sales.units_last_14d
+       FROM v_sales
+       JOIN product_variants v ON v.id = v_sales.variant_id
+       JOIN products p ON p.id = v.product_id
+      WHERE v_sales.units_30d >= 4
+        AND v_sales.units_last_14d = 0
+        AND p.status = 'ACTIVE'
+      LIMIT 50`,
+    start14,
+    start30
+  );
+  return rows.map((r) => ({
+    signalKind: 'velocity-anomaly' as const,
+    severity: 'normal' as const,
+    title: `${r.product_title}${r.title && r.title !== 'Default' ? ` (${r.title})` : ''}: ${Number(r.units_30d)} units in prior 30d, 0 in last 14d`,
+    evidence: [
+      { metricName: 'units_30d', metricValue: Number(r.units_30d) },
+      { metricName: 'units_last_14d', metricValue: 0 },
+      { note: 'Possible mis-mapping or seasonality — audit variant', sourceLinks: [{ label: 'Open variant', href: `/ops/inventory?variantId=${r.variant_id}` }] },
+    ],
+    targetEntityType: 'productVariant' as const,
+    targetEntityId: r.variant_id,
+    actionPayload: {
+      kind: 'navigate',
+      label: 'Audit variant',
+      params: { href: `/ops/inventory?variantId=${r.variant_id}` },
+    },
+  }));
+}

--- a/src/lib/operations/detectors/signals-a.ts
+++ b/src/lib/operations/detectors/signals-a.ts
@@ -104,7 +104,17 @@ export async function detectPickInventoryLag(now: Date = new Date()): Promise<Op
   return recs;
 }
 
-/** Signal #3: same variant shorted on ≥2 distinct orders in last 7 days. */
+/**
+ * Signal #3: same variant shorted on ≥2 distinct orders in last 7 days.
+ *
+ * Known gap: the SQL joins `order_items oi ON oi.title = pks.item_key`, but
+ * `OrderItemPickState.item_key` for bundle components is
+ * `${itemTitle}::${bundleComponentTitle}` (see pick-inventory-service.ts:9–11).
+ * Those rows won't match a line item directly and shorts on bundle components
+ * are dropped here. Acceptable for now — bundle components are a minority and
+ * their parent line still gets counted. Revisit when bundles drive enough
+ * shorts to matter.
+ */
 export async function detectRepeatedShorts(now: Date = new Date()): Promise<OperationsRecommendationInput[]> {
   const cutoff = new Date(now.getTime() - 7 * DAY_MS);
   const rows = await prisma.$queryRawUnsafe<Array<{ variant_id: string; title: string; orders: bigint; total_short: bigint }>>(

--- a/src/lib/operations/detectors/signals-b.ts
+++ b/src/lib/operations/detectors/signals-b.ts
@@ -1,0 +1,270 @@
+/**
+ * Drift-signal detectors — batch B (signals 6-9 + pre-fulfillment shortage).
+ *
+ *  6. ai-note-backlog         InventoryNote.status='pending' AND createdAt < now-24h
+ *  7. variant-mismapping      Sibling has growing committed without sales
+ *  8. cost-coverage-gap       Variant ≥5 units sold in 30d but costPerUnit IS NULL
+ *  9. cycle-count-overdue     Top-20 by 14d volume with no count movement in 7d
+ * 10. pre-fulfillment-shortage Any PAID order line in next 14d with available < 0
+ *
+ * See docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md §6 for the full spec.
+ */
+
+import { prisma } from '@/lib/database/client';
+import type { OperationsRecommendationInput } from '../types';
+import { DAY_MS, HOUR_MS } from '../detector-helpers';
+
+/** Signal #6: inventory notes stuck in pending ≥24h. */
+export async function detectAiNoteBacklog(now: Date = new Date()): Promise<OperationsRecommendationInput[]> {
+  const cutoff = new Date(now.getTime() - 24 * HOUR_MS);
+  const notes = await prisma.inventoryNote.findMany({
+    where: { status: 'pending', createdAt: { lt: cutoff } },
+    select: { id: true, content: true, createdAt: true },
+    take: 100,
+  });
+  return notes.map((n) => {
+    const hours = Math.round((now.getTime() - n.createdAt.getTime()) / HOUR_MS);
+    const preview = n.content.length > 70 ? `${n.content.slice(0, 67)}…` : n.content;
+    return {
+      signalKind: 'ai-note-backlog' as const,
+      severity: 'high' as const,
+      title: `Inventory note pending ${hours}h: "${preview}"`,
+      evidence: [
+        { metricName: 'hours_pending', metricValue: hours },
+        { note: preview, sourceLinks: [{ label: 'Review and apply', href: `/ops/inventory?openNote=${n.id}` }] },
+      ],
+      targetEntityType: 'inventoryNote' as const,
+      targetEntityId: n.id,
+      actionPayload: {
+        kind: 'navigate',
+        label: 'Review and apply',
+        params: { href: `/ops/inventory?openNote=${n.id}` },
+      },
+    };
+  });
+}
+
+/**
+ * Signal #7: sibling-variant mismapping. Variant A has 30d sales; sibling B
+ * (same product) has growing committed_quantity but no sales — orders likely
+ * binding to the wrong variant.
+ */
+export async function detectVariantMismapping(now: Date = new Date()): Promise<OperationsRecommendationInput[]> {
+  const start = new Date(now.getTime() - 30 * DAY_MS);
+  const rows = await prisma.$queryRawUnsafe<
+    Array<{
+      product_id: string;
+      product_title: string;
+      suspect_variant_id: string;
+      suspect_title: string;
+      suspect_committed: number;
+      sibling_variant_id: string;
+      sibling_title: string;
+      sibling_units_30d: bigint;
+    }>
+  >(
+    `WITH sales AS (
+       SELECT oi.variant_id, oi.product_id, SUM(oi.quantity)::bigint AS units
+         FROM order_items oi
+         JOIN orders o ON o.id = oi.order_id
+        WHERE o.financial_status = 'PAID' AND o.created_at >= $1::timestamp
+        GROUP BY oi.variant_id, oi.product_id
+     )
+     SELECT v_sus.product_id, p.title AS product_title,
+            v_sus.id AS suspect_variant_id, v_sus.title AS suspect_title,
+            v_sus.committed_quantity AS suspect_committed,
+            v_sib.id AS sibling_variant_id, v_sib.title AS sibling_title,
+            COALESCE(sales.units, 0)::bigint AS sibling_units_30d
+       FROM product_variants v_sus
+       JOIN product_variants v_sib ON v_sib.product_id = v_sus.product_id AND v_sib.id <> v_sus.id
+       JOIN products p ON p.id = v_sus.product_id
+       LEFT JOIN sales ON sales.variant_id = v_sib.id
+      WHERE v_sus.track_inventory = TRUE
+        AND v_sus.committed_quantity >= 5
+        AND COALESCE((SELECT units FROM sales s WHERE s.variant_id = v_sus.id), 0) = 0
+        AND COALESCE(sales.units, 0) > 0
+      LIMIT 30`,
+    start
+  );
+  const seen = new Set<string>();
+  const recs: OperationsRecommendationInput[] = [];
+  for (const r of rows) {
+    if (seen.has(r.suspect_variant_id)) continue;
+    seen.add(r.suspect_variant_id);
+    recs.push({
+      signalKind: 'variant-mismapping',
+      severity: 'normal',
+      title: `${r.product_title}: ${r.suspect_title} has ${r.suspect_committed} committed but 0 sales — sibling ${r.sibling_title} sold ${Number(r.sibling_units_30d)}`,
+      evidence: [
+        { metricName: 'suspect_committed', metricValue: r.suspect_committed },
+        { metricName: 'sibling_units_30d', metricValue: Number(r.sibling_units_30d) },
+        { note: 'Likely binding error — verify variant IDs match Shopify', sourceLinks: [
+          { label: 'Open suspect variant', href: `/ops/inventory?variantId=${r.suspect_variant_id}` },
+          { label: 'Open sibling', href: `/ops/inventory?variantId=${r.sibling_variant_id}` },
+        ] },
+      ],
+      targetEntityType: 'productVariant',
+      targetEntityId: r.suspect_variant_id,
+      actionPayload: {
+        kind: 'navigate',
+        label: 'Audit variant binding',
+        params: { href: `/ops/inventory?variantId=${r.suspect_variant_id}&sibling=${r.sibling_variant_id}` },
+      },
+    });
+  }
+  return recs;
+}
+
+/** Signal #8: high-velocity variants with no cost — blocks margin attribution. */
+export async function detectCostCoverageGap(now: Date = new Date()): Promise<OperationsRecommendationInput[]> {
+  const start = new Date(now.getTime() - 30 * DAY_MS);
+  const rows = await prisma.$queryRawUnsafe<
+    Array<{ variant_id: string; title: string; product_title: string; units_30d: bigint }>
+  >(
+    `SELECT oi.variant_id AS variant_id, MIN(v.title) AS title, MIN(p.title) AS product_title,
+            SUM(oi.quantity)::bigint AS units_30d
+       FROM order_items oi
+       JOIN orders o ON o.id = oi.order_id
+       JOIN product_variants v ON v.id = oi.variant_id
+       JOIN products p ON p.id = v.product_id
+      WHERE o.financial_status = 'PAID'
+        AND o.created_at >= $1::timestamp
+        AND v.cost_per_unit IS NULL
+      GROUP BY oi.variant_id
+     HAVING SUM(oi.quantity) >= 5
+      ORDER BY SUM(oi.quantity) DESC
+      LIMIT 50`,
+    start
+  );
+  return rows.map((r) => ({
+    signalKind: 'cost-coverage-gap' as const,
+    severity: 'normal' as const,
+    title: `${r.product_title}${r.title && r.title !== 'Default' ? ` (${r.title})` : ''}: ${Number(r.units_30d)} units sold in 30d, no cost set`,
+    evidence: [
+      { metricName: 'units_30d', metricValue: Number(r.units_30d) },
+      { note: 'Margin/ROI math depends on this cost being populated', sourceLinks: [{ label: 'Open variant', href: `/ops/inventory?variantId=${r.variant_id}` }] },
+    ],
+    targetEntityType: 'productVariant' as const,
+    targetEntityId: r.variant_id,
+    actionPayload: {
+      kind: 'navigate',
+      label: 'Enter cost',
+      params: { href: `/ops/inventory?variantId=${r.variant_id}&editCost=1` },
+    },
+  }));
+}
+
+/**
+ * Signal #9: top-20 by unit volume (trailing 14d) with no count-flavored
+ * InventoryMovement in last 7d.
+ */
+export async function detectCycleCountOverdue(now: Date = new Date()): Promise<OperationsRecommendationInput[]> {
+  const start14 = new Date(now.getTime() - 14 * DAY_MS);
+  const start7 = new Date(now.getTime() - 7 * DAY_MS);
+  const top = await prisma.$queryRawUnsafe<
+    Array<{ variant_id: string; title: string; product_title: string; units_14d: bigint }>
+  >(
+    `SELECT oi.variant_id AS variant_id, MIN(v.title) AS title, MIN(p.title) AS product_title,
+            SUM(oi.quantity)::bigint AS units_14d
+       FROM order_items oi
+       JOIN orders o ON o.id = oi.order_id
+       JOIN product_variants v ON v.id = oi.variant_id
+       JOIN products p ON p.id = v.product_id
+      WHERE o.financial_status = 'PAID'
+        AND o.created_at >= $1::timestamp
+        AND v.track_inventory = TRUE
+      GROUP BY oi.variant_id
+      ORDER BY SUM(oi.quantity) DESC
+      LIMIT 20`,
+    start14
+  );
+  const recs: OperationsRecommendationInput[] = [];
+  for (const r of top) {
+    const recentCount = await prisma.inventoryMovement.findFirst({
+      where: {
+        variantId: r.variant_id,
+        createdAt: { gte: start7 },
+        OR: [
+          { type: 'AI_COUNT' },
+          { type: 'ADJUSTMENT', reason: { contains: 'count', mode: 'insensitive' } },
+        ],
+      },
+      select: { id: true },
+    });
+    if (recentCount) continue;
+    recs.push({
+      signalKind: 'cycle-count-overdue',
+      severity: 'normal',
+      title: `${r.product_title}${r.title && r.title !== 'Default' ? ` (${r.title})` : ''}: top mover (${Number(r.units_14d)} units in 14d), not counted in ≥7d`,
+      evidence: [
+        { metricName: 'units_14d', metricValue: Number(r.units_14d) },
+        { note: 'Recommend physical count to keep ledger honest', sourceLinks: [{ label: 'Open variant', href: `/ops/inventory?variantId=${r.variant_id}` }] },
+      ],
+      targetEntityType: 'productVariant',
+      targetEntityId: r.variant_id,
+      actionPayload: {
+        kind: 'navigate',
+        label: 'Mark counted',
+        params: { href: `/ops/inventory?openNoteFor=${r.variant_id}&prefill=Counted+%5BN%5D+units` },
+      },
+    });
+  }
+  return recs;
+}
+
+/**
+ * Pre-fulfillment shortage: ANY variant in a PAID order in the next 14 days with
+ * available < 0. Urgent — operator needs to order or substitute.
+ */
+export async function detectPreFulfillmentShortage(now: Date = new Date()): Promise<OperationsRecommendationInput[]> {
+  const start = new Date(now);
+  start.setUTCHours(0, 0, 0, 0);
+  const end = new Date(now);
+  end.setUTCDate(end.getUTCDate() + 14);
+  end.setUTCHours(23, 59, 59, 999);
+  const rows = await prisma.$queryRawUnsafe<
+    Array<{
+      variant_id: string;
+      title: string;
+      product_title: string;
+      demand: bigint;
+      available: number;
+      earliest: Date;
+    }>
+  >(
+    `SELECT oi.variant_id AS variant_id, MIN(v.title) AS title, MIN(p.title) AS product_title,
+            SUM(oi.quantity)::bigint AS demand,
+            MIN(v.inventory_quantity - v.committed_quantity) AS available,
+            MIN(o.delivery_date) AS earliest
+       FROM order_items oi
+       JOIN orders o ON o.id = oi.order_id
+       JOIN product_variants v ON v.id = oi.variant_id
+       JOIN products p ON p.id = v.product_id
+      WHERE o.financial_status = 'PAID'
+        AND o.status <> 'CANCELLED'
+        AND o.delivery_date >= $1::timestamp
+        AND o.delivery_date <= $2::timestamp
+        AND v.track_inventory = TRUE
+      GROUP BY oi.variant_id
+     HAVING MIN(v.inventory_quantity - v.committed_quantity) < 0`,
+    start,
+    end
+  );
+  return rows.map((r) => ({
+    signalKind: 'pre-fulfillment-shortage' as const,
+    severity: 'urgent' as const,
+    title: `${r.product_title}${r.title && r.title !== 'Default' ? ` (${r.title})` : ''}: short by ${Math.abs(r.available)} for paid orders by ${r.earliest.toISOString().slice(0, 10)}`,
+    evidence: [
+      { metricName: 'paid_demand_14d', metricValue: Number(r.demand) },
+      { metricName: 'available', metricValue: r.available },
+      { metricName: 'earliest_delivery', metricValue: r.earliest.toISOString().slice(0, 10), sourceLinks: [{ label: 'Open purchase plan', href: `/ops/inventory?variantId=${r.variant_id}&plan=1` }] },
+    ],
+    targetEntityType: 'productVariant' as const,
+    targetEntityId: r.variant_id,
+    actionPayload: {
+      kind: 'navigate',
+      label: 'Open in purchase plan',
+      params: { href: `/ops/inventory?variantId=${r.variant_id}&plan=1` },
+    },
+  }));
+}

--- a/src/lib/operations/recommendation-store.ts
+++ b/src/lib/operations/recommendation-store.ts
@@ -1,0 +1,175 @@
+/**
+ * Persistence for OperationsRecommendation.
+ *
+ * Mirrors src/lib/analytics/recommendation-store.ts in shape but:
+ *  - upserts by dedupeKey (one open rec per signal+target)
+ *  - refreshes evidence + bumps severity when the same signal re-detects worse
+ *  - exposes appendActionLog for the rec-card inline-action audit trail
+ */
+
+import { prisma } from '@/lib/database/client';
+import type { Prisma, OperationsRecommendation } from '@prisma/client';
+import type { RecommendationStatus as SharedStatus } from '@/lib/recommendations/lifecycle';
+import { isValidTransition } from '@/lib/recommendations/lifecycle';
+import {
+  buildDedupeKey,
+  isHigherSeverity,
+  type ActionLogEntry,
+  type OperationsRecommendationInput,
+  type OpsSeverity,
+} from './types';
+
+export interface UpsertSummary {
+  created: number;
+  updated: number;
+  skipped: number;
+}
+
+/**
+ * Bulk upsert with dedupe. If an open rec with the same dedupeKey exists,
+ * refresh evidence + actionPayload + title and bump severity if worse. If a
+ * non-open rec exists with the same dedupeKey, skip — the operator already
+ * acted; we'll revisit if/when it gets re-opened.
+ */
+export async function upsertRecommendations(
+  recs: OperationsRecommendationInput[]
+): Promise<UpsertSummary> {
+  let created = 0;
+  let updated = 0;
+  let skipped = 0;
+
+  for (const rec of recs) {
+    const dedupeKey = rec.dedupeKey ?? buildDedupeKey(rec.signalKind, rec.targetEntityId);
+    const existing = await prisma.operationsRecommendation.findUnique({
+      where: { dedupeKey },
+      select: { id: true, status: true, severity: true },
+    });
+
+    if (!existing) {
+      await prisma.operationsRecommendation.create({
+        data: {
+          dedupeKey,
+          signalKind: rec.signalKind,
+          severity: rec.severity,
+          title: rec.title,
+          evidence: rec.evidence as unknown as Prisma.InputJsonValue,
+          targetEntityType: rec.targetEntityType,
+          targetEntityId: rec.targetEntityId,
+          actionPayload: rec.actionPayload as unknown as Prisma.InputJsonValue,
+          source: rec.source ?? 'auto-snapshot',
+          status: 'open',
+        },
+      });
+      created += 1;
+      continue;
+    }
+
+    if (existing.status !== 'open') {
+      skipped += 1;
+      continue;
+    }
+
+    // Open rec already exists — refresh fields. Only raise severity, never lower
+    // (the operator may want to see the worst the heuristic has seen).
+    const existingSeverity = existing.severity as OpsSeverity;
+    const nextSeverity = isHigherSeverity(rec.severity, existingSeverity)
+      ? rec.severity
+      : existingSeverity;
+
+    await prisma.operationsRecommendation.update({
+      where: { id: existing.id },
+      data: {
+        severity: nextSeverity,
+        title: rec.title,
+        evidence: rec.evidence as unknown as Prisma.InputJsonValue,
+        actionPayload: rec.actionPayload as unknown as Prisma.InputJsonValue,
+      },
+    });
+    updated += 1;
+  }
+
+  return { created, updated, skipped };
+}
+
+/**
+ * Set status with shared lifecycle validation. Pass dismissReason when
+ * transitioning to rejected/invalidated; pass snoozeUntil when transitioning
+ * to snoozed. shippedAt auto-stamped on transition to shipped.
+ */
+export async function markStatus(
+  id: string,
+  status: SharedStatus,
+  opts?: { dismissReason?: string; snoozeUntil?: Date | null }
+): Promise<OperationsRecommendation> {
+  const current = await prisma.operationsRecommendation.findUnique({
+    where: { id },
+    select: { status: true },
+  });
+  if (!current) throw new Error(`OperationsRecommendation ${id} not found`);
+
+  const from = current.status as SharedStatus;
+  if (!isValidTransition(from, status)) {
+    throw new Error(`Invalid transition: ${from} → ${status}`);
+  }
+
+  const data: Prisma.OperationsRecommendationUpdateInput = { status };
+  if (status === 'shipped') data.shippedAt = new Date();
+  if (opts?.dismissReason !== undefined) data.dismissReason = opts.dismissReason;
+  if (opts?.snoozeUntil !== undefined) data.snoozeUntil = opts.snoozeUntil;
+  // Re-opening clears prior dismissal context.
+  if (status === 'open') {
+    data.dismissReason = null;
+    data.snoozeUntil = null;
+  }
+
+  return prisma.operationsRecommendation.update({ where: { id }, data });
+}
+
+/**
+ * Append an action-log entry atomically. Reads existing array inside a
+ * transaction, appends, writes back. Postgres JSONB lacks a built-in atomic
+ * array-append; a small txn is the safe path.
+ */
+export async function appendActionLog(
+  id: string,
+  entry: ActionLogEntry
+): Promise<void> {
+  await prisma.$transaction(async (tx) => {
+    const row = await tx.operationsRecommendation.findUnique({
+      where: { id },
+      select: { actionLog: true },
+    });
+    if (!row) throw new Error(`OperationsRecommendation ${id} not found`);
+    const log = Array.isArray(row.actionLog) ? (row.actionLog as unknown as ActionLogEntry[]) : [];
+    log.push(entry);
+    await tx.operationsRecommendation.update({
+      where: { id },
+      data: { actionLog: log as unknown as Prisma.InputJsonValue },
+    });
+  });
+}
+
+export async function getActiveByDedupeKey(
+  dedupeKey: string
+): Promise<OperationsRecommendation | null> {
+  return prisma.operationsRecommendation.findUnique({ where: { dedupeKey } });
+}
+
+/**
+ * Look up recently-resolved recs for a dedupeKey (within `days` calendar
+ * days). Used by generators to suppress noise from snoozed/rejected signals.
+ */
+export async function findRecentResolved(
+  dedupeKey: string,
+  days = 30
+): Promise<OperationsRecommendation | null> {
+  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+  return prisma.operationsRecommendation.findFirst({
+    where: {
+      dedupeKey,
+      status: { in: ['snoozed', 'rejected', 'invalidated'] },
+      updatedAt: { gte: cutoff },
+    },
+    orderBy: { updatedAt: 'desc' },
+  });
+}

--- a/src/lib/operations/recommendation-store.ts
+++ b/src/lib/operations/recommendation-store.ts
@@ -126,9 +126,16 @@ export async function markStatus(
 }
 
 /**
- * Append an action-log entry atomically. Reads existing array inside a
- * transaction, appends, writes back. Postgres JSONB lacks a built-in atomic
- * array-append; a small txn is the safe path.
+ * Append an action-log entry. Read-modify-write inside `$transaction`.
+ *
+ * Concurrency note: Postgres doesn't row-lock until the UPDATE statement, so
+ * two simultaneous appends on the same rec can both read the same baseline
+ * and the later UPDATE wins (lost-update). Acceptable here because the
+ * action log is driven by a single operator clicking inline buttons one at
+ * a time — concurrent appends on the same rec aren't a realistic workflow.
+ * If this assumption stops holding, swap the read-modify-write for an
+ * atomic `jsonb_set(action_log, '{<idx>}', $1, true)` via $executeRawUnsafe
+ * or a SELECT … FOR UPDATE inside the transaction.
  */
 export async function appendActionLog(
   id: string,

--- a/src/lib/operations/recommendations.ts
+++ b/src/lib/operations/recommendations.ts
@@ -1,0 +1,121 @@
+/**
+ * Operations Director recommendation orchestrator.
+ *
+ * Composes the 10 drift detectors (detectors.ts) with the snooze/reject
+ * suppression filter described in §5d, then hands the result to the store
+ * for upsert. The crons stay thin — they call generateAll / generateHourly,
+ * call upsertRecommendations, and return a summary.
+ *
+ * Suppression rules (per §5d, "snooze/dismiss feeds back into scoring"):
+ *   - snoozed + snoozeUntil in the future  → drop entirely
+ *   - rejected | invalidated in last 30d   → still surface, severity -1 tier
+ *   - otherwise                            → pass through unchanged
+ */
+
+import {
+  detectAiNoteBacklog,
+  detectCostCoverageGap,
+  detectCycleCountOverdue,
+  detectNegativeAvailable,
+  detectPickInventoryLag,
+  detectPreFulfillmentShortage,
+  detectReceivingLag,
+  detectRepeatedShorts,
+  detectVariantMismapping,
+  detectVelocityAnomaly,
+} from './detectors';
+import { findRecentResolved } from './recommendation-store';
+import {
+  buildDedupeKey,
+  knockDownSeverity,
+  type OperationsRecommendationInput,
+  type SignalKind,
+} from './types';
+
+type DetectorFn = (now?: Date) => Promise<OperationsRecommendationInput[]>;
+
+/** Daily snapshot — all 10 detectors. */
+export const ALL_DETECTORS: ReadonlyArray<readonly [SignalKind, DetectorFn]> = [
+  ['receiving-lag', detectReceivingLag],
+  ['pick-inventory-lag', detectPickInventoryLag],
+  ['repeated-shorts', detectRepeatedShorts],
+  ['negative-available', detectNegativeAvailable],
+  ['velocity-anomaly', detectVelocityAnomaly],
+  ['ai-note-backlog', detectAiNoteBacklog],
+  ['variant-mismapping', detectVariantMismapping],
+  ['cost-coverage-gap', detectCostCoverageGap],
+  ['cycle-count-overdue', detectCycleCountOverdue],
+  ['pre-fulfillment-shortage', detectPreFulfillmentShortage],
+] as const;
+
+/** Hourly fast loop — only the time-sensitive signals (§7 Phase 1B). */
+export const HOURLY_DETECTORS: ReadonlyArray<readonly [SignalKind, DetectorFn]> = [
+  ['receiving-lag', detectReceivingLag],
+  ['pick-inventory-lag', detectPickInventoryLag],
+  ['ai-note-backlog', detectAiNoteBacklog],
+  ['pre-fulfillment-shortage', detectPreFulfillmentShortage],
+] as const;
+
+export interface GenerateResult {
+  proposals: OperationsRecommendationInput[];
+  bySignal: Record<string, number>;
+  suppressedSnoozed: number;
+  suppressedKnockdown: number;
+}
+
+/**
+ * Apply suppression to a list of detector outputs. Pure-ish: only reads
+ * recently-resolved rows from the store, never writes.
+ */
+export async function applySuppression(
+  candidates: OperationsRecommendationInput[],
+  now: Date = new Date()
+): Promise<{ kept: OperationsRecommendationInput[]; suppressedSnoozed: number; suppressedKnockdown: number }> {
+  const kept: OperationsRecommendationInput[] = [];
+  let suppressedSnoozed = 0;
+  let suppressedKnockdown = 0;
+  for (const c of candidates) {
+    const dedupeKey = c.dedupeKey ?? buildDedupeKey(c.signalKind, c.targetEntityId);
+    const recent = await findRecentResolved(dedupeKey, 30);
+    if (!recent) {
+      kept.push(c);
+      continue;
+    }
+    if (recent.status === 'snoozed' && recent.snoozeUntil && recent.snoozeUntil.getTime() > now.getTime()) {
+      suppressedSnoozed += 1;
+      continue;
+    }
+    if (recent.status === 'rejected' || recent.status === 'invalidated') {
+      kept.push({ ...c, severity: knockDownSeverity(c.severity) });
+      suppressedKnockdown += 1;
+      continue;
+    }
+    // Expired snooze → fall through, surface again.
+    kept.push(c);
+  }
+  return { kept, suppressedSnoozed, suppressedKnockdown };
+}
+
+async function runDetectors(
+  detectors: ReadonlyArray<readonly [SignalKind, DetectorFn]>,
+  now: Date,
+  source: 'auto-snapshot' | 'auto-hourly'
+): Promise<GenerateResult> {
+  const proposals: OperationsRecommendationInput[] = [];
+  const bySignal: Record<string, number> = {};
+  for (const [kind, fn] of detectors) {
+    const raw = await fn(now);
+    bySignal[kind] = raw.length;
+    for (const r of raw) proposals.push({ ...r, source });
+  }
+  const { kept, suppressedSnoozed, suppressedKnockdown } = await applySuppression(proposals, now);
+  return { proposals: kept, bySignal, suppressedSnoozed, suppressedKnockdown };
+}
+
+export function generateAll(now: Date = new Date()): Promise<GenerateResult> {
+  return runDetectors(ALL_DETECTORS, now, 'auto-snapshot');
+}
+
+export function generateHourly(now: Date = new Date()): Promise<GenerateResult> {
+  return runDetectors(HOURLY_DETECTORS, now, 'auto-hourly');
+}

--- a/src/lib/operations/snapshot.ts
+++ b/src/lib/operations/snapshot.ts
@@ -1,0 +1,154 @@
+/**
+ * Snapshot metric computations for OperationsSnapshot.
+ *
+ * Each function isolated + DB-only so it can be tested + replaced. The cron
+ * route calls these in parallel, then writes a single row.
+ *
+ * See docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md §12 for metric definitions.
+ */
+
+import { prisma } from '@/lib/database/client';
+
+const MS_PER_HOUR = 60 * 60 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Proxy from §12. Count-type adjustments where the delta was within ±50 units
+ * of zero are "confirmation" counts (ledger was right). Larger deltas measure
+ * how wrong it was. Rolling 30 days. Null if no counts yet.
+ */
+export async function computeInventoryAccuracyPct(now: Date = new Date()): Promise<number | null> {
+  const cutoff = new Date(now.getTime() - 30 * DAY_MS);
+  const counts = await prisma.inventoryMovement.findMany({
+    where: {
+      createdAt: { gte: cutoff },
+      OR: [
+        { type: 'AI_COUNT' },
+        { type: 'ADJUSTMENT', reason: { contains: 'count', mode: 'insensitive' } },
+      ],
+    },
+    select: { quantity: true },
+  });
+  if (counts.length === 0) return null;
+  const within = counts.filter((c) => Math.abs(c.quantity) <= 50).length;
+  return Math.round((within / counts.length) * 10000) / 100; // 2dp
+}
+
+/**
+ * variants_with_costPerUnit_set / variants_sold_in_30d * 100.
+ * "Sold in 30d" = appears in OrderItem with order.financialStatus = PAID.
+ */
+export async function computeCostCoveragePct(now: Date = new Date()): Promise<number> {
+  const cutoff = new Date(now.getTime() - 30 * DAY_MS);
+  const variantIds = await prisma.orderItem.findMany({
+    where: {
+      order: { financialStatus: 'PAID', createdAt: { gte: cutoff } },
+    },
+    distinct: ['variantId'],
+    select: { variantId: true },
+  });
+  if (variantIds.length === 0) return 0;
+  const withCost = await prisma.productVariant.count({
+    where: {
+      id: { in: variantIds.map((v) => v.variantId) },
+      costPerUnit: { not: null },
+    },
+  });
+  return Math.round((withCost / variantIds.length) * 10000) / 100;
+}
+
+export interface ReceivingLagPercentiles {
+  p50: number | null;
+  p90: number | null;
+}
+
+/**
+ * Hours from ReceivingInvoice.createdAt → appliedAt for invoices applied in
+ * last 30d. Null when fewer than 2 samples — percentile of 1 is meaningless.
+ */
+export async function computeReceivingLagPercentiles(
+  now: Date = new Date()
+): Promise<ReceivingLagPercentiles> {
+  const cutoff = new Date(now.getTime() - 30 * DAY_MS);
+  const invoices = await prisma.receivingInvoice.findMany({
+    where: {
+      status: 'APPLIED',
+      appliedAt: { gte: cutoff, not: null },
+    },
+    select: { createdAt: true, appliedAt: true },
+  });
+  const hours = invoices
+    .map((i) => (i.appliedAt!.getTime() - i.createdAt.getTime()) / MS_PER_HOUR)
+    .filter((h) => Number.isFinite(h) && h >= 0)
+    .sort((a, b) => a - b);
+  if (hours.length < 2) return { p50: null, p90: null };
+  return {
+    p50: pickPercentile(hours, 0.5),
+    p90: pickPercentile(hours, 0.9),
+  };
+}
+
+function pickPercentile(sorted: number[], q: number): number {
+  // Nearest-rank — simple, deterministic, plenty for a 30d operational metric.
+  const idx = Math.min(sorted.length - 1, Math.floor(q * sorted.length));
+  return Math.round(sorted[idx] * 100) / 100;
+}
+
+/**
+ * Count of distinct PAID order line items in the next 14 days where the variant
+ * would have negative available stock (inventoryQuantity - committedQuantity < 0).
+ *
+ * Uses raw SQL — Prisma can't express a column-column comparison without N round
+ * trips. Counts at the line-item level, mirroring the buildout doc's wording.
+ */
+export async function computePaidOrders14dShortageCount(
+  now: Date = new Date()
+): Promise<number> {
+  const start = new Date(now);
+  start.setUTCHours(0, 0, 0, 0);
+  const end = new Date(now);
+  end.setUTCDate(end.getUTCDate() + 14);
+  end.setUTCHours(23, 59, 59, 999);
+
+  const rows = await prisma.$queryRawUnsafe<Array<{ count: bigint }>>(
+    `SELECT COUNT(*)::bigint AS count
+       FROM order_items oi
+       JOIN orders o ON o.id = oi.order_id
+       JOIN product_variants v ON v.id = oi.variant_id
+      WHERE o.financial_status = 'PAID'
+        AND o.status <> 'CANCELLED'
+        AND o.delivery_date >= $1::timestamp
+        AND o.delivery_date <= $2::timestamp
+        AND v.track_inventory = TRUE
+        AND (v.inventory_quantity - v.committed_quantity) < 0`,
+    start,
+    end
+  );
+  return Number(rows[0]?.count ?? 0);
+}
+
+/**
+ * Count of cycle-count InventoryNote rows processed in last 7 days.
+ * Used by the dashboard to track operator follow-through on count
+ * recommendations.
+ */
+export async function computeCycleCountsCompletedLast7d(
+  now: Date = new Date()
+): Promise<number> {
+  const cutoff = new Date(now.getTime() - 7 * DAY_MS);
+  // Treat any processed InventoryNote OR any count-flavored InventoryMovement
+  // as evidence the operator completed a physical count.
+  const notes = await prisma.inventoryNote.count({
+    where: { status: 'processed', updatedAt: { gte: cutoff } },
+  });
+  const movements = await prisma.inventoryMovement.count({
+    where: {
+      createdAt: { gte: cutoff },
+      OR: [
+        { type: 'AI_COUNT' },
+        { type: 'ADJUSTMENT', reason: { contains: 'count', mode: 'insensitive' } },
+      ],
+    },
+  });
+  return notes + movements;
+}

--- a/src/lib/operations/types.ts
+++ b/src/lib/operations/types.ts
@@ -1,0 +1,103 @@
+/**
+ * Shared TS types for the Operations Director pipeline.
+ *
+ * These are the in-memory shapes the heuristic generators produce and the
+ * store consumes. The DB row (Prisma OperationsRecommendation) is a thin
+ * persisted version of OperationsRecommendationInput plus lifecycle columns.
+ */
+
+import type { ActionPayload, Evidence } from '@/lib/recommendations/card-types';
+
+/**
+ * Each of the 9 drift signals (§6) + pre-fulfillment shortage. Open string
+ * union so future signals can be added without touching the DB schema.
+ */
+export type SignalKind =
+  | 'receiving-lag'
+  | 'pick-inventory-lag'
+  | 'repeated-shorts'
+  | 'negative-available'
+  | 'velocity-anomaly'
+  | 'ai-note-backlog'
+  | 'variant-mismapping'
+  | 'cost-coverage-gap'
+  | 'cycle-count-overdue'
+  | 'pre-fulfillment-shortage';
+
+/**
+ * Severity — Ops uses a 3-tier scale distinct from the shared 4-tier Severity
+ * in card-types.ts. Map 'urgent'→'critical', 'high'→'high', 'normal'→'medium'
+ * when rendering through the shared card.
+ */
+export type OpsSeverity = 'urgent' | 'high' | 'normal';
+
+export type OpsTargetEntityType =
+  | 'productVariant'
+  | 'order'
+  | 'draftOrder'
+  | 'inventoryNote'
+  | 'receivingInvoice'
+  | 'vendor';
+
+export interface OpsEvidence extends Evidence {
+  metricName?: string;
+  metricValue?: string | number;
+  sourceLinks?: Array<{ label: string; href: string }>;
+  note?: string;
+}
+
+/**
+ * Generator output. Persisted via recommendation-store.upsertRecommendations.
+ */
+export interface OperationsRecommendationInput {
+  signalKind: SignalKind;
+  severity: OpsSeverity;
+  title: string;
+  evidence: OpsEvidence[];
+  targetEntityType: OpsTargetEntityType;
+  targetEntityId: string;
+  actionPayload: ActionPayload;
+  /** Optional override; default = `${signalKind}:${targetEntityId}`. */
+  dedupeKey?: string;
+  source?: 'auto-snapshot' | 'auto-hourly' | 'director';
+}
+
+/**
+ * Audit trail entry on OperationsRecommendation.actionLog.
+ */
+export interface ActionLogEntry {
+  timestamp: string; // ISO
+  actionLabel: string;
+  result: 'success' | 'error';
+  errorMessage?: string;
+  relatedMovementId?: string;
+  actor?: string;
+}
+
+export function buildDedupeKey(signalKind: SignalKind, targetEntityId: string): string {
+  return `${signalKind}:${targetEntityId}`;
+}
+
+/**
+ * Severity precedence — used when a re-detection wants to bump up an existing
+ * rec. Higher index = louder.
+ */
+const SEVERITY_RANK: Record<OpsSeverity, number> = {
+  normal: 0,
+  high: 1,
+  urgent: 2,
+};
+
+export function isHigherSeverity(a: OpsSeverity, b: OpsSeverity): boolean {
+  return SEVERITY_RANK[a] > SEVERITY_RANK[b];
+}
+
+/**
+ * Knock severity down one tier — used when a rec was previously rejected and
+ * we want to surface again but quieter. Reason: noise tolerance — see §5d.
+ */
+export function knockDownSeverity(s: OpsSeverity): OpsSeverity {
+  if (s === 'urgent') return 'high';
+  if (s === 'high') return 'normal';
+  return 'normal';
+}

--- a/src/lib/recommendations/card-types.ts
+++ b/src/lib/recommendations/card-types.ts
@@ -1,0 +1,102 @@
+/**
+ * Shared types for the RecommendationCard UI.
+ *
+ * Marketing recs are advisory (actionPayload is always null) — operator
+ * reads, decides, ships outside the queue. Operations recs (Phase 1B/1C)
+ * will carry an ActionPayload describing an inline button: re-pack a cooler,
+ * adjust inventory, etc.
+ */
+
+import type { RecommendationStatus, RiskTier, EffortTier } from './lifecycle';
+
+/**
+ * Domain identifier. Open string so adding `ops`, `finance`, `cs` doesn't
+ * require touching this file each time a new director comes online.
+ */
+export type RecommendationDomainId = 'marketing' | 'seo' | 'ops' | 'finance' | 'cs' | string;
+
+/**
+ * Visual severity hint. Distinct from RiskTier (which gates autonomy) —
+ * severity is "how loud should this card look in the queue".
+ */
+export type Severity = 'low' | 'medium' | 'high' | 'critical';
+
+export interface Evidence {
+  metric?: string | null;
+  currentValue?: string | null;
+  targetValue?: string | null;
+  impactDollarsMonthly?: number | null;
+  segment?: string | null;
+}
+
+/**
+ * Describes an inline action the operator can trigger from the card.
+ * Marketing recs leave this null. Operations recs carry e.g.
+ * { kind: 'repack-cooler', params: { coolerId: '...', items: [...] } }.
+ * The card component renders a button when present; the click handler is
+ * passed in from the page via RecommendationCardProps.onExecuteAction.
+ */
+export interface ActionPayload {
+  kind: string;
+  label?: string;
+  params: Record<string, unknown>;
+}
+
+export interface MetricSnapshot {
+  capturedAt: string;
+  snapshotDate: string;
+  revenue: number;
+  orders: number;
+  averageOrderValue: number;
+  marginCoveragePct: number | null;
+}
+
+/**
+ * The shape the card renders. Compatible with the API GET response —
+ * page-level types should extend this rather than duplicating fields.
+ */
+export interface RecommendationCardData {
+  id: string;
+  domain: RecommendationDomainId;
+  source: string;
+  generatedAt: string;
+  title: string;
+  body: string | null;
+  segment: string | null;
+  metric: string | null;
+  currentValue: string | null;
+  targetValue: string | null;
+  impactDollarsMonthly: number | null;
+  effortTier: EffortTier | null;
+  riskTier: RiskTier;
+  status: RecommendationStatus;
+  shippedAt: string | null;
+  notes: string | null;
+  resultMetricBefore: MetricSnapshot | null;
+  resultMetricAfter: MetricSnapshot | null;
+  /** Null for advisory (Marketing) recs; populated for actionable (Ops) recs. */
+  actionPayload?: ActionPayload | null;
+  /** Optional severity hint. Marketing today doesn't set this. */
+  severity?: Severity;
+}
+
+export interface RecommendationCardProps {
+  rec: RecommendationCardData;
+  /**
+   * When true, the domain badge is rendered (used when the queue is showing
+   * mixed-domain results). Marketing-only view hides it.
+   */
+  showDomainBadge?: boolean;
+  isSaving?: boolean;
+  isExpanded?: boolean;
+  isEditingNotes?: boolean;
+  notesValue?: string;
+  onToggleExpand?: (id: string) => void;
+  onRequestTransition?: (rec: RecommendationCardData, to: RecommendationStatus) => void;
+  onStartEditNotes?: (id: string, initial: string) => void;
+  onNotesChange?: (value: string) => void;
+  onSaveNotes?: (id: string) => void;
+  onCancelEditNotes?: () => void;
+  /** Reserved for Phase 1B/1C — Marketing today never invokes this. */
+  onExecuteAction?: (rec: RecommendationCardData) => void;
+}

--- a/src/lib/recommendations/lifecycle.ts
+++ b/src/lib/recommendations/lifecycle.ts
@@ -1,0 +1,117 @@
+/**
+ * Recommendation lifecycle — shared status state machine.
+ *
+ * Used by Marketing today; will be reused by Operations, SEO, Finance, CS.
+ * Domain-specific code decides which subset of statuses it actually exposes
+ * (e.g. Marketing currently ignores `snoozed`). The state machine itself is
+ * domain-agnostic.
+ *
+ * Transitions:
+ *   open ─→ approved ─→ shipped ─→ (measured via resultMetricAfter)
+ *     │        │           │
+ *     │        └────────── re-open ─┐
+ *     ├──→ rejected ───── re-open ──┤
+ *     ├──→ invalidated ── re-open ──┤
+ *     └──→ snoozed ───── re-open ───┘
+ */
+
+export type RecommendationStatus =
+  | 'open'
+  | 'approved'
+  | 'shipped'
+  | 'rejected'
+  | 'invalidated'
+  | 'snoozed';
+
+export type RiskTier = 'autonomous' | 'recommend' | 'hard_stop';
+export type EffortTier = 's' | 'm' | 'l';
+
+export const ALL_STATUSES: RecommendationStatus[] = [
+  'open',
+  'approved',
+  'shipped',
+  'rejected',
+  'invalidated',
+  'snoozed',
+];
+
+/**
+ * Statuses currently used by the Marketing Director queue. Operations Director
+ * (Phase 1B/1C) may opt into the full set.
+ */
+export const MARKETING_STATUSES: RecommendationStatus[] = [
+  'open',
+  'approved',
+  'shipped',
+  'rejected',
+  'invalidated',
+];
+
+/**
+ * What you can transition TO from each status.
+ */
+export const VALID_TRANSITIONS: Record<RecommendationStatus, RecommendationStatus[]> = {
+  open: ['approved', 'rejected', 'invalidated', 'snoozed'],
+  approved: ['shipped', 'open', 'rejected'],
+  shipped: ['open'],
+  rejected: ['open'],
+  invalidated: ['open'],
+  snoozed: ['open', 'rejected', 'invalidated'],
+};
+
+export function isValidTransition(
+  from: RecommendationStatus,
+  to: RecommendationStatus
+): boolean {
+  if (from === to) return false;
+  return VALID_TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+/**
+ * Whether a status transition should prompt the operator for a reason.
+ * - required: dismissals need an audit trail (mirrored to Obsidian).
+ * - optional: outcome notes are useful but not enforced.
+ * - none: keep the happy path frictionless.
+ */
+export const REASON_MODE: Record<RecommendationStatus, 'required' | 'optional' | 'none'> = {
+  rejected: 'required',
+  invalidated: 'required',
+  shipped: 'optional',
+  snoozed: 'optional',
+  open: 'none',
+  approved: 'none',
+};
+
+export const REASON_MIN_CHARS = 10;
+
+export type TransitionTone = 'primary' | 'neutral' | 'danger';
+
+export interface TransitionOption {
+  to: RecommendationStatus;
+  label: string;
+  tone: TransitionTone;
+}
+
+/**
+ * Buttons offered for each current status in the triage UI. Subset of
+ * VALID_TRANSITIONS — some valid transitions don't need a top-level button
+ * (e.g. open→snoozed is wired through a separate "Snooze" action when Ops
+ * needs it).
+ */
+export const NEXT_TRANSITIONS: Record<RecommendationStatus, TransitionOption[]> = {
+  open: [
+    { to: 'approved', label: 'Approve', tone: 'primary' },
+    { to: 'rejected', label: 'Reject', tone: 'neutral' },
+  ],
+  approved: [
+    { to: 'shipped', label: 'Mark shipped', tone: 'primary' },
+    { to: 'open', label: 'Re-open', tone: 'neutral' },
+  ],
+  shipped: [{ to: 'open', label: 'Re-open', tone: 'neutral' }],
+  rejected: [{ to: 'open', label: 'Re-open', tone: 'neutral' }],
+  invalidated: [{ to: 'open', label: 'Re-open', tone: 'neutral' }],
+  snoozed: [
+    { to: 'open', label: 'Re-open', tone: 'neutral' },
+    { to: 'rejected', label: 'Reject', tone: 'neutral' },
+  ],
+};

--- a/src/lib/recommendations/measurement.ts
+++ b/src/lib/recommendations/measurement.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared measurement window math.
+ *
+ * A recommendation is "due for measurement" once it's been shipped for
+ * MEASUREMENT_WINDOW_DAYS — the cron route then captures a fresh metric
+ * snapshot into resultMetricAfter. Marketing today; reused by Operations,
+ * Finance, and any other domain that ships rec-driven changes.
+ *
+ * Pure functions — no DB, no I/O. The marketing cron route owns "what
+ * to capture" (revenue/AOV/coverage); this module owns "when to capture".
+ */
+
+export const MEASUREMENT_WINDOW_DAYS = 14;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Recommendations shipped at or before this cutoff are due for measurement.
+ */
+export function measurementCutoff(now: Date = new Date()): Date {
+  return new Date(now.getTime() - MEASUREMENT_WINDOW_DAYS * MS_PER_DAY);
+}
+
+/**
+ * True when a shipped rec has crossed the measurement window. Returns false
+ * for null/undefined shippedAt so callers don't need to null-check.
+ */
+export function isDueForMeasurement(
+  shippedAt: Date | string | null | undefined,
+  now: Date = new Date()
+): boolean {
+  if (!shippedAt) return false;
+  const shipped = typeof shippedAt === 'string' ? new Date(shippedAt) : shippedAt;
+  if (Number.isNaN(shipped.getTime())) return false;
+  return shipped.getTime() <= measurementCutoff(now).getTime();
+}
+
+/**
+ * Whole days between shippedAt and now. Floors at 0 — never negative.
+ */
+export function daysSinceShipped(
+  shippedAt: Date | string,
+  now: Date = new Date()
+): number {
+  const shipped = typeof shippedAt === 'string' ? new Date(shippedAt) : shippedAt;
+  const diff = now.getTime() - shipped.getTime();
+  if (diff <= 0) return 0;
+  return Math.floor(diff / MS_PER_DAY);
+}

--- a/vercel.json
+++ b/vercel.json
@@ -35,6 +35,18 @@
     {
       "path": "/api/cron/group-orders-v2",
       "schedule": "0 */2 * * *"
+    },
+    {
+      "path": "/api/cron/operations-snapshot",
+      "schedule": "30 7 * * *"
+    },
+    {
+      "path": "/api/cron/operations-drift-hourly",
+      "schedule": "0 * * * *"
+    },
+    {
+      "path": "/api/cron/measure-operations-recommendations",
+      "schedule": "0 8 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Phase 1B of the Operations Director: the **drift-detection pipeline** that
feeds the triage queue.

This PR adds:

- **10 drift-signal detectors** (the 9 from §6 + pre-fulfillment shortage) with
  dedupe by `signalKind + targetEntityId` and snooze/reject feedback into
  scoring (§5d).
- **`OperationsRecommendation` + `OperationsSnapshot` models**, additive only,
  shipped via raw SQL (`scripts/apply-operations-schema.ts`) — **not** via
  `prisma db push`, per the saved memory note about schema drift.
- **Daily snapshot cron** at `07:30 UTC` (right after Marketing's 07:00) that
  computes the snapshot metrics and runs all 10 detectors.
- **Hourly drift cron** at `:00` that re-runs the time-sensitive subset
  (receiving-lag, pick-inventory-lag, ai-note-backlog, pre-fulfillment-shortage).
- **14-day measurement loop** — parallel to the Marketing measurement cron,
  re-runs the matching detector and records whether the same drift signal
  recurred after the operator's action.
- **76 unit tests** (well over the 36-test minimum: 8 types, 10 snapshot, 12
  store, 6 orchestrator suppression, 40 detector cases — 4 per signal).

> **No UI in this PR — recs land in the DB only. The triage queue + inline-action
> handlers ship in Phase 1C.**

Builds on top of **PR #43** (shared `src/lib/recommendations/` lib) — `lifecycle`,
`measurement`, `card-types` are imported from there. If #43 hasn't merged yet,
this branch carries its commits along for review.

Reference: [docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md](docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md)
§7 (Phase 1B), §6 (the 10 detectors), §10 (hard rules), §11 (resolved decisions).

## The 10 detectors

| # | Signal | Severity | Inline action |
|---|---|---|---|
| 1 | `receiving-lag` | high | navigate → `/ops/inventory/receiving/[id]` |
| 2 | `pick-inventory-lag` | high | apiCall → POST reconcile-pack |
| 3 | `repeated-shorts` | high | navigate → `openNoteFor=…&prefill=…` |
| 4 | `negative-available` | urgent | navigate → count + adjust modal |
| 5 | `velocity-anomaly` | normal | navigate → variant edit |
| 6 | `ai-note-backlog` | high | navigate → `openNote=…` |
| 7 | `variant-mismapping` | normal | navigate → variant comparison |
| 8 | `cost-coverage-gap` | normal | navigate → `editCost=1` |
| 9 | `cycle-count-overdue` | normal | navigate → count modal |
| 10 | `pre-fulfillment-shortage` | urgent | navigate → purchase plan |

## Sample detector output

`detectReceivingLag` against a fixture invoice 30 hours old:

```json
{
  "signalKind": "receiving-lag",
  "severity": "high",
  "title": "Receiving invoice A-123 stuck in PENDING_REVIEW (30h, RNDC)",
  "evidence": [
    {
      "metricName": "hours_pending",
      "metricValue": 30,
      "sourceLinks": [{ "label": "Open receiving invoice", "href": "/ops/inventory/receiving/inv_1" }]
    },
    { "note": "Distributor: RNDC" }
  ],
  "targetEntityType": "receivingInvoice",
  "targetEntityId": "inv_1",
  "actionPayload": {
    "kind": "navigate",
    "label": "Open receiving",
    "params": { "href": "/ops/inventory/receiving/inv_1" }
  }
}
```

`detectPickInventoryLag` against a fixture group order packed 36 hours ago
(Cynthia Cruz cruise; payer Maria Mercado):

```json
{
  "signalKind": "pick-inventory-lag",
  "severity": "high",
  "title": "Order #99 (Cynthia Cruz (paid by Maria Mercado)) — packed 36h ago, inventory not decremented",
  "evidence": [
    { "metricName": "packed_lines", "metricValue": 4 },
    { "metricName": "hours_since_pack", "metricValue": 36 },
    {
      "note": "Manifest: Cynthia Cruz (paid by Maria Mercado)",
      "sourceLinks": [{ "label": "Open order", "href": "/ops/orders/o3" }]
    }
  ],
  "targetEntityType": "order",
  "targetEntityId": "o3",
  "actionPayload": {
    "kind": "apiCall",
    "label": "Reconcile pick → inventory",
    "params": {
      "method": "POST",
      "path": "/api/admin/operations/recommendations/reconcile-pack",
      "body": { "orderId": "o3" }
    }
  }
}
```

## Suppression behavior (§5d)

`applySuppression()` reads recent `OperationsRecommendation` rows for the same
`dedupeKey` and:

- **snoozed + future snoozeUntil** → drop the rec entirely.
- **expired snooze** → surface again at original severity.
- **rejected | invalidated within 30 days** → still surface, but severity
  knocked down one tier (`urgent → high → normal → normal`).

Covered by 6 tests in `src/lib/operations/__tests__/recommendations.test.ts`.

## Migration path

`scripts/apply-operations-schema.ts` applies the two new tables + their
indexes via `CREATE TABLE IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS`.
Idempotent — safe to run multiple times.

**To run against prod:**
\`\`\`bash
DATABASE_URL=<prod> npx tsx scripts/apply-operations-schema.ts
\`\`\`

`schema.prisma` is updated for typing, but the DDL goes through this script.
Did **not** run `prisma db push` and did **not** run `prisma migrate dev`.

## Test plan

- [x] `npm run test:run` — **76/76 ops tests pass**, full suite 166 pass (6
      pre-existing failures in `src/__tests__/group-v2-payments.test.ts`,
      confirmed to exist on `main` before this PR)
- [x] `npx tsc --noEmit` — clean (the 1 pre-existing TS error in
      `group-v2-payments.test.ts` is unrelated; verified on `main`)
- [x] `npx next lint` — no new warnings (only pre-existing `<img>` warnings)
- [x] All files under 500 lines, all components under 200, all functions under
      50 (per project CLAUDE.md). Largest new file: `detectors/signals-b.ts`
      at 270 lines.
- [ ] **Operator runs `npx tsx scripts/apply-operations-schema.ts` against
      prod before deploy** (additive — safe to run multiple times).
- [ ] **Operator hand-executes the snapshot cron** in dev with curl + the
      `CRON_SECRET` after deploy:
      \`\`\`bash
      curl -H "Authorization: Bearer \$CRON_SECRET" \\
        https://<host>/api/cron/operations-snapshot | jq
      \`\`\`
      Expect: a JSON response with `bySignal` counts, `upsert` summary, and
      a fresh `operations_snapshots` row written.

## Out of scope (next PRs)

- **Phase 1C:** Triage queue UI at `/admin/operations/recommendations` (or
  filter chips on `/admin/analytics/recommendations`), inline-action handler,
  `markStatus` API.
- **Phase 1D:** Monday briefing email + `/admin/operations` dashboard page.
- **Phase 1E:** Agent file (`.claude/agents/operations-director.md`) + the
  Obsidian memory wiring.
- **Phase 2:** Auto-applying AI inventory notes, vendor scoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)