### PR TITLE
feat(operations): Monday briefing + health dashboard (Phase 1D for Ops Director)

### DIFF
--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -82,6 +82,12 @@ export default function DashboardPage(): ReactElement {
                 </button>
               ))}
               <Link
+                href="/admin/operations"
+                className="px-4 py-2 text-sm font-semibold rounded-md bg-white text-gray-700 border border-gray-300 hover:bg-gray-50 transition-colors inline-flex items-center gap-1.5"
+              >
+                Ops health
+              </Link>
+              <Link
                 href="/admin/recommendations"
                 className="px-4 py-2 text-sm font-semibold rounded-md bg-brand-blue text-white hover:bg-blue-700 transition-colors inline-flex items-center gap-1.5"
               >

--- a/src/app/admin/operations/_components/sparkline.tsx
+++ b/src/app/admin/operations/_components/sparkline.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+/**
+ * Inline SVG sparkline. Same math as the briefing email's sparkline but
+ * scoped to the dashboard's tone palette.
+ */
+
+import type { ReactElement } from 'react';
+
+const TONE_STROKE: Record<'good' | 'caution' | 'urgent' | 'neutral', string> = {
+  good: '#15803d',
+  caution: '#d97706',
+  urgent: '#dc2626',
+  neutral: '#374151',
+};
+
+export interface SparklineProps {
+  values: number[];
+  tone: 'good' | 'caution' | 'urgent' | 'neutral';
+}
+
+export function Sparkline({ values, tone }: SparklineProps): ReactElement | null {
+  if (!values.length) return null;
+  const W = 200;
+  const H = 36;
+  const PAD = 3;
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const xs = values.map((_, i) => PAD + (i * (W - 2 * PAD)) / (values.length - 1 || 1));
+  const ys = values.map((v) => H - PAD - ((v - min) / range) * (H - 2 * PAD));
+  const points = xs.map((x, i) => `${x.toFixed(1)},${ys[i].toFixed(1)}`).join(' ');
+  const lastX = xs[xs.length - 1];
+  const lastY = ys[ys.length - 1];
+  const stroke = TONE_STROKE[tone];
+  return (
+    <svg width="100%" height={H} viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" aria-hidden="true">
+      <polyline
+        fill="none"
+        stroke={stroke}
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        points={points}
+      />
+      <circle cx={lastX.toFixed(1)} cy={lastY.toFixed(1)} r="2.4" fill={stroke} />
+    </svg>
+  );
+}

