### PR TITLE
feat(operations): director agent + Obsidian sync + GitHub mirrors (Phase 1E)

### DIFF
--- a/.claude/agents/operations-director.md
+++ b/.claude/agents/operations-director.md
@@ -1,0 +1,143 @@
+---
+name: operations-director
+description: Senior operations analyst for Party On Delivery. Reviews the daily ops snapshot (inventory accuracy, drift events, cost coverage, urgent shortages), surfaces the most-load-bearing reconciliation work, and proposes inline actions on the unified triage queue. Use whenever the user asks "what should I fix in ops next," "are we short on anything this week," for inventory accuracy / drift questions, dangling-draft cleanup, or weekly operations review.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+# Operations Director — Party On Delivery
+
+You are the senior operations analyst for **Party On Delivery**, a premium alcohol delivery + party coordination service in Austin, TX. Your job is to read the daily operations snapshot, look at the active drift signals + recommendation queue, and surface what the operator should fix this week.
+
+**This agent is recommendations-only in Phase 1. Never auto-mutate inventory.** When you propose an action, route it through the existing inline-action contract on each rec card — the operator clicks to execute. (See [docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md](../../docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md) §10 — "Phase 1 never auto-mutates inventory.")
+
+---
+
+## Business context (always true)
+
+- **Inventory accuracy is the bottleneck**, not inventory features. The three-tier model (In Stock / Committed / Available) is solid; the data inside it drifts because reality and the ledger update on different clocks.
+- **Cost coverage is the leverage point for everything else.** Until `ProductVariant.costPerUnit` is populated for the top movers, margin attribution is approximate and the Marketing Director's ROI recs are unreliable (see ADR M0001 in `Memory/Marketing/Decisions/`).
+- **Variants ARE the case.** No split-case ordering. Quantity logic treats the variant as the unit. (Per saved memory `weekly_purchase_plan.md`.)
+- **PAID orders only** for shortage detection — mirrors the existing weekly purchase plan.
+- **Group order manifest names** — when an order has `groupOrderV2Id`, always show the manifest name via `resolveGroupLabel` from `src/lib/operations/detector-helpers.ts`, not just `Order.customerName`. (Saved memory `group_order_manifest_name_rule.md`.)
+- **24h SLA** on receiving lag. Don't fire false positives on same-day-evening invoice processing.
+
+## Autonomy tiers (Phase 1 — all require an operator click)
+
+| Tier | Examples | Authority |
+|---|---|---|
+| Autonomous (Phase 2+) | high-confidence AI-parsed inventory notes auto-apply, idempotent reconcile-pack | flag as "low-risk, can auto-execute in Phase 2" |
+| Recommend-only | every inline action button on a rec card today (navigate to count modal, cost-entry, receiving, etc.) | always recommend-only — operator clicks |
+| **Hard stop** | direct DB writes from your session, anything bypassing the inline-action contract | never propose — flag as out of scope |
+
+## First action every invocation
+
+0. **Obsidian vault sync** — the project's PreToolUse hook in `.claude/settings.json` runs `npm run sync:operations` automatically whenever this subagent is invoked. The vault is up-to-date by the time you bootstrap. If you ever see stale state (e.g. a `rejected` rec still showing `proposed`), run the sync manually:
+   ```bash
+   npm run sync:operations
+   ```
+   The hook fires from `Task` tool calls only; if you're invoked via a slash command or direct prompt that doesn't go through the Agent tool, sync won't auto-run.
+
+1. **Bootstrap from Obsidian** at `/Users/allan/Projects/Obsidian/Obsidian/PartyOn2/Memory/Operations/`:
+   - Read the most recent 2 `Briefings/YYYY-Www.md` files (this week + last week)
+   - Read all `Recommendations/*.md` where status is `proposed` or `accepted` (the active queue)
+   - Read the most recent 1-2 `Decisions/O*.md` (current operational posture)
+   - Read `Open-Questions.md`
+
+2. **Read the latest ops snapshot.** Three sources, in this order:
+   - `docs/operations/weekly/YYYY-Www.md` — the deterministic Monday briefing (this file is the snapshot + active recs + cycle counts + dangling drafts captured for that week)
+   - `GET /api/admin/operations/snapshot` — live JSON with the latest `OperationsSnapshot` row + 30-day history + active-rec counts (returned by `src/lib/operations/dashboard-data.ts`)
+   - `GET /api/admin/recommendations?domain=operations&status=open,approved` — the current open queue
+
+   Curl examples (all require ops session cookie or ops JWT):
+   ```bash
+   curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/operations/snapshot'
+   curl -s -H "Cookie: $OPS_COOKIE" 'http://localhost:3000/api/admin/recommendations?domain=operations&status=open,approved'
+   ```
+
+3. **Check the dashboard surface** for trend context: `/admin/operations` shows inventory accuracy, drift events, cost coverage, and urgent shortages with 30-day sparklines.
+
+4. When you need deeper inventory analysis, lean on the existing ops scripts:
+   - `scripts/ops/check-inventory.mjs` — query stock for a variant
+   - `scripts/ops/low-stock.mjs` — current low-stock list
+   - `scripts/ops/upcoming-orders.mjs` — paid demand window
+   - `scripts/ops/purchase-plan.mjs` — Monday weekly plan (automated via Vercel cron)
+   - `scripts/ops/enter-cogs.mjs` — interactive cost entry (the cost-coverage rec links here)
+
+   Or delegate to a skill:
+   - **`/inventory`** — stock levels, adjustments, weekly plan
+   - **`/ops`** — orders, customers, dashboards, pick lists
+   - **`/weekly-summary`** — printable Friday delivery checklist
+
+## The 9 drift signals + pre-fulfillment shortage
+
+Phase 1 detectors (in `src/lib/operations/detectors/signals-{a,b}.ts`) emit recs for these — re-read the buildout doc §6 if you need the thresholds. Your job is to **synthesize across them**, not re-detect:
+
+| # | Signal | When it matters |
+|---|---|---|
+| 1 | Receiving lag | Distributor invoice stuck >24h — every hour of lag is a hour of bad available-stock math. |
+| 2 | Pick-inventory lag | Packed but not decremented — the system has a transactional gap. Phase 1A wiring closed it forward-looking; older orders surface here. |
+| 3 | Repeated shorts | Same SKU shorting twice in a week ≈ ledger drift. Recommend a count + adjustment. |
+| 4 | Negative available | `committedQuantity > inventoryQuantity` — math is broken. **Urgent** when deficit ≥6. |
+| 5 | Velocity anomaly | Top mover went silent for 14d with no status change — mis-mapped variant or seasonality. |
+| 6 | AI-note backlog | Pending notes stuck >24h — operator-confirmable adjustments waiting. |
+| 7 | Variant mismapping | Sibling variant has committed but no sales — orders likely binding to the wrong variant. |
+| 8 | Cost-coverage gap | Top mover with no cost set — gates Marketing's margin recs. |
+| 9 | Cycle-count overdue | Top-20 mover not counted in ≥7d — recommend a count before the ledger drifts again. |
+| 10 | Pre-fulfillment shortage | PAID order line in next 14d with available < 0 — **urgent**. Operator needs to order or substitute. |
+
+## Decision frameworks
+
+**Flag for the operator's attention when:**
+- Inventory accuracy drops below 70% (or 85% if previously high)
+- Urgent shortages count is ≥1 — every urgent rec is an order-at-risk
+- Cost coverage falls below 15% (urgent) or stays below 30% (caution — the Phase-1 goal)
+- Drift events total trends up week-over-week for 2+ weeks
+- A single SKU shows up across multiple signals (e.g. repeated-shorts + negative-available + cycle-count-overdue) — that variant is the bottleneck
+
+**Prioritize within active recs by:**
+1. Severity (`urgent` always first)
+2. Estimated dollar impact (only if cost coverage on that variant is ≥70% — otherwise treat as directionally uncertain, see saved memory `feedback_audit_before_acting_on_heuristic_recs.md`)
+3. Time-to-act window (a Friday-delivery shortage today beats a Tuesday-delivery shortage in a week)
+
+**Cluster recs by root cause** when you can. Three "repeated-shorts" recs on the same SKU don't mean three problems — they mean one count is overdue and three orders ran short. Recommend the count, not three reactive fixes.
+
+## Known data gaps (Phase 1)
+
+- **Cost coverage** typically sits at 4–30%. Until it's ≥70%, treat **direction of margin/ROI claims as uncertain**, per ADR M0001 (saved memory `project_marketing_adr_m0001.md`). Quote the numbers, but explicitly label the sign as directionally uncertain.
+- **Inventory accuracy** is null when no count-style `InventoryMovement` rows exist in the last 30d. Recommend running a few cycle counts before relying on the metric.
+- **Receiving lag p50/p90** is null until ≥2 APPLIED invoices have landed in the last 30d.
+- **Bundle component shorts** are dropped by detector #3 — the `OrderItemPickState.item_key` for bundle components is `${itemTitle}::${bundleComponentTitle}` and won't match an order_item title directly. Surface this as a known undercount when bundle-heavy weeks come up.
+- **No driver telemetry** yet — Phase 1 is silent on on-time delivery, route quality, driver-side fulfillment errors. Don't speculate.
+
+## Output format
+
+Respond with a **prioritized rec list**, each item containing:
+
+```
+### 1. [Short action] — severity: urgent / high / normal
+- **Why now**: which signal flagged it + the numbers from the snapshot
+- **Action**: which existing inline button to click (e.g. "Open receiving" → `/ops/inventory/receiving/<id>`)
+- **Effort**: small (one-click) | medium (count + adjust) | large (multi-day backfill)
+- **Already in queue?**: yes / no (and the rec id if yes — recommend a status change or snooze rather than a duplicate)
+- **Connects to other recs**: link to other open recs that touch the same SKU / order / vendor
+```
+
+Close with a one-line summary of **what the operator should click first** and why.
+
+## Persisting your output
+
+The snapshot cron (`/api/cron/operations-snapshot` daily 07:30 UTC) and hourly drift cron (`/api/cron/operations-drift-hourly`) auto-persist heuristic recs from the 10 detectors. Your job is to add what those miss — narrative patterns, cross-signal clustering, novel framings.
+
+When you propose a NEW recommendation in a session that the heuristic detectors won't reach (e.g. a synthesis rec like "consolidate three repeated-shorts recs by counting the parent SKU"), do **not** insert it directly to the DB. Instead, draft an Obsidian Recommendation file at `Memory/Operations/Recommendations/<period>-<slug>.md` with `status: proposed` in frontmatter. **Show the draft to the operator before writing.** Once the operator approves, write the file. Never write a Decision (ADR `O####`) without explicit approval.
+
+When the operator transitions a rec via the triage queue (`POST /api/admin/recommendations/[id]/{execute,snooze,dismiss}`), the recommendation-mirror writes to `docs/operations/recommendations/` on GitHub and the next `sync:operations` pulls it into the vault. Append-only `## Updates` section; do not edit prior entries.
+
+## Never do
+
+- **Never auto-mutate inventory.** Every action requires the operator clicking an inline button on a rec card. Even when you're confident the fix is obvious.
+- Never recommend bypassing the inline-action contract (e.g. "just run this SQL manually" or "POST directly to `/api/v1/inventory`") — the rec card + execute endpoint exists exactly so the audit log catches every change.
+- Never assert margin/ROI direction (profitable vs. unprofitable) while `marginCoveragePct` is below 70%. Per ADR M0001, even at ≥70% coverage, affiliate ROI specifically has known attribution leaks — keep the sign as directionally uncertain there.
+- Never invent metrics. If the snapshot returns `null` for inventory accuracy, say "not enough cycle counts in the last 30d" rather than guessing.
+- Never recommend a count-and-adjust larger than ±N units without flagging it as a recount candidate. A 100-unit adjustment with no second count is how the ledger gets wrong in the other direction.
+- **Never edit the Obsidian vault outside `Memory/Operations/`.** Marketing's memory and engineering's memory have their own owners. Do not touch them.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "input=$(cat); subagent=$(echo \"$input\" | jq -r '.tool_input.subagent_type // \"\"'); if [ \"$subagent\" = \"marketing-director\" ]; then echo \"[marketing-sync] firing\"; cd \"$CLAUDE_PROJECT_DIR\" && npm run sync:marketing 2>&1 | tail -5 || true; fi",
+            "command": "input=$(cat); subagent=$(echo \"$input\" | jq -r '.tool_input.subagent_type // \"\"'); if [ \"$subagent\" = \"marketing-director\" ]; then echo \"[marketing-sync] firing\"; cd \"$CLAUDE_PROJECT_DIR\" && npm run sync:marketing 2>&1 | tail -5 || true; elif [ \"$subagent\" = \"operations-director\" ]; then echo \"[operations-sync] firing\"; cd \"$CLAUDE_PROJECT_DIR\" && npm run sync:operations 2>&1 | tail -5 || true; fi",
             "timeout": 30
           }
         ]

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint:tokens": "node scripts/lint-design-tokens.js",
     "sync:marketing": "node scripts/marketing/sync-obsidian.mjs",
     "sync:marketing:watch": "node scripts/marketing/sync-obsidian.mjs --watch",
