### PR TITLE
fix(seo): align FAQ schema with visible page content (weddings, boat-parties)

### DIFF
--- a/src/components/seo/BoatPartiesSchemas.tsx
+++ b/src/components/seo/BoatPartiesSchemas.tsx
@@ -6,27 +6,34 @@ import { generateFAQSchema, generateEventSchema } from '@/lib/seo/schemas';
  * are in initial HTML for search engine crawlers
  */
 export default function BoatPartiesSchemas() {
-  // FAQ Data for Schema
+  // FAQ Data for Schema — these Q&A pairs match the visible content
+  // in the "Frequently Asked Questions" section of src/app/boat-parties/page.tsx.
+  // Google requires FAQ schema to mirror visible page content; otherwise
+  // the entire page can be disqualified from rich results.
   const faqs = [
     {
-      question: "Can you deliver to our boat at the marina?",
-      answer: "Yes! We deliver to all Lake Travis marinas and can coordinate with your rental company. Just provide the dock number and boat name when ordering."
+      question: "Dock vs. boat delivery?",
+      answer: "Both—we do slip handoffs or boat delivery to your anchored location."
     },
     {
-      question: "How do we handle drinks in the Texas heat?",
-      answer: "All deliveries include insulated coolers and ice packs. For longer trips, add our Ice Replenishment service ($49) for a second cooler delivery mid-day."
+      question: "How far ahead to book?",
+      answer: "72 hours recommended; peak lake weekends fill fast."
     },
     {
-      question: "What's the minimum order for Lake Travis delivery?",
-      answer: "Lake Travis deliveries have a $200 minimum due to distance. Most boat parties order $300-500 worth for 8-12 people."
+      question: "Can you provide a bartender?",
+      answer: "Yes for premium/yacht events via TABC-certified partners."
     },
     {
-      question: "Can you deliver to Devil's Cove?",
-      answer: "We deliver to marinas only, not open water. Most groups get delivery at the marina before departure or arrange a mid-day dock meetup."
+      question: "Glassware on the lake?",
+      answer: "Boat-safe options available; disposables recommended for safety."
     },
     {
-      question: "What if our boat rental gets canceled?",
-      answer: "Cancel or modify your delivery up to 24 hours before your scheduled time for a full refund. We understand weather happens on the lake!"
+      question: "Only need ice & cans?",
+      answer: "Use Order Now → Lake Day Essentials for quick delivery."
+    },
+    {
+      question: "Are you insured/licensed?",
+      answer: "Yes, fully insured and licensed for marine delivery."
     }
   ];
 

--- a/src/components/seo/WeddingsSchemas.tsx
+++ b/src/components/seo/WeddingsSchemas.tsx
@@ -6,27 +6,34 @@ import { generateFAQSchema, generateEventSchema } from '@/lib/seo/schemas';
  * are in initial HTML for search engine crawlers
  */
 export default function WeddingsSchemas() {
-  // FAQ Data for Schema
+  // FAQ Data for Schema — these Q&A pairs match the visible content
+  // in the "Frequently Asked Questions" section of src/app/weddings/page.tsx.
+  // Google requires FAQ schema to mirror visible page content; otherwise
+  // the entire page can be disqualified from rich results.
   const faqs = [
     {
-      question: "Can you provide bartenders for our wedding?",
-      answer: "Yes! All our bartenders are TABC-certified and experienced with weddings. Packages start at $250 for 4 hours and include setup, service, and cleanup."
-    },
-    {
-      question: "Do you handle champagne service for toasts?",
-      answer: "Absolutely. We coordinate champagne service timing with your wedding planner or venue coordinator to ensure perfect toast moments."
-    },
-    {
-      question: "What's included in a signature cocktail package?",
-      answer: "Our signature cocktail packages include custom recipe development, all ingredients, garnishes, specialty glassware, and a dedicated bartender to make them."
+      question: "Do you provide bartenders?",
+      answer: "Yes, via vetted TABC-certified partners for full-service packages."
     },
     {
       question: "How far in advance should we book?",
-      answer: "We recommend booking 2-3 months in advance for peak wedding season (April-October). For off-season weddings, 4-6 weeks is usually sufficient."
+      answer: "72 hours minimum recommended; peak wedding dates fill fast."
     },
     {
-      question: "Can you accommodate dietary restrictions?",
-      answer: "Yes! We offer non-alcoholic signature mocktails, low-sugar options, and can work with specific dietary requirements. Just let us know during planning."
+      question: "Do you deliver to Lake Travis/Hill Country venues?",
+      answer: "Yes, we specialize in Austin, Hill Country, and Lake Travis locations."
+    },
+    {
+      question: "What about glassware & equipment?",
+      answer: "Included with full-service packages; disposable upgrades available for delivery-only."
+    },
+    {
+      question: "Are you licensed & insured?",
+      answer: "Yes, fully licensed and insured for events."
+    },
+    {
+      question: "Already have a bartender?",
+      answer: "Perfect! Use our Delivery-Only option for curated alcohol delivery."
     }
   ];
 


### PR DESCRIPTION
## Summary

Task 10 of `seo-improvements-2026-05-14`: add `FAQPage` JSON-LD to top service pages. **Audit found the original problem was the opposite of what we expected.**

`/weddings` and `/boat-parties` already had FAQ schema attached — but the Q&A in the schema **didn't match the visible Q&A on the page**. Google explicitly disqualifies a page from rich results when structured data diverges from visible content, and can flag the site as misleading, so the existing schemas were actively hurting SEO instead of helping.

Examples of the divergence on `/weddings`:
- Schema claimed *"Packages start at $250 for 4 hours and include setup, service, and cleanup"* — no such pricing claim appears anywhere on the page.
- Schema invented an entire *"Can you accommodate dietary restrictions?"* Q&A — not on the page.

Same pattern on `/boat-parties` (Devil's Cove, $200 minimum, 24-hour cancellation — none of those answers appear in the visible FAQ section).

## Changes

Two files, mechanical — only the FAQ arrays inside two server-side schema components:

- **`src/components/seo/WeddingsSchemas.tsx`** — replace the 5 invented Q&A with the 6 verbatim Q&A from the `/weddings` "Frequently Asked Questions" section (page.tsx lines 631–695).
- **`src/components/seo/BoatPartiesSchemas.tsx`** — replace the 5 invented Q&A with the 6 verbatim Q&A from the `/boat-parties` FAQ section (page.tsx lines 512–571).

No user-visible page content changed.

## Pages NOT changed (verified already correct)

| Page | Status |
|------|--------|
| `/` | `page.tsx` defines `homepageFAQs` inline; already matches the visible FAQ |
| `/bach-parties` | `BachPartiesSchemas` Q&A already matches `page.tsx` lines 645–681 verbatim |

## Pages excluded from Task 10

| Page | Why |
|------|-----|
| `/order` | Client-side redirect to `/dashboard/[code]` — no FAQ content on the page, nothing to attach `FAQPage` schema to |

## Test plan

- [x] `npx tsc --noEmit` — my files clean (pre-existing errors unchanged)
- [x] `npx next lint` on changed files — no warnings or errors
- [ ] **Vercel preview validation** — once preview builds, fetch `/weddings` and `/boat-parties`, extract the FAQ JSON-LD, and confirm:
  - The `mainEntity` array has the 6 Q&A pairs from the visible page
  - Every `Question.name` appears as a visible `<h3>` on the page
  - Every `Answer.text` appears as a visible `<p>` on the page
- [ ] Post-merge: run the URLs through https://search.google.com/test/rich-results to confirm FAQ rich results are eligible.

## Refs

Completes Phase D Task 10 of the SEO sprint. Phase B Task 6 (canonical-tag cascade fix) shipped in #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)