### PR TITLE
feat(dashboard): custom hero band + strikethrough title (Ashley's birthday)

### DIFF
--- a/scripts/ops/create-ashley-birthday.mjs
+++ b/scripts/ops/create-ashley-birthday.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * One-off: create Ashley's 38th-→-21st birthday boat-party dashboard.
+ *
+ * Single tab, BOAT context, fixed delivery details supplied by ops:
+ *   Date:    Sunday, May 17, 2026
+ *   Time:    3:30 PM – 7:30 PM
+ *   Marina:  13993 FM 2769, Leander, TX 78641 (Anderson Mill Marina)
+ *
+ * Name is stored with `~~38th~~` markup so the dashboard renders the
+ * strikethrough joke. `parseTitleMarkup` in src/lib/dashboard handles it.
+ *
+ * Usage:
+ *   node scripts/ops/create-ashley-birthday.mjs --email ashley@example.com --phone +15125551234
+ *
+ * After running, paste the printed shareCode into customDashboardThemes
+ * in src/lib/dashboard/custom-themes.ts (replace the ASHLEY key).
+ */
+import { PrismaClient } from '@prisma/client';
+import { randomBytes, randomInt } from 'crypto';
+
+const prisma = new PrismaClient();
+
+const DASHBOARD_NAME = "Ashley's ~~38th~~ 21st Birthday Boat Party";
+const HOST_NAME = 'Ashley';
+
+const MARINA_ADDRESS = {
+  address1: '13993 Farm to Market Rd 2769',
+  city: 'Leander',
+  province: 'TX',
+  zip: '78641',
+  country: 'US',
+};
+
+// Delivery: Sun May 17, 2026, 3:30 PM Central Time = 20:30 UTC (CDT, UTC-5)
+const DELIVERY_DATE_UTC = new Date('2026-05-17T20:30:00Z');
+const DELIVERY_TIME_LABEL = '3:30 PM - 7:30 PM';
+const TAB_NAME = 'Boat Party';
+const DELIVERY_FEE = 65;
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith('--')) continue;
+    const key = a.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      args[key] = true;
+    } else {
+      args[key] = next;
+      i++;
+    }
+  }
+  return args;
+}
+
+function generateShareCode() {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  let code = '';
+  for (let i = 0; i < 6; i++) code += chars[randomInt(0, chars.length)];
+  return code;
+}
+
+async function uniqueShareCode() {
+  for (let i = 0; i < 10; i++) {
+    const code = generateShareCode();
+    const existing = await prisma.groupOrderV2.findUnique({ where: { shareCode: code } });
+    if (!existing) return code;
+  }
+  throw new Error('Could not generate unique share code after 10 tries');
+}
+
+function computeOrderDeadline(deliveryDate) {
+  const d = new Date(deliveryDate);
+  d.setUTCHours(d.getUTCHours() - 4);
+  return d;
+}
+
+function defaultExpiresAt() {
+  const d = new Date();
+  d.setDate(d.getDate() + 90);
+  return d;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+
+  const shareCode = await uniqueShareCode();
+  const hostClaimToken = randomBytes(24).toString('hex');
+
+  const group = await prisma.groupOrderV2.create({
+    data: {
+      name: DASHBOARD_NAME,
+      hostName: HOST_NAME,
+      hostEmail: args.email || null,
+      hostPhone: args.phone || null,
+      shareCode,
+      hostClaimToken,
+      partyType: 'BOAT',
+      source: 'DIRECT',
+      isLastMinute: true,
+      expiresAt: defaultExpiresAt(),
+      tabs: {
+        create: [
+          {
+            name: TAB_NAME,
+            position: 0,
+            deliveryDate: DELIVERY_DATE_UTC,
+            deliveryTime: DELIVERY_TIME_LABEL,
+            deliveryAddress: MARINA_ADDRESS,
+            orderDeadline: computeOrderDeadline(DELIVERY_DATE_UTC),
+            deliveryFee: DELIVERY_FEE,
+            deliveryContextType: 'BOAT',
+          },
+        ],
+      },
+    },
+    select: { id: true, shareCode: true },
+  });
+
+  const dashboardUrl = `https://partyondelivery.com/dashboard/${group.shareCode}`;
+  const hostClaimUrl = `${dashboardUrl}?claim=${hostClaimToken}`;
+
+  console.log('\nCreated Ashley\'s birthday boat dashboard:');
+  console.log(`  shareCode:     ${group.shareCode}`);
+  console.log(`  dashboardUrl:  ${dashboardUrl}`);
+  console.log(`  hostClaimUrl:  ${hostClaimUrl}`);
+  console.log('\nNext steps:');
+  console.log(`  1. Replace the ASHLEY key in src/lib/dashboard/custom-themes.ts with "${group.shareCode}".`);
+  console.log('  2. Save Ashley\'s photo to /public/images/dashboards/ashley-birthday.webp.');
+  console.log(`  3. Open ${dashboardUrl} to verify.\n`);
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/app/dashboard/[code]/page.tsx
+++ b/src/app/dashboard/[code]/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo, useCallback, useRef, type ReactElement } 
 import { useParams, useSearchParams, useRouter } from 'next/navigation';
 import { useGroupOrderV2 } from '@/lib/group-orders-v2/hooks';
 import DashboardHeader from '@/components/dashboard/DashboardHeader';