+    "sync:operations": "node scripts/operations/sync-obsidian.mjs",
+    "sync:operations:watch": "node scripts/operations/sync-obsidian.mjs --watch",
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/scripts/operations/sync-obsidian.mjs
+++ b/scripts/operations/sync-obsidian.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+/**
+ * Sync the GitHub operations-mirror into the local Obsidian vault.
+ *
+ * Mirrors three folders:
+ *   docs/operations/weekly/             → <vault>/Memory/Operations/Briefings/
+ *   docs/operations/recommendations/    → <vault>/Memory/Operations/Recommendations/
+ *   docs/operations/decisions/          → <vault>/Memory/Operations/Decisions/   (when present)
+ *
+ * Idempotent: compares the remote SHA against a local cache file
+ * (Memory/Operations/.sync-state.json) and only writes when something changed.
+ *
+ * Usage:
+ *   node scripts/operations/sync-obsidian.mjs                    # one-shot
+ *   node scripts/operations/sync-obsidian.mjs --watch             # poll every 5 min
+ *   node scripts/operations/sync-obsidian.mjs --dry-run           # show what would change
+ *
+ * Env (in .env.local):
+ *   GITHUB_REPO_TOKEN            required — repo:contents:read scope
+ *   OBSIDIAN_VAULT_OPERATIONS    optional — defaults to
+ *                                 /Users/allan/Projects/Obsidian/Obsidian/PartyOn2/Memory/Operations
+ *   GITHUB_REPO_OWNER            defaults to allan-cmyk
+ *   GITHUB_REPO_NAME             defaults to PartyOn2
+ *   GITHUB_REPO_BRANCH           defaults to main
+ *
+ * Same pattern as scripts/marketing/sync-obsidian.mjs — copy-and-paramaterise
+ * was preferred over abstraction in Phase 1E so each director's sync stays
+ * legible on its own. Pull these together if a third director ships.
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import url from 'url';
+import { execSync } from 'child_process';
+
+const __filename = url.fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+async function loadEnv() {
+  const envPath = path.join(REPO_ROOT, '.env.local');
+  try {
+    const content = await fs.readFile(envPath, 'utf-8');
+    for (const line of content.split('\n')) {
+      const m = line.match(/^([A-Z_][A-Z0-9_]*)\s*=\s*(.*)$/);
+      if (!m) continue;
+      const key = m[1];
+      let val = m[2];
+      if (val.startsWith('"') && val.endsWith('"')) val = val.slice(1, -1);
+      if (val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
+      if (!process.env[key]) process.env[key] = val;
+    }
+  } catch {
+    // no .env.local → rely on real env
+  }
+}
+
+await loadEnv();
+
+function resolveToken() {
+  if (process.env.GITHUB_REPO_TOKEN) return process.env.GITHUB_REPO_TOKEN;
+  try {
+    return execSync('gh auth token', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
+  } catch {
+    return null;
+  }
+}
+
+const TOKEN = resolveToken();
+const OWNER = process.env.GITHUB_REPO_OWNER ?? 'allan-cmyk';
+const REPO = process.env.GITHUB_REPO_NAME ?? 'PartyOn2';
+const BRANCH = process.env.GITHUB_REPO_BRANCH ?? 'main';
+const VAULT = process.env.OBSIDIAN_VAULT_OPERATIONS
+  ?? '/Users/allan/Projects/Obsidian/Obsidian/PartyOn2/Memory/Operations';
+
+const args = process.argv.slice(2);
+const WATCH = args.includes('--watch');
+const DRY_RUN = args.includes('--dry-run');
+const POLL_MS = 5 * 60 * 1000;
+
+if (!TOKEN) {
+  console.error(
+    'No GitHub auth available. Either set GITHUB_REPO_TOKEN in .env.local or run `gh auth login`.'
+  );
+  process.exit(1);
+}
+
+const FOLDER_MAP = [
+  { remote: 'docs/operations/weekly', local: path.join(VAULT, 'Briefings') },
+  { remote: 'docs/operations/recommendations', local: path.join(VAULT, 'Recommendations') },
+  { remote: 'docs/operations/decisions', local: path.join(VAULT, 'Decisions') },
+];
+
+const SYNC_STATE_PATH = path.join(VAULT, '.sync-state.json');
+
+async function readSyncState() {
+  try {
+    const raw = await fs.readFile(SYNC_STATE_PATH, 'utf-8');
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+async function writeSyncState(state) {
+  await fs.mkdir(VAULT, { recursive: true });
+  await fs.writeFile(SYNC_STATE_PATH, JSON.stringify(state, null, 2));
+}
+
+async function listRemoteDir(remotePath) {
+  const url = `https://api.github.com/repos/${OWNER}/${REPO}/contents/${remotePath}?ref=${BRANCH}`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  });
+  if (res.status === 404) return [];
+  if (!res.ok) throw new Error(`GitHub list ${remotePath}: ${res.status} ${await res.text()}`);
+  const body = await res.json();
+  return Array.isArray(body) ? body : [];
+}
+
+async function fetchRemoteFile(downloadUrl) {
+  const res = await fetch(downloadUrl, {
+    headers: { Authorization: `Bearer ${TOKEN}` },
+  });
+  if (!res.ok) throw new Error(`Download ${downloadUrl}: ${res.status}`);
+  return await res.text();
+}
+
+async function syncOnce() {
+  const state = await readSyncState();
+  const newState = { ...state };
+  const summary = { written: [], unchanged: [], skipped: [], errors: [] };
+
+  for (const { remote, local } of FOLDER_MAP) {
+    let entries;
+    try {
+      entries = await listRemoteDir(remote);
+    } catch (err) {
+      summary.errors.push({ folder: remote, error: err.message });
+      continue;
+    }
+
+    if (!DRY_RUN) await fs.mkdir(local, { recursive: true });
+
+    for (const entry of entries) {
+      if (entry.type !== 'file') continue;
+      if (!entry.name.endsWith('.md')) continue;
+
+      const key = `${remote}/${entry.name}`;
+      const localPath = path.join(local, entry.name);
+      const cachedSha = state[key];
+
+      if (cachedSha === entry.sha) {
+        summary.unchanged.push(key);
+        continue;
+      }
+
+      if (DRY_RUN) {
+        summary.written.push({ key, action: cachedSha ? 'update' : 'create', local: localPath });
+        newState[key] = entry.sha;
+        continue;
+      }
+
+      try {
+        const content = await fetchRemoteFile(entry.download_url);
+        await fs.writeFile(localPath, content);
+        newState[key] = entry.sha;
+        summary.written.push({ key, action: cachedSha ? 'update' : 'create', local: localPath });
+      } catch (err) {
+        summary.errors.push({ key, error: err.message });
+      }
+    }
+  }
+
+  if (!DRY_RUN) await writeSyncState(newState);
+  return summary;
+}
+
+function reportSummary(s) {
+  const stamp = new Date().toISOString().replace('T', ' ').slice(0, 19);
+  const lines = [];
+  lines.push(`[${stamp}] sync: ${s.written.length} written, ${s.unchanged.length} unchanged, ${s.errors.length} errors`);
+  for (const w of s.written) lines.push(`  ${w.action === 'create' ? '+' : '~'} ${w.local}`);
+  for (const e of s.errors) lines.push(`  ! ${e.key ?? e.folder}: ${e.error}`);
+  console.log(lines.join('\n'));
+}
+
+if (WATCH) {
+  console.log(`Watching ${OWNER}/${REPO}@${BRANCH} → ${VAULT} (poll every ${POLL_MS / 1000}s, ctrl-c to stop)`);
+  for (;;) {
+    try {
+      const s = await syncOnce();
+      if (s.written.length > 0 || s.errors.length > 0) reportSummary(s);
+    } catch (err) {
+      console.error(`[${new Date().toISOString()}] sync error:`, err.message);
+    }
+    await new Promise((r) => setTimeout(r, POLL_MS));
+  }
+} else {
+  const s = await syncOnce();
+  reportSummary(s);
+  if (s.errors.length > 0) process.exit(2);
+}

--- a/src/app/api/cron/operations-briefing/route.ts
+++ b/src/app/api/cron/operations-briefing/route.ts
@@ -5,10 +5,13 @@
  * Marketing briefing so the operator gets both back-to-back without one
  * blocking the other.
  *
- * Stage A only in Phase 1D — deterministic email + payload. No LLM narrative
- * pass yet (defer to Phase 1E with the operations-director agent file). No
- * GitHub commit either — the /admin/operations dashboard is the persistent
- * archive surface.
+ * Stage A: deterministic email + payload + GitHub commit to
+ * docs/operations/weekly/YYYY-Www.md. The committed markdown is what the
+ * operator's Obsidian vault picks up via scripts/operations/sync-obsidian.mjs.
+ *
+ * No LLM narrative pass yet — leave Stage B for a follow-up once the
+ * operations-director agent has been used for a few weeks and the operator
+ * has a sense for what narrative would add over the deterministic content.
  *
  * See docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md §7 Phase 1D.
  */
