### PR TITLE
feat(nav): repoint Services dropdown to /austin-*-delivery landing pages

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -132,10 +132,11 @@ export default function Navigation({
   }
 
   const services = [
-    { href: '/weddings', label: 'WEDDINGS' },
+    { href: '/austin-wedding-weekend-delivery', label: 'WEDDINGS' },
+    { href: '/austin-bachelor-party-delivery', label: 'BACHELOR PARTIES' },
+    { href: '/austin-bachelorette-party-delivery', label: 'BACHELORETTE PARTIES' },
     { href: '/boat-parties', label: 'BOAT PARTIES' },
-    { href: '/bach-parties', label: 'CELEBRATIONS' },
-    { href: '/corporate', label: 'CORPORATE' },
+    { href: '/austin-corporate-event-delivery', label: 'CORPORATE' },
     { href: '/kegs', label: 'KEG DELIVERY' },
     { href: '/cocktail-kits', label: 'COCKTAIL KITS' },
   ];
@@ -186,7 +187,7 @@ export default function Navigation({
 
                 {/* Dropdown Menu */}
                 <div
-                  className={`absolute top-full left-0 mt-2 w-48 bg-white rounded-lg shadow-lg border border-gray-200 transition-all duration-200 ${
+                  className={`absolute top-full left-0 mt-2 w-60 bg-white rounded-lg shadow-lg border border-gray-200 transition-all duration-200 ${
                     isServicesOpen ? 'opacity-100 translate-y-0 visible' : 'opacity-0 -translate-y-2 invisible'
                   }`}
                   onMouseEnter={() => setIsServicesOpen(true)}


### PR DESCRIPTION
## Summary

Adds the 4 commercial-intent landing pages to the main nav so they have a discoverable user-facing path, not just sitemap discoverability (PR #55) and blog CTAs (PR #53).

## Changes to the Services dropdown

**Before** (6 items):
- WEDDINGS → `/weddings`
- BOAT PARTIES → `/boat-parties`
- CELEBRATIONS → `/bach-parties`
- CORPORATE → `/corporate`
- KEG DELIVERY → `/kegs`
- COCKTAIL KITS → `/cocktail-kits`

**After** (7 items):
- WEDDINGS → `/austin-wedding-weekend-delivery` *(href changed, label kept)*
- BACHELOR PARTIES → `/austin-bachelor-party-delivery` *(new)*
- BACHELORETTE PARTIES → `/austin-bachelorette-party-delivery` *(new)*
- BOAT PARTIES → `/boat-parties` *(unchanged — no `/austin-boat-party-delivery` landing exists)*
- CORPORATE → `/austin-corporate-event-delivery` *(href changed, label kept)*
- KEG DELIVERY → `/kegs` *(unchanged)*
- COCKTAIL KITS → `/cocktail-kits` *(unchanged)*

The single CELEBRATIONS entry was split into two so both new landing pages get explicit nav exposure.

Dropdown width bumped `w-48` → `w-60` so "BACHELORETTE PARTIES" doesn't wrap.

## Implementation notes

- Both desktop and mobile menus iterate the same `services` array, so one edit covers both surfaces.
- The old service pages (`/weddings`, `/bach-parties`, `/corporate`) remain live — this PR just stops sending nav traffic to them. They still get traffic from external backlinks and blog body links.
- This is the cannibalization trade-off you accepted earlier: nav authority now flows to the new conversion-oriented landing pages instead of the older service pages.

## Test plan

- [x] `npx tsc --noEmit` clean for Navigation.tsx
- [x] `npx next lint` on Navigation.tsx — only a pre-existing `<img>` warning on line 321 (the logo, unrelated to this change)
- [ ] Vercel preview: hover the SERVICES dropdown and confirm the 7 items render with the right hrefs, no wrap on "BACHELORETTE PARTIES"
- [ ] Mobile menu: open the hamburger, confirm the SERVICES section shows the same 7 items

## Refs

Completes the nav/footer follow-up flagged in [#55](https://github.com/allan-cmyk/PartyOn2/pull/55). With this + #55 merged, the 4 landing pages have: sitemap inclusion, nav exposure, and blog CTAs (via [#53](https://github.com/allan-cmyk/PartyOn2/pull/53)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)