### PR TITLE
fix(group-orders): never auto-close group dashboards

### DIFF
--- a/src/app/api/cron/group-orders-v2/route.ts
+++ b/src/app/api/cron/group-orders-v2/route.ts
@@ -28,21 +28,15 @@ export async function GET(request: NextRequest) {
       },
     });
 
-    // Close expired group orders (30 days old)
-    const expiredGroups = await prisma.groupOrderV2.updateMany({
-      where: {
-        status: 'ACTIVE',
-        expiresAt: { lt: now },
-      },
-      data: {
-        status: 'CLOSED',
-      },
-    });
+    // Auto-close of expired group orders is intentionally disabled.
+    // Business rule: dashboards must never close on their own — a customer
+    // hitting a CLOSED group sees "not accepting new participants" and we
+    // lose the order. If a group genuinely needs to be ended, do it manually.
 
     return NextResponse.json({
       success: true,
       tabsLocked: result.count,
-      groupsClosed: expiredGroups.count,
+      groupsClosed: 0,
       timestamp: now.toISOString(),
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- Removes the auto-close block in [src/app/api/cron/group-orders-v2/route.ts](src/app/api/cron/group-orders-v2/route.ts) that was flipping ACTIVE groups → CLOSED when \`expiresAt\` passed.
- Business rule from ops: **dashboards must never close on their own.** A CLOSED group triggers \`"Group order is not accepting new participants"\` in [service.ts:517](src/lib/group-orders-v2/service.ts:517) and we lose the order.
- Tab-locking (OPEN → LOCKED at \`orderDeadline\`) is preserved — that's about freezing carts at the cutoff, separate from dashboard accessibility.

## Incident
A customer called today saying the dashboard told him it wasn't accepting more participants. Audit found 9 dashboards for this coming weekend (5/22-5/24) had been auto-closed by this cron — root cause is that the Premier auto-create webhook sets a short \`expiresAt\` (about a week out), but cruises are often booked further out, so groups close before delivery. All 9 have been manually reopened with \`expiresAt\` pushed to 2030-01-01.

## Test plan
- [ ] Vercel build succeeds
- [ ] After deploy, no new groups get flipped to CLOSED by the next cron run

🤖 Generated with [Claude Code](https://claude.com/claude-code)