@@ -16,7 +19,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/database/client';
 import { resend } from '@/lib/email/resend-client';
+import { putFileToRepo } from '@/lib/github/put-file';
 import { buildOperationsBriefingPayload } from '@/lib/operations/briefing-payload';
+import { renderBriefingMarkdown } from '@/lib/operations/briefing-markdown';
 import {
   renderOperationsBriefingEmail,
   renderOperationsBriefingText,
@@ -90,6 +95,15 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     }
   }
 
+  // Commit deterministic markdown to GitHub so the Obsidian vault picks it
+  // up on the next sync:operations run. Fails soft.
+  const markdown = renderBriefingMarkdown(payload);
+  const commit = await putFileToRepo({
+    path: `docs/operations/weekly/${week.label}.md`,
+    content: markdown,
+    message: `chore(operations): weekly briefing ${week.label}`,
+  }).catch((err) => ({ committed: false, error: err instanceof Error ? err.message : String(err) }));
+
   return NextResponse.json({
     ok: true,
     week: week.label,
@@ -99,7 +113,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       cycleCounts: payload.cycleCounts.length,
       danglingDrafts: payload.danglingDrafts.length,
     },
-    delivery: { email, recipient },
+    delivery: { email, recipient, commit },
     payload,
   });
 }

--- a/src/lib/operations/__tests__/briefing-markdown.test.ts
+++ b/src/lib/operations/__tests__/briefing-markdown.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { renderBriefingMarkdown } from '../briefing-markdown';
+import type { OpsBriefingPayload } from '../briefing-payload';
+
+function payload(over: Partial<OpsBriefingPayload> = {}): OpsBriefingPayload {
+  return {
+    weekLabel: '2026-W21',
+    issueNumber: 21,
+    year: 2026,
+    generatedDate: 'Monday, May 18',
+    generatedAtIso: '2026-05-18T14:00:00.000Z',
+    stats: [
+      { label: 'Inventory Accuracy', value: '92%', tone: 'good' },
+      { label: 'Urgent Shortages', value: '1', tone: 'caution' },
+      { label: 'Cost Coverage', value: '14%', tone: 'urgent' },
+      { label: 'Drift Events', value: '12', tone: 'caution' },
+    ],
+    topUrgentRec: null,
+    driftEvents: [],
+    cycleCounts: [],
+    danglingDrafts: [],
+    costCoveragePct: 14,
+    costCoverageSpark: [12, 13, 14],
+    costCoverageGoalPct: 30,
+    receivingLagP50Hours: 6.5,
+    receivingLagP90Hours: 28,
+    whatsLacking: [],
+    links: {
+      queueUrl: 'https://example.com/admin/recommendations?domain=operations',
+      dashboardUrl: 'https://example.com/admin/operations',
+    },
+    ...over,
+  };
+}
+
+describe('renderBriefingMarkdown', () => {
+  it('emits an Obsidian-shaped frontmatter block', () => {
+    const md = renderBriefingMarkdown(payload());
+    expect(md.startsWith('---\n')).toBe(true);
+    expect(md).toContain('title: "Operations weekly briefing — 2026-W21"');
+    expect(md).toContain('period: 2026-W21');
+    expect(md).toContain('cost_coverage_pct: 14');
+    expect(md).toContain('cost_coverage_goal_pct: 30');
+  });
+
+  it('renders fallback prose for each empty list section', () => {
+    const md = renderBriefingMarkdown(payload());
+    expect(md).toContain('No active drift events this week');
+    expect(md).toContain('No overdue cycle counts');
+    expect(md).toContain('No dangling invoices');
+  });
+
+  it('renders the Urgent block only when topUrgentRec is present', () => {
+    expect(renderBriefingMarkdown(payload())).not.toContain('## Urgent — act first');
+    const withUrgent = renderBriefingMarkdown(payload({
+      topUrgentRec: { title: 'INV-1 stuck', signalKind: 'receiving-lag', href: 'https://example.com/x' },
+    }));
+    expect(withUrgent).toContain('## Urgent — act first');
+    expect(withUrgent).toContain('INV-1 stuck');
+  });
+
+  it('emits drift-event tables with severity icons + signal kinds', () => {
+    const md = renderBriefingMarkdown(payload({
+      driftEvents: [
+        { id: 'a', title: 'Negative available — Tito', severity: 'urgent', signalKind: 'negative-available', ageHours: 3 },
+        { id: 'b', title: 'High lag', severity: 'high', signalKind: 'receiving-lag', ageHours: 28 },
+      ],
+    }));
+    expect(md).toContain('## Drift events');
+    expect(md).toContain('🔴 urgent');
+    expect(md).toContain('🟠 high');
+    expect(md).toContain('Negative available — Tito');
+    expect(md).toContain('`negative-available`');
+  });
+
+  it('renders receiving lag percentiles in the stats table', () => {
+    const md = renderBriefingMarkdown(payload());
+    expect(md).toContain('| Receiving lag p50 | 6.5h |');
+    expect(md).toContain('| Receiving lag p90 | 28.0h |');
+  });
+
+  it('emits the whats-lacking section when items are present', () => {
+    const md = renderBriefingMarkdown(payload({ whatsLacking: ['cost coverage low'] }));
+    expect(md).toContain('## What this brief lacks');
+    expect(md).toContain('- cost coverage low');
+  });
+});

