### PR TITLE
fix(stripe): remove unused Prisma import in webhooks.ts

### DIFF
--- a/src/lib/stripe/webhooks.ts
+++ b/src/lib/stripe/webhooks.ts
@@ -10,7 +10,6 @@ import { prisma } from '@/lib/database/client';
 import { createOrderFromCheckout, createRefund, getOrderByCheckoutSession, createOrderFromDraftOrder } from '@/lib/inventory/services/order-service';
 import { getCartById } from '@/lib/inventory/services/cart-service';
 import { getDraftOrderById, updateDraftOrderStatus, DraftOrderWithTotal } from '@/lib/draft-orders';
-import { Prisma } from '@prisma/client';
 import {
   sendOrderConfirmationEmail,
   sendPaymentFailedEmail,


### PR DESCRIPTION
## Summary
- Removes a leftover \`import { Prisma } from '@prisma/client'\` in [src/lib/stripe/webhooks.ts:13](src/lib/stripe/webhooks.ts:13) that was unused.
- This is what failed the production build after PR #64 (the build had been broken since commit 7d56090a but only got caught now).

## Test plan
- [x] \`npx next lint --file src/lib/stripe/webhooks.ts\` passes locally
- [ ] Vercel build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)