### PR TITLE
fix(seo): add 4 /austin-*-delivery landing pages to sitemap

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -83,6 +83,20 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: route === '' ? 1 : route === '/order' ? 0.9 : 0.8
   }))
 
+  // /austin-*-delivery conversion-oriented landing pages (added 2026-05-06).
+  // Priority 0.9 to match /order — these are commercial-intent destinations.
+  const austinDeliveryLandingPages = [
+    '/austin-bachelor-party-delivery',
+    '/austin-bachelorette-party-delivery',
+    '/austin-corporate-event-delivery',
+    '/austin-wedding-weekend-delivery',
+  ].map(route => ({
+    url: `${baseUrl}${route}`,
+    lastModified: new Date('2026-05-06'),
+    changeFrequency: 'weekly' as const,
+    priority: 0.9
+  }))
+
   // Product pages (dynamic) - filter out test products
   const productPages = products
     .filter(product => !product.handle.includes('test'))
@@ -148,6 +162,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   return [
     ...staticPages,
+    ...austinDeliveryLandingPages,
     ...productPages,
     ...locationPages,
     ...jsonBlogPosts,


### PR DESCRIPTION
## Summary

The 4 commercial-intent landing pages that shipped on 2026-05-06 (commit 4b30576a) are live, indexable, and self-canonical — but missing from the sitemap and not linked from the main nav or footer. Google currently has no standard discovery path to them.

This PR fixes the sitemap gap. The nav/footer question is surfaced separately for your decision (see below).

## Audit findings

| URL | HTTP | Robots | Canonical | In sitemap? | In nav/footer? |
|-----|:----:|--------|-----------|:-----------:|:---:|
| `/austin-bachelor-party-delivery` | 200 | index,follow | self ✓ | **❌** | ❌ |
| `/austin-bachelorette-party-delivery` | 200 | index,follow | self ✓ | **❌** | ❌ |
| `/austin-corporate-event-delivery` | 200 | index,follow | self ✓ | **❌** | ❌ |
| `/austin-wedding-weekend-delivery` | 200 | index,follow | self ✓ | **❌** | ❌ |

References across `src/`: only internal tooling (the noindex `/landing-pages` preview directory, the `/landing-page-playbook` admin doc, lead-magnet configs). Zero links from `Navigation.tsx` or the homepage footer.

## What this PR changes

`src/app/sitemap.ts` — adds a new `austinDeliveryLandingPages` array with priority 0.9 (matching `/order` since these are conversion destinations) and `lastModified: 2026-05-06` (the commit date). Spread into the final sitemap output between `staticPages` and `productPages`.

After this merges, the sitemap will include all 4 URLs and Google's standard crawl path will pick them up.

## What this PR does NOT do (your call)

**Nav and footer still don't link to these pages.** Adding them is a UX decision, not pure SEO — affects every page on the site. Options for follow-up:

1. **Add to the main nav dropdown.** Discoverable for users, strongest crawl signal. Might bloat a small nav bar.
2. **Add to the footer "Services" column.** Common pattern for landing pages — visible everywhere without bloating nav.
3. **Leave as-is — rely on sitemap + the BlogTopicCTA from [PR #53](https://github.com/allan-cmyk/PartyOn2/pull/53) for discoverability.** Simplest, but no header/footer presence.

Surfacing — not auto-deciding because it's a header/footer UX change that affects every page.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx next lint` clean
- [ ] Vercel preview: `curl -sL <preview>/sitemap.xml | grep austin-bachelor-party-delivery` → 1 match
- [ ] Full sitemap URL count drops from 647 → 651 (4 new entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)