### PR TITLE
fix(operations): severity tiering + volume cap + accuracy guard (Phase 1B-fix)

### DIFF
--- a/src/lib/operations/__tests__/detectors-batch-a.test.ts
+++ b/src/lib/operations/__tests__/detectors-batch-a.test.ts
@@ -179,7 +179,31 @@ describe('detectNegativeAvailable', () => {
     ]);
     const recs = await detectNegativeAvailable();
     expect(recs).toHaveLength(1);
+    // shortfall = 7 → urgent
     expect(recs[0].severity).toBe('urgent');
+  });
+
+  it('tiers severity by shortfall magnitude (1 → normal, 3 → high, 10 → urgent)', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([
+      { id: 'v_small', title: 'Default', product_title: 'Jameson 750ml', inventory_quantity: 0, committed_quantity: 1 },
+      { id: 'v_mid', title: 'Default', product_title: 'Modelo 12pk', inventory_quantity: 2, committed_quantity: 5 },
+      { id: 'v_big', title: 'Default', product_title: 'Dripping Springs Vodka', inventory_quantity: 0, committed_quantity: 10 },
+    ]);
+    const recs = await detectNegativeAvailable();
+    expect(recs).toHaveLength(3);
+    expect(recs[0].severity).toBe('normal');
+    expect(recs[1].severity).toBe('high');
+    expect(recs[2].severity).toBe('urgent');
+  });
+
+  it('boundary: shortfall=2 is high, shortfall=6 is urgent', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValue([
+      { id: 'v_2', title: 'X', product_title: 'Y', inventory_quantity: 0, committed_quantity: 2 },
+      { id: 'v_6', title: 'X', product_title: 'Y', inventory_quantity: 0, committed_quantity: 6 },
+    ]);
+    const recs = await detectNegativeAvailable();
+    expect(recs[0].severity).toBe('high');
+    expect(recs[1].severity).toBe('urgent');
   });
 
   it('returns [] when no variants in deficit', async () => {

--- a/src/lib/operations/__tests__/detectors-batch-b.test.ts
+++ b/src/lib/operations/__tests__/detectors-batch-b.test.ts
@@ -137,6 +137,22 @@ describe('detectCostCoverageGap', () => {
     const [rec] = await detectCostCoverageGap();
     expect((rec.actionPayload.params as { href: string }).href).toContain('editCost=1');
   });
+
+  it('caps output at the top 15 variants in velocity order', async () => {
+    const rows = Array.from({ length: 30 }, (_, i) => ({
+      variant_id: `v${i}`,
+      title: `T${i}`,
+      product_title: `P${i}`,
+      // 30, 29, 28, ... 1 — SQL already sorted DESC
+      units_30d: BigInt(30 - i),
+    }));
+    prismaMock.$queryRawUnsafe.mockResolvedValue(rows);
+    const recs = await detectCostCoverageGap();
+    expect(recs).toHaveLength(15);
+    // first rec is the highest-velocity variant, last is the 15th
+    expect(recs[0].targetEntityId).toBe('v0');
+    expect(recs[14].targetEntityId).toBe('v14');
+  });
 });
 
 // ─── Signal #9: cycle-count-overdue ───────────────────────────────────

