### PR TITLE
fix(redirects): 301 for ping-pong-balls-10pcs → 6pcs slug rename

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -182,6 +182,13 @@ const nextConfig: NextConfig = {
         permanent: true,
       },
 
+      // Product slug rename: ping pong balls 10pcs → 6pcs (pack size changed)
+      {
+        source: '/products/ping-pong-balls-10pcs',
+        destination: '/products/ping-pong-balls-6pcs',
+        permanent: true,
+      },
+
       // Main ordering page redirects
       {
         source: '/products',


### PR DESCRIPTION
Product handle was updated in the DB from `ping-pong-balls-10pcs` to `ping-pong-balls-6pcs` because the pack size changed. This PR adds a 301 redirect so old links don't 404.

## Test plan
- [ ] After deploy, `curl -sI https://partyondelivery.com/products/ping-pong-balls-10pcs` returns 308/301 to `/products/ping-pong-balls-6pcs`
- [ ] `/products/ping-pong-balls-6pcs` resolves normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)