### PR TITLE
docs(directors): preserve SEO + Finance buildout briefs

### DIFF
--- a/docs/FINANCE-DIRECTOR-AGENT-BUILDOUT.md
+++ b/docs/FINANCE-DIRECTOR-AGENT-BUILDOUT.md
@@ -1,0 +1,480 @@
+# Finance Director Agent — Buildout Brief
+
+**Drop this entire file into a new Claude Code session.** It is self-contained — the new session will have no memory of the conversation that produced it.
+
+**Goal of the new session:** Build the entire Finance Director across all 11 phases in dynamic-loop mode (`/loop` no interval), self-paced via `ScheduleWakeup`. See §1.5 for the loop protocol. Phase 0 lays foundation; subsequent phases ship one PR each.
+
+---
+
+## 1. Context — why this agent exists
+
+Party On Delivery (premium alcohol + party coordination delivery, Austin TX) is being reorganized around an "agentic org structure" — director-level Claude agents that own a functional area, surface decisions to the operator (Allan), and execute routine work autonomously. Three directors are now live:
+
+- **Marketing Director** — shipped Apr 2026, weekly analytics + recommendation triage. See `.claude/agents/marketing-director.md`, `Programs/Marketing-Director.md` in the Obsidian vault.
+- **Operations Director** — shipped May 2026, 10-signal inventory drift detection + reconciliation. See `.claude/agents/operations-director.md`, `docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md`.
+- **SEO Director** — Phase 0 shipped May 2026, weekly SEMrush snapshots via a Cowork browser-automation skill. See `docs/SEO-DIRECTOR-AGENT-BUILDOUT.md`.
+
+The Finance Director is **director #4** and the most ambitious by scope. Where Marketing and Ops watch metrics inside the PartyOn database, Finance acts as a **CFO** — it owns external connections (QuickBooks Online, Plaid bank feed, Stripe API beyond what webhooks capture), produces P&L statements, reconciles books monthly, prepares tax documents, and tracks operating expenses + sales tax + contractor 1099s.
+
+The original 6-director plan (Apr 18, 2026) described Finance as: *"owns unit economics and cash flow. Sub-agents: margin analysis agent, pricing agent, forecasting agent, bookkeeping agent."* Phase 1 collapses these into a single Finance Director that grows sub-agents only if the prompt gets unwieldy.
+
+---
+
+## 1.5 Loop protocol (how this session operates)
+
+You are running in **dynamic-loop mode** (`/loop` with no interval). The first message of this session invoked `/loop` — you self-pace via `ScheduleWakeup` and continue across phases until you've completed all 11 phases or hit a stop condition. The operator is not clicking through ten chips; you keep going on your own.
+
+### Iteration ritual (start of every wakeup)
+
+1. **Pull main + check state.** `git pull --ff-only`. Run `gh pr list --state all --limit 15 --json number,title,state,mergedAt --search "finance"`. Identify the most recent Finance Director PR and its status.
+2. **Run health checks on the last shipped phase's deliverables.** After Phase 0: hit `/api/admin/finance/qb/health` and `/api/admin/finance/plaid/health` in prod, verify green. After 1A: fire `/api/cron/finance-stripe-sync` and verify a row written + no errors. Similar pattern for every phase — touch what the last PR shipped and confirm it works against real data.
+3. **Verify tests still pass.** `npm run test:run`, `npx tsc --noEmit`, `npx next lint`. If any new regressions appear (vs the pre-existing `group-v2-payments.test.ts` failures from main, which are unrelated), STOP and surface them to the operator before building the next phase.
+4. **Decide next action** based on state:
+   - Last PR not merged yet → schedule wakeup in 3600s (1h, the max delay)
+   - Last PR merged + health checks green → pick the next phase from §7 and build it
+   - Last PR merged but post-merge verification failed → open a follow-up PR fixing the regression, then resume the planned sequence
+   - Blocked on an unanswered operator question → do NOT schedule a wakeup; the operator's answer resumes you
+   - All 11 phases done → post a final summary message, do NOT schedule a wakeup, stop
+
+### Question-asking protocol
+
+- **Batch decisions via `AskUserQuestion` (up to 4 questions per call).** Your first iteration asks all the §12 credentials questions in ONE batch — Intuit app, Plaid app, QB tier, bank institution, Stripe payout schedule — not one at a time.
+- **Never ask "should I proceed?"** If you've completed a phase + verified it works, just open the PR and schedule the next wakeup. Operator's PR review is the human gate, not a chat prompt.
+- **If a phase needs a decision mid-build** (e.g., QB chart-of-accounts mapping in Phase 2A), batch all decisions for that phase into one AskUserQuestion call before writing code.
+
+### Sleep intervals
+
+| Situation | Delay |
+|---|---|
+| Mid-phase, just shipped code, want to verify | 60–270s (keeps cache warm) |
+| Phase complete, PR opened, awaiting operator review | 3600s (1h — the max) |
+| Blocked on unanswered question | Do not schedule; wait |
+| All phases done | Do not schedule; stop |
+
+### Stop conditions (post a final summary, then end)
+
+1. **All 11 phases done** (counting 1A, 1B, 1C, 2A, 2B, 2C as separate phases: 0 + 1A + 1B + 1C + 2A + 2B + 2C + 3 + 4 + 5 + 6 = 11)
+2. **Same phase fails post-merge verification 3 times in a row** → escalate to operator, stop
+3. **Operator explicitly tells you to stop**
+4. **Schema drift detected** that requires operator decision (e.g., production data conflicts with new migration) → surface and stop
+
+### What you may NOT do autonomously (these need operator action in the actual app, not just PR review)
+
+- Run any raw SQL migration against production — operator runs each phase's `prisma/migrations/manual/*.sql` file manually after the PR merges
+- Toggle the autonomy ceiling broader than "auto-categorize only" (the decision from §3)
+- Move money via any API — Stripe Transfers, ACH, distributor payment, tax remittance
+- Promote QB or Plaid from sandbox → production tier (operator swaps env vars after each phase merges)
+- Force-push, `--no-verify`, skip signing, or commit secrets
+
+### Each phase opens its own PR
+
+Do not bundle multiple phases into one PR. Phase 0 → its own PR. Phase 1A → its own PR. Etc. PR title pattern: `feat(finance): <short phase description> (Phase <N> for Finance Director)`. Operator reviews each independently. The loop continues across PRs whether or not the operator has merged yet — but the next phase doesn't start until the prior phase is merged.
+
+---
+
+## 2. The execution model
+
+**The whole build is genuinely big — 11 phases, 1 PR each.** You build them sequentially in a single long-running session that self-paces via the loop protocol above. Each phase ships a focused PR; the operator reviews on their normal cadence; you sleep between iterations.
+
+Phase 0 is the smallest and lays the foundation (QB + Plaid OAuth + 4 empty models). Phase 5 is where the Director becomes invokable as a Claude agent. Phase 6 is post-trust graduation (config flag only, not new code). The other phases (1A through 4) ship the data plumbing the Director consumes.
+
+Anything beyond "the next phase in sequence" is out of scope at any given moment. Don't skip ahead. Don't bundle.
+
+---
+
+## 3. Operator's decisions (locked in 2026-05-19)
+
+| Decision | Choice | Implication |
+|---|---|---|
+| Accounting software | **QuickBooks Online** | Use Intuit Developer API. OAuth2 connection, sandbox first, then production. Can read AND write to QB. |
+| Bank feed | **Plaid (real-time API)** | Plaid Link in admin UI; subscribe to transaction webhooks; auto-match deposits → Stripe payouts and outflows → distributor invoice payments. |
+| Payroll | **Only contractor 1099s** | No W-2 payroll integration needed. Track contractor payouts (via Stripe Connect / ACH / outflow categorization) for year-end 1099-NEC prep. Threshold: $600/year per contractor per IRS rules. |
+| Autonomy ceiling | **Auto-categorize, recommend everything else** | Director can apply expense categories to bank transactions in QuickBooks without asking. Everything else (post journal entries, send payments, file taxes, mark distributor invoices paid) requires operator click. Mirrors the pattern of Marketing recommending + Ops giving inline action buttons. |
+
+---
+
+## 4. What's already in the PartyOn database (audited 2026-05-19)
+
+This list is exhaustive — these are the financial data sources Finance can pull from on day one. Do not re-audit; trust this and verify only when something seems off.
+
+### Revenue side (complete)
+
+| Model | Coverage | Sample stats |
+|---|---|---|
+| `Order` | All paid orders. Fields: subtotal, taxAmount, discountAmount, deliveryFee, tipAmount, total, marginAmount, marginCoveragePct, stripePaymentIntentId, stripeChargeId, utmSource, landingPage | 232 orders, $87,460.57 revenue, $6,226.28 tax collected |
+| `OrderItem` | Per line item: price, quantity, unitCost, totalCost | 1,308 items; cost data populated for orders post-margin-pipeline only |
+| `Refund` | stripeRefundId, amount, reason, status | 57 refunds |
+| `Discount` + `DiscountUsage` | Promo code tracking | 60 codes, 7 usage logs (gap — discount-applied-but-not-logged is common) |
+| `DraftOrder` | Outstanding invoices (AR), states: PENDING / SENT / VIEWED / PAID / CANCELLED | 62 drafts, $62,901.92 outstanding |
+| `GroupOrderV2` / `SubOrder` / `ParticipantPayment` | Group order revenue | 2,014 groups, 2,539 sub-orders |
+
+### Cost side (improving — Ops Director is pushing coverage up)
+
+| Model | Coverage | Notes |
+|---|---|---|
+| `ProductVariant.costPerUnit` | **20.6% of variants today** (57 / 1,203). Was 4% in April. | Ops Director's `cost-coverage-gap` detector surfaces top-velocity uncosted SKUs for operator to enter |
+| `OrderItem.unitCost`, `totalCost` | 51% of orders have full cost data | Snapshot taken at order creation via `snapshotItemCost()` |
+| `Order.marginAmount`, `marginCoveragePct` | 119 / 232 orders | Populated via `finalizeOrderMargin()` at order completion |
+| `ReceivingInvoice` + `ReceivingInvoiceLine` | 18 invoices, 87 lines, 10 APPLIED, 8 PENDING_REVIEW | AI-parsed from operator photo uploads, status: PENDING_REVIEW → APPLIED → cost-per-unit written to variant |
+| `InventoryMovement` | 1,896 audit-trail rows | RECEIVING / SALE / ADJUSTMENT type. Read-only history. |
+
+**Key constraint (saved memory):** Marketing's ADR M0001 says **affiliate ROI / margin-leak decisions are blocked until cost coverage hits ≥70%**. Finance must respect this — do not generate "pause this affiliate" or "reprice this SKU" recommendations that conflict. Marketing owns those once coverage is fixed; Finance complements with P&L and tax-side decisions.
+
+### Sales tax (complete liability tracking, no remittance log)
+
+- 8.25% TX rate hardcoded in `src/lib/tax/rates.ts`
+- Per-order tax in `Order.taxAmount`
+- Cumulative tax collected = `SELECT SUM(taxAmount) FROM orders WHERE created_at BETWEEN ...`
+- **Gap:** no model for tax remittance (when filed, what period, amount paid)
+
+### Affiliate commissions (complete)
+
+- `Affiliate` (24 active), `AffiliateCommission` (122, with $1,722.84 in HELD+APPROVED), `AffiliatePayout` (9 batches)
+- Monthly batch generation via `/api/admin/affiliates/payouts/generate?year=Y&month=M`
+- **Gap:** no Stripe Transfers integration — payouts are DB records, paid manually via ACH
+
+### What's MISSING from PartyOn DB (Phase 0–2 will add)
+
+| Gap | Why it matters | Phase to address |
+|---|---|---|
+| Stripe fees per charge | Can't compute true net revenue | Phase 1A |
+| Stripe payouts → bank | Can't reconcile bank deposits | Phase 1A |
+| Stripe disputes / chargebacks | Subscribed to webhook but no handler | Phase 1A |
+| AP on `ReceivingInvoice` (total, due date, paid status) | Can't tell which distributor invoices are unpaid | Phase 1B |
+| Operating expenses (rent, software, fuel, contractor pay) | Lives 100% in QB / Allan's head today | Phase 2 (QB sync) |
+| Tax remittance log | Can compute liability, can't prove what's been paid | Phase 4 |
+| Contractor 1099-NEC tracking | Need annual rollup ≥$600/contractor for IRS | Phase 3 |
+| Bank account state | No reconciliation possible | Phase 2 (Plaid) |
+
+---
+
+## 5. Existing infrastructure to reuse — DO NOT rebuild
+
+### Reuse from prior directors
+
+| Asset | Path | What to reuse |
+|---|---|---|
+| Shared recommendation lib | `src/lib/recommendations/{lifecycle,measurement,card-types}.ts` | Status state machine, ActionPayload shape, RecommendationCardData — Finance recs plug into the unified `/admin/recommendations` queue |
+| Shared card component | `src/components/admin/RecommendationCard.tsx` | Already accepts `domain` and `actionPayload`. Add `finance` to the domain enum. |
+| Unified queue page | `src/app/admin/recommendations/page.tsx` | Add a `Finance` filter chip; cards rendered with the same component. |
+| Action execution endpoint | `src/app/api/admin/recommendations/[id]/execute/route.ts` | Dispatcher already handles `navigate` and `apiCall` kinds. Add `qb-categorize` kind for auto-categorize actions (only kind allowed without operator click per autonomy decision). |
+| Snooze + dismiss-with-reason | Same `[id]` route group | Identical behavior. Finance recs persist `dismissReason` for the feedback loop. |
+| Marketing/Ops director patterns | `.claude/agents/{marketing,operations}-director.md` | Use as templates. Same Sonnet model, same Read/Grep/Glob/Bash tools, same bootstrap-ritual pattern. |
+| Obsidian memory layout | `Memory/{Marketing,Operations}/{Briefings,Recommendations,Decisions,Channel-Performance,Open-Questions.md,README.md}` | Mirror exactly. Use `F` prefix for Finance ADRs (`F0001-...`). |
+| GitHub-mirror + Obsidian-sync pattern | `src/lib/operations/recommendation-mirror.ts`, `scripts/operations/sync-obsidian.mjs`, `.claude/settings.json` PreToolUse hook | Same idempotent-SHA pattern. Mirror `docs/finance/{weekly,monthly-close,recommendations,decisions}/` → vault. |
+| Cost / margin computation | `src/lib/inventory/services/margin-service.ts`, `scripts/backfill-order-margins.ts` | Finance computes P&L on top of this; do not duplicate margin math. |
+| Affiliate payout pipeline | `src/lib/affiliates/`, `/api/admin/affiliates/payouts/*` | Pull AffiliatePayout totals into P&L expense; Finance does not own payout generation. |
+| Cron + admin-API patterns | `src/app/api/cron/operations-*` and `src/app/api/admin/operations/*` | Copy structure for `finance-*` equivalents. |
+
+### Existing reports (extend, don't replace)
+
+| Path | What it does |
+|---|---|
+| `/admin/reports` | Top-level reports nav |
+| `/admin/reports/sales` | Revenue over time (7/30/90d), category breakdown |
+| `/admin/reports/customers` | Customer-side metrics |
+| `/admin/reports/inventory` | Stock analysis |
+
+Finance adds `/admin/reports/finance` (or `/admin/finance`) as a peer — the P&L surface.
+
+---
+
+## 6. Architectural decisions
+
+### Recommendation model: parallel, mirror Ops
+
+Add `FinanceRecommendation` model with same shape as `OperationsRecommendation` (status enum, severity, evidence JSON, actionPayload, actionLog, dismissReason, snoozeUntil). Reasons match those in `docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md` §5a — own table per director, shared library.
+
+### Auto-categorize is the ONLY autonomous action in Phase 5+
+
+Per operator decision #4, the Director can write a category to a QuickBooks transaction without asking. Every other write — journal entries, expense edits, payout marking, tax filing — requires operator click via the inline-action button. The action dispatcher's `qb-categorize` kind is the only `apiCall` path that bypasses the "requires click" gate.
+
+Auto-categorize actions still write `actionLog` entries on the rec so every auto-decision is reconstructible. Operator can revert any auto-categorization via a one-click undo button on the rec card.
+
+### Chart of accounts mapping lives in TypeScript, not DB
+
+Map PartyOn revenue/cost concepts to QB chart-of-accounts IDs in `src/lib/finance/qb-account-map.ts`. Operator-edited via a settings page. Persisting in TS rather than DB matches the "rates as TypeScript, not DB" decision from ADR 0002 (per saved memory).
+
+### Phase 0–2 schema additions go through raw SQL ALTER
+
+Per saved memory `prisma_schema_drift.md`: avoid `prisma db push` on production. Use raw SQL `CREATE TABLE IF NOT EXISTS` and `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` for additive migrations. Bundle migrations into each PR's deploy notes.
+
+### External secrets in env vars only
+
+`INTUIT_CLIENT_ID`, `INTUIT_CLIENT_SECRET`, `INTUIT_OAUTH_REFRESH_TOKEN`, `INTUIT_REALM_ID`, `PLAID_CLIENT_ID`, `PLAID_SECRET`, `PLAID_ENV` (sandbox / development / production). Add to `.env.example` + Vercel env config. **Never commit any credential.**
+
+---
+
+## 7. Phased build sequence
+
+This is genuinely multi-quarter work. Each phase is one or more PRs.
+
+### Phase 0 — Foundation (THIS PR) (1–2 weeks)
+
+**Deliverables:**
+
+- **QuickBooks Online OAuth scaffolding**
+  - Intuit Developer app created (operator does this, hands you the client_id/client_secret)
+  - `/admin/finance/connect-quickbooks` page: "Connect QuickBooks" button → OAuth redirect → callback that stores refresh token in DB (new `IntuitOAuthState` model with single-row pattern)
+  - `src/lib/finance/qb-client.ts` — wraps Intuit's node SDK with refresh-token rotation
+  - Health check: `GET /api/admin/finance/qb/health` returns connection status + company name
+- **Plaid scaffolding**
+  - Plaid app created (sandbox tier first)
+  - `/admin/finance/connect-bank` page: Plaid Link button → onSuccess callback → store access_token in DB (new `PlaidItem` + `PlaidAccount` models)
+  - `src/lib/finance/plaid-client.ts` — wraps Plaid node SDK
+  - Health check: `GET /api/admin/finance/plaid/health` returns connection status + account names
+- **Empty internal scaffolding** (no UI yet, just schema):
+  - `FinanceRecommendation` model (mirror `OperationsRecommendation`)
+  - `FinanceSnapshot` model (placeholder columns: id, snapshotDate, payload JSONB, createdAt)
+  - `IntuitOAuthState` model
+  - `PlaidItem`, `PlaidAccount`, `PlaidTransaction` models (transactions ingested in Phase 2 — schema in Phase 0)
+  - Raw SQL migration committed to `prisma/migrations/manual/<date>-finance-phase-0.sql` per saved memory
+- **No agent file in Phase 0.** Director is not invokable yet — there's nothing for it to read.
+- **No cron in Phase 0.** Add in Phase 1.
+
+**Exit criterion for Phase 0:** Operator clicks "Connect QuickBooks" + "Connect Bank" in admin UI; both report green health. No data flows yet — that's Phase 1.
+
+### Phase 1A — Stripe data deepening (2 PRs)
+
+- Add `stripeChargeAmountCents`, `stripeFeesCents`, `netReceivedCents` to `Order`
+- Add `StripePayout`, `StripeBalance`, `ChargeDispute` models
+- Webhook handlers for `payout.created`, `payout.paid`, `balance.available`, `charge.dispute.*`
+- Backfill historical Stripe data via Stripe API (one-shot script: pull last 12 months of charges, fees, payouts)
+- Daily cron `/api/cron/finance-stripe-sync` to pull yesterday's balance transactions + payouts
+
+**Why first:** Until Stripe net amounts are reconciliable, nothing else is trustworthy.
+
+### Phase 1B — AP on ReceivingInvoice (1 PR)
+
+- `ALTER TABLE receiving_invoices ADD COLUMN invoice_total_cents BIGINT, due_date DATE, paid_at TIMESTAMP, paid_via TEXT`
+- Receiving UI gets fields for invoice total + due date at invoice-apply time
+- New "Outstanding AP" surface in `/admin/finance/ap` showing unpaid distributor invoices with aging
+
+### Phase 1C — Internal P&L (1 PR)
+
+- Daily cron `/api/cron/finance-snapshot` at 07:45 UTC (after Marketing 07:00 + Ops 07:30)
+- Computes: revenue, refunds, COGS-where-known, gross margin, sales tax accrual, affiliate commission accrual
+- Writes `FinanceSnapshot` row with payload JSON
+- `/admin/finance` dashboard page: same card-grid pattern as `/admin/operations`
+- No recommendations yet — just data visibility
+
+### Phase 2A — QuickBooks: read OpEx (1 PR)
+
+- Weekly cron `/api/cron/finance-qb-pull` pulls QB expense transactions for trailing 30 days
+- Categorize by QB account (chart of accounts lives in QB already — pull via API)
+- Surface in `/admin/finance` dashboard as "OpEx by category"
+- Internal P&L becomes: revenue − COGS − OpEx (from QB) = net income
+
+### Phase 2B — QuickBooks: write sales journals (1 PR)
+
+- Daily cron posts yesterday's sales summary to QB as a sales journal entry
+- Operator approval required per entry (autonomy decision #4)
+- Audit trail: every QB write logged with the source query + the resulting QB transaction ID
+
+### Phase 2C — Plaid: auto-match + auto-categorize (1 PR)
+
+- Webhook + nightly sync of Plaid transactions to `PlaidTransaction` model
+- Auto-match logic:
+  - Bank deposits → Stripe payouts (via amount + date)
+  - Bank outflows → `ReceivingInvoice` (mark paid)
+  - Bank outflows → contractor payments (track for 1099)
+- Auto-categorize remaining transactions in QB (the one autonomous action per autonomy decision)
+- Every auto-categorize writes a `FinanceRecommendation` row with status `shipped` + reversal button
+
+### Phase 3 — Contractor 1099-NEC tracking (1 PR)
+
+- New `Contractor` model (name, tax ID, address, payment method)
+- Aggregate annual payouts per contractor (from Plaid outflows + AffiliatePayout)
+- Threshold flag at $600/year (IRS 1099-NEC requirement)
+- Year-end report at `/admin/finance/1099-prep` — exports CSV ready for e-file service (e.g., Track1099) or print-and-mail
+
+### Phase 4 — Tax filing surfaces (1 PR)
+
+- **TX sales tax:** Quarterly report at `/admin/finance/sales-tax` formatted for TX Comptroller webfile entry (gross sales, taxable sales, tax collected per period). Track remittance via new `TaxRemittance` model.
+- **Federal/state income tax prep:** Annual revenue + expense rollup at `/admin/finance/annual-rollup` — exports CSV ready for accountant or TurboTax import.
+- No e-file automation in Phase 4. Reports only; operator submits.
+
+### Phase 5 — Director surface (1 PR — the actual agent)
+
+- `.claude/agents/finance-director.md` — Sonnet, Read/Grep/Glob/Bash tools, bootstrap reads latest snapshot + active recs + QB connection state + Plaid connection state. Hard rules include ADR M0001 (no affiliate-margin recs until coverage ≥70%), group-order manifest-name rule, autonomy ceiling (auto-categorize only).
+- Weekly Monday briefing email at 14:00 UTC (after Marketing 13:00 + Ops 13:30)
+- Monthly close email on 1st of month at 14:00 UTC (deeper P&L + reconciliation status)
+- Heuristic generators in `src/lib/finance/recommendations.ts` (signals listed below)
+- Obsidian sync: `scripts/finance/sync-obsidian.mjs` + PreToolUse hook in `.claude/settings.json`
+- Vault shell: `Programs/Finance-Director.md` + `Memory/Finance/{Briefings,Recommendations,Decisions,MonthlyClose,Open-Questions.md,README.md}`
+
+### Phase 6 — Auto-categorize graduation (post-trust)
+
+Only after the operator has reviewed Phase 5 briefings for 4+ weeks and feels confident, graduate the Director's auto-categorize behavior from "one-by-one with reversal button" to "batch auto-categorize with weekly audit summary." This is a config flag, not new code.
+
+---
+
+## 8. The Director's signals (Phase 5)
+
+Heuristics the Finance Director surfaces as recommendations. These are starting points — tune from operator feedback. Each has a severity (urgent / high / normal) and an inline action where applicable.
+
+| # | Signal | Detection | Severity | Inline action |
+|---|---|---|---|---|
+| 1 | **Stripe payout failed to match a bank deposit** | StripePayout marked `paid` but no corresponding PlaidTransaction within 4 banking days | high | "Investigate" → opens Stripe payout + Plaid transaction comparison view |
+| 2 | **Distributor invoice past due** | `ReceivingInvoice.dueDate < today AND paidAt IS NULL` | high → urgent at >7d past due | "Mark paid" → opens AP page with invoice highlighted |
+| 3 | **Cash runway < 30 days** | (Bank balance + outstanding AR - committed AP) / avg daily burn < 30 | urgent | "Open cash dashboard" |
+| 4 | **Gross margin trending down** | 30-day rolling gross margin % drops > 5pp from prior 30 days | high | "Open margin analysis" |
+| 5 | **Sales tax accrual exceeds remittance pace** | Cumulative taxAmount collected − cumulative tax remitted > one quarter's expected liability | high | "Open sales-tax dashboard" |
+| 6 | **Contractor approaching 1099 threshold** | Single contractor cumulative YTD payouts > $500 (early warning before $600 IRS threshold) | normal | "Review contractor totals" |
+| 7 | **OpEx category spiking** | Any QB expense category's 30-day total > 150% of trailing 90-day average | normal | "Open OpEx breakdown" |
+| 8 | **Affiliate commission accrual aging** | AffiliateCommission status = HELD or APPROVED for >30 days | normal | "Open affiliate payouts" |
+| 9 | **Discount over-use** | Discount code's total dollars given > $X in 7d (configurable) | normal | "Review discount usage" |
+| 10 | **Untouched bank transaction** | PlaidTransaction unreconciled (not matched to Stripe payout / ReceivingInvoice / QB entry) for >7 days | normal | "Categorize in QB" (the auto-categorize action) |
+| 11 | **QB sync error** | QB API call fails (token expired, account deleted, rate limit) | urgent | "Reconnect QuickBooks" |
+| 12 | **Plaid sync error** | Plaid item login required (bank changed password) or connection error | urgent | "Reconnect bank" |
+
+---
+
+## 9. Files this build will likely touch
+
+Across all phases. Phase 0's first PR will touch only the rows marked `[P0]`.
+
+```
+.claude/agents/finance-director.md                                       [P5 NEW]
+.claude/settings.json                                                    [P5 hook]
+scripts/finance/sync-obsidian.mjs                                        [P5 NEW]
+scripts/finance/backfill-stripe-history.ts                               [P1A NEW]
+scripts/finance/manual-migrate-finance-phase-N.sql                       [P0+ NEW per phase]
+prisma/schema.prisma                                                     [P0+ ADDS]
+prisma/migrations/manual/<date>-finance-phase-N.sql                      [P0+ NEW per phase]
+
+src/lib/finance/qb-client.ts                                             [P0 NEW]
+src/lib/finance/qb-account-map.ts                                        [P2A NEW]
+src/lib/finance/plaid-client.ts                                          [P0 NEW]
+src/lib/finance/snapshot.ts                                              [P1C NEW]
+src/lib/finance/pl-calculation.ts                                        [P1C NEW]
+src/lib/finance/recommendations.ts                                       [P5 NEW]
+src/lib/finance/recommendation-store.ts                                  [P5 NEW]
+src/lib/finance/recommendation-mirror.ts                                 [P5 NEW]
+src/lib/finance/briefing-payload.ts                                      [P5 NEW]
+src/lib/finance/briefing-markdown.ts                                     [P5 NEW]
+src/lib/finance/stripe-extended.ts                                       [P1A NEW]
+src/lib/finance/ap-service.ts                                            [P1B NEW]
+src/lib/finance/contractor-service.ts                                    [P3 NEW]
+src/lib/finance/tax-reporting.ts                                         [P4 NEW]
+src/lib/email/templates/finance-weekly-briefing.ts                       [P5 NEW]
+src/lib/email/templates/finance-monthly-close.ts                         [P5 NEW]
+
+src/app/api/admin/finance/qb/connect/route.ts                            [P0 NEW]
+src/app/api/admin/finance/qb/callback/route.ts                           [P0 NEW]
+src/app/api/admin/finance/qb/health/route.ts                             [P0 NEW]
+src/app/api/admin/finance/plaid/link-token/route.ts                      [P0 NEW]
+src/app/api/admin/finance/plaid/exchange/route.ts                        [P0 NEW]
+src/app/api/admin/finance/plaid/health/route.ts                          [P0 NEW]
+src/app/api/admin/finance/snapshot/route.ts                              [P1C NEW]
+src/app/api/admin/finance/ap/route.ts                                    [P1B NEW]
+src/app/api/admin/finance/1099/route.ts                                  [P3 NEW]
+src/app/api/admin/finance/sales-tax/route.ts                             [P4 NEW]
+src/app/api/cron/finance-stripe-sync/route.ts                            [P1A NEW]
+src/app/api/cron/finance-snapshot/route.ts                               [P1C NEW]
+src/app/api/cron/finance-qb-pull/route.ts                                [P2A NEW]
+src/app/api/cron/finance-qb-post-sales/route.ts                          [P2B NEW]
+src/app/api/cron/finance-plaid-sync/route.ts                             [P2C NEW]
+src/app/api/cron/finance-weekly-briefing/route.ts                        [P5 NEW]
+src/app/api/cron/finance-monthly-close/route.ts                          [P5 NEW]
+src/app/api/cron/measure-finance-recommendations/route.ts                [P5 NEW]
+src/app/api/webhooks/stripe/route.ts                                     [P1A handlers added]
+src/app/api/webhooks/plaid/route.ts                                      [P2C NEW]
+
+src/app/admin/finance/page.tsx                                           [P1C NEW]
+src/app/admin/finance/connect-quickbooks/page.tsx                        [P0 NEW]
+src/app/admin/finance/connect-bank/page.tsx                              [P0 NEW]
+src/app/admin/finance/ap/page.tsx                                        [P1B NEW]
+src/app/admin/finance/1099/page.tsx                                      [P3 NEW]
+src/app/admin/finance/sales-tax/page.tsx                                 [P4 NEW]
+src/app/admin/finance/annual-rollup/page.tsx                             [P4 NEW]
+src/app/admin/recommendations/page.tsx                                   [P5 add Finance chip]
+
+vercel.json                                                              [P1A+ add crons]
+.env.example                                                             [P0+ add secrets]
+
+# Obsidian vault (manual creates, not in repo)
+PartyOn2/Programs/Finance-Director.md                                    [P5 NEW]
+PartyOn2/Memory/Finance/README.md                                        [P5 NEW]
+PartyOn2/Memory/Finance/Open-Questions.md                                [P5 NEW]
+PartyOn2/Memory/Finance/{Briefings,Recommendations,Decisions,MonthlyClose}/  [P5 shells]
+```
+
+---
+
+## 10. First-iteration checklist (your first wakeup in the loop)
+
+1. **Read this entire doc.**
+2. **Read these reference files in order:**
+   - `docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md` — full pattern Finance mirrors
+   - `.claude/agents/marketing-director.md`, `.claude/agents/operations-director.md` — agent file templates
+   - `~/Projects/Obsidian/Obsidian/PartyOn2/Programs/Operations-Director.md` — program doc template
+   - `~/Projects/Obsidian/Obsidian/PartyOn2/Memory/Operations/README.md` — memory conventions
+   - `src/lib/recommendations/{lifecycle,measurement,card-types}.ts` — shared rec lib
+   - `src/app/api/admin/recommendations/[id]/execute/route.ts` — action dispatcher to extend later with `qb-categorize` kind
+   - `prisma/schema.prisma` — read the inventory + order + affiliate + receiving sections (lines 555–700, 800–1030, 1980–2080)
+3. **Read saved memory** at `~/.claude/projects/-Users-allan-Projects-Party-On-Delivery-Website-PartyOn2/memory/MEMORY.md` and every entry it indexes. Especially:
+   - `prisma_schema_drift.md` (use raw SQL for additive migrations)
+   - `project_marketing_adr_m0001.md` (no affiliate-margin recs until coverage ≥70%)
+   - `group_order_manifest_name_rule.md` (always show manifest name for group-order rec evidence)
+   - `ops_recommendation_store_behavior.md` (no auto-downgrade, no auto-invalidate)
+4. **Ask the operator for credentials BEFORE writing any client code:**
+   - Intuit Developer app: `INTUIT_CLIENT_ID`, `INTUIT_CLIENT_SECRET`, redirect URI for OAuth (e.g., `https://partyondelivery.com/api/admin/finance/qb/callback`), preferred environment (sandbox vs production for initial test)
+   - Plaid app: `PLAID_CLIENT_ID`, `PLAID_SECRET`, env (`sandbox` first)
+   - Add to `.env.example` with placeholder values; ask operator to add to Vercel env config
+5. **Build Phase 0.** Connections + scaffolding. Health checks green. No data flows.
+6. **Open the Phase 0 PR.** Title: `feat(finance): QuickBooks + Plaid OAuth scaffolding (Phase 0 for Finance Director)`. PR description must:
+   - Link this doc
+   - State explicitly that no data flows yet
+   - List the 4 new models added to Prisma
+   - Include the raw-SQL migration file in `prisma/migrations/manual/`
+   - Include a screenshot of both health endpoints returning green
+   - Note that Phase 1A (Stripe deepening) is the next PR
+7. **Schedule your next wakeup** (`ScheduleWakeup` with delay 3600s, reason "checking whether operator merged Phase 0 PR"). Sleep.
+8. **On every subsequent wakeup**, follow the §1.5 iteration ritual: pull main, health-check the last phase, run tests, decide next action, build or wait, schedule wakeup again. Continue until all 11 phases ship or you hit a stop condition.
+
+---
+
+## 11. Hard rules (apply throughout all phases)
+
+- **All Director writes that touch money require operator click** except the single `qb-categorize` action kind (per autonomy decision #4). Every auto-categorize writes an `actionLog` entry on the rec + supports one-click revert.
+- **Never propose a recommendation that conflicts with ADR M0001** — affiliate ROI and margin-leak decisions stay with Marketing until cost coverage ≥70%. Finance complements with P&L and tax-side decisions.
+- **Group orders:** when surfacing recs that target an `Order` with `groupOrderV2Id`, resolve and display the manifest name via `scripts/ops/_group-label.mjs:resolveGroupLabel()`. Tested-and-working pattern from Ops Director.
+- **Schema changes use raw SQL** `CREATE TABLE IF NOT EXISTS` and `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` per saved memory `prisma_schema_drift.md`. Bundle each phase's migration into `prisma/migrations/manual/<date>-finance-phase-N.sql`.
+- **Credentials in env vars only.** Never commit Intuit or Plaid client_id / secret / refresh_token / access_token.
+- **Sandbox first.** Start QB connection in Intuit sandbox + Plaid sandbox environment. Move to production only after Phase 0 PR merges and operator manually swaps env vars.
+- **All admin endpoints behind `requireOpsAuth`.** All cron endpoints behind `CRON_SECRET` bearer. Match Marketing/Ops patterns.
+- **No `any` type, files <500 lines, components <200 lines, functions <50 lines** (project CLAUDE.md).
+- **Files in `scripts/` are excluded from `@/` path alias** (saved memory `reference_worktree_env_and_github_token.md`).
+- **TABC + alcohol compliance is unchanged by Finance.** Tax calculations remain at 8.25% TX rate. Finance reports cumulative liability; does not change per-order math.
+
+---
+
+## 12. Open questions for the operator (ask in the first session, before building)
+
+The Phase 0 session must ask these BEFORE writing code:
+
+1. **Intuit Developer app provisioning** — does an app exist yet, or does the operator need to create one at https://developer.intuit.com? If new, walk through the create-app flow with the operator (5 min) to get `INTUIT_CLIENT_ID` + `INTUIT_CLIENT_SECRET`. Specify redirect URI matches `https://partyondelivery.com/api/admin/finance/qb/callback`.
+2. **Plaid environment + tier** — `sandbox` is free, `development` is free with limits, `production` requires paid plan. Confirm: start in sandbox, move to production after Phase 0 lands.
+3. **QB Online tier** — Simple Start / Essentials / Plus / Advanced? Affects which API endpoints are available (e.g., class-tracking + budgeting need Plus or Advanced).
+4. **Bank institution** — which bank? Plaid covers most US banks but check coverage upfront.
+5. **Stripe payout schedule** — daily / weekly / custom? Phase 1A's reconciliation logic depends on this.
+6. **Existing QB chart of accounts** — already configured (revenue, COGS, OpEx categories) or fresh QB file? Affects Phase 2A complexity.
+7. **Year-end 1099 e-file preference** — Track1099 / Tax1099 / print-and-mail / accountant handles it? Affects Phase 3 export format.
+
+---
+
+## 13. Success metrics (set baselines in Phase 0, measure quarterly)
+
+- **Cost coverage %** — currently 20.6%, target 70%+ (gates ADR M0001 unlock for Marketing too)
+- **Margin coverage % on orders** — currently 51%, target 90%+
+- **Stripe payout reconciliation rate** — % of bank deposits auto-matched to Stripe payouts (Phase 1A onward)
+- **Distributor invoice on-time payment rate** — Phase 1B baseline + monitor
+- **OpEx categorization auto-rate** — % of Plaid transactions auto-categorized in QB without operator click (Phase 2C onward; informs Phase 6 graduation decision)
+- **Monthly close completion time** — hours between month-end and "books reconciled" state (Phase 2 onward)
+- **Tax-filing prep time** — hours operator spends preparing TX sales-tax filing per quarter (target: under 30 min after Phase 4)
+- **Cash runway visibility** — yes/no operator can answer "how many weeks of cash do I have?" from the dashboard without manual math (Phase 1C onward)
+
+---
+
+That's everything. Phase 0 is a small, focused PR — connections + empty scaffolding. The next nine phases (1A through 5) each get their own scoped PR with its own buildout brief produced by the session that builds them. Iterate, ship small, prove pattern, expand.

--- a/docs/SEO-DIRECTOR-AGENT-BUILDOUT.md
+++ b/docs/SEO-DIRECTOR-AGENT-BUILDOUT.md
@@ -1,0 +1,356 @@
+# SEO Director Agent — Buildout Brief
+
+**Drop this entire file into a new Claude Code session.** It is self-contained — the new session will have no memory of the conversation that produced it.
+
+**Goal of the new session:** Build the SEO Director agent for Party On Delivery and ship it through Phase 1 (read-only / recommendations), then scope Phase 2 (autonomous content production).
+
+---
+
+## 1. Context — why this agent exists
+
+Party On Delivery (premium alcohol + party coordination delivery, Austin TX) is being reorganized around an "agentic org structure" — director-level Claude agents that own a functional area, surface decisions to the operator (Allan), and execute routine work autonomously. The original 6-director scope (Apr 18, 2026) was:
+
+1. Marketing Director ← **shipped & mature**, see `docs/marketing/` and `Programs/Marketing-Director.md` in the Obsidian vault
+2. Sales & Partnerships Director — not built
+3. Operations Director — being built next, in parallel with this agent
+4. Finance Director — not built
+5. Customer Success Director — not built
+6. Product Director — not built
+
+Plus a Chief of Staff agent above all of them (not built).
+
+In the original sketch, **SEO was a sub-agent under Marketing**. We are promoting it to **its own director** because:
+
+- **Time horizon mismatch.** Marketing Director runs weekly tactical cycles (pause this affiliate, ship this landing-page test). SEO operates on 30–90 day feedback loops. Mixing them confuses the triage queue.
+- **Output-type mismatch.** Marketing Director *recommends*; the operator ships. SEO *produces content* (blog posts, internal links, schema, alt text). It is a write-mode agent, not a read-mode agent.
+- **Dedicated data sources.** SEMrush (accessed via a custom Cowork browser-automation skill — see §3) plus Google Search Console give SEO a data surface that doesn't overlap with Marketing's GA4/Vercel/GBP/orders pipeline.
+- **Strategic weight.** Organic search is currently a near-zero channel for partyondelivery.com (per `docs/seo-audit-2026-03-30.md`: 1,289 URLs in sitemap, ~0 indexed at audit time). It needs sustained, focused ownership — not a sidecar to a busy director.
+
+---
+
+## 2. Scope
+
+### In scope (own these outcomes)
+
+- **Position tracking** across target keywords. Detect rank movement, lost-position alerts, new ranking opportunities.
+- **Keyword research and prioritization.** Identify the next 5–10 keywords worth targeting given current authority + commercial intent + competition.
+- **Content production.**
+  - Blog post drafts (the existing `/api/cron/generate-blog` route is currently broken — see §6).
+  - Internal linking improvements (interlace existing 133 blog posts + service pages to spread authority).
+  - On-page SEO fixes (titles, meta descriptions, H1/H2 hierarchy, schema.org JSON-LD).
+- **Technical SEO monitoring.** Indexation status (was 0/1289 in March), crawl errors, Core Web Vitals from Vercel, sitemap freshness.
+- **Backlink monitoring.** New refdomains, lost backlinks, anchor-text drift.
+- **Competitive watch.** Track competitor organic-traffic movement and content cadence.
+- **SERP feature opportunities.** Featured snippets, People Also Ask, local pack.
+
+### Out of scope (other directors own these)
+
+- Paid search and ad spend → Marketing Director
+- Conversion-rate optimization on landing pages once they rank → Marketing Director
+- Affiliate / partner referral attribution → Marketing Director (governed by ADR M0001 in vault)
+- Email/SMS retention sequences → Marketing Director (eventually CS Director)
+
+### Deliverables for the operator
+
+Mirror the Marketing Director cadence so the surfaces feel familiar:
+
+- **Weekly briefing email** (ISO week, Monday morning) — top movers, lost positions, new opportunities, blog-post output of the week, this-week recommendations.
+- **Triage queue** — same `MarketingRecommendation` model pattern (or a parallel `SEORecommendation` model) with statuses `proposed → accepted → executed → measured`.
+- **Monthly content calendar** — what got published, what's drafted next, paired with target keyword & internal-link map.
+- **Quarterly strategic review** — keyword strategy, pillar/cluster map, technical-debt items.
+
+---
+
+## 3. Available data sources
+
+There is **no Ahrefs subscription and no SEMrush MCP**. Do not propose either. The data pipeline for the SEO Director is built from these four sources:
+
+### A. SEMrush — via a custom Cowork browser-automation skill (NEW — build this)
+
+The operator has a paid SEMrush account but is not connecting it via API or MCP. Instead, the SEO Director will get SEMrush data through a **Cowork skill that drives a real browser** (Playwright) into the SEMrush UI on a weekly schedule. The skill must:
+
+1. Log into the operator's SEMrush account using credentials stored in env vars (`SEMRUSH_EMAIL`, `SEMRUSH_PASSWORD`) — handle 2FA if enabled by pausing for operator confirmation, or use a long-lived session cookie
+2. Navigate to the relevant SEMrush dashboards for `partyondelivery.com`:
+   - **Position Tracking** — current rank for tracked keywords + week-over-week deltas
+   - **Organic Research** — top-ranking pages, total organic traffic estimate, keyword count
+   - **Backlink Analytics** — new + lost referring domains
+   - **Site Audit** — technical issues count, severity breakdown
+   - **Keyword Magic Tool** — for any keywords queued by the SEO Director for research
+3. **Take screenshots** of each dashboard view (full-page) and save under `data/seo/semrush/<YYYY-MM-DD>/<dashboard>.png`
+4. **Scrape the data tables** on each page (rank, change, search volume, keyword, URL, date, etc.) and write to `data/seo/semrush/<YYYY-MM-DD>/<dashboard>.json` — structured data the SEO Director can read
+5. Run **weekly** via Cowork's scheduling (Monday morning, before the SEO briefing email goes out)
+6. On failure (login broken, layout changed, captcha): write a `data/seo/semrush/<YYYY-MM-DD>/FAILED.md` with the error and screenshots of the failure point, and the SEO Director's briefing flags it to the operator
+
+**Existing tools in this environment that help build the skill:**
+
+- The `webapp-testing` skill (Playwright-based) — start here; it's the closest existing pattern.
+- The `Claude_in_Chrome` MCP tools (`mcp__Claude_in_Chrome__*`) — gives a Claude session a real Chrome browser with `navigate`, `find`, `form_input`, `read_page`, `read_network_requests`, etc. Useful during skill *development* to record selectors interactively.
+- The `mcp__Claude_Preview__preview_screenshot` and `preview_eval` tools — for capturing + extracting in dev.
+
+**Skill name suggestion:** `seo-semrush-snapshot` — lives at `.claude/skills/seo-semrush-snapshot/SKILL.md` with a `script.ts` that runs the Playwright flow.
+
+**Important constraints:**
+
+- Respect SEMrush's UI rate limits — sleep between navigations, don't spam.
+- Do not commit screenshots to the repo. Add `data/seo/semrush/` to `.gitignore`. Sync the JSON-only summary to a structured DB table (`SEORanking` model — see §4) so historical trends are queryable.
+- Login credentials must come from env vars only — never hardcoded. Add to `.env.example` and Vercel env config.
+- The skill is the **only** place that touches SEMrush. The SEO Director consumes the JSON output, not the live site.
+
+### B. Google Search Console — already piped in
+
+GSC data is already pulled by the existing `analytics-snapshot` cron at `src/app/api/cron/analytics-snapshot/route.ts` and surfaced at `/api/admin/analytics/internal`. The SEO Director should:
+
+- Read the GSC fields from the daily `AnalyticsSnapshot` rows for trend analysis
+- If anything is missing (specific queries, position-history granularity), **extend the existing snapshot cron** — don't build a parallel GSC pipeline.
+
+GSC is the source of truth for **clicks, impressions, CTR, average position, and indexation**. SEMrush is third-party-estimated and often inflates traffic numbers.
+
+### C. Google Analytics 4 — already piped in
+
+GA4 lives at `/api/admin/analytics/ga4` (behind `requireOpsAuth`). Use it for:
+
+- Behavior of organic visitors after they land (engagement, conversion to order)
+- Revenue attribution to organic traffic via `Order.utmSource` + `Order.landingPage`
+- Comparison of organic vs. other channels
+
+### D. Vercel Web Vitals + first-party events
+
+- **Vercel Web Vitals** at `/api/admin/analytics/vercel` — Core Web Vitals per page. Bad LCP/CLS hurts rankings; the SEO Director surfaces top offenders.
+- **`AnalyticsEvent` model** — populated by `AttributionTracker` on every page load. Lets the SEO Director query "users who landed on /blog/X then converted within N days" without round-tripping through GA4.
+
+### Summary of the data flow
+
+```
+SEMrush UI ──Cowork weekly skill (Playwright)──> data/seo/semrush/<date>/*.json + *.png
+                                                          │
+                                                          ▼
+                                              SEORanking (DB table)
+                                                          │
+GSC ──> existing analytics-snapshot ─────> AnalyticsSnapshot ─┐
+                                                          │   │
+GA4 ──> existing /api/admin/analytics/ga4 ────────────────┼───┤
+                                                          │   ▼
+Vercel ──> existing /api/admin/analytics/vercel ──────────┼─> seo-snapshot cron ──> SEOSnapshot ──> seo-briefing email + triage queue
+                                                          │
+First-party events ──> AnalyticsEvent ────────────────────┘
+```
+
+---
+
+## 4. Existing infrastructure to reuse — DO NOT rebuild
+
+### The Marketing Director template
+
+The SEO Director should structurally mirror the Marketing Director. Read these in order before designing anything:
+
+1. `.claude/agents/marketing-director.md` — the agent definition (Sonnet, recommendations-only Phase 1, tools restricted to Read/Grep/Glob/Bash). Use the same frontmatter shape.
+2. `~/Projects/Obsidian/Obsidian/PartyOn2/Programs/Marketing-Director.md` — the program doc explaining the data pipeline, cron schedule, admin surface, and memory layout. The SEO equivalent should be `Programs/SEO-Director.md`.
+3. `~/Projects/Obsidian/Obsidian/PartyOn2/Memory/Marketing/README.md` — the memory conventions (folders, frontmatter schemas, lifecycle, hard rules). Mirror this exactly under `Memory/SEO/`.
+4. `src/app/api/cron/analytics-snapshot/route.ts` — the daily snapshot cron pattern.
+5. `src/app/api/cron/weekly-briefing/route.ts` + `src/lib/email/templates/marketing-briefing.ts` + `src/lib/analytics/briefing-payload.ts` — Monday email pipeline.
+6. `src/app/api/cron/measure-recommendations/route.ts` — 14-day measurement loop that captures outcomes for shipped recs.
+7. `src/app/admin/analytics/recommendations/` — triage queue UI (read it; build the SEO version as `/admin/seo/recommendations` or merge into the same UI with a `domain` filter).
+8. `src/lib/analytics/experiment-significance.ts` — two-proportion z-test, useful when measuring blog-post performance lifts.
+
+### Database models to reuse or extend
+
+Look at `prisma/schema.prisma` for:
+
+- `AnalyticsSnapshot` — daily snapshot of marketing metrics. SEO can either piggyback (add columns) or add a parallel `SEOSnapshot` model. **Recommendation: parallel model.** Marketing snapshot is already wide; keep concerns separated.
+- `MarketingRecommendation` — the rec lifecycle model. Mirror as `SEORecommendation` (same status enum: `open|approved|shipped|rejected|invalidated`, plus `measured`).
+- `BlogPost` — the blog content model. Existing 133 posts live as MDX in `content/blog/posts/`, **not** in the DB. Read `content/blog/posts/` directly via filesystem; do not migrate to DB unless you have a specific reason.
+- `AnalyticsEvent` — first-party event log. Useful for "users who landed on /blog/X then converted."
+
+### Existing scripts to wire in
+
+Don't rewrite these — call or extend them:
+
+- `scripts/seo-audit.ts` — checks `'use client'` pages for proper SSR metadata. Run this on a schedule and surface diffs.
+- `scripts/validate-blog-links.ts` — finds broken outbound links in blog posts. Run weekly.
+- `scripts/automated-daily-blog.ts` — the original blog generator. **Currently broken** (see §6). The SEO Director should own fixing/replacing this.
+- `scripts/generate-blog-images.ts` — image generation for blog posts (uses local `image-generator-tool`).
+- `scripts/migrate-shopify-blogs.ts` — historical migration script, probably done; just for reference.
+- `scripts/topics.json` — the 107 blog topics; per memory note all are currently published. New topics need to come from the SEMrush Cowork skill output + GSC striking-distance keyword analysis.
+
+### Most recent SEO ground-truth
+
+`docs/seo-audit-2026-03-30.md` — full audit from late March. Read it. Key findings to address:
+- 0 of 1,289 URLs were indexed at audit time
+- Sitemap `<lastmod>` was being regenerated on every request (now fixed)
+- GSC verification status uncertain — confirm
+
+The SEO Director's first job in Phase 1 is to **re-run the audit and produce a delta**: what got fixed, what's still broken, what's new.
+
+---
+
+## 5. Architectural decision — sibling director, not Marketing sub-agent
+
+Already explained in §1 but to make it operational:
+
+- New agent definition file: `.claude/agents/seo-director.md`
+- New Obsidian program doc: `Programs/SEO-Director.md`
+- New Obsidian memory tree: `Memory/SEO/{Briefings,Recommendations,Decisions,Channel-Performance,Open-Questions.md,README.md}` mirroring `Memory/Marketing/`
+- New cron(s) under `src/app/api/cron/seo-*`
+- New admin surface under `/admin/seo/` (or extend `/admin/analytics/` with an SEO tab)
+- New `MarketingRecommendation`-style model: `SEORecommendation`
+- Decision ADRs prefixed `S` (so `S0001`, `S0002`...) to not collide with engineering ADRs (numeric) or marketing ADRs (`M0001`...)
+
+Marketing Director and SEO Director will collaborate but not depend on each other:
+- Marketing reads the SEO snapshot for context (how much organic is contributing)
+- SEO reads Marketing's `Order` data for revenue-per-keyword attribution
+
+---
+
+## 6. Known broken thing — fix early
+
+`src/app/api/cron/generate-blog/route.ts` uses a dead OpenRouter model and has not been generating blogs. From the saved memory note: "blog generator broken — pending SEO sub-agent." This is now your responsibility.
+
+Two paths:
+
+**Path A — minimal fix.** Update the model ID to a current one (`anthropic/claude-3.5-sonnet` or `anthropic/claude-sonnet-4-6` via OpenRouter, or call the Anthropic SDK directly). Keep the existing topic/MDX flow.
+
+**Path B — rebuild it properly under the SEO Director.** Replace the topic-list-driven generator with one that:
+1. Reads current rankings from the latest `SEORanking` rows (sourced from the SEMrush Cowork skill output) plus GSC data in `AnalyticsSnapshot`
+2. Identifies a target keyword cluster the site is close to ranking for (positions 11–25 on a meaningful-volume keyword = "striking distance")
+3. Drafts a post optimized for that cluster + internal-links to existing related posts on the site
+4. Writes to `content/blog/posts/` as MDX with proper frontmatter (see existing posts for the schema)
+5. Logs the published post + target keyword + initial position to a `BlogPostPerformance` table for measurement
+
+Recommendation: **Path B**, but in two phases. Phase 1: get rankings + keyword research wired in and surface "next post to write" recommendations to the operator. Phase 2: actually draft + publish autonomously once Phase 1 has earned trust.
+
+---
+
+## 7. Suggested phased build
+
+### Phase 0 — Setup (Day 1)
+
+- Create `.claude/agents/seo-director.md` (mirror Marketing Director frontmatter).
+- Create empty Obsidian memory shell at `Memory/SEO/`.
+- Read all 8 reference files listed in §4.
+- Confirm GSC + GA4 + Vercel admin endpoints return data (these already exist).
+- Sketch the SEMrush Cowork skill (`.claude/skills/seo-semrush-snapshot/SKILL.md`) — selectors, dashboards to capture, output schema. Don't implement the Playwright flow yet; that's Phase 1.
+
+### Phase 1 — Read-only & recommendations (Weeks 1–2)
+
+- **Build the SEMrush Cowork skill first** — this is the data input. Without it, the snapshot cron has no rank data. Implement Playwright login, navigate, screenshot, scrape for the 5 dashboards listed in §3.A. Write outputs to `data/seo/semrush/<date>/`.
+- Add `SEORanking` model (per-keyword, per-snapshot-date row: `keyword`, `position`, `previousPosition`, `searchVolume`, `url`, `capturedAt`, `source: 'semrush' | 'gsc'`).
+- Build `src/app/api/cron/seo-snapshot/route.ts` — daily pull from GSC + the latest SEMrush JSON (already on disk from the weekly skill run) + on-page audit (`scripts/seo-audit.ts`). Writes one `SEOSnapshot` row per day.
+- Build `SEORecommendation` model + heuristic generators inside the snapshot cron (e.g. "page X dropped from position 5 to 11 — investigate", "keyword Y has rising volume and you rank #14 — write a post").
+- Build the Monday `seo-briefing` email + template.
+- Surface the queue in admin UI.
+- The agent itself is invokable via `Agent({ subagent_type: "seo-director", ... })` and produces narrative analyses on top of the snapshot.
+
+**Exit criterion for Phase 1:** Allan reads the Monday SEO briefing for 2 consecutive weeks and the recommendations are useful enough to act on.
+
+### Phase 2 — Autonomous content production (Week 3+)
+
+- Fix or replace the blog generator (Path B from §6).
+- Add internal-linking pass: after a new post publishes, find related posts and add reciprocal links.
+- Add schema.org enrichment: enhance existing posts with FAQPage, HowTo, Product where relevant.
+- Add monthly competitive-content scan: what topics are competitors ranking for that we aren't covering.
+
+**Exit criterion for Phase 2:** SEO Director publishes ≥4 posts/month autonomously, internal-link graph density measurably improves, indexation rate climbs.
+
+### Phase 3 — Authority building (Quarter 2+)
+
+- Surface backlink prospects from the SEMrush Backlink Analytics + Organic Research dashboards (extend the Cowork skill to capture competitor data on the same weekly run).
+- Draft outreach email templates (handed to operator to send — not autonomous).
+- Track digital-PR opportunities (HARO equivalents, podcast pitches).
+
+---
+
+## 8. Files this build will likely touch
+
+```
+.claude/agents/seo-director.md                     [NEW]
+.claude/skills/seo-semrush-snapshot/SKILL.md       [NEW — Cowork browser-automation skill]
+.claude/skills/seo-semrush-snapshot/script.ts      [NEW — Playwright login + scrape]
+.claude/skills/seo-semrush-snapshot/selectors.ts   [NEW — SEMrush DOM selectors, isolated for easy fixes]
+prisma/schema.prisma                               [+SEORecommendation, +SEOSnapshot, +SEORanking, +BlogPostPerformance]
+src/app/api/cron/seo-snapshot/route.ts             [NEW]
+src/app/api/cron/seo-briefing/route.ts             [NEW]
+src/app/api/cron/measure-seo-recommendations/route.ts   [NEW]
+src/app/api/admin/seo/snapshot/route.ts            [NEW]
+src/app/api/admin/seo/recommendations/route.ts     [NEW]
+src/app/api/admin/seo/keywords/route.ts            [NEW]
+src/app/admin/seo/page.tsx                         [NEW]
+src/app/admin/seo/recommendations/page.tsx         [NEW]
+src/lib/seo/snapshot.ts                            [NEW — GSC + SEMrush-JSON reader]
+src/lib/seo/semrush-import.ts                      [NEW — reads data/seo/semrush/<date>/*.json into SEORanking]
+src/lib/seo/keyword-prioritizer.ts                 [NEW — heuristic ranker]
+src/lib/seo/internal-linker.ts                     [NEW]
+src/lib/seo/blog-generator.ts                      [NEW or replaces scripts/automated-daily-blog.ts]
+src/lib/email/templates/seo-briefing.ts            [NEW]
+src/app/api/cron/generate-blog/route.ts            [FIX or RETIRE — see §6]
+vercel.json                                        [+ new cron schedules]
+.gitignore                                         [+ data/seo/semrush/]
+.env.example                                       [+ SEMRUSH_EMAIL, SEMRUSH_PASSWORD]
+data/seo/semrush/                                  [NEW dir — gitignored]
+docs/marketing/weekly/                             [Marketing keeps writing here]
+docs/seo/weekly/                                   [NEW — SEO writes here]
+docs/seo/recommendations/                          [NEW]
+content/blog/posts/                                [SEO Director writes here in Phase 2]
+
+# Obsidian vault (manual creates, not in repo)
+PartyOn2/Programs/SEO-Director.md
+PartyOn2/Memory/SEO/README.md
+PartyOn2/Memory/SEO/Open-Questions.md
+PartyOn2/Memory/SEO/Briefings/
+PartyOn2/Memory/SEO/Recommendations/
+PartyOn2/Memory/SEO/Decisions/
+PartyOn2/Memory/SEO/Channel-Performance/
+```
+
+---
+
+## 9. First-session checklist (drop-into-new-session steps)
+
+1. Read this entire doc.
+2. Read the 8 reference files in §4 (especially the Marketing Director vault doc — it's the template).
+3. Confirm GSC, GA4, and Vercel admin endpoints work (these already exist; no new MCPs to wire). Make sure `SEMRUSH_EMAIL` and `SEMRUSH_PASSWORD` env vars exist or get added — the Cowork skill needs them.
+4. Read `docs/seo-audit-2026-03-30.md` and re-check current indexation status (via the existing GSC pipe in `analytics-snapshot`).
+5. **Write Phase 0 deliverables**: the `.claude/agents/seo-director.md` file + the Obsidian `Programs/SEO-Director.md` skeleton + the `Memory/SEO/README.md` (copy Marketing's, swap names).
+6. **Open a PR** with just the Phase 0 scaffolding before writing any cron / model / UI code. Get operator review.
+7. Once Phase 0 PR merges, scope Phase 1 in a follow-up PR — start with the snapshot cron + DB models, no UI yet.
+
+---
+
+## 10. Hard rules (apply throughout)
+
+- **Never publish a blog post or commit content edits without operator approval until Phase 2 is explicitly approved.** Phase 1 is recommendations-only.
+- **Never delete or rewrite an existing blog post** — append, don't rewrite (mirroring vault rule).
+- **All decisions go through ADR** — `Memory/SEO/Decisions/S0001-...md` etc. Never write an ADR without operator approval.
+- **27% margin floor doesn't apply here**, but the SEO Director should never recommend keyword targets that would lead to traffic with no commercial intent (e.g., generic Austin tourism queries).
+- **TABC compliance** — any auto-generated content must not make medical claims about alcohol, must include responsible-drinking disclaimers where appropriate, must respect age-gating on the site.
+- **No `any` type, files <500 lines, components <200 lines, functions <50 lines** (per project CLAUDE.md).
+- **Use existing design system** for any admin UI (`.btn-primary`, `.card`, etc. — see project CLAUDE.md design system section).
+
+---
+
+## 11. Open questions for the operator (ask before building)
+
+1. **SEMrush plan tier** — confirm which subscription tier (affects keyword/project quotas the Cowork skill should respect) and which projects/dashboards are already configured for `partyondelivery.com`.
+2. **SEMrush 2FA status** — is 2FA enabled on the SEMrush account? If yes, the Cowork skill needs a one-time interactive setup to capture a long-lived session cookie; if no, simple email/password login works.
+3. **Where do credentials live?** — Vercel env vars (for production crons), `.env.local` (for local dev), or a separate secret store? Confirm before the skill is built.
+4. **GSC verification** — has GSC been re-verified since the March audit? (Check by looking at the latest `AnalyticsSnapshot` rows for non-null GSC fields.)
+5. **Indexation status now** — has the 0/1289 indexation issue resolved since March? Re-check via the GSC data in `analytics-snapshot` and Google's `site:partyondelivery.com` query.
+6. **Blog cadence target** — 1/week, 2/week, daily? Affects Phase 2 scope.
+7. **Editorial voice constraints** — any topics off-limits? Any Austin neighborhoods we don't serve and shouldn't write content targeting?
+8. **Image generation cost cap** — `automated-daily-blog.ts` uses a local `image-generator-tool`. Confirm the cost model and monthly cap.
+
+---
+
+## 12. Success metrics (set baselines in Phase 0, measure quarterly)
+
+- **Indexation rate** — % of sitemap URLs in Google's index (baseline: ~0% in March 2026)
+- **Total organic clicks/month** — from GSC
+- **Keywords ranking in top 10 / top 3** — from the SEMrush Position Tracking dashboard (captured weekly via the Cowork skill)
+- **Average position** for tracked keywords
+- **Authority Score (SEMrush)** trend — captured weekly
+- **Referring domains** — net new per month, from SEMrush Backlink Analytics
+- **Internal-link graph density** — average inbound internal links per blog post
+- **Revenue attributable to organic search** — join `Order.utmSource` + `Order.landingPage` against organic-landing-page set
+
+---
+
+That's everything a fresh session needs. Once they finish Phase 0, the agent will be invokable as `subagent_type: "seo-director"` and the Operations Director (which is being built in parallel in this conversation) will have a sibling to coordinate with.


### PR DESCRIPTION
## Summary

Commits two reference docs that future Director sessions need:

- **`docs/FINANCE-DIRECTOR-AGENT-BUILDOUT.md`** (480 lines) — full plan for director #4. QuickBooks Online + Plaid integrations, 11 phases (0 → 1A → 1B → 1C → 2A → 2B → 2C → 3 → 4 → 5 → 6), one PR per phase. Includes a "loop protocol" (§1.5) for autonomous self-paced execution via \`/loop\` + \`ScheduleWakeup\` so the build runs without manual chip clicks between phases.
- **`docs/SEO-DIRECTOR-AGENT-BUILDOUT.md`** (356 lines) — was untracked in worktree; preserved as forward-looking reference for SEO Phase 1+ work. Phase 0 already shipped via #28.

Both follow the pattern established by `docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md` — self-contained briefs that drop cleanly into a fresh Claude Code session.

## Operator decisions locked into the Finance brief (2026-05-19)

| Decision | Choice |
|---|---|
| Accounting | QuickBooks Online (Intuit Developer API) |
| Bank feed | Plaid (real-time API) |
| Payroll | Contractor 1099s only (no W-2) |
| Autonomy ceiling | Auto-categorize, recommend everything else |

## Why now

The Finance Director is being built right now by a separate autonomous-loop session spawned from the planning conversation. That session will re-copy this doc into its own first PR (Phase 0), but committing it here means:

1. The brief is preserved even if the loop session crashes
2. Anyone reviewing the repo can see the full Finance plan independent of any specific session
3. The Changelog gets a clean entry for "this is when we decided what Finance Director would do"

## Test plan

- [ ] Verify both docs render properly on GitHub
- [ ] No code changes — pure docs PR

## See also

Companion vault entry: `Memory/Sessions/2026-05-19-agent-buildout-survey-and-finance-director-planning.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)