--- a/src/app/admin/operations/page.tsx
+++ b/src/app/admin/operations/page.tsx
@@ -1,0 +1,286 @@
+'use client';
+
+/**
+ * Operations Director — health dashboard.
+ *
+ * One-page view: latest snapshot stats, drift trend, drift by signal, top
+ * urgent recs. Deep-links every actionable surface back to the unified
+ * triage queue at /admin/recommendations?domain=operations.
+ *
+ * See docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md §7 Phase 1D.
+ */
+
+import { useEffect, useState, type ReactElement } from 'react';
+import Link from 'next/link';
+import type {
+  DashboardData,
+  SnapshotSummary,
+} from '@/lib/operations/dashboard-data';
+import { SIGNAL_LABELS } from '@/lib/operations/dashboard-data';
+import type { SignalKind } from '@/lib/operations/types';
+import { Sparkline } from './_components/sparkline';
+
+type Tone = 'good' | 'caution' | 'urgent' | 'neutral';
+
+interface StatDef {
+  label: string;
+  value: string;
+  tone: Tone;
+  spark: number[];
+  hint?: string;
+}
+
+function tone(value: number | null, good: number, caution: number, lowerIsBetter = false): Tone {
+  if (value == null) return 'neutral';
+  if (lowerIsBetter) {
+    if (value <= good) return 'good';
+    if (value <= caution) return 'caution';
+    return 'urgent';
+  }
+  if (value >= good) return 'good';
+  if (value >= caution) return 'caution';
+  return 'urgent';
+}
+
+function buildStats(d: DashboardData): StatDef[] {
+  const s = d.latestSnapshot;
+  const history = d.history;
+  if (!s) return [];
+  const accuracySpark = history.map((h) => h.inventoryAccuracyPct ?? 0);
+  const coverageSpark = history.map((h) => h.costCoveragePct);
+  const driftSpark = history.map((h) => h.driftEventsTotal);
+  const urgentSpark = history.map((h) => h.urgentShortagesCount);
+  return [
+    {
+      label: 'Inventory accuracy (30d)',
+      value: s.inventoryAccuracyPct == null ? '—' : `${Math.round(s.inventoryAccuracyPct)}%`,
+      tone: tone(s.inventoryAccuracyPct, 85, 70),
+      spark: accuracySpark,
+      hint: 'Counts within ±50 units of zero / total counts',
+    },
+    {
+      label: 'Cost coverage',
+      value: `${Math.round(s.costCoveragePct)}%`,
+      tone: tone(s.costCoveragePct, 30, 15),
+      spark: coverageSpark,
+      hint: 'Variants with cost / variants sold (30d)',
+    },
+    {
+      label: 'Drift events (active)',
+      value: String(d.activeRecCounts.total),
+      tone: d.activeRecCounts.total === 0 ? 'good' : d.activeRecCounts.total >= 20 ? 'urgent' : 'caution',
+      spark: driftSpark,
+      hint: 'Open + approved recs across all signals',
+    },
+    {
+      label: 'Urgent shortages',
+      value: String(s.urgentShortagesCount),
+      tone: s.urgentShortagesCount === 0 ? 'good' : s.urgentShortagesCount >= 5 ? 'urgent' : 'caution',
+      spark: urgentSpark,
+      hint: 'PAID orders in next 14d with available < 0',
+    },
+  ];
+}
+
+const TONE_BG: Record<Tone, string> = {
+  good: 'bg-green-50 border-green-200',
+  caution: 'bg-amber-50 border-amber-200',
+  urgent: 'bg-red-50 border-red-200',
+  neutral: 'bg-gray-50 border-gray-200',
+};
+const TONE_TEXT: Record<Tone, string> = {
+  good: 'text-green-700',
+  caution: 'text-amber-700',
+  urgent: 'text-red-700',
+  neutral: 'text-gray-700',
+};
+
+export default function OperationsDashboardPage(): ReactElement {
+  const [data, setData] = useState<DashboardData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/api/admin/operations/snapshot');
+        if (res.ok) setData(await res.json());
+      } catch (err) {
+        console.error('Failed to load dashboard', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    void load();
+  }, []);
+
+  const stats = data ? buildStats(data) : [];
+
+  return (
+    <div className="p-4 md:p-8 bg-gray-50 min-h-screen">
+      <div className="max-w-6xl mx-auto">
+        <div className="flex items-center gap-3 mb-1">
+          <Link href="/admin/dashboard" className="text-blue-600 text-sm hover:underline">← Admin</Link>
+          <span className="text-gray-300">/</span>
+          <span className="text-sm text-gray-500">Operations</span>
+        </div>
+        <div className="flex flex-col md:flex-row md:items-end justify-between gap-4 mb-6">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900 font-heading tracking-[0.05em]">Operations health</h1>
+            <p className="text-gray-500 mt-1 text-sm">
+              Inventory accuracy, drift events, cost coverage, and shortages — refreshed daily at 07:30 UTC.
+            </p>
+          </div>
+          <Link
+            href="/admin/recommendations?domain=operations"
+            className="px-4 py-2 bg-brand-blue text-white rounded-lg font-medium hover:bg-blue-700 text-sm shadow-sm min-h-[44px] inline-flex items-center"
+          >
+            Open triage queue →
+          </Link>
+        </div>
+
+        {loading && !data ? (
+          <SkeletonGrid />
+        ) : !data?.latestSnapshot ? (
+          <EmptyState />
+        ) : (
+          <div className="space-y-6">
+            <StatGrid stats={stats} />
+            <DriftBySignalCard data={data} />
+            <TopUrgentCard data={data} />
+            <FooterMeta s={data.latestSnapshot} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StatGrid({ stats }: { stats: StatDef[] }): ReactElement {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      {stats.map((s) => (
+        <div key={s.label} className={`rounded-xl border p-5 ${TONE_BG[s.tone]}`}>
+          <div className="text-xs uppercase tracking-wider text-gray-500 font-medium">{s.label}</div>
+          <div className={`mt-2 text-4xl font-bold ${TONE_TEXT[s.tone]} leading-none`}>{s.value}</div>
+          {s.spark.length >= 2 && (
+            <div className="mt-3">
+              <Sparkline values={s.spark} tone={s.tone} />
+            </div>
+          )}
+          {s.hint && <div className="mt-2 text-xs text-gray-600 leading-snug">{s.hint}</div>}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function DriftBySignalCard({ data }: { data: DashboardData }): ReactElement {
+  const rows = data.activeRecCounts.bySignal;
+  const max = Math.max(1, ...rows.map((r) => r.count));
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 p-5 shadow-sm">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-gray-900">Active drift by signal</h2>
+        <div className="text-sm text-gray-500">
+          {data.activeRecCounts.bySeverity.urgent} urgent · {data.activeRecCounts.bySeverity.high} high · {data.activeRecCounts.bySeverity.normal} normal
+        </div>
+      </div>
+      {rows.length === 0 ? (
+        <p className="text-sm text-gray-500">No active drift events. The ledger is calm.</p>
+      ) : (
+        <div className="space-y-2">
+          {rows.map((r) => {
+            const label = SIGNAL_LABELS[r.signalKind as SignalKind] ?? r.signalKind;
+            const widthPct = (r.count / max) * 100;
+            return (
+              <div key={r.signalKind} className="flex items-center gap-3">
+                <div className="w-44 text-sm text-gray-700 shrink-0">{label}</div>
+                <div className="flex-1 h-5 bg-gray-100 rounded overflow-hidden">
+                  <div className="h-full bg-brand-blue" style={{ width: `${widthPct}%` }} />
+                </div>
+                <div className="w-12 text-right text-sm font-mono text-gray-900">{r.count}</div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TopUrgentCard({ data }: { data: DashboardData }): ReactElement {
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 p-5 shadow-sm">
+      <h2 className="text-lg font-semibold text-gray-900 mb-3">Top urgent recommendations</h2>
+      {data.topUrgent.length === 0 ? (
+        <p className="text-sm text-gray-500">Nothing urgent open right now.</p>
+      ) : (
+        <ul className="divide-y divide-gray-100">
+          {data.topUrgent.map((r) => (
+            <li key={r.id} className="py-3 flex items-start gap-3">
+              <span
+                className={`inline-block text-xs font-bold uppercase tracking-wider px-2 py-1 rounded ${
+                  r.severity === 'urgent'
+                    ? 'bg-red-100 text-red-700'
+                    : r.severity === 'high'
+                    ? 'bg-amber-100 text-amber-800'
+                    : 'bg-gray-100 text-gray-700'
+                }`}
+              >
+                {r.severity}
+              </span>
+              <div className="flex-1">
+                <div className="text-sm text-gray-900 font-medium">{r.title}</div>
+                <div className="text-xs text-gray-500 font-mono mt-0.5">{r.signalKind}</div>
+              </div>
+              <Link
+                href={`/admin/recommendations?domain=operations`}
+                className="text-sm text-brand-blue hover:underline shrink-0"
+              >
+                Open →
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function FooterMeta({ s }: { s: SnapshotSummary }): ReactElement {
+  const lagBits: string[] = [];
+  if (s.receivingLagP50Hours != null) lagBits.push(`p50 ${s.receivingLagP50Hours.toFixed(1)}h`);
+  if (s.receivingLagP90Hours != null) lagBits.push(`p90 ${s.receivingLagP90Hours.toFixed(1)}h`);
+  return (
+    <div className="text-xs text-gray-500 text-center pt-2">
+      Snapshot {new Date(s.capturedAt).toLocaleString()} ·
+      Receiving lag: {lagBits.length ? lagBits.join(' · ') : 'not enough data yet'} ·
+      Cycle counts completed last 7d: {s.cycleCountsCompletedLast7d}
+    </div>
+  );
+}
+
+function SkeletonGrid(): ReactElement {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4" aria-label="Loading dashboard">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className="bg-white rounded-xl border border-gray-200 p-5 animate-pulse">
+          <div className="h-3 w-20 bg-gray-200 rounded mb-3" />
+          <div className="h-9 w-24 bg-gray-200 rounded mb-3" />
+          <div className="h-6 w-full bg-gray-100 rounded" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EmptyState(): ReactElement {
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 p-12 text-center">
+      <p className="text-gray-600 text-sm">No operations snapshot yet.</p>
+      <p className="text-gray-400 text-xs mt-2">
+        Run <code className="px-1 bg-gray-100 rounded font-mono">/api/cron/operations-snapshot</code> to populate.
+      </p>
+    </div>
+  );
+}

--- a/src/app/api/admin/operations/snapshot/route.ts
+++ b/src/app/api/admin/operations/snapshot/route.ts
@@ -1,0 +1,22 @@
+/**
+ * GET /api/admin/operations/snapshot
+ *
+ * One-stop JSON for the Operations Director dashboard + the agent.
+ * Returns the latest OperationsSnapshot, the last 30 snapshots for trend
+ * sparklines, active-rec counts (by severity + by signal), and the top-N
+ * urgent recs. Shared with /admin/operations RSC via dashboard-data.
+ */
+
+import { NextResponse } from 'next/server';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
+import { loadDashboardData } from '@/lib/operations/dashboard-data';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(): Promise<NextResponse> {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  const data = await loadDashboardData();
+  return NextResponse.json(data);
+}

--- a/src/app/api/cron/operations-briefing/route.ts
+++ b/src/app/api/cron/operations-briefing/route.ts
@@ -1,0 +1,105 @@
+/**
+ * Operations Director — weekly briefing cron.
+ *
+ * Schedule: Monday 13:30 UTC (8:30am Central) — runs 30 minutes after the
+ * Marketing briefing so the operator gets both back-to-back without one
+ * blocking the other.
+ *
+ * Stage A only in Phase 1D — deterministic email + payload. No LLM narrative
+ * pass yet (defer to Phase 1E with the operations-director agent file). No
+ * GitHub commit either — the /admin/operations dashboard is the persistent
+ * archive surface.
+ *
+ * See docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md §7 Phase 1D.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/database/client';
+import { resend } from '@/lib/email/resend-client';
+import { buildOperationsBriefingPayload } from '@/lib/operations/briefing-payload';
+import {
+  renderOperationsBriefingEmail,
+  renderOperationsBriefingText,
+} from '@/lib/email/templates/operations-briefing';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 120;
+
+function isoWeek(date: Date): { year: number; week: number; label: string } {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const dayNum = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const week = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+  const label = `${d.getUTCFullYear()}-W${String(week).padStart(2, '0')}`;
+  return { year: d.getUTCFullYear(), week, label };
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = request.headers.get('authorization');
+  if (auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const now = new Date();
+  const week = isoWeek(now);
+
+  const snapshot = await prisma.operationsSnapshot.findFirst({ orderBy: { capturedAt: 'desc' } });
+  if (!snapshot) {
+    return NextResponse.json(
+      { error: 'no operations snapshot exists yet — run /api/cron/operations-snapshot first' },
+      { status: 503 }
+    );
+  }
+
+  const payload = await buildOperationsBriefingPayload({
+    snapshot,
+    weekLabel: week.label,
+    issueNumber: week.week,
+    year: week.year,
+    generatedAt: now,
+    queueUrl: 'https://partyondelivery.com/admin/recommendations?domain=operations',
+    dashboardUrl: 'https://partyondelivery.com/admin/operations',
+  });
+
+  // Deliver email — fails soft so the cron stays green and the JSON response
+  // always returns the payload (operator can inspect via curl if email's down).
+  const recipient = process.env.OPS_BRIEFING_TO
+    || process.env.MARKETING_BRIEFING_TO
+    || 'allan@partyondelivery.com';
+
+  let email: { sent: boolean; error?: string } = { sent: false, error: 'not attempted' };
+  if (!resend) {
+    email = { sent: false, error: 'RESEND_API_KEY not configured' };
+  } else {
+    try {
+      const html = renderOperationsBriefingEmail(payload);
+      const text = renderOperationsBriefingText(payload);
+      const fromEmail = process.env.RESEND_FROM_EMAIL || 'orders@partyondelivery.com';
+      await resend.emails.send({
+        from: `Party On Delivery — Operations Director <${fromEmail}>`,
+        to: recipient,
+        subject: `Operations weekly briefing — ${week.label}`,
+        html,
+        text,
+      });
+      email = { sent: true };
+    } catch (err) {
+      email = { sent: false, error: err instanceof Error ? err.message : String(err) };
+      console.error('[operations-briefing] email send failed:', err);
+    }
+  }
+
+  return NextResponse.json({
+    ok: true,
+    week: week.label,
+    capturedAt: snapshot.capturedAt.toISOString(),
+    counts: {
+      driftEvents: payload.driftEvents.length,
+      cycleCounts: payload.cycleCounts.length,
+      danglingDrafts: payload.danglingDrafts.length,
+    },
+    delivery: { email, recipient },
+    payload,
+  });
+}

--- a/src/lib/email/templates/__tests__/operations-briefing.test.ts
+++ b/src/lib/email/templates/__tests__/operations-briefing.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import {
+  renderOperationsBriefingEmail,
+  renderOperationsBriefingText,
+} from '../operations-briefing';
+import type { OpsBriefingPayload } from '@/lib/operations/briefing-payload';
+
+function basePayload(over: Partial<OpsBriefingPayload> = {}): OpsBriefingPayload {
+  return {
+    weekLabel: '2026-W21',
+    issueNumber: 21,
+    year: 2026,
+    generatedDate: 'Monday, May 18',
+    generatedAtIso: '2026-05-18T14:00:00.000Z',
+    stats: [
+      { label: 'Inventory Accuracy', value: '92%', tone: 'good' },
+      { label: 'Urgent Shortages', value: '1', tone: 'caution' },
+      { label: 'Cost Coverage', value: '14%', tone: 'urgent', spark: [12, 13, 14] },
+      { label: 'Drift Events', value: '12', tone: 'caution' },
+    ],
+    topUrgentRec: null,
+    driftEvents: [],
+    cycleCounts: [],
+    danglingDrafts: [],
+    costCoveragePct: 14,
+    costCoverageSpark: [12, 13, 14],
+    costCoverageGoalPct: 30,
+    receivingLagP50Hours: 6.5,
+    receivingLagP90Hours: 28,
+    whatsLacking: ['Cost coverage at 14% — Phase 1 goal is 30%.'],
+    links: {
+      queueUrl: 'https://example.com/admin/recommendations?domain=operations',
+      dashboardUrl: 'https://example.com/admin/operations',
+    },
+    ...over,
+  };
+}
+
+describe('renderOperationsBriefingEmail', () => {
+  it('renders an HTML document with the week label in the title', () => {
+    const html = renderOperationsBriefingEmail(basePayload());
+    expect(html).toContain('<!doctype html>');
+    expect(html).toContain('Operations Weekly Briefing — 2026-W21');
+  });
+
+  it('includes the masthead title text', () => {
+    const html = renderOperationsBriefingEmail(basePayload());
+    expect(html).toContain('Operations');
+    expect(html).toContain('Weekly Briefing');
+  });
+
+  it('omits the urgent callout when topUrgentRec is null', () => {
+    const html = renderOperationsBriefingEmail(basePayload({ topUrgentRec: null }));
+    expect(html).not.toContain('Urgent — Act Now');
+  });
+
+  it('renders the urgent callout with title + href when topUrgentRec present', () => {
+    const html = renderOperationsBriefingEmail(basePayload({
+      topUrgentRec: {
+        title: 'Receiving invoice INV-1 stuck',
+        signalKind: 'receiving-lag',
+        href: 'https://example.com/admin/recommendations?domain=operations#rec-r1',
+      },
+    }));
+    expect(html).toContain('Urgent — Act Now');
+    expect(html).toContain('Receiving invoice INV-1 stuck');
+    expect(html).toContain('rec-r1');
+  });
+
+  it('escapes HTML in titles to prevent injection', () => {
+    const html = renderOperationsBriefingEmail(basePayload({
+      driftEvents: [{
+        id: 'd1',
+        title: '<script>alert(1)</script>',
+        severity: 'urgent',
+        signalKind: 'receiving-lag',
+        ageHours: 30,
+      }],
+    }));
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('renders fallback text when sections are empty', () => {
+    const html = renderOperationsBriefingEmail(basePayload());
+    expect(html).toContain('No active drift events');
+    expect(html).toContain('No overdue cycle counts');
+    expect(html).toContain('No dangling invoices');
+  });
+
+  it('always renders the cost-coverage progress block', () => {
+    const html = renderOperationsBriefingEmail(basePayload());
+    expect(html).toContain('Cost Coverage — Progress to Goal');
+    expect(html).toContain('14%');
+    expect(html).toContain('/ 30% goal');
+  });
+
+  it('renders triage queue + dashboard CTA buttons', () => {
+    const html = renderOperationsBriefingEmail(basePayload());
+    expect(html).toContain('Triage Queue');
+    expect(html).toContain('Ops Dashboard');
+    expect(html).toContain('href="https://example.com/admin/recommendations?domain=operations"');
+    expect(html).toContain('href="https://example.com/admin/operations"');
+  });
+});
+
+describe('renderOperationsBriefingText', () => {
+  it('produces a plain-text fallback with key sections', () => {
+    const text = renderOperationsBriefingText(basePayload({
+      topUrgentRec: { title: 'URG A', signalKind: 'receiving-lag', href: 'http://x' },
+      driftEvents: [{ id: 'd1', title: 'Drift A', severity: 'high', signalKind: 'repeated-shorts', ageHours: 12 }],
+    }));
+    expect(text).toContain('Operations weekly briefing — 2026-W21');
+    expect(text).toContain('URGENT — URG A');
+    expect(text).toContain('[HIGH] Drift A');
+    expect(text).toContain('Cost coverage: 14% / 30% goal');
+  });
+});

--- a/src/lib/email/templates/operations-briefing.ts
+++ b/src/lib/email/templates/operations-briefing.ts
@@ -1,0 +1,417 @@
+/**
+ * Operations Director — weekly briefing email template.
+ *
+ * Same editorial aesthetic as marketing-briefing.ts (cream paper, hairline
+ * rules, gold accents). Ops content is more list-y than marketing's chart
+ * content — fewer SVG flourishes, more scannable line-items.
+ *
+ * Render pipeline:
+ *   buildOperationsBriefingPayload() → OpsBriefingPayload
+ *   renderOperationsBriefingEmail(payload) → HTML string
+ */
+
+import type {
+  OpsBriefingPayload,
+  OpsBriefingTone,
+  OpsBriefingStat,
+  OpsBriefingDriftEvent,
+} from '@/lib/operations/briefing-payload';
+import type { OpsSeverity } from '@/lib/operations/types';
+
+const COLORS = {
+  paper: '#FBFAF5',
+  ink: '#0a0a0a',
+  inkBody: '#1a1a1a',
+  inkMute: '#3a3a3a',
+  hairline: '#e7e3d6',
+  cellHairline: '#f0ebd8',
+  ivoryAlt: '#FBF6E0',
+  goldAccent: '#7a6a1f',
+  gold: '#D4AF37',
+  yellow: '#F2D34F',
+  blue: '#0B74B8',
+  good: '#15803d',
+  caution: '#d97706',
+  urgent: '#dc2626',
+  mute: '#8a8576',
+  muteText: '#6b6b6b',
+};
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function toneColor(t: OpsBriefingTone | undefined): string {
+  if (t === 'good') return COLORS.good;
+  if (t === 'caution') return COLORS.caution;
+  if (t === 'urgent') return COLORS.urgent;
+  return COLORS.ink;
+}
+
+function severityColor(s: OpsSeverity): string {
+  if (s === 'urgent') return COLORS.urgent;
+  if (s === 'high') return COLORS.caution;
+  return COLORS.muteText;
+}
+
+function severityLabel(s: OpsSeverity): string {
+  if (s === 'urgent') return 'URGENT';
+  if (s === 'high') return 'HIGH';
+  return 'NORMAL';
+}
+
+function renderSparkline(values: number[], color: string): string {
+  if (!values.length) return '';
+  const W = 120;
+  const H = 28;
+  const PAD = 2;
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const xs = values.map((_, i) => PAD + (i * (W - 2 * PAD)) / (values.length - 1 || 1));
+  const ys = values.map((v) => H - PAD - 4 - ((v - min) / range) * (H - 2 * PAD - 8));
+  const points = xs.map((x, i) => `${x.toFixed(1)},${ys[i].toFixed(1)}`).join(' ');
+  const lastX = xs[xs.length - 1];
+  const lastY = ys[ys.length - 1];
+  return `
+    <svg width="120" height="28" viewBox="0 0 120 28" xmlns="http://www.w3.org/2000/svg" style="display:block;margin:0 auto;">
+      <polyline fill="none" stroke="${color}" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" points="${points}"/>
+      <circle cx="${lastX.toFixed(1)}" cy="${lastY.toFixed(1)}" r="2.4" fill="${COLORS.gold}"/>
+    </svg>
+  `;
+}
+
+function renderMasthead(d: OpsBriefingPayload): string {
+  return `
+    <tr>
+      <td style="padding:8px 0 24px;text-align:center;">
+        <div style="font-family:'Inter',sans-serif;font-size:10px;letter-spacing:3px;color:${COLORS.muteText};text-transform:uppercase;margin-bottom:18px;">Party On Delivery &nbsp;·&nbsp; Austin, Texas</div>
+        <div style="font-family:'Barlow Condensed','Helvetica Neue','Arial Narrow',sans-serif;font-size:38px;font-weight:700;letter-spacing:4px;color:${COLORS.ink};text-transform:uppercase;line-height:1;">Operations<br>Weekly Briefing</div>
+        <div style="margin-top:18px;font-family:'Inter',sans-serif;font-size:11px;letter-spacing:2px;color:${COLORS.muteText};text-transform:uppercase;">Issue ${d.issueNumber} &nbsp;·&nbsp; ${d.year} &nbsp;·&nbsp; ${escapeHtml(d.generatedDate)}</div>
+        <div style="height:2px;background:${COLORS.gold};width:48px;margin:26px auto 0;line-height:2px;font-size:0;">&nbsp;</div>
+      </td>
+    </tr>
+  `;
+}
+
+function renderTopUrgent(d: OpsBriefingPayload): string {
+  if (!d.topUrgentRec) return '';
+  return `
+    <tr>
+      <td style="padding:8px 0 0;">
+        <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="${COLORS.ink}" style="background:${COLORS.ink};border-radius:2px;">
+          <tr>
+            <td width="4" bgcolor="${COLORS.urgent}" style="background:${COLORS.urgent};width:4px;line-height:1px;font-size:0;">&nbsp;</td>
+            <td style="padding:34px 36px 36px;">
+              <div style="font-family:'Inter',sans-serif;font-size:10px;letter-spacing:3px;color:${COLORS.urgent};text-transform:uppercase;font-weight:600;margin-bottom:14px;">Urgent — Act Now</div>
+              <div style="font-family:'Barlow Condensed','Helvetica Neue','Arial Narrow',sans-serif;font-size:24px;font-weight:600;line-height:1.2;color:#ffffff;letter-spacing:0.5px;">${escapeHtml(d.topUrgentRec.title)}</div>
+              <div style="margin-top:14px;font-family:'SFMono-Regular','Menlo',monospace;font-size:11px;color:#d8d8d8;letter-spacing:1px;">${escapeHtml(d.topUrgentRec.signalKind)}</div>
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin-top:20px;">
+                <tr>
+                  <td bgcolor="${COLORS.yellow}" style="background:${COLORS.yellow};padding:8px 14px;border-radius:2px;">
+                    <a href="${escapeHtml(d.topUrgentRec.href)}" style="font-family:'Inter',sans-serif;font-size:12px;font-weight:700;letter-spacing:1.5px;color:${COLORS.ink};text-transform:uppercase;text-decoration:none;">Open in queue →</a>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  `;
+}
+
+function renderStatStrip(stats: OpsBriefingStat[]): string {
+  const cells = stats
+    .map((s, i) => {
+      const isLast = i === stats.length - 1;
+      const valColor = toneColor(s.tone);
+      const sparkColor =
+        s.tone === 'urgent' ? COLORS.urgent :
+        s.tone === 'caution' ? COLORS.caution :
+        s.tone === 'good' ? COLORS.good : COLORS.ink;
+      const spark = s.spark ? renderSparkline(s.spark, sparkColor) : '';
+      return `
+        <td width="${100 / stats.length}%" valign="top" style="padding:22px 10px 18px;text-align:center;${isLast ? '' : `border-right:1px solid ${COLORS.hairline};`}">
+          <div style="font-family:'Inter',sans-serif;font-size:9px;letter-spacing:2px;color:${COLORS.mute};text-transform:uppercase;margin-bottom:8px;">${escapeHtml(s.label)}</div>
+          <div style="font-family:'Barlow Condensed','Helvetica Neue',sans-serif;font-size:34px;font-weight:600;color:${valColor};line-height:1;">${escapeHtml(s.value)}</div>
+          ${spark ? `<div style="margin-top:10px;line-height:0;">${spark}</div>` : ''}
+        </td>
+      `;
+    })
+    .join('');
+  return `
+    <tr>
+      <td style="padding:36px 0 0;">
+        <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="border-top:1px solid ${COLORS.hairline};border-bottom:1px solid ${COLORS.hairline};">
+          <tr>${cells}</tr>
+        </table>
+      </td>
+    </tr>
+  `;
+}
+
+function renderSectionHeader(eyebrow: string, title: string): string {
+  return `
+    <tr>
+      <td style="padding:48px 0 0;">
+        <div style="font-family:'Inter',sans-serif;font-size:10px;letter-spacing:3px;color:${COLORS.muteText};text-transform:uppercase;font-weight:600;text-align:center;margin-bottom:8px;">${escapeHtml(eyebrow)}</div>
+        <div style="font-family:'Barlow Condensed','Helvetica Neue',sans-serif;font-size:24px;font-weight:600;color:${COLORS.ink};text-align:center;letter-spacing:1px;text-transform:uppercase;">${escapeHtml(title)}</div>
+        <div style="height:1px;background:${COLORS.hairline};margin:24px auto 0;line-height:1px;font-size:0;">&nbsp;</div>
+      </td>
+    </tr>
+  `;
+}
+
+function renderDriftEvents(events: OpsBriefingDriftEvent[]): string {
+  if (!events.length) {
+    return `
+      <tr>
+        <td style="padding:24px 0 0;">
+          <div style="font-family:Georgia,'Times New Roman',serif;font-style:italic;font-size:14px;color:${COLORS.muteText};text-align:center;">No active drift events this week — ledger is clean.</div>
+        </td>
+      </tr>
+    `;
+  }
+  const rows = events
+    .map((e) => `
+      <tr>
+        <td valign="top" style="padding:18px 0 18px 0;border-bottom:1px solid ${COLORS.hairline};">
+          <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+            <tr>
+              <td valign="top" width="90" style="padding-right:14px;">
+                <span style="display:inline-block;font-family:'Inter',sans-serif;font-size:9px;letter-spacing:1.5px;color:#ffffff;text-transform:uppercase;font-weight:700;background:${severityColor(e.severity)};padding:4px 8px;border-radius:2px;">${severityLabel(e.severity)}</span>
+              </td>
+              <td valign="top">
+                <div style="font-family:'Inter',sans-serif;font-size:14px;color:${COLORS.ink};line-height:1.5;font-weight:600;">${escapeHtml(e.title)}</div>
+                <div style="margin-top:4px;font-family:'SFMono-Regular','Menlo',monospace;font-size:10px;color:${COLORS.muteText};letter-spacing:0.5px;">${escapeHtml(e.signalKind)} · ${e.ageHours}h old</div>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    `)
+    .join('');
+  return `<tr><td><table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">${rows}</table></td></tr>`;
+}
+
+function renderCycleCounts(cc: OpsBriefingPayload['cycleCounts']): string {
+  if (!cc.length) {
+    return `
+      <tr>
+        <td style="padding:24px 0 0;">
+          <div style="font-family:Georgia,'Times New Roman',serif;font-style:italic;font-size:14px;color:${COLORS.muteText};text-align:center;">No overdue cycle counts — top movers are fresh.</div>
+        </td>
+      </tr>
+    `;
+  }
+  const rows = cc
+    .map((c) => `
+      <tr>
+        <td style="padding:14px 0;border-bottom:1px solid ${COLORS.cellHairline};">
+          <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+            <tr>
+              <td><span style="font-family:'Inter',sans-serif;font-size:13px;color:${COLORS.ink};font-weight:500;">${escapeHtml(c.title)}</span></td>
+              <td align="right" width="100"><span style="font-family:'SFMono-Regular','Menlo',monospace;font-size:11px;color:${COLORS.muteText};">${c.unitsLast14d} u / 14d</span></td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    `)
+    .join('');
+  return `<tr><td><table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">${rows}</table></td></tr>`;
+}
+
+function renderDanglingDrafts(dd: OpsBriefingPayload['danglingDrafts']): string {
+  if (!dd.length) {
+    return `
+      <tr>
+        <td style="padding:24px 0 0;">
+          <div style="font-family:Georgia,'Times New Roman',serif;font-style:italic;font-size:14px;color:${COLORS.muteText};text-align:center;">No dangling invoices — every sent draft is either paid or fresh.</div>
+        </td>
+      </tr>
+    `;
+  }
+  const rows = dd
+    .map((d) => `
+      <tr>
+        <td style="padding:14px 0;border-bottom:1px solid ${COLORS.cellHairline};">
+          <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+            <tr>
+              <td>
+                <div style="font-family:'Inter',sans-serif;font-size:13px;color:${COLORS.ink};font-weight:600;">${escapeHtml(d.customerName)}</div>
+                <div style="font-family:'SFMono-Regular','Menlo',monospace;font-size:10px;color:${COLORS.muteText};margin-top:2px;">${escapeHtml(d.status)} · ${d.ageDays}d old</div>
+              </td>
+              <td align="right" width="100"><span style="font-family:'SFMono-Regular','Menlo',monospace;font-size:12px;color:${COLORS.ink};font-weight:700;">${escapeHtml(d.total)}</span></td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    `)
+    .join('');
+  return `<tr><td><table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">${rows}</table></td></tr>`;
+}
+
+function renderCostCoverage(d: OpsBriefingPayload): string {
+  const spark = d.costCoverageSpark.length >= 2
+    ? renderSparkline(d.costCoverageSpark, COLORS.gold)
+    : '';
+  return `
+    <tr>
+      <td style="padding:24px 0 0;">
+        <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="${COLORS.ivoryAlt}" style="background:${COLORS.ivoryAlt};">
+          <tr>
+            <td width="4" bgcolor="${COLORS.yellow}" style="background:${COLORS.yellow};width:4px;line-height:1px;font-size:0;">&nbsp;</td>
+            <td style="padding:22px 26px;">
+              <div style="font-family:'Inter',sans-serif;font-size:10px;letter-spacing:3px;color:${COLORS.goldAccent};text-transform:uppercase;font-weight:600;margin-bottom:8px;">Cost Coverage — Progress to Goal</div>
+              <div style="font-family:'Barlow Condensed','Helvetica Neue',sans-serif;font-size:32px;font-weight:600;color:${COLORS.ink};line-height:1;">${d.costCoveragePct}% <span style="font-size:14px;color:${COLORS.muteText};">/ ${d.costCoverageGoalPct}% goal</span></div>
+              ${spark ? `<div style="margin-top:12px;text-align:left;">${spark}</div>` : ''}
+              <div style="margin-top:10px;font-family:'Inter',sans-serif;font-size:12px;color:${COLORS.inkMute};line-height:1.55;">
+                Margin attribution accuracy depends on this number. The cycle-count + cost-coverage recs in the queue feed it.
+              </div>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  `;
+}
+
+function renderWhatsLacking(items: string[]): string {
+  if (!items.length) return '';
+  return `
+    <tr>
+      <td style="padding:48px 0 0;">
+        <div style="font-family:'Inter',sans-serif;font-size:10px;letter-spacing:3px;color:${COLORS.muteText};text-transform:uppercase;font-weight:600;margin-bottom:10px;">What this brief lacks</div>
+        <ul style="margin:0;padding:0 0 0 18px;font-family:'Inter',sans-serif;font-size:14px;line-height:1.7;color:${COLORS.inkMute};">
+          ${items.map((s) => `<li>${escapeHtml(s)}</li>`).join('')}
+        </ul>
+      </td>
+    </tr>
+  `;
+}
+
+function renderButtons(d: OpsBriefingPayload): string {
+  return `
+    <tr>
+      <td style="padding:48px 0 0;">
+        <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+          <tr>
+            <td align="center" style="padding:0;">
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                <tr>
+                  <td style="padding:0 6px;"><a href="${escapeHtml(d.links.queueUrl)}" style="display:inline-block;padding:13px 22px;background:${COLORS.blue};color:#ffffff;text-decoration:none;font-family:'Inter',sans-serif;font-size:12px;letter-spacing:1.5px;font-weight:600;text-transform:uppercase;border-radius:2px;">Triage Queue</a></td>
+                  <td style="padding:0 6px;"><a href="${escapeHtml(d.links.dashboardUrl)}" style="display:inline-block;padding:13px 22px;background:#ffffff;color:${COLORS.ink};text-decoration:none;font-family:'Inter',sans-serif;font-size:12px;letter-spacing:1.5px;font-weight:600;text-transform:uppercase;border:1px solid ${COLORS.ink};border-radius:2px;">Ops Dashboard</a></td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  `;
+}
+
+function renderFooter(d: OpsBriefingPayload): string {
+  const lagBits: string[] = [];
+  if (d.receivingLagP50Hours != null) lagBits.push(`p50 ${d.receivingLagP50Hours.toFixed(1)}h`);
+  if (d.receivingLagP90Hours != null) lagBits.push(`p90 ${d.receivingLagP90Hours.toFixed(1)}h`);
+  const lagLine = lagBits.length ? `Receiving lag: ${lagBits.join(' · ')}` : 'Receiving lag: not enough data yet.';
+  return `
+    <tr>
+      <td style="padding:56px 0 24px;">
+        <div style="height:1px;background:${COLORS.ink};width:48px;margin:0 auto 22px;line-height:1px;font-size:0;">&nbsp;</div>
+        <div style="text-align:center;font-family:Georgia,'Times New Roman',serif;font-style:italic;font-size:14px;color:${COLORS.inkMute};line-height:1.5;">Filed by the Operations Director</div>
+        <div style="text-align:center;margin-top:6px;font-family:'Inter',sans-serif;font-size:11px;letter-spacing:2px;color:${COLORS.mute};text-transform:uppercase;">Party On Delivery · Austin</div>
+      </td>
+    </tr>
+    <tr>
+      <td style="padding:24px 0 0;border-top:1px solid ${COLORS.hairline};">
+        <div style="font-family:'Inter',sans-serif;font-size:11px;line-height:1.6;color:${COLORS.mute};text-align:center;">
+          Generated ${escapeHtml(d.generatedAtIso.slice(0, 10))} · ${escapeHtml(lagLine)}<br>
+          Phase 1 never auto-mutates inventory — every action requires an operator click on a rec card.
+        </div>
+      </td>
+    </tr>
+  `;
+}
+
+export function renderOperationsBriefingEmail(d: OpsBriefingPayload): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="color-scheme" content="light">
+<meta name="supported-color-schemes" content="light">
+<title>Operations Weekly Briefing — ${escapeHtml(d.weekLabel)}</title>
+</head>
+<body style="margin:0;padding:0;background:${COLORS.paper};font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:${COLORS.ink};-webkit-font-smoothing:antialiased;">
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" bgcolor="${COLORS.paper}" style="background:${COLORS.paper};">
+  <tr>
+    <td align="center" style="padding:40px 16px 56px;">
+      <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="640" style="width:100%;max-width:640px;">
+        ${renderMasthead(d)}
+        ${renderTopUrgent(d)}
+        ${renderStatStrip(d.stats)}
+        ${renderSectionHeader('The Drift', 'Top urgent + high events')}
+        ${renderDriftEvents(d.driftEvents)}
+        ${renderSectionHeader('The Counts', 'Cycle counts due this week')}
+        ${renderCycleCounts(d.cycleCounts)}
+        ${renderSectionHeader('Dangling Drafts', 'Sent invoices sitting unpaid')}
+        ${renderDanglingDrafts(d.danglingDrafts)}
+        ${renderCostCoverage(d)}
+        ${renderWhatsLacking(d.whatsLacking)}
+        ${renderButtons(d)}
+        ${renderFooter(d)}
+      </table>
+    </td>
+  </tr>
+</table>
+</body>
+</html>`;
+}
+
+/**
+ * Render a plain-text fallback for the briefing — used by Resend so email
+ * clients with HTML disabled still see something useful.
+ */
+export function renderOperationsBriefingText(d: OpsBriefingPayload): string {
+  const lines: string[] = [];
+  lines.push(`Operations weekly briefing — ${d.weekLabel}`);
+  lines.push(`Generated ${d.generatedDate} (issue ${d.issueNumber}, ${d.year}).`);
+  lines.push('');
+  if (d.topUrgentRec) {
+    lines.push(`URGENT — ${d.topUrgentRec.title}`);
+    lines.push(`Open: ${d.topUrgentRec.href}`);
+    lines.push('');
+  }
+  for (const s of d.stats) lines.push(`${s.label}: ${s.value}`);
+  lines.push('');
+  if (d.driftEvents.length) {
+    lines.push('Drift events:');
+    for (const e of d.driftEvents) {
+      lines.push(`  - [${severityLabel(e.severity)}] ${e.title} (${e.signalKind}, ${e.ageHours}h)`);
+    }
+    lines.push('');
+  }
+  if (d.cycleCounts.length) {
+    lines.push('Cycle counts overdue:');
+    for (const c of d.cycleCounts) lines.push(`  - ${c.title} (${c.unitsLast14d} u / 14d)`);
+    lines.push('');
+  }
+  if (d.danglingDrafts.length) {
+    lines.push('Dangling invoices:');
+    for (const dd of d.danglingDrafts) lines.push(`  - ${dd.customerName} · ${dd.total} · ${dd.status} · ${dd.ageDays}d`);
+    lines.push('');
+  }
+  lines.push(`Cost coverage: ${d.costCoveragePct}% / ${d.costCoverageGoalPct}% goal.`);
+  lines.push('');
+  lines.push(`Triage queue: ${d.links.queueUrl}`);
+  lines.push(`Ops dashboard: ${d.links.dashboardUrl}`);
+  return lines.join('\n');
+}

--- a/src/lib/operations/__tests__/briefing-payload.test.ts
+++ b/src/lib/operations/__tests__/briefing-payload.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const prismaMock = vi.hoisted(() => ({
+  operationsSnapshot: { findMany: vi.fn() },
+  operationsRecommendation: { findMany: vi.fn() },
+  draftOrder: { findMany: vi.fn() },
+}));
+
+vi.mock('@/lib/database/client', () => ({ prisma: prismaMock }));
+
+import { buildOperationsBriefingPayload } from '../briefing-payload';
+
+function mkSnapshot(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 's1',
+    capturedAt: new Date('2026-05-18T07:30:00Z'),
+    inventoryAccuracyPct: 92,
+    driftEventsTotal: 12,
+    driftEventsBySignal: { 'receiving-lag': 3, 'repeated-shorts': 2 },
+    urgentShortagesCount: 1,
+    costCoveragePct: 14,
+    receivingLagP50Hours: 6.5,
+    receivingLagP90Hours: 28,
+    cycleCountsCompletedLast7d: 8,
+    paidOrders14dShortageCount: 4,
+    ...over,
+  };
+}
+
+function mkRec(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'r1',
+    signalKind: 'receiving-lag',
+    severity: 'urgent',
+    title: 'Receiving invoice INV-1 stuck',
+    evidence: [{ metricName: 'hours_pending', metricValue: 30 }],
+    targetEntityType: 'receivingInvoice',
+    targetEntityId: 'inv_1',
+    actionPayload: { kind: 'navigate', params: {} },
+    status: 'open',
+    snoozeUntil: null,
+    dismissReason: null,
+    actionLog: [],
+    source: 'auto-snapshot',
+    shippedAt: null,
+    measuredAt: null,
+    measurementResult: null,
+    dedupeKey: 'receiving-lag:inv_1',
+    createdAt: new Date('2026-05-17T07:30:00Z'),
+    updatedAt: new Date('2026-05-17T07:30:00Z'),
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  prismaMock.operationsSnapshot.findMany.mockReset();
+  prismaMock.operationsRecommendation.findMany.mockReset();
+  prismaMock.draftOrder.findMany.mockReset();
+  prismaMock.operationsSnapshot.findMany.mockResolvedValue([mkSnapshot()]);
+  prismaMock.operationsRecommendation.findMany.mockResolvedValue([]);
+  prismaMock.draftOrder.findMany.mockResolvedValue([]);
+});
+
+const baseInput = () => ({
+  snapshot: mkSnapshot() as never,
+  weekLabel: '2026-W21',
+  issueNumber: 21,
+  year: 2026,
+  generatedAt: new Date('2026-05-18T14:00:00Z'),
+  queueUrl: 'https://example.com/admin/recommendations?domain=operations',
+  dashboardUrl: 'https://example.com/admin/operations',
+});
+
+describe('buildOperationsBriefingPayload', () => {
+  it('produces stats with the four required cards', async () => {
+    const out = await buildOperationsBriefingPayload(baseInput());
+    expect(out.stats.map((s) => s.label)).toEqual([
+      'Inventory Accuracy',
+      'Urgent Shortages',
+      'Cost Coverage',
+      'Drift Events',
+    ]);
+  });
+
+  it('tones cost coverage as urgent when below 15%', async () => {
+    const snap = mkSnapshot({ costCoveragePct: 4 });
+    const out = await buildOperationsBriefingPayload({ ...baseInput(), snapshot: snap as never });
+    const coverage = out.stats.find((s) => s.label === 'Cost Coverage');
+    expect(coverage?.tone).toBe('urgent');
+  });
+
+  it('promotes the highest-severity rec to topUrgentRec', async () => {
+    prismaMock.operationsRecommendation.findMany.mockResolvedValue([
+      mkRec({ id: 'r-normal', severity: 'normal' }),
+      mkRec({ id: 'r-urgent', severity: 'urgent', title: 'Urgent A' }),
+    ]);
+    const out = await buildOperationsBriefingPayload(baseInput());
+    expect(out.topUrgentRec?.title).toBe('Urgent A');
+  });
+
+  it('returns null topUrgentRec when no urgent recs exist', async () => {
+    prismaMock.operationsRecommendation.findMany.mockResolvedValue([mkRec({ severity: 'high' })]);
+    const out = await buildOperationsBriefingPayload(baseInput());
+    expect(out.topUrgentRec).toBeNull();
+  });
+
+  it('caps driftEvents at 6 high+ recs and skips normal severity', async () => {
+    const recs = [
+      ...Array.from({ length: 4 }, (_, i) => mkRec({ id: `u${i}`, severity: 'urgent', title: `Urgent ${i}` })),
+      ...Array.from({ length: 4 }, (_, i) => mkRec({ id: `h${i}`, severity: 'high', title: `High ${i}` })),
+      mkRec({ id: 'n1', severity: 'normal', title: 'Normal noise' }),
+    ];
+    prismaMock.operationsRecommendation.findMany.mockResolvedValue(recs);
+    const out = await buildOperationsBriefingPayload(baseInput());
+    expect(out.driftEvents).toHaveLength(6);
+    expect(out.driftEvents.every((d) => d.severity !== 'normal')).toBe(true);
+    expect(out.driftEvents[0].severity).toBe('urgent');
+  });
+
+  it('extracts cycle-count overdue recs with their units_14d metric', async () => {
+    prismaMock.operationsRecommendation.findMany.mockResolvedValue([
+      mkRec({
+        id: 'cc1',
+        signalKind: 'cycle-count-overdue',
+        severity: 'normal',
+        title: 'Tito Vodka: top mover, not counted in 10d',
+        evidence: [{ metricName: 'units_14d', metricValue: 47 }],
+      }),
+    ]);
+    const out = await buildOperationsBriefingPayload(baseInput());
+    expect(out.cycleCounts).toHaveLength(1);
+    expect(out.cycleCounts[0].unitsLast14d).toBe(47);
+  });
+
+  it('surfaces dangling drafts older than the threshold', async () => {
+    prismaMock.draftOrder.findMany.mockResolvedValue([
+      {
+        id: 'd1',
+        customerName: 'Bach Party',
+        total: 425.5,
+        sentAt: new Date('2026-05-13T07:30:00Z'), // 5 days before generatedAt
+        status: 'SENT',
+      },
+    ]);
+    const out = await buildOperationsBriefingPayload(baseInput());
+    expect(out.danglingDrafts).toHaveLength(1);
+    expect(out.danglingDrafts[0].total).toBe('$426');
+    expect(out.danglingDrafts[0].ageDays).toBe(5);
+  });
+
+  it('adds whatsLacking entries for missing data + coverage gap', async () => {
+    const snap = mkSnapshot({ inventoryAccuracyPct: null, receivingLagP50Hours: null, costCoveragePct: 4 });
+    const out = await buildOperationsBriefingPayload({ ...baseInput(), snapshot: snap as never });
+    expect(out.whatsLacking.length).toBeGreaterThanOrEqual(3);
+    expect(out.whatsLacking.some((s) => s.includes('accuracy'))).toBe(true);
+    expect(out.whatsLacking.some((s) => s.includes('Receiving lag'))).toBe(true);
+    expect(out.whatsLacking.some((s) => s.includes('Cost coverage'))).toBe(true);
+  });
+
+  it('exposes spark series only when the snapshot history has ≥2 rows', async () => {
+    prismaMock.operationsSnapshot.findMany.mockResolvedValue([mkSnapshot()]);
+    const oneRowOut = await buildOperationsBriefingPayload(baseInput());
+    expect(oneRowOut.stats.find((s) => s.label === 'Cost Coverage')?.spark).toBeUndefined();
+
+    prismaMock.operationsSnapshot.findMany.mockResolvedValue([mkSnapshot(), mkSnapshot({ costCoveragePct: 10 })]);
+    const out = await buildOperationsBriefingPayload(baseInput());
+    expect(out.costCoverageSpark.length).toBe(2);
+  });
+});

--- a/src/lib/operations/__tests__/dashboard-data.test.ts
+++ b/src/lib/operations/__tests__/dashboard-data.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const prismaMock = vi.hoisted(() => ({
+  operationsSnapshot: { findMany: vi.fn() },
+  operationsRecommendation: { findMany: vi.fn() },
+}));
+
+vi.mock('@/lib/database/client', () => ({ prisma: prismaMock }));
+
+import { loadDashboardData } from '../dashboard-data';
+
+function mkSnapshot(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 's1',
+    capturedAt: new Date('2026-05-18T07:30:00Z'),
+    inventoryAccuracyPct: 92,
+    driftEventsTotal: 12,
+    driftEventsBySignal: { 'receiving-lag': 3 },
+    urgentShortagesCount: 1,
+    costCoveragePct: 14,
+    receivingLagP50Hours: 6.5,
+    receivingLagP90Hours: 28,
+    cycleCountsCompletedLast7d: 8,
+    paidOrders14dShortageCount: 4,
+    ...over,
+  };
+}
+
+function mkRec(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'r1',
+    signalKind: 'receiving-lag',
+    severity: 'urgent',
+    title: 'A',
+    createdAt: new Date('2026-05-17T07:30:00Z'),
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  prismaMock.operationsSnapshot.findMany.mockReset();
+  prismaMock.operationsRecommendation.findMany.mockReset();
+});
+
+describe('loadDashboardData', () => {
+  it('returns null latestSnapshot when there are no snapshots yet', async () => {
+    prismaMock.operationsSnapshot.findMany.mockResolvedValue([]);
+    prismaMock.operationsRecommendation.findMany.mockResolvedValue([]);
+    const data = await loadDashboardData();
+    expect(data.latestSnapshot).toBeNull();
+    expect(data.history).toEqual([]);
+    expect(data.activeRecCounts.total).toBe(0);
+  });
+
+  it('chronologically orders the history (oldest → newest)', async () => {
+    prismaMock.operationsSnapshot.findMany.mockResolvedValue([
+      mkSnapshot({ capturedAt: new Date('2026-05-18T07:30:00Z'), driftEventsTotal: 3 }),
+      mkSnapshot({ capturedAt: new Date('2026-05-17T07:30:00Z'), driftEventsTotal: 2 }),
+      mkSnapshot({ capturedAt: new Date('2026-05-16T07:30:00Z'), driftEventsTotal: 1 }),
+    ]);
+    prismaMock.operationsRecommendation.findMany.mockResolvedValue([]);
+    const data = await loadDashboardData();
+    expect(data.history.map((h) => h.driftEventsTotal)).toEqual([1, 2, 3]);
+  });
+
+  it('counts active recs by severity and by signal', async () => {
+    prismaMock.operationsSnapshot.findMany.mockResolvedValue([mkSnapshot()]);
+    prismaMock.operationsRecommendation.findMany.mockResolvedValue([
+      mkRec({ id: 'a', severity: 'urgent', signalKind: 'receiving-lag' }),
+      mkRec({ id: 'b', severity: 'urgent', signalKind: 'receiving-lag' }),
+      mkRec({ id: 'c', severity: 'high', signalKind: 'repeated-shorts' }),
+      mkRec({ id: 'd', severity: 'normal', signalKind: 'cycle-count-overdue' }),
+    ]);
+    const data = await loadDashboardData();
+    expect(data.activeRecCounts.bySeverity).toEqual({ urgent: 2, high: 1, normal: 1 });
+    const recvLag = data.activeRecCounts.bySignal.find((r) => r.signalKind === 'receiving-lag');
+    expect(recvLag?.count).toBe(2);
+    // Sorted by count desc — receiving-lag should be first.
+    expect(data.activeRecCounts.bySignal[0].signalKind).toBe('receiving-lag');
+  });
+
+  it('sorts topUrgent so urgents lead, then by recency', async () => {
+    prismaMock.operationsSnapshot.findMany.mockResolvedValue([mkSnapshot()]);
+    prismaMock.operationsRecommendation.findMany.mockResolvedValue([
+      mkRec({ id: 'old-urgent', severity: 'urgent', createdAt: new Date('2026-05-15T00:00:00Z') }),
+      mkRec({ id: 'new-high', severity: 'high', createdAt: new Date('2026-05-17T00:00:00Z') }),
+      mkRec({ id: 'new-urgent', severity: 'urgent', createdAt: new Date('2026-05-17T01:00:00Z') }),
+    ]);
+    const data = await loadDashboardData();
+    expect(data.topUrgent.map((r) => r.id)).toEqual(['new-urgent', 'old-urgent', 'new-high']);
+  });
+});

--- a/src/lib/operations/briefing-payload.ts
+++ b/src/lib/operations/briefing-payload.ts
@@ -1,0 +1,288 @@
+/**
+ * Operations Director — weekly briefing payload assembler.
+ *
+ * Pulls the latest OperationsSnapshot + recent history + active drift recs
+ * + cycle-count list + dangling drafts. Mirrors marketing's
+ * buildBriefingPayloadFromSnapshot in shape so the email template can be a
+ * straight port of marketing-briefing's editorial dossier aesthetic.
+ *
+ * See docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md §7 Phase 1D.
+ */
+
+import { prisma } from '@/lib/database/client';
+import type { OperationsSnapshot, OperationsRecommendation } from '@prisma/client';
+import type { OpsSeverity } from './types';
+
+export type OpsBriefingTone = 'neutral' | 'good' | 'caution' | 'urgent';
+
+export interface OpsBriefingStat {
+  label: string;
+  value: string;
+  tone?: OpsBriefingTone;
+  spark?: number[];
+}
+
+export interface OpsBriefingDriftEvent {
+  id: string;
+  title: string;
+  severity: OpsSeverity;
+  signalKind: string;
+  ageHours: number;
+}
+
+export interface OpsBriefingCycleCount {
+  title: string;
+  unitsLast14d: number;
+}
+
+export interface OpsBriefingDanglingDraft {
+  id: string;
+  customerName: string;
+  total: string;
+  ageDays: number;
+  status: string;
+}
+
+export interface OpsBriefingPayload {
+  weekLabel: string;
+  issueNumber: number;
+  year: number;
+  generatedDate: string;
+  generatedAtIso: string;
+  stats: OpsBriefingStat[];
+  topUrgentRec: {
+    title: string;
+    signalKind: string;
+    href: string;
+  } | null;
+  driftEvents: OpsBriefingDriftEvent[];
+  cycleCounts: OpsBriefingCycleCount[];
+  danglingDrafts: OpsBriefingDanglingDraft[];
+  costCoveragePct: number;
+  costCoverageSpark: number[];
+  costCoverageGoalPct: number;
+  receivingLagP50Hours: number | null;
+  receivingLagP90Hours: number | null;
+  whatsLacking: string[];
+  links: {
+    queueUrl: string;
+    dashboardUrl: string;
+  };
+}
+
+interface BuildInput {
+  snapshot: OperationsSnapshot;
+  weekLabel: string;
+  issueNumber: number;
+  year: number;
+  generatedAt: Date;
+  queueUrl: string;
+  dashboardUrl: string;
+}
+
+const COST_COVERAGE_GOAL_PCT = 30;
+const DANGLING_DRAFT_AGE_DAYS = 3;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const HOUR_MS = 60 * 60 * 1000;
+
+function severityRank(s: OpsSeverity): number {
+  return s === 'urgent' ? 2 : s === 'high' ? 1 : 0;
+}
+
+function severityFrom(value: string): OpsSeverity {
+  return value === 'urgent' || value === 'high' ? value : 'normal';
+}
+
+function fmtMoney(n: number): string {
+  return `$${n.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+}
+
+function formatGeneratedDate(d: Date): string {
+  return d.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'America/Chicago',
+  });
+}
+
+export async function buildOperationsBriefingPayload(
+  input: BuildInput
+): Promise<OpsBriefingPayload> {
+  const { snapshot, weekLabel, issueNumber, year, generatedAt, queueUrl, dashboardUrl } = input;
+  const now = generatedAt;
+
+  // Recent snapshots for sparklines (chronological, oldest → newest).
+  const recentSnapshots = await prisma.operationsSnapshot.findMany({
+    orderBy: { capturedAt: 'desc' },
+    take: 8,
+    select: {
+      capturedAt: true,
+      costCoveragePct: true,
+      driftEventsTotal: true,
+      urgentShortagesCount: true,
+      inventoryAccuracyPct: true,
+    },
+  });
+  const trend = recentSnapshots.slice().reverse();
+
+  const costCoverageSpark = trend.map((s) => Math.round(s.costCoveragePct));
+  const driftSpark = trend.map((s) => s.driftEventsTotal);
+  const urgentSpark = trend.map((s) => s.urgentShortagesCount);
+  const accuracySpark = trend
+    .map((s) => (s.inventoryAccuracyPct == null ? null : Math.round(s.inventoryAccuracyPct)))
+    .filter((v): v is number => v != null);
+
+  // Active recs — sorted by severity then age for the body lists.
+  const activeRecs = await prisma.operationsRecommendation.findMany({
+    where: { status: { in: ['open', 'approved'] } },
+    orderBy: { createdAt: 'desc' },
+    take: 200,
+  });
+  const sortedRecs = activeRecs.slice().sort((a, b) => {
+    const sb = severityRank(severityFrom(b.severity)) - severityRank(severityFrom(a.severity));
+    if (sb !== 0) return sb;
+    return b.createdAt.getTime() - a.createdAt.getTime();
+  });
+
+  const topUrgent = sortedRecs.find((r) => severityFrom(r.severity) === 'urgent');
+  const topUrgentRec = topUrgent
+    ? {
+        title: topUrgent.title,
+        signalKind: topUrgent.signalKind,
+        href: `${queueUrl}#rec-${topUrgent.id}`,
+      }
+    : null;
+
+  const driftEvents: OpsBriefingDriftEvent[] = sortedRecs
+    .filter((r) => severityFrom(r.severity) !== 'normal')
+    .slice(0, 6)
+    .map((r) => ({
+      id: r.id,
+      title: r.title,
+      severity: severityFrom(r.severity),
+      signalKind: r.signalKind,
+      ageHours: Math.round((now.getTime() - r.createdAt.getTime()) / HOUR_MS),
+    }));
+
+  const cycleCounts = sortedRecs
+    .filter((r) => r.signalKind === 'cycle-count-overdue')
+    .slice(0, 8)
+    .map((r) => ({
+      title: r.title,
+      unitsLast14d: extractMetric(r, 'units_14d'),
+    }));
+
+  const danglingDrafts = await loadDanglingDrafts(now);
+
+  // Stat strip — four cards, mirrors marketing's layout.
+  const accuracy = snapshot.inventoryAccuracyPct;
+  const stats: OpsBriefingStat[] = [
+    {
+      label: 'Inventory Accuracy',
+      value: accuracy == null ? '—' : `${Math.round(accuracy)}%`,
+      tone:
+        accuracy == null ? 'neutral' :
+        accuracy >= 85 ? 'good' :
+        accuracy >= 70 ? 'caution' : 'urgent',
+      spark: accuracySpark.length >= 2 ? accuracySpark : undefined,
+    },
+    {
+      label: 'Urgent Shortages',
+      value: String(snapshot.urgentShortagesCount),
+      tone: snapshot.urgentShortagesCount === 0 ? 'good' : snapshot.urgentShortagesCount >= 5 ? 'urgent' : 'caution',
+      spark: urgentSpark.length >= 2 ? urgentSpark : undefined,
+    },
+    {
+      label: 'Cost Coverage',
+      value: `${Math.round(snapshot.costCoveragePct)}%`,
+      tone:
+        snapshot.costCoveragePct >= COST_COVERAGE_GOAL_PCT ? 'good' :
+        snapshot.costCoveragePct >= 15 ? 'caution' : 'urgent',
+      spark: costCoverageSpark.length >= 2 ? costCoverageSpark : undefined,
+    },
+    {
+      label: 'Drift Events',
+      value: String(snapshot.driftEventsTotal),
+      tone: snapshot.driftEventsTotal === 0 ? 'good' : snapshot.driftEventsTotal >= 20 ? 'urgent' : 'caution',
+      spark: driftSpark.length >= 2 ? driftSpark : undefined,
+    },
+  ];
+
+  // Whats-lacking — surface known data gaps without fail-soft silence.
+  const whatsLacking: string[] = [];
+  if (accuracy == null) {
+    whatsLacking.push('Inventory accuracy metric needs ≥1 cycle-count adjustment in the last 30d.');
+  }
+  if (snapshot.receivingLagP50Hours == null) {
+    whatsLacking.push('Receiving lag percentiles need ≥2 APPLIED invoices in the last 30d.');
+  }
+  if (snapshot.costCoveragePct < COST_COVERAGE_GOAL_PCT) {
+    whatsLacking.push(
+      `Cost coverage at ${Math.round(snapshot.costCoveragePct)}% — Phase 1 goal is ${COST_COVERAGE_GOAL_PCT}%. Margin attribution stays approximate until then.`
+    );
+  }
+
+  return {
+    weekLabel,
+    issueNumber,
+    year,
+    generatedDate: formatGeneratedDate(generatedAt),
+    generatedAtIso: generatedAt.toISOString(),
+    stats,
+    topUrgentRec,
+    driftEvents,
+    cycleCounts,
+    danglingDrafts,
+    costCoveragePct: Math.round(snapshot.costCoveragePct),
+    costCoverageSpark,
+    costCoverageGoalPct: COST_COVERAGE_GOAL_PCT,
+    receivingLagP50Hours: snapshot.receivingLagP50Hours,
+    receivingLagP90Hours: snapshot.receivingLagP90Hours,
+    whatsLacking,
+    links: { queueUrl, dashboardUrl },
+  };
+}
+
+function extractMetric(rec: OperationsRecommendation, name: string): number {
+  const evidence = Array.isArray(rec.evidence) ? rec.evidence : [];
+  for (const row of evidence) {
+    if (row && typeof row === 'object' && 'metricName' in row) {
+      const r = row as { metricName?: string; metricValue?: unknown };
+      if (r.metricName === name && typeof r.metricValue === 'number') return r.metricValue;
+      if (r.metricName === name && typeof r.metricValue === 'string') {
+        const n = Number(r.metricValue);
+        if (Number.isFinite(n)) return n;
+      }
+    }
+  }
+  return 0;
+}
+
+async function loadDanglingDrafts(now: Date): Promise<OpsBriefingDanglingDraft[]> {
+  const cutoff = new Date(now.getTime() - DANGLING_DRAFT_AGE_DAYS * DAY_MS);
+  const drafts = await prisma.draftOrder.findMany({
+    where: {
+      status: { in: ['SENT', 'VIEWED'] },
+      sentAt: { lt: cutoff, not: null },
+    },
+    orderBy: { sentAt: 'asc' },
+    take: 8,
+    select: {
+      id: true,
+      customerName: true,
+      total: true,
+      sentAt: true,
+      status: true,
+    },
+  });
+  return drafts.map((d) => ({
+    id: d.id,
+    customerName: d.customerName,
+    total: fmtMoney(Number(d.total)),
+    ageDays: d.sentAt
+      ? Math.floor((now.getTime() - d.sentAt.getTime()) / DAY_MS)
+      : 0,
+    status: d.status,
+  }));
+}

--- a/src/lib/operations/dashboard-data.ts
+++ b/src/lib/operations/dashboard-data.ts
@@ -1,0 +1,142 @@
+/**
+ * Health-dashboard data assembler.
+ *
+ * Consumed by `/admin/operations` (RSC) and `/api/admin/operations/snapshot`
+ * (JSON). Keep this side-effect-free and DB-only — both surfaces share the
+ * exact same shape.
+ */
+
+import { prisma } from '@/lib/database/client';
+import type { OperationsSnapshot } from '@prisma/client';
+import type { OpsSeverity, SignalKind } from './types';
+
+export interface DashboardData {
+  latestSnapshot: SnapshotSummary | null;
+  history: SnapshotSummary[];   // chronological — oldest → newest, up to 30 rows
+  activeRecCounts: {
+    bySeverity: Record<OpsSeverity, number>;
+    bySignal: Array<{ signalKind: string; count: number }>;
+    total: number;
+  };
+  topUrgent: ActiveRecRow[];
+  cycleCounts7d: number;
+}
+
+export interface SnapshotSummary {
+  capturedAt: string;
+  inventoryAccuracyPct: number | null;
+  driftEventsTotal: number;
+  driftEventsBySignal: Record<string, number>;
+  urgentShortagesCount: number;
+  costCoveragePct: number;
+  receivingLagP50Hours: number | null;
+  receivingLagP90Hours: number | null;
+  cycleCountsCompletedLast7d: number;
+  paidOrders14dShortageCount: number;
+}
+
+export interface ActiveRecRow {
+  id: string;
+  title: string;
+  signalKind: string;
+  severity: OpsSeverity;
+  createdAt: string;
+}
+
+const HISTORY_LIMIT = 30;
+const TOP_URGENT_LIMIT = 8;
+
+function toSnapshotSummary(s: OperationsSnapshot): SnapshotSummary {
+  const byKind = s.driftEventsBySignal && typeof s.driftEventsBySignal === 'object'
+    ? (s.driftEventsBySignal as Record<string, number>)
+    : {};
+  return {
+    capturedAt: s.capturedAt.toISOString(),
+    inventoryAccuracyPct: s.inventoryAccuracyPct,
+    driftEventsTotal: s.driftEventsTotal,
+    driftEventsBySignal: byKind,
+    urgentShortagesCount: s.urgentShortagesCount,
+    costCoveragePct: s.costCoveragePct,
+    receivingLagP50Hours: s.receivingLagP50Hours,
+    receivingLagP90Hours: s.receivingLagP90Hours,
+    cycleCountsCompletedLast7d: s.cycleCountsCompletedLast7d,
+    paidOrders14dShortageCount: s.paidOrders14dShortageCount,
+  };
+}
+
+function normaliseSeverity(value: string): OpsSeverity {
+  return value === 'urgent' || value === 'high' ? value : 'normal';
+}
+
+export async function loadDashboardData(): Promise<DashboardData> {
+  const [recent, activeRecs] = await Promise.all([
+    prisma.operationsSnapshot.findMany({
+      orderBy: { capturedAt: 'desc' },
+      take: HISTORY_LIMIT,
+    }),
+    prisma.operationsRecommendation.findMany({
+      where: { status: { in: ['open', 'approved'] } },
+      orderBy: { createdAt: 'desc' },
+      take: 500,
+    }),
+  ]);
+
+  const latestSnapshot = recent[0] ? toSnapshotSummary(recent[0]) : null;
+  const history = recent.slice().reverse().map(toSnapshotSummary);
+
+  const bySeverity: Record<OpsSeverity, number> = { urgent: 0, high: 0, normal: 0 };
+  const signalCounts = new Map<string, number>();
+  for (const rec of activeRecs) {
+    const sev = normaliseSeverity(rec.severity);
+    bySeverity[sev] += 1;
+    signalCounts.set(rec.signalKind, (signalCounts.get(rec.signalKind) ?? 0) + 1);
+  }
+  const bySignal = Array.from(signalCounts.entries())
+    .map(([signalKind, count]) => ({ signalKind, count }))
+    .sort((a, b) => b.count - a.count);
+
+  const topUrgent: ActiveRecRow[] = activeRecs
+    .slice()
+    .sort((a, b) => {
+      const sa = normaliseSeverity(a.severity);
+      const sb = normaliseSeverity(b.severity);
+      const rank = (s: OpsSeverity) => (s === 'urgent' ? 2 : s === 'high' ? 1 : 0);
+      const sd = rank(sb) - rank(sa);
+      if (sd !== 0) return sd;
+      return b.createdAt.getTime() - a.createdAt.getTime();
+    })
+    .slice(0, TOP_URGENT_LIMIT)
+    .map((r) => ({
+      id: r.id,
+      title: r.title,
+      signalKind: r.signalKind,
+      severity: normaliseSeverity(r.severity),
+      createdAt: r.createdAt.toISOString(),
+    }));
+
+  return {
+    latestSnapshot,
+    history,
+    activeRecCounts: {
+      bySeverity,
+      bySignal,
+      total: activeRecs.length,
+    },
+    topUrgent,
+    cycleCounts7d: latestSnapshot?.cycleCountsCompletedLast7d ?? 0,
+  };
+}
+
+/** Re-exported so the page can render fixed signal labels. */
+export const SIGNAL_LABELS: Record<SignalKind, string> = {
+  'receiving-lag': 'Receiving lag',
+  'pick-inventory-lag': 'Pick-inventory lag',
+  'repeated-shorts': 'Repeated shorts',
+  'negative-available': 'Negative available',
+  'velocity-anomaly': 'Velocity anomaly',
+  'ai-note-backlog': 'AI-note backlog',
+  'variant-mismapping': 'Variant mismapping',
+  'cost-coverage-gap': 'Cost-coverage gap',
+  'cycle-count-overdue': 'Cycle-count overdue',
+  'pre-fulfillment-shortage': 'Pre-fulfillment shortage',
+};

--- a/vercel.json
+++ b/vercel.json
@@ -49,6 +49,10 @@
       "schedule": "0 8 * * *"
     },
     {
+      "path": "/api/cron/operations-briefing",
+      "schedule": "30 13 * * 1"
+    },
+    {
       "path": "/api/cron/event-abandoned-rsvps",
       "schedule": "*/15 * * * *"
     }


### PR DESCRIPTION
## Summary

Phase 1D of the [Operations Director buildout](docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md). Ships the briefing email + health dashboard on top of Phase 1B (detectors) and Phase 1C (triage UI).

**5 things shipped:**
1. **Monday 13:30 UTC briefing email** — runs 30 min after Marketing's 13:00 briefing. Editorial-dossier aesthetic mirroring `marketing-briefing.ts`: 4-card stat strip (inventory accuracy, urgent shortages, cost coverage, drift events) with inline SVG sparklines, top-urgent callout, drift events list, cycle-count list, dangling drafts (DraftOrder SENT/VIEWED ≥3 days), cost-coverage progress, whats-lacking section, dual CTA (Triage Queue + Ops Dashboard).
2. **Health dashboard** at `/admin/operations` — 4-card stat grid with tone-coloured borders + sparklines, "Active drift by signal" horizontal bar chart, "Top urgent recommendations" list deep-linking to the triage queue, snapshot footer with receiving lag percentiles + cycle counts last 7d. Skeleton loader + empty state.
3. **Briefing payload assembler** — pure DB-only function in [src/lib/operations/briefing-payload.ts](src/lib/operations/briefing-payload.ts). Tested in isolation.
4. **Dashboard data helper** — `loadDashboardData()` shared by the page (via JSON endpoint) and future agent surfaces. Returns latest snapshot + 30-day chronological history + active-rec counts by severity/signal + top-N urgent.
5. **Surface discoverability** — adds an "Ops health" link to `/admin/dashboard` next to the existing Recommendations CTA.

## Routes added

| Route | Purpose |
|---|---|
| `GET /api/cron/operations-briefing` | Monday 13:30 UTC cron (registered in [vercel.json](vercel.json)) |
| `GET /api/admin/operations/snapshot` | `requireOpsAuth`-gated JSON for the dashboard / future agent |
| `GET /admin/operations` | One-page health dashboard |

## Deferred to Phase 1E (per the brief)

- **LLM narrative pass (Stage B)** for the briefing — best layered in after the `.claude/agents/operations-director.md` agent file exists so the prompt has the right business context.
- **GitHub commit of the deterministic briefing markdown** — the dashboard already archives the data; markdown can be added when the operator wants weekly diffs in the repo.

## Test plan

- [x] `npx tsc --noEmit` clean on all Phase 1D files
- [x] `npx next lint` on changed files — no warnings/errors
- [x] `npx vitest run` — 22 new tests pass (briefing payload mapping/severity/dangling drafts/whats-lacking; email template structure + HTML-escape + section fallbacks; dashboard-data sorting + counts)
- [x] 79 existing ops tests still green
- [ ] Manual cron dry-run on local dev with `curl -H "Authorization: Bearer $CRON_SECRET" http://localhost:3000/api/cron/operations-briefing` (defer to operator — needs `RESEND_API_KEY` to actually send)
- [ ] Manual dashboard load against prod-like data (defer to operator)

Pre-existing `group-v2-payments.test.ts` failures (6) are unrelated to this PR — same on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)