### PR TITLE
fix(analytics): fire first-party tracker even when GA4 is unavailable

### DIFF
--- a/src/lib/analytics/ga4-events.ts
+++ b/src/lib/analytics/ga4-events.ts
@@ -47,8 +47,15 @@ export function trackCTAClick(
   experimentId?: string,
   variantId?: string
 ): void {
+  // Always mirror to first-party event stream — sample-free, joinable in
+  // our own DB, and not blocked by ad blockers / missing GA4 config.
+  trackPodEvent(
+    'cta_click',
+    { button_text: buttonText, button_url: buttonUrl, section },
+    { experimentId, variantId }
+  );
+
   if (!isGtagAvailable()) {
-    // Log in development for debugging
     if (process.env.NODE_ENV === 'development') {
       console.log('[GA4 Dev] cta_click:', { buttonText, buttonUrl, section, experimentId, variantId });
     }
@@ -63,12 +70,6 @@ export function trackCTAClick(
     ...(experimentId && { experiment_id: experimentId }),
     ...(variantId && { variant_id: variantId }),
   });
-
-  trackPodEvent(
-    'cta_click',
-    { button_text: buttonText, button_url: buttonUrl, section },
-    { experimentId, variantId }
-  );
 }
 
 /**
@@ -76,6 +77,8 @@ export function trackCTAClick(
  * @param percentage - The scroll percentage reached
  */
 export function trackScrollDepth(percentage: 25 | 50 | 75 | 100): void {
+  trackPodEvent('scroll_depth', { percent_scrolled: percentage });
+
   if (!isGtagAvailable()) {
     if (process.env.NODE_ENV === 'development') {
       console.log('[GA4 Dev] scroll_depth:', { percentage });
@@ -87,8 +90,6 @@ export function trackScrollDepth(percentage: 25 | 50 | 75 | 100): void {
     percent_scrolled: percentage,
     page_location: window.location.href,
   });
-
-  trackPodEvent('scroll_depth', { percent_scrolled: percentage });
 }
 
 /**
@@ -96,6 +97,8 @@ export function trackScrollDepth(percentage: 25 | 50 | 75 | 100): void {
  * @param sectionName - The name of the section viewed
  */
 export function trackSectionView(sectionName: string): void {
+  trackPodEvent('section_view', { section_name: sectionName });
+
   if (!isGtagAvailable()) {
     if (process.env.NODE_ENV === 'development') {
       console.log('[GA4 Dev] section_view:', { sectionName });
@@ -107,8 +110,6 @@ export function trackSectionView(sectionName: string): void {
     section_name: sectionName,
     page_location: window.location.href,
   });
-
-  trackPodEvent('section_view', { section_name: sectionName });
 }
 
 /**
@@ -122,6 +123,12 @@ export function trackHeroVariant(
   variantId: string,
   elementId: string = 'hero'
 ): void {
+  trackPodEvent(
+    'experiment_exposure',
+    { element_id: elementId },
+    { experimentId, variantId }
+  );
+
   if (!isGtagAvailable()) {
     if (process.env.NODE_ENV === 'development') {
       console.log('[GA4 Dev] experiment_impression:', { experimentId, variantId, elementId });
@@ -135,12 +142,6 @@ export function trackHeroVariant(
     element_id: elementId,
     page_location: window.location.href,
   });
-
-  trackPodEvent(
-    'experiment_exposure',
-    { element_id: elementId },
-    { experimentId, variantId }
-  );
 }
 
 /**
@@ -156,6 +157,12 @@ export function trackExperimentConversion(
   conversionType: 'purchase' | 'signup' | 'lead' | 'checkout',
   value?: number
 ): void {
+  trackPodEvent(
+    'experiment_conversion',
+    { conversion_type: conversionType, value: value ?? null },
+    { experimentId, variantId }
+  );
+
   if (!isGtagAvailable()) {
     if (process.env.NODE_ENV === 'development') {
       console.log('[GA4 Dev] experiment_conversion:', { experimentId, variantId, conversionType, value });
@@ -170,12 +177,6 @@ export function trackExperimentConversion(
     ...(value !== undefined && { value }),
     page_location: window.location.href,
   });
-
-  trackPodEvent(
-    'experiment_conversion',
-    { conversion_type: conversionType, value: value ?? null },
-    { experimentId, variantId }
-  );
 }
 
 /**
@@ -210,6 +211,12 @@ export function trackBlogCtaClick(
   slug: string,
   href: string
 ): void {
+  trackPodEvent('blog_cta_click', {
+    blog_topic: topic,
+    blog_slug: slug,
+    destination_url: href,
+  });
+
   if (!isGtagAvailable()) {
     if (process.env.NODE_ENV === 'development') {
       console.log('[GA4 Dev] blog_cta_click:', { topic, slug, href });
@@ -222,12 +229,6 @@ export function trackBlogCtaClick(
     blog_slug: slug,
     destination_url: href,
     page_location: window.location.href,
-  });
-
-  trackPodEvent('blog_cta_click', {
-    blog_topic: topic,
-    blog_slug: slug,
-    destination_url: href,
   });
 }
 


### PR DESCRIPTION
## Why

While verifying the BlogTopicCTA click event shipped in [#59](https://github.com/allan-cmyk/PartyOn2/pull/59), discovered that **production is silently dropping ALL tracking events from this file** because:

1. `NEXT_PUBLIC_GA_MEASUREMENT_ID` is set in `.env.local` but **not in Vercel production** (curl-verified: zero GA4 loader scripts in prod HTML).
2. So `window.gtag` never becomes a function in prod.
3. So `isGtagAvailable()` returns false.
4. So every helper in `ga4-events.ts` early-returns — **including the `trackPodEvent` call that mirrors to the first-party `AnalyticsEvent` stream.**

This contradicts the documented intent at the top of the file:

> _"Every event mirrors to the first-party AnalyticsEvent stream via `trackPodEvent` so we have a sample-free, joinable copy in our own DB."_

That copy is what feeds the experiment significance code, A/B test analysis, and join-to-orders queries. It needs to fire regardless of whether GA4 is available, has been configured, or is being blocked by an ad blocker.

## What this fixes

Hoists the `trackPodEvent` call **above** the `isGtagAvailable()` check in each of the 6 affected helpers:

- `trackCTAClick`
- `trackScrollDepth`
- `trackSectionView`
- `trackHeroVariant`
- `trackExperimentConversion`
- `trackBlogCtaClick`

`trackOutboundClick` and `trackEngagementTime` intentionally don't have `trackPodEvent` mirrors (GA4-only by design) and are left alone.

## What this does NOT fix

GA4 still won't emit events in production until `NEXT_PUBLIC_GA_MEASUREMENT_ID` is set in Vercel env. That's an operator step, not code — Vercel dashboard → Settings → Environment Variables, add the GA4 measurement ID (format `G-XXXXXXXXXX`) for production.

After this PR merges, you can verify the blog CTA click event via:

```bash
source .env.local
psql "$DATABASE_URL" -c "SELECT created_at, event_name, properties FROM \"AnalyticsEvent\" WHERE event_name = 'blog_cta_click' ORDER BY created_at DESC LIMIT 10;"
```

(That table also lets you query `cta_click`, `scroll_depth`, `section_view`, etc. — anything routed through this file.)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx next lint` clean
- [ ] After merge: click the blog CTA on prod, query `AnalyticsEvent` table, confirm a row exists with `event_name = 'blog_cta_click'` and the topic/slug/destination in `properties`
- [ ] Operator: set `NEXT_PUBLIC_GA_MEASUREMENT_ID` in Vercel env so the GA4 side also fires

## Refs

Follow-up to [#59](https://github.com/allan-cmyk/PartyOn2/pull/59) which surfaced the bug. The bug was pre-existing across all helpers; the PR #59 instrumentation just happened to be the first place we tried to verify it end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)