### PR TITLE
fix(seo): repair canonical tag cascade + drop orphan sitemap entries

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -991,27 +991,50 @@ interface BlogPostPageProps {
 
 export async function generateMetadata({ params }: BlogPostPageProps): Promise<Metadata> {
   const { slug } = await params
-  const post = blogPosts.find(p => p.slug === slug)
+  const canonicalUrl = `${seoConfig.siteUrl}/blog/${slug}`
+  const jsonPost = blogPosts.find(p => p.slug === slug)
 
-  if (!post) {
-    return { title: 'Post Not Found' }
+  if (jsonPost) {
+    return {
+      title: jsonPost.seo?.title || jsonPost.title,
+      description: jsonPost.seo?.description || jsonPost.excerpt,
+      keywords: jsonPost.seo?.keywords || jsonPost.tags,
+      alternates: { canonical: canonicalUrl },
+      openGraph: {
+        title: jsonPost.seo?.title || jsonPost.title,
+        description: jsonPost.seo?.description || jsonPost.excerpt,
+        url: canonicalUrl,
+        type: 'article',
+        publishedTime: jsonPost.publishedAt || jsonPost.date,
+        authors: [jsonPost.author],
+        images: jsonPost.image?.url ? [{ url: jsonPost.image.url, alt: jsonPost.image.alt }] : [],
+      },
+    }
+  }
+
+  const mdxPost = getMDXPost(slug)
+  if (mdxPost) {
+    return {
+      title: mdxPost.title,
+      description: mdxPost.excerpt,
+      keywords: [mdxPost.category, ...mdxPost.keywords].filter(Boolean),
+      alternates: { canonical: canonicalUrl },
+      openGraph: {
+        title: mdxPost.title,
+        description: mdxPost.excerpt,
+        url: canonicalUrl,
+        type: 'article',
+        publishedTime: mdxPost.date,
+        authors: [mdxPost.author],
+        images: mdxPost.image ? [{ url: mdxPost.image, alt: mdxPost.title }] : [],
+      },
+    }
   }
 
   return {
-    title: post.seo?.title || post.title,
-    description: post.seo?.description || post.excerpt,
-    keywords: post.seo?.keywords || post.tags,
-    alternates: {
-      canonical: `${seoConfig.siteUrl}/blog/${slug}`,
-    },
-    openGraph: {
-      title: post.seo?.title || post.title,
-      description: post.seo?.description || post.excerpt,
-      type: 'article',
-      publishedTime: post.publishedAt || post.date,
-      authors: [post.author],
-      images: post.image?.url ? [{ url: post.image.url, alt: post.image.alt }] : [],
-    },
+    title: 'Post Not Found',
+    alternates: { canonical: canonicalUrl },
+    robots: { index: false, follow: false },
   }
 }
 

--- a/src/app/blog/layout.tsx
+++ b/src/app/blog/layout.tsx
@@ -4,9 +4,10 @@ export const metadata: Metadata = {
   title: 'Austin Event Planning Blog - Cocktail Tips',
   description: 'Expert advice on event planning, cocktail recipes, party hosting, and alcohol selection. Tips for weddings, bachelorette parties, corporate events, and more in Austin.',
   keywords: 'event planning blog Austin, cocktail recipes, party planning tips, bachelorette party ideas, wedding alcohol planning, corporate event tips',
-  alternates: {
-    canonical: 'https://partyondelivery.com/blog',
-  },
+  // No alternates.canonical here. Per-post canonicals are set by
+  // generateMetadata in [slug]/page.tsx; the index page sets its own
+  // canonical in page.tsx. Setting it here cascades into child routes
+  // that miss a generateMetadata path and points them at /blog.
   openGraph: {
     title: 'Blog | Event Planning & Cocktail Tips | Party On Delivery',
     description: 'Expert advice on event planning, cocktail recipes, and party hosting in Austin.',

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,10 +1,16 @@
 import React from 'react'
 import Link from 'next/link'
+import type { Metadata } from 'next'
 import Navigation from "@/components/Navigation"
 import migratedPosts from '@/data/blog-posts/posts.json'
 import { getAllMDXPosts, mdxPostToLegacyFormat } from '@/lib/blog-mdx'
+import { seoConfig } from '@/lib/seo/config'
 import BlogPageClient from './BlogPageClient'
 import BlogSearchFilter from './BlogSearchFilter'
+
+export const metadata: Metadata = {
+  alternates: { canonical: `${seoConfig.siteUrl}/blog` },
+}
 
 interface BlogPost {
   slug: string;

--- a/src/app/delivery/[location]/layout.tsx
+++ b/src/app/delivery/[location]/layout.tsx
@@ -1,16 +1,16 @@
 import { Metadata } from 'next'
 
+// Layout-level fallback metadata only. Per-location title/description/
+// canonical are set by generateMetadata in page.tsx. Do NOT add
+// alternates.canonical here — it cascades to every /delivery/<slug>
+// and points them at /delivery-areas (the parent listing page).
 export const metadata: Metadata = {
   title: 'Alcohol Delivery | Party On Delivery Austin',
   description: 'Premium alcohol delivery in Austin, TX. Same-day and scheduled delivery of spirits, wine, beer, and cocktail ingredients to your neighborhood.',
   keywords: 'alcohol delivery Austin, liquor delivery, wine delivery, beer delivery, spirits delivery, same-day alcohol delivery',
-  alternates: {
-    canonical: '/delivery-areas',
-  },
   openGraph: {
     title: 'Alcohol Delivery | Party On Delivery Austin',
     description: 'Premium alcohol delivery in Austin. Same-day and scheduled delivery to your neighborhood.',
-    url: 'https://partyondelivery.com/delivery-areas',
     type: 'website',
   },
   robots: {

--- a/src/app/delivery/[location]/page.tsx
+++ b/src/app/delivery/[location]/page.tsx
@@ -2,8 +2,10 @@
 import React from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
+import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import Navigation from "@/components/Navigation"
+import { seoConfig } from '@/lib/seo/config'
 
 // Location data for Austin neighborhoods
 const locations: Record<string, {
@@ -73,6 +75,33 @@ const locations: Record<string, {
     deliveryFee: 30,
     minimum: 100,
     popularVenues: ['The Domain', 'Arboretum', 'Top Golf']
+  }
+}
+
+export async function generateMetadata(
+  { params }: { params: Promise<{ location: string }> }
+): Promise<Metadata> {
+  const { location } = await params
+  const data = locations[location]
+  const canonical = `${seoConfig.siteUrl}/delivery/${location}`
+
+  if (!data) {
+    return {
+      alternates: { canonical },
+      robots: { index: false, follow: false },
+    }
+  }
+
+  return {
+    title: `${data.title} | Party On Delivery`,
+    description: data.description,
+    alternates: { canonical },
+    openGraph: {
+      title: data.title,
+      description: data.description,
+      url: canonical,
+      type: 'website',
+    },
   }
 }
 

--- a/src/app/order/layout.tsx
+++ b/src/app/order/layout.tsx
@@ -10,9 +10,13 @@ export const metadata: Metadata = {
   title: 'Order | Party On Delivery - Your Bar, Delivered',
   description:
     'Your bar, delivered. Tap, add, party on. Fast alcohol delivery in Austin with one-tap ordering. Beer, wine, spirits, and cocktail kits delivered to your door.',
+  alternates: {
+    canonical: '/order',
+  },
   openGraph: {
     title: 'Your Bar, Delivered | Party On Delivery',
     description: 'Tap. Add. Party On. Fast alcohol delivery in Austin.',
+    url: 'https://partyondelivery.com/order',
     type: 'website',
   },
 };

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -53,15 +53,20 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   // Fetch dynamic data
   const products = await getProducts();
 
-  // Static pages (excluding /account pages blocked by robots.txt)
+  // Static pages (excluding /account pages blocked by robots.txt).
+  // Routes that intentionally canonicalize to another URL are not
+  // listed here — including a URL in the sitemap while its canonical
+  // points elsewhere is flagged as "Incorrect pages found in
+  // sitemap.xml" by site-audit tools and confuses Google:
+  //   - /plan-event       canonicalizes to /order
+  //   - /austin-partners  canonicalizes to /partners
+  //   - /blogs/news       has no page; canonical resolves to /
   const staticPages = [
     '',
     '/about',
     '/contact',
     '/order',
-    '/plan-event',
     '/blog',
-    '/blogs/news',
     '/weddings',
     '/boat-parties',
     '/bach-parties',
@@ -70,8 +75,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     '/terms',
     '/privacy',
     '/faqs',
-    '/partners',
-    '/austin-partners'
+    '/partners'
   ].map(route => ({
     url: `${baseUrl}${route}`,
     lastModified: new Date('2026-03-27'),


### PR DESCRIPTION
## Summary

SEMrush flagged **135 \"Incorrect pages found in sitemap.xml\"** in the 2026-05-13 site audit. The previous SEO sprint session (PRs #45 / #46) ruled out HTTP-status issues (0/650 non-200s) and left a handoff note: drill into per-URL detail before writing code.

The Cowork SEMrush snapshot only captures summary counts, so I ran my own audit instead — probed every one of the 650 live sitemap URLs for canonical + robots tags. Result: **143 URLs emit a `<link rel=\"canonical\">` pointing to a different URL than the page itself**, which is what SEMrush's flag covers (close enough to 135; gap likely SEMrush sampling).

**The bug was in canonical generation, not the sitemap.** Removing those 143 URLs from the sitemap would have been a band-aid — Google would still de-index them based on the canonical tag.

## Root causes

| Count | URL pattern | Wrong canonical | Source |
|------:|-------------|-----------------|--------|
| 133 | `/blog/<mdx-slug>` | `/blog` | `blog/[slug]/page.tsx` `generateMetadata` only looked up JSON posts; MDX posts returned `{ title: 'Post Not Found' }` with no alternates → `blog/layout.tsx` `canonical: '/blog'` cascaded through |
| 6 | `/delivery/<slug>` | `/delivery-areas` | `delivery/[location]/layout.tsx` hardcoded `canonical: '/delivery-areas'`; the page had no `generateMetadata` to override |
| 1 | `/order` | `/` | `order/layout.tsx` had no `alternates.canonical`; root layout's `/` leaked through |
| 1 | `/plan-event` | `/order` | Intentional; remove from sitemap |
| 1 | `/austin-partners` | `/partners` | Intentional; remove from sitemap |
| 1 | `/blogs/news` | `/` | Orphan (no page at this URL); remove from sitemap |

The 133 MDX blog posts in particular have been telling Google \"I am not canonical — see `/blog`\" for an unknown stretch of time. This is a plausible large contributor to the SEMrush -21% visibility WoW signal that GSC partially denied (PR #45 / Task 1).

## Changes

- **`src/app/blog/[slug]/page.tsx`** — `generateMetadata` now falls back to `getMDXPost(slug)` and emits a per-post canonical, title, description, and openGraph for MDX posts. The not-found path also pins a canonical so a future regression can't silently leak the layout's value.
- **`src/app/blog/layout.tsx`** — drop `alternates.canonical: '/blog'`. Per-post canonicals are now set by `generateMetadata`; the index page sets its own canonical via `metadata` export.
- **`src/app/blog/page.tsx`** — add `metadata.alternates.canonical = '/blog'` so the index page keeps its self-canonical after the layout change.
- **`src/app/delivery/[location]/layout.tsx`** — drop `alternates.canonical: '/delivery-areas'`. The fallback metadata stays.
- **`src/app/delivery/[location]/page.tsx`** — add `generateMetadata` that builds a per-location canonical from the slug param.
- **`src/app/order/layout.tsx`** — add `alternates.canonical: '/order'`.
- **`src/app/sitemap.ts`** — drop `/plan-event`, `/austin-partners`, `/blogs/news` from `staticPages`. Their canonicals legitimately point elsewhere (or no page exists); honor the canonical signal by not sitemapping them. Added a comment explaining the rule.

## Test plan

- [x] `npx tsc --noEmit` — my files clean (pre-existing errors unchanged: `@microsoft/clarity` types, Stripe types, one test)
- [x] `npx next lint` on the 7 changed files — no warnings or errors
- [ ] **Vercel preview canonical sweep** — re-run the 650-URL audit against the preview URL; expect mismatch count to drop from 143 to ≤ 3
- [ ] Spot-check 4 URLs on the preview:
  - `/blog/austin-elopement-ideas-minimalist` (MDX) → canonical = self
  - `/blog/austin-elopement-ideas-for-minimalist-couples` (MDX) → canonical = self
  - `/delivery/downtown-austin` → canonical = self
  - `/order` → canonical = self
- [ ] After merge: wait for next SEMrush weekly snapshot; \"Incorrect pages found in sitemap.xml\" should drop to ≤ 10.

## Refs

Third PR in the SEO sprint, completing Phase B alongside #45 (4xx URLs) and #46 (broken images). Parent plan: `~/.claude/plans/seo-improvements-2026-05-14.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)