--- a/src/lib/operations/__tests__/recommendation-mirror.test.ts
+++ b/src/lib/operations/__tests__/recommendation-mirror.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderOperationsRecommendationMarkdown } from '../recommendation-mirror';
+import type { OperationsRecommendation } from '@prisma/client';
+
+function mkRec(over: Partial<Record<string, unknown>> = {}): OperationsRecommendation {
+  return {
+    id: 'cuid_1',
+    signalKind: 'receiving-lag',
+    severity: 'urgent',
+    title: 'Receiving invoice INV-1 stuck',
+    evidence: [
+      { metricName: 'hours_pending', metricValue: 30 },
+      { note: 'Distributor: RNDC', sourceLinks: [{ label: 'Open', href: '/ops/inventory/receiving/inv_1' }] },
+    ],
+    targetEntityType: 'receivingInvoice',
+    targetEntityId: 'inv_1',
+    actionPayload: { kind: 'navigate', label: 'Open receiving', params: { href: '/ops/inventory/receiving/inv_1' } } as never,
+    status: 'open',
+    snoozeUntil: null,
+    dismissReason: null,
+    actionLog: [],
+    source: 'auto-snapshot',
+    shippedAt: null,
+    measuredAt: null,
+    measurementResult: null,
+    dedupeKey: 'receiving-lag:inv_1',
+    createdAt: new Date('2026-05-18T07:30:00Z'),
+    updatedAt: new Date('2026-05-18T07:30:00Z'),
+    ...over,
+  } as OperationsRecommendation;
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('renderOperationsRecommendationMarkdown', () => {
+  it('emits an Obsidian-shaped frontmatter block with the required keys', () => {
+    const md = renderOperationsRecommendationMarkdown(mkRec());
+    expect(md.startsWith('---\n')).toBe(true);
+    expect(md).toContain('title: "Receiving invoice INV-1 stuck"');
+    expect(md).toContain('period_proposed: 2026-W21');
+    expect(md).toContain('date_proposed: 2026-05-18');
+    expect(md).toContain('status: proposed');
+    expect(md).toContain('severity: urgent');
+    expect(md).toContain('signal_kind: receiving-lag');
+    expect(md).toContain('target_entity_type: receivingInvoice');
+    expect(md).toContain('target_entity_id: inv_1');
+    expect(md).toContain('dedupe_key: receiving-lag:inv_1');
+  });
+
+  it('maps DB status → Obsidian status correctly', () => {
+    const cases: Array<[string, string]> = [
+      ['open', 'proposed'],
+      ['approved', 'accepted'],
+      ['shipped', 'executed'],
+      ['rejected', 'dismissed'],
+      ['invalidated', 'superseded'],
+      ['snoozed', 'snoozed'],
+    ];
+    for (const [db, vault] of cases) {
+      const md = renderOperationsRecommendationMarkdown(mkRec({ status: db }));
+      expect(md).toContain(`status: ${vault}`);
+    }
+  });
+
+  it('emits evidence rows with notes + metrics + nested source links', () => {
+    const md = renderOperationsRecommendationMarkdown(mkRec());
+    expect(md).toContain('## Evidence');
+    expect(md).toContain('- **hours_pending**: 30');
+    expect(md).toContain('- Distributor: RNDC');
+    expect(md).toContain('  - [Open](/ops/inventory/receiving/inv_1)');
+  });
+
+  it('renders an Action log block when actionLog has entries', () => {
+    const md = renderOperationsRecommendationMarkdown(mkRec({
+      actionLog: [
+        { timestamp: '2026-05-18T07:31:00Z', actionKind: 'navigate', actionLabel: 'Open receiving', result: 'navigated' },
+      ] as never,
+    }));
+    expect(md).toContain('## Action log');
+    expect(md).toContain('navigated · Open receiving');
+  });
+
+  it('omits the Action log block when actionLog is empty', () => {
+    const md = renderOperationsRecommendationMarkdown(mkRec({ actionLog: [] as never }));
+    expect(md).not.toContain('## Action log');
+  });
+
+  it('synthesizes a creation entry in Updates', () => {
+    const md = renderOperationsRecommendationMarkdown(mkRec());
+    expect(md).toContain('## Updates');
+    expect(md).toContain('2026-05-18 — Created with status `proposed`');
+  });
+
+  it('appends a status-change event when provided', () => {
+    const md = renderOperationsRecommendationMarkdown(mkRec({ status: 'rejected', dismissReason: 'intentional buffer' }), {
+      date: '2026-05-19',
+      fromStatus: 'open',
+      toStatus: 'rejected',
+      notes: 'intentional buffer',
+      actor: 'operator',
+    });
+    expect(md).toContain('2026-05-19 — Status open → rejected (operator).');
+    expect(md).toContain('Notes: intentional buffer');
+  });
+
+  it('emits a Dismiss reason block when dismissReason is populated', () => {
+    const md = renderOperationsRecommendationMarkdown(mkRec({ status: 'rejected', dismissReason: 'duplicate of O0001' }));
+    expect(md).toContain('## Dismiss reason');
+    expect(md).toContain('duplicate of O0001');
+  });
+});

--- a/src/lib/operations/briefing-markdown.ts
+++ b/src/lib/operations/briefing-markdown.ts
@@ -1,0 +1,122 @@
+/**
+ * Render the Operations briefing as deterministic markdown — committed to
+ * docs/operations/weekly/YYYY-Www.md by the cron and pulled into the
+ * Obsidian vault via scripts/operations/sync-obsidian.mjs.
+ *
+ * Kept separate from the HTML email template so the markdown stays
+ * git-diffable and the email stays presentation-only.
+ */
+
+import type { OpsBriefingPayload } from './briefing-payload';
+
+function severityIcon(s: 'urgent' | 'high' | 'normal'): string {
+  if (s === 'urgent') return '🔴';
+  if (s === 'high') return '🟠';
+  return '⚪';
+}
+
+export function renderBriefingMarkdown(d: OpsBriefingPayload): string {
+  const lines: string[] = [];
+
+  lines.push('---');
+  lines.push(`title: "Operations weekly briefing — ${d.weekLabel}"`);
+  lines.push(`period: ${d.weekLabel}`);
+  lines.push(`date_generated: ${d.generatedAtIso.slice(0, 10)}`);
+  lines.push(`cost_coverage_pct: ${d.costCoveragePct}`);
+  lines.push(`cost_coverage_goal_pct: ${d.costCoverageGoalPct}`);
+  lines.push(`drift_events: ${d.driftEvents.length}`);
+  lines.push(`cycle_counts_overdue: ${d.cycleCounts.length}`);
+  lines.push(`dangling_drafts: ${d.danglingDrafts.length}`);
+  lines.push(`tags: [briefing, operations, weekly]`);
+  lines.push('---');
+  lines.push('');
+  lines.push(`# Operations weekly briefing — ${d.weekLabel}`);
+  lines.push('');
+  lines.push(`_Generated ${d.generatedAtIso} (issue ${d.issueNumber}, ${d.year})._`);
+  lines.push('');
+
+  if (d.topUrgentRec) {
+    lines.push('## Urgent — act first');
+    lines.push('');
+    lines.push(`- **${d.topUrgentRec.title}**`);
+    lines.push(`  - Signal: \`${d.topUrgentRec.signalKind}\``);
+    lines.push(`  - Open: ${d.topUrgentRec.href}`);
+    lines.push('');
+  }
+
+  lines.push('## Stats');
+  lines.push('');
+  lines.push('| Metric | Value |');
+  lines.push('|---|---|');
+  for (const stat of d.stats) lines.push(`| ${stat.label} | ${stat.value} |`);
+  if (d.receivingLagP50Hours != null || d.receivingLagP90Hours != null) {
+    const p50 = d.receivingLagP50Hours == null ? '—' : `${d.receivingLagP50Hours.toFixed(1)}h`;
+    const p90 = d.receivingLagP90Hours == null ? '—' : `${d.receivingLagP90Hours.toFixed(1)}h`;
+    lines.push(`| Receiving lag p50 | ${p50} |`);
+    lines.push(`| Receiving lag p90 | ${p90} |`);
+  }
+  lines.push('');
+
+  lines.push('## Drift events');
+  lines.push('');
+  if (d.driftEvents.length === 0) {
+    lines.push('_No active drift events this week — ledger is clean._');
+  } else {
+    lines.push('| Severity | Signal | Title | Age |');
+    lines.push('|---|---|---|---:|');
+    for (const e of d.driftEvents) {
+      lines.push(`| ${severityIcon(e.severity)} ${e.severity} | \`${e.signalKind}\` | ${e.title} | ${e.ageHours}h |`);
+    }
+  }
+  lines.push('');
+
+  lines.push('## Cycle counts due this week');
+  lines.push('');
+  if (d.cycleCounts.length === 0) {
+    lines.push('_No overdue cycle counts — top movers are fresh._');
+  } else {
+    lines.push('| Variant | Units (14d) |');
+    lines.push('|---|---:|');
+    for (const c of d.cycleCounts) lines.push(`| ${c.title} | ${c.unitsLast14d} |`);
+  }
+  lines.push('');
+
+  lines.push('## Dangling drafts');
+  lines.push('');
+  if (d.danglingDrafts.length === 0) {
+    lines.push('_No dangling invoices — every sent draft is either paid or fresh._');
+  } else {
+    lines.push('| Customer | Status | Age | Total |');
+    lines.push('|---|---|---:|---:|');
+    for (const dd of d.danglingDrafts) {
+      lines.push(`| ${dd.customerName} | ${dd.status} | ${dd.ageDays}d | ${dd.total} |`);
+    }
+  }
+  lines.push('');
+
+  lines.push('## Cost coverage');
+  lines.push('');
+  lines.push(`Current: **${d.costCoveragePct}%** · Phase-1 goal: **${d.costCoverageGoalPct}%**`);
+  lines.push('');
+  lines.push('Margin attribution accuracy depends on this. Until it climbs to goal, Marketing\'s margin-derived recs gate at directionally-uncertain. The cycle-count + cost-coverage recs in the queue feed it.');
+  lines.push('');
+
+  if (d.whatsLacking.length) {
+    lines.push('## What this brief lacks');
+    lines.push('');
+    for (const item of d.whatsLacking) lines.push(`- ${item}`);
+    lines.push('');
+  }
+
+  lines.push('## Links');
+  lines.push('');
+  lines.push(`- Triage queue: ${d.links.queueUrl}`);
+  lines.push(`- Ops dashboard: ${d.links.dashboardUrl}`);
+  lines.push('');
+  lines.push('---');
+  lines.push('');
+  lines.push(`_Filed by the Operations Director. Phase 1 never auto-mutates inventory — every action requires an operator click on a rec card._`);
+  lines.push('');
+
+  return lines.join('\n');
+}

--- a/src/lib/operations/recommendation-mirror.ts
+++ b/src/lib/operations/recommendation-mirror.ts
@@ -1,0 +1,206 @@
+/**
+ * Operations recommendation mirror — renders an OperationsRecommendation as
+ * Obsidian-shaped markdown (frontmatter + body + Updates log) and commits to
+ * GitHub at docs/operations/recommendations/<period>-<slug>.md.
+ *
+ * Triggered on every status change via the unified [id] endpoints. Fails soft
+ * so an unconfigured GITHUB_REPO_TOKEN doesn't block the DB update or the
+ * triage queue.
+ *
+ * Parallels src/lib/analytics/recommendation-mirror.ts. Kept separate rather
+ * than abstracted because the two models (OperationsRecommendation vs.
+ * RecommendationItem) carry different columns — forcing a shared shape now
+ * would leak detail.
+ */
+
+import type { OperationsRecommendation } from '@prisma/client';
+import { putFileToRepo } from '@/lib/github/put-file';
+import { slugifyTitle } from '@/lib/analytics/recommendation-mirror';
+import type { ActionLogEntry, OpsSeverity, SignalKind } from './types';
+
+export interface MirrorResult {
+  mirrored: boolean;
+  path?: string;
+  url?: string;
+  error?: string;
+}
+
+export interface StatusChangeEvent {
+  date: string;
+  fromStatus: string | null;
+  toStatus: string;
+  notes?: string;
+  actor?: string;
+}
+
+function isoWeekFromDate(date: Date): string {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const dayNum = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const week = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+  return `${d.getUTCFullYear()}-W${String(week).padStart(2, '0')}`;
+}
+
+function mapDbStatusToObsidian(s: string): string {
+  switch (s) {
+    case 'open': return 'proposed';
+    case 'approved': return 'accepted';
+    case 'shipped': return 'executed';
+    case 'rejected': return 'dismissed';
+    case 'invalidated': return 'superseded';
+    case 'snoozed': return 'snoozed';
+    default: return s;
+  }
+}
+
+function severityFrom(value: string): OpsSeverity {
+  return value === 'urgent' || value === 'high' ? value : 'normal';
+}
+
+interface EvidenceRow {
+  metricName?: string;
+  metricValue?: string | number;
+  note?: string;
+  sourceLinks?: Array<{ label: string; href: string }>;
+}
+
+function evidenceLines(rec: OperationsRecommendation): string[] {
+  const evidence = Array.isArray(rec.evidence) ? (rec.evidence as unknown as EvidenceRow[]) : [];
+  const lines: string[] = [];
+  for (const row of evidence) {
+    if (row?.note) lines.push(`- ${row.note}`);
+    if (row?.metricName && row.metricValue !== undefined && row.metricValue !== null) {
+      lines.push(`- **${row.metricName}**: ${row.metricValue}`);
+    }
+    if (row?.sourceLinks) {
+      for (const link of row.sourceLinks) {
+        lines.push(`  - [${link.label}](${link.href})`);
+      }
+    }
+  }
+  return lines;
+}
+
+function actionLogLines(rec: OperationsRecommendation): string[] {
+  const log = Array.isArray(rec.actionLog) ? (rec.actionLog as unknown as ActionLogEntry[]) : [];
+  if (log.length === 0) return [];
+  const lines: string[] = ['', '## Action log', ''];
+  for (const entry of log) {
+    const ts = entry.timestamp?.slice(0, 19).replace('T', ' ') ?? '?';
+    const err = entry.errorMessage ? ` — ${entry.errorMessage}` : '';
+    lines.push(`- ${ts} · \`${entry.actionKind ?? '?'}\` · ${entry.result} · ${entry.actionLabel}${err}`);
+  }
+  return lines;
+}
+
+/**
+ * Render the operations recommendation as the canonical markdown doc, with
+ * a synthesized creation entry + optionally a new status-change entry.
+ */
+export function renderOperationsRecommendationMarkdown(
+  rec: OperationsRecommendation,
+  newEvent?: StatusChangeEvent
+): string {
+  const slug = slugifyTitle(rec.title);
+  const period = isoWeekFromDate(rec.createdAt);
+  const severity = severityFrom(rec.severity);
+  const dateAccepted = rec.status === 'approved' || rec.status === 'shipped' ? rec.createdAt : null;
+  const dateExecuted = rec.status === 'shipped' ? rec.shippedAt : null;
+
+  const fm: Array<[string, string | number | null]> = [
+    ['title', JSON.stringify(rec.title)],
+    ['period_proposed', period],
+    ['date_proposed', rec.createdAt.toISOString().slice(0, 10)],
+    ['date_accepted', dateAccepted ? dateAccepted.toISOString().slice(0, 10) : 'null'],
+    ['date_executed', dateExecuted ? dateExecuted.toISOString().slice(0, 10) : 'null'],
+    ['date_measured', rec.measuredAt ? rec.measuredAt.toISOString().slice(0, 10) : 'null'],
+    ['status', mapDbStatusToObsidian(rec.status)],
+    ['severity', severity],
+    ['signal_kind', rec.signalKind as SignalKind],
+    ['target_entity_type', rec.targetEntityType],
+    ['target_entity_id', rec.targetEntityId],
+    ['source', rec.source],
+    ['related_briefing', period],
+    ['db_id', rec.id],
+    ['dedupe_key', rec.dedupeKey],
+    ['tags', '[recommendation, operations]'],
+  ];
+
+  const fmBlock = fm.map(([k, v]) => `${k}: ${v}`).join('\n');
+
+  const evidence = evidenceLines(rec);
+  const evidenceBlock = evidence.length ? evidence.join('\n') : '_(no evidence recorded)_';
+
+  const dismissReason = (rec.dismissReason ?? '').trim();
+  const reasonBlock = dismissReason ? `\n## Dismiss reason\n\n${dismissReason}\n` : '';
+
+  // Updates log: synthesize creation + (if provided) the new event.
+  const updates: string[] = [];
+  updates.push(
+    `- ${rec.createdAt.toISOString().slice(0, 10)} — Created with status \`${mapDbStatusToObsidian(rec.status)}\` (severity \`${severity}\`) from \`${rec.source}\`.`
+  );
+  if (newEvent) {
+    const noteSuffix = newEvent.notes ? ` Notes: ${newEvent.notes}` : '';
+    const actor = newEvent.actor ?? 'operator';
+    const transition = newEvent.fromStatus
+      ? `${newEvent.fromStatus} → ${newEvent.toStatus}`
+      : `set to ${newEvent.toStatus}`;
+    updates.push(`- ${newEvent.date} — Status ${transition} (${actor}).${noteSuffix}`);
+  }
+
+  const actionLog = actionLogLines(rec).join('\n');
+
+  return `---
+${fmBlock}
+---
+
+# ${rec.title}
+
+## Signal
+
+\`${rec.signalKind}\` · severity \`${severity}\` · target \`${rec.targetEntityType}:${rec.targetEntityId}\`
+
+## Evidence
+
+${evidenceBlock}
+${reasonBlock}
+## Updates
+
+${updates.join('\n')}
+${actionLog}
+
+---
+_Mirror file. Edited automatically by the triage queue when status changes. Source of truth is the database (id: \`${rec.id}\`, dedupe key: \`${rec.dedupeKey}\`). Slug: \`${slug}\`._
+`;
+}
+
+/**
+ * Commit the operations rec mirror to GitHub. Path:
+ *   docs/operations/recommendations/<period>-<slug>.md
+ *
+ * Returns soft-fail result; never throws.
+ */
+export async function mirrorOperationsRecommendation(
+  rec: OperationsRecommendation,
+  event?: StatusChangeEvent
+): Promise<MirrorResult> {
+  try {
+    const slug = slugifyTitle(rec.title);
+    const period = isoWeekFromDate(rec.createdAt);
+    const path = `docs/operations/recommendations/${period}-${slug}.md`;
+    const message = event
+      ? `chore(operations): rec "${rec.title.slice(0, 50)}" → ${event.toStatus}`
+      : `chore(operations): mirror rec "${rec.title.slice(0, 50)}"`;
+    const content = renderOperationsRecommendationMarkdown(rec, event);
+    const result = await putFileToRepo({ path, content, message });
+    return {
+      mirrored: result.committed,
+      path,
+      url: result.htmlUrl,
+      error: result.error,
+    };
+  } catch (err) {
+    return { mirrored: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/src/lib/recommendations/mutation-helpers.ts
+++ b/src/lib/recommendations/mutation-helpers.ts
@@ -10,6 +10,7 @@
 import { prisma } from '@/lib/database/client';
 import type { Prisma } from '@prisma/client';
 import { appendActionLog } from '@/lib/operations/recommendation-store';
+import { mirrorOperationsRecommendation } from '@/lib/operations/recommendation-mirror';
 import { buildActionLogEntry } from './unified-list';
 import type { ActionLogEntry } from '@/lib/operations/types';
 import type { RecommendationStatus } from './lifecycle';
@@ -48,7 +49,18 @@ export async function applyStatusUpdate(
       data.dismissReason = null;
       data.snoozeUntil = null;
     }
-    await prisma.operationsRecommendation.update({ where: { id }, data });
+    const updated = await prisma.operationsRecommendation.update({ where: { id }, data });
+    // Mirror to GitHub so the next `sync:operations` picks up the change in
+    // the operator's vault. Fail-soft — never blocks the DB update.
+    void mirrorOperationsRecommendation(updated, {
+      date: new Date().toISOString().slice(0, 10),
+      fromStatus: currentStatus,
+      toStatus: update.status,
+      notes: update.dismissReason ?? update.notes,
+      actor: 'operator',
+    }).catch((err) => {
+      console.warn('[ops-rec-mirror] non-fatal:', err instanceof Error ? err.message : err);
+    });
     return;
   }
 


### PR DESCRIPTION
## Summary

Phase 1E of the [Operations Director buildout](docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md) — the final phase. Closes the agentic-org loop by giving Operations the same surfaces Marketing has had since PR #20.

**5 things shipped:**
1. **`operations-director` subagent** at [.claude/agents/operations-director.md](.claude/agents/operations-director.md) — Sonnet, `Read/Grep/Glob/Bash` tools, full bootstrap ritual (vault sync → latest snapshot → active queue → 10-signal map → Phase-1 hard rules). Invoked when the operator asks "what should I fix in ops next," for drift / inventory accuracy / dangling-draft questions, or for the weekly operations review.
2. **Obsidian sync** at [scripts/operations/sync-obsidian.mjs](scripts/operations/sync-obsidian.mjs) + `npm run sync:operations` / `sync:operations:watch`. Idempotent SHA-cached pull from `docs/operations/{weekly,recommendations,decisions}/` → `Memory/Operations/{Briefings,Recommendations,Decisions}/`. Mirrors `scripts/marketing/sync-obsidian.mjs` exactly.
3. **PreToolUse hook** in [.claude/settings.json](.claude/settings.json) — fires `npm run sync:operations` whenever the operations-director subagent is invoked via the Agent tool. Vault is up-to-date before the agent bootstraps.
4. **Recommendation GitHub mirror** at [src/lib/operations/recommendation-mirror.ts](src/lib/operations/recommendation-mirror.ts) — every triage-queue status transition (execute / snooze / dismiss) commits an Obsidian-shaped markdown to `docs/operations/recommendations/<period>-<slug>.md`. Fired fail-soft from `applyStatusUpdate` so it never blocks the DB write.
5. **Briefing GitHub commit** — the Monday cron now writes deterministic Stage A markdown to `docs/operations/weekly/<week>.md` via [src/lib/operations/briefing-markdown.ts](src/lib/operations/briefing-markdown.ts). Vault picks it up on the next sync.

**Obsidian vault** (lives outside this repo, in `/Users/allan/Projects/Obsidian/Obsidian/PartyOn2/`):
- `Memory/Operations/README.md` — folder conventions, status lifecycle, frontmatter schemas, bootstrap ritual, hard rules
- `Memory/Operations/Open-Questions.md` — operations parking lot
- `Memory/Operations/{Briefings,Recommendations,Decisions}/` — empty shells for the sync to populate
- `Programs/Operations-Director.md` — program doc: pipeline overview, cron schedule, admin surfaces, 10-signal map

## Deferred (intentionally)

- **Stage B LLM narrative** pass for the weekly briefing — wait until the operator has run the deterministic briefing for a few weeks first and has a sense for what narrative would add.
- **Direct apiCall mutations** from execute payloads — still scaffolded as 501. Phase 1C-b territory.

## Test plan

- [x] `npx tsc --noEmit` clean on all Phase 1E files
- [x] `npx next lint` clean
- [x] 14 new tests pass (recommendation-mirror across 8 cases + briefing markdown across 6 cases)
- [x] All 139 Phase 1 ops/recommendations tests green
- [x] `npm run sync:operations` dry-run against empty `docs/operations/*` returns clean (0 written, 0 errors)
- [ ] Manual end-to-end: trigger the briefing cron locally with `curl -H "Authorization: Bearer $CRON_SECRET" http://localhost:3000/api/cron/operations-briefing`, confirm the markdown commit hits GitHub, then `npm run sync:operations` and verify the vault folder receives it (defer to operator — needs prod `GITHUB_REPO_TOKEN`)
- [ ] Invoke the operations-director subagent from a fresh Claude Code session and confirm the PreToolUse hook fires the sync (defer to operator)

Pre-existing `group-v2-payments.test.ts` failures (6) are unrelated — same on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)