--- a/src/lib/operations/__tests__/snapshot.test.ts
+++ b/src/lib/operations/__tests__/snapshot.test.ts
@@ -27,9 +27,11 @@ beforeEach(() => {
 });
 
 describe('computeInventoryAccuracyPct', () => {
-  it('returns null when no counts exist', async () => {
+  it('returns null when no counts exist (divide-by-zero guard, not 100)', async () => {
     prismaMock.inventoryMovement.findMany.mockResolvedValue([]);
-    expect(await computeInventoryAccuracyPct()).toBeNull();
+    const result = await computeInventoryAccuracyPct();
+    expect(result).toBeNull();
+    expect(result).not.toBe(100);
   });
 
   it('returns 100 when all counts confirmed (|delta|≤50)', async () => {

--- a/src/lib/operations/detectors/signals-a.ts
+++ b/src/lib/operations/detectors/signals-a.ts
@@ -167,9 +167,13 @@ export async function detectNegativeAvailable(): Promise<OperationsRecommendatio
   return rows.map((r) => {
     const deficit = r.committed_quantity - r.inventory_quantity;
     const display = `${r.product_title}${r.title && r.title !== 'Default' ? ` (${r.title})` : ''}`;
+    // Tier by shortfall magnitude — a 1-unit short is picker noise, a 6+ short
+    // means we likely can't fulfill without intervention.
+    const severity: 'urgent' | 'high' | 'normal' =
+      deficit >= 6 ? 'urgent' : deficit >= 2 ? 'high' : 'normal';
     return {
       signalKind: 'negative-available' as const,
-      severity: 'urgent' as const,
+      severity,
       title: `${display}: ${deficit} units committed but not on hand (in-stock ${r.inventory_quantity}, committed ${r.committed_quantity})`,
       evidence: [
         { metricName: 'in_stock', metricValue: r.inventory_quantity },

--- a/src/lib/operations/detectors/signals-b.ts
+++ b/src/lib/operations/detectors/signals-b.ts
@@ -136,7 +136,10 @@ export async function detectCostCoverageGap(now: Date = new Date()): Promise<Ope
       LIMIT 50`,
     start
   );
-  return rows.map((r) => ({
+  // Cap to the top 15 movers — the long tail clogs the triage queue without
+  // adding signal. Remaining uncosted variants still count toward
+  // costCoveragePct, just not the rec queue.
+  return rows.slice(0, 15).map((r) => ({
     signalKind: 'cost-coverage-gap' as const,
     severity: 'normal' as const,
     title: `${r.product_title}${r.title && r.title !== 'Default' ? ` (${r.title})` : ''}: ${Number(r.units_30d)} units sold in 30d, no cost set`,


### PR DESCRIPTION
## Summary

Three tightly-scoped fixes to the Operations Director Phase 1B code, found during prod testing on 2026-05-15. **Unblocks Phase 1C** (triage UI).

Reference: [`docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md`](docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md)

### Fix #1 — Severity tiering on `negative-available`

Prod-data evidence: 220 active recs, 131 flagged urgent, **83 from `negative-available`** — most are 1-unit shortfalls on slow-moving spirits (e.g., "Jameson 750ml: 1 unit committed, 0 in stock").

Tier by `shortfall = committed - inventoryQuantity`:
- 1 unit → `normal`
- 2–5 units → `high`
- 6+ units → `urgent`

Detection criteria unchanged — still detects all `available < 0`. Only the severity field changes. Validates against real rows: Jameson shortfall 1 → `normal`; Dripping Springs Vodka shortfall 12 → `urgent`.

### Fix #2 — Volume cap on `cost-coverage-gap`

Prod-data evidence: detector returned **36 recs** (Surfside Variety Pack 63 units, Outdoor Chair Rental 60, Oyster Bay 26, …). Signal is real but clogs the queue.

Cap to the top 15 by `units_sold_30d DESC`. Simple `.slice(0, 15)` after sorting. No schema change, no new severity, no "informational" tier. The snapshot's `costCoveragePct` metric is still computed across the full variant universe — only the rec count is capped.

### Fix #3 — Divide-by-zero guard on `inventoryAccuracyPct`

Audit found the guard at [`src/lib/operations/snapshot.ts:32`](src/lib/operations/snapshot.ts#L32) already returns `null` when `counts.length === 0`. The Prisma field `OperationsSnapshot.inventoryAccuracyPct` is already `Float?` (nullable). The cron route passes `accuracy` through directly with no `.toFixed()` or arithmetic. So no production code changes needed for #3.

Added an explicit "not 100" assertion to the existing test to lock in the guard against future regressions. If anyone observes `inventoryAccuracyPct: 100` with `cycleCountsCompletedLast7d: 0`, that's the windows differing (30d vs 7d) — count-flavored movements existed in the last 30 days, all with |delta| ≤ 50 — not a divide-by-zero.

## Hard constraints honored

- ONE PR, one commit
- NO new severity values
- NO rollup pattern for shortages
- NO changes to detection criteria
- NO schema changes
- NO Phase 1C UI work touched

## Test plan

- [x] `npm run test:run` — 169 passed, 6 pre-existing `group-v2-payments.test.ts` failures (same Prisma-mock issue as main, unrelated)
- [x] `npx tsc --noEmit` — clean
- [x] `npx next lint --file src/lib/operations` — no warnings or errors
- [x] New unit tests, all green:
  - Severity tiering: `shortfall=1 → normal`, `shortfall=3 → high`, `shortfall=10 → urgent`, plus boundaries at 2 and 6
  - Volume cap: 30 mock variants in → exactly 15 recs out, in velocity order (v0…v14)
  - Divide-by-zero: `findMany` returns `[]` → `computeInventoryAccuracyPct()` returns `null`, not `100`

🤖 Generated with [Claude Code](https://claude.com/claude-code)