+import DashboardCustomHero from '@/components/dashboard/DashboardCustomHero';
 import DeliveryHeroSection from '@/components/dashboard/DeliveryHeroSection';
 import OnboardingPopup from '@/components/dashboard/OnboardingPopup';
 import OrderSidebar from '@/components/dashboard/OrderSidebar';
@@ -23,6 +24,7 @@ import PromoCodeInput from '@/components/dashboard/PromoCodeInput';
 import PremierPerksBanner from '@/components/dashboard/PremierPerksBanner';
 import { OnboardingTourProvider, DashboardTour } from '@/components/dashboard/tour';
 import { getHiddenProductIds } from '@/lib/affiliates/product-exclusions';
+import { getCustomDashboardTheme } from '@/lib/dashboard/custom-themes';
 
 const CONFETTI_COLORS = ['#003087', '#FFD700', '#FF6B35', '#00B4D8', '#FF1493'];
 
@@ -115,6 +117,13 @@ export default function DashboardPage(): ReactElement {
   // Restore applied promo from localStorage
   useEffect(() => {
     if (!code) return;
+    // Private custom-themed dashboards never carry an applied promo —
+    // clear any stale entry that was set by a prior visit before this guard existed.
+    if (getCustomDashboardTheme(code)) {
+      localStorage.removeItem(`${PROMO_KEY_PREFIX}${code}`);
+      setAppliedPromo(null);
+      return;
+    }
     try {
       const stored = localStorage.getItem(`${PROMO_KEY_PREFIX}${code}`);
       if (stored) {
@@ -134,6 +143,8 @@ export default function DashboardPage(): ReactElement {
   // Auto-load affiliate from cookie (with confetti on first apply)
   useEffect(() => {
     if (!code || !participantId) return;
+    // Skip auto-attribution for private custom-themed dashboards (e.g. Ashley's birthday)
+    if (getCustomDashboardTheme(code)) return;
     // Skip if promo already applied
     const stored = localStorage.getItem(`${PROMO_KEY_PREFIX}${code}`);
     if (stored) return;
@@ -163,6 +174,8 @@ export default function DashboardPage(): ReactElement {
   // Fallback: auto-apply affiliate promo from groupOrder data (no cookie needed)
   useEffect(() => {
     if (!code || !participantId || !groupOrder) return;
+    // Skip auto-attribution for private custom-themed dashboards (e.g. Ashley's birthday)
+    if (getCustomDashboardTheme(code)) return;
     // Skip if promo already applied
     const stored = localStorage.getItem(`${PROMO_KEY_PREFIX}${code}`);
     if (stored) return;
@@ -386,6 +399,7 @@ export default function DashboardPage(): ReactElement {
     checkoutMode === 'all' ? tab.draftItems : myDraftItems;
 
   const currentIsHost = !!groupOrder.participants.find(p => p.id === participantId)?.isHost;
+  const customTheme = getCustomDashboardTheme(groupOrder.shareCode);
 
   // Compute effective promo per-tab: boat tabs get free delivery unconditionally,
   // other tabs need to meet the minimum order amount
@@ -409,6 +423,9 @@ export default function DashboardPage(): ReactElement {
         hasPartyType={!!groupOrder.partyType}
         shareCode={code}
       />
+      {customTheme && (
+        <DashboardCustomHero groupOrder={groupOrder} theme={customTheme} />
+      )}
       <DashboardHeader
         groupOrder={groupOrder}
         participantId={participantId}

--- a/src/components/dashboard/DashboardCustomHero.tsx
+++ b/src/components/dashboard/DashboardCustomHero.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import Image from 'next/image';
+import type { ReactElement } from 'react';
+import type { GroupOrderV2Full } from '@/lib/group-orders-v2/types';
+import type { CustomDashboardTheme } from '@/lib/dashboard/custom-themes';
+import { parseTitleMarkup } from '@/lib/dashboard/parse-title-markup';
+
+interface Props {
+  groupOrder: GroupOrderV2Full;
+  theme: CustomDashboardTheme;
+}
+
+function formatDeliveryDate(date: Date): string {
+  return date.toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'America/Chicago',
+  });
+}
+
+export default function DashboardCustomHero({ groupOrder, theme }: Props): ReactElement {
+  const firstTab = groupOrder.tabs[0];
+  const deliveryDate = firstTab ? formatDeliveryDate(new Date(firstTab.deliveryDate)) : null;
+  const deliveryTime = firstTab?.deliveryTime ?? null;
+  const cityState = firstTab
+    ? `${firstTab.deliveryAddress.city}, ${firstTab.deliveryAddress.province}`
+    : null;
+
+  const titleNodes = parseTitleMarkup(groupOrder.name);
+
+  return (
+    <section className="relative h-[50vh] md:h-[55vh] overflow-hidden">
+      <Image
+        src={theme.heroImageUrl}
+        alt={theme.heroAlt}
+        fill
+        priority
+        sizes="100vw"
+        className="object-cover"
+      />
+      <div className="absolute inset-0 bg-gradient-to-b from-gray-900/40 via-gray-900/20 to-gray-900/80" />
+
+      <div className="relative h-full flex flex-col items-center justify-end text-center text-white px-4 pb-10 md:pb-14 z-10">
+        {theme.eyebrow && (
+          <p className="text-sm md:text-base font-semibold tracking-[0.18em] uppercase text-white/90 mb-3 drop-shadow">
+            {theme.eyebrow}
+          </p>
+        )}
+
+        <h1 className="font-heading font-bold tracking-[0.04em] text-3xl sm:text-4xl md:text-6xl lg:text-7xl leading-tight max-w-5xl drop-shadow-lg">
+          {titleNodes}
+        </h1>
+
+        {(deliveryDate || deliveryTime || cityState) && (
+          <div className="mt-5 flex flex-wrap items-center justify-center gap-x-5 gap-y-1.5 text-sm md:text-base text-white/95 font-medium drop-shadow">
+            {deliveryDate && (
+              <span className="inline-flex items-center gap-1.5">
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+                {deliveryDate}
+              </span>
+            )}
+            {deliveryTime && (
+              <span className="inline-flex items-center gap-1.5">
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                {deliveryTime}
+              </span>
+            )}
+            {cityState && (
+              <span className="inline-flex items-center gap-1.5">
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a2 2 0 01-2.827 0L6.343 16.657A8 8 0 1117.657 16.657z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+                {cityState}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import type { GroupOrderV2Full } from '@/lib/group-orders-v2/types';
 import { updateGroupOrderV2 } from '@/lib/group-orders-v2/api-client';
+import { parseTitleMarkup } from '@/lib/dashboard/parse-title-markup';
 import ParticipantPanel from './ParticipantPanel';
 
 interface Props {
@@ -123,7 +124,7 @@ export default function DashboardHeader({
                 className="group flex items-center gap-2 cursor-pointer hover:opacity-80 min-w-0"
               >
                 <h1 className="text-xl md:text-3xl font-heading font-bold tracking-[0.06em] text-gray-900 truncate">
-                  {displayName}
+                  {parseTitleMarkup(displayName)}
                 </h1>
                 <svg className="w-4 h-4 text-gray-400 group-hover:text-brand-blue transition-colors flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />

--- a/src/lib/dashboard/custom-themes.ts
+++ b/src/lib/dashboard/custom-themes.ts
@@ -1,0 +1,29 @@
+/**
+ * One-off custom themes for specific GroupOrderV2 dashboards.
+ *
+ * Keyed by shareCode. If a dashboard's shareCode is in this map, a tall
+ * branded hero band is rendered at the top of the page. Otherwise the
+ * dashboard renders normally.
+ *
+ * To remove a theme (after the party): just delete the entry.
+ */
+export interface CustomDashboardTheme {
+  heroImageUrl: string;
+  heroAlt: string;
+  /** Optional short subtitle under the title (e.g. "Boat Party") */
+  eyebrow?: string;
+}
+
+export const customDashboardThemes: Record<string, CustomDashboardTheme> = {
+  // Ashley's birthday boat party — Sunday May 17, 2026
+  IHWM6B: {
+    heroImageUrl: '/images/dashboards/ashley-birthday.png',
+    heroAlt: "Ashley's birthday boat party",
+    eyebrow: 'Anderson Mill Marina · Sun, May 17',
+  },
+};
+
+export function getCustomDashboardTheme(shareCode: string | undefined): CustomDashboardTheme | null {
+  if (!shareCode) return null;
+  return customDashboardThemes[shareCode] ?? null;
+}

--- a/src/lib/dashboard/parse-title-markup.ts
+++ b/src/lib/dashboard/parse-title-markup.ts
@@ -1,0 +1,44 @@
+import type { ReactNode } from 'react';
+import { createElement, Fragment } from 'react';
+
+/**
+ * Parses a dashboard title for `~~strikethrough~~` markup and returns a list
+ * of ReactNodes — plain text segments interleaved with `<span class="line-through">`
+ * segments. Used for the "Ashley's ~~38th~~ 21st Birthday" joke pattern.
+ *
+ * Input/output examples:
+ *   "Plain title"             → ["Plain title"]
+ *   "Ashley's ~~38th~~ 21st"  → ["Ashley's ", <span>38th</span>, " 21st"]
+ *
+ * Unmatched `~~` are rendered as literal text — no fancy recovery, just safe.
+ */
+export function parseTitleMarkup(input: string): ReactNode[] {
+  if (!input) return [input];
+
+  const segments: ReactNode[] = [];
+  const regex = /~~([^~]+)~~/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  let key = 0;
+
+  while ((match = regex.exec(input)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push(input.slice(lastIndex, match.index));
+    }
+    segments.push(
+      createElement(
+        'span',
+        { key: `s${key++}`, className: 'line-through opacity-70 decoration-[0.12em]' },
+        match[1]
+      )
+    );
+    lastIndex = regex.lastIndex;
+  }
+
+  if (lastIndex < input.length) {
+    segments.push(input.slice(lastIndex));
+  }
+
+  // Wrap in a fragment-friendly array; callers can render directly.
+  return segments.length > 0 ? segments : [createElement(Fragment, null, input)];
+}


### PR DESCRIPTION
## Summary
- One-off custom theming for Ashley's birthday boat-party dashboard (shareCode `IHWM6B`).
- Adds a tiny reusable mechanism so future private dashboards can opt into a hero band + `~~strikethrough~~` title with a single map entry — no schema changes.
- Skips affiliate auto-attribution and clears stale localStorage promos on private dashboards.

## What's in the PR
- `src/lib/dashboard/parse-title-markup.ts` — turns `~~38th~~` into `<span class="line-through">38th</span>`.
- `src/lib/dashboard/custom-themes.ts` — `shareCode → { heroImageUrl, heroAlt, eyebrow? }` registry. Currently maps `IHWM6B → ashley-birthday.png`.
- `src/components/dashboard/DashboardCustomHero.tsx` — 50vh hero band with image + dark overlay + parsed title + date/time/city pills.
- `src/app/dashboard/[code]/page.tsx` — renders the custom hero above the sticky header when the shareCode is in the theme map; skips affiliate auto-apply and clears any stale promo on those dashboards.
- `src/components/dashboard/DashboardHeader.tsx` — runs `displayName` through the markup parser so the sticky title also shows the strikethrough.
- `scripts/ops/create-ashley-birthday.mjs` — one-off creation script. Already run; the row is live.
- `public/images/dashboards/ashley-birthday.png` — hero photo.

## Removal path
After the party, delete the `IHWM6B` entry from `custom-themes.ts` and the dashboard reverts to the standard layout. The parser stays harmless (no-op on titles without `~~`).

## Test plan
- [ ] Visit `/dashboard/IHWM6B` — hero band shows Ashley's photo, title reads "Ashley's ~~38th~~ 21st Birthday Boat Party" with `38th` struck through.
- [ ] Sticky header (after scroll) also renders the strikethrough.
- [ ] No "Free Delivery (via Inn Cahoots)" or other affiliate promo auto-applied.
- [ ] Last-minute menu only (cocktail kits, etc.).
- [ ] Visit any other dashboard share code — no hero, normal layout, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)