### PR TITLE
feat(seo): landing-page follow-ups — titles, FAQ schema, cross-links, H1 keyword

### DIFF
--- a/src/components/landing/LandingPageTemplate.tsx
+++ b/src/components/landing/LandingPageTemplate.tsx
@@ -11,6 +11,37 @@ import QuickBuyModal from './QuickBuyModal';
 import HeroSlideshow from './HeroSlideshow';
 import type { LandingConfig, Catalog, Package, ThemeColors } from './types';
 import type { UpsellProducts } from '@/lib/landing/getUpsellProducts';
+import { generateFAQSchema } from '@/lib/seo/schemas';
+
+// All 4 /austin-*-delivery landing pages. Used to render an "other event
+// types we cover" cross-link section near the final CTA — gives sibling
+// pages reciprocal internal links (was 0 cross-linking before).
+const ALL_AUSTIN_LANDING_PAGES = [
+  {
+    slug: 'austin-bachelor-party-delivery',
+    title: 'Bachelor Parties',
+    blurb:
+      'Beer, liquor, and cocktail kits to Airbnbs, Lake Travis docks, and party buses.',
+  },
+  {
+    slug: 'austin-bachelorette-party-delivery',
+    title: 'Bachelorette Parties',
+    blurb:
+      'Champagne, rosé, and brunch mimosa bars to your weekend home base.',
+  },
+  {
+    slug: 'austin-corporate-event-delivery',
+    title: 'Corporate Events',
+    blurb:
+      'Premium spirits and bar setups for offsites, client dinners, and team events.',
+  },
+  {
+    slug: 'austin-wedding-weekend-delivery',
+    title: 'Wedding Weekends',
+    blurb:
+      'Welcome reception, rehearsal dinner, reception bar, and after-party — coordinated.',
+  },
+];
 
 type Props = {
   config: LandingConfig;
@@ -48,8 +79,28 @@ export default function LandingPageTemplate({ config, catalog, upsellProducts }:
     return 'wedding';
   })();
 
+  // FAQ schema — Schema.org FAQPage built from the same Q&A rendered
+  // on the page. Eligible for FAQ rich-snippet treatment in SERPs.
+  // Note: Google requires the schema's questions/answers to match the
+  // visible content; we read directly from config.faqs so they can't
+  // drift.
+  const faqSchema = generateFAQSchema(
+    config.faqs.map((f) => ({ question: f.q, answer: f.a }))
+  );
+
+  // Sibling landing pages (the other 3) for the cross-linking section.
+  const siblingLandingPages = ALL_AUSTIN_LANDING_PAGES.filter(
+    (p) => p.slug !== config.slug
+  );
+
   return (
     <main className="bg-white text-gray-900">
+      {/* FAQ schema — server-rendered into initial HTML so search crawlers see it */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+
       {/* Slim header */}
       <header
         className="sticky top-0 z-40 backdrop-blur border-b"
@@ -100,12 +151,17 @@ export default function LandingPageTemplate({ config, catalog, upsellProducts }:
               WebkitBackdropFilter: 'blur(4px)',
             }}
           >
-            <p
+            {/*
+              Rendered as <h2> rather than <p> so the target keyword phrase
+              (e.g. "AUSTIN BACHELOR PARTY ALCOHOL DELIVERY") is in a
+              semantic heading element. Visual rendering is unchanged.
+            */}
+            <h2
               className="inline-block text-xs sm:text-sm font-bold tracking-[0.15em] px-3 py-1.5 rounded mb-6 shadow-lg"
               style={{ background: T.primary, color: T.primaryText }}
             >
               {config.heroEyebrow}
-            </p>
+            </h2>
 
             <h1
               className="font-heading font-bold text-white text-4xl sm:text-5xl md:text-7xl leading-[1.05] tracking-tight mb-5"
@@ -495,6 +551,48 @@ export default function LandingPageTemplate({ config, catalog, upsellProducts }:
           </div>
         </div>
       </section>
+
+      {/* OTHER AUSTIN EVENT TYPES — internal cross-link to sibling /austin-*-delivery pages */}
+      {siblingLandingPages.length > 0 && (
+        <section className="py-20 bg-white border-t border-gray-100">
+          <div className="max-w-6xl mx-auto px-4 sm:px-6">
+            <h2
+              className="font-heading text-3xl md:text-4xl font-bold text-center mb-3"
+              style={{ color: T.navy }}
+            >
+              Other Austin event types we cover
+            </h2>
+            <p className="text-center text-gray-600 mb-12 max-w-2xl mx-auto">
+              Different occasion? Same on-time, ice-cold delivery — tailored to the event.
+            </p>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+              {siblingLandingPages.map((p) => (
+                <Link
+                  key={p.slug}
+                  href={`/${p.slug}`}
+                  className="block p-6 rounded-xl border border-gray-200 hover:border-gray-400 hover:shadow-md transition-all bg-white"
+                >
+                  <h3
+                    className="font-heading text-xl font-bold mb-2 tracking-[0.05em]"
+                    style={{ color: T.navy }}
+                  >
+                    {p.title}
+                  </h3>
+                  <p className="text-sm text-gray-600 leading-relaxed mb-4">
+                    {p.blurb}
+                  </p>
+                  <span
+                    className="text-sm font-semibold inline-flex items-center gap-1"
+                    style={{ color: T.blue }}
+                  >
+                    See packages →
+                  </span>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
 
       {/* FINAL CTA */}
       <section className="relative py-24 overflow-hidden">

--- a/src/components/landing/configs/bachelor.ts
+++ b/src/components/landing/configs/bachelor.ts
@@ -4,8 +4,8 @@ const PHONE_DISPLAY = '(737) 371-9700';
 
 export const bachelorConfig: LandingConfig = {
   slug: 'austin-bachelor-party-delivery',
-  metaTitle:
-    'Austin Bachelor Party Alcohol Delivery | Stocked Cold, On Time | Party On Delivery',
+  // Title trimmed to <60 chars so it doesn't truncate in SERPs.
+  metaTitle: 'Austin Bachelor Party Alcohol Delivery | Party On Delivery',
   metaDescription:
     'Beer, liquor, mixers and ice delivered cold to your Airbnb, hotel, party bus or Lake Travis dock. Group ordering, split pay, cocktail kits. 500+ Austin groups served.',
   ogImage: '/images/services/bach-parties/bachelor-party-epic.webp',

--- a/src/components/landing/configs/bachelorette.ts
+++ b/src/components/landing/configs/bachelorette.ts
@@ -4,8 +4,8 @@ const PHONE_DISPLAY = '(737) 371-9700';
 
 export const bacheloretteConfig: LandingConfig = {
   slug: 'austin-bachelorette-party-delivery',
-  metaTitle:
-    'Austin Bachelorette Party Alcohol Delivery | Champagne, Cocktails & More | Party On Delivery',
+  // Title trimmed to <60 chars so it doesn't truncate in SERPs.
+  metaTitle: 'Austin Bachelorette Alcohol Delivery | Party On Delivery',
   metaDescription:
     "Champagne, rosé, cocktail kits and brunch mimosa bars delivered to your Austin Airbnb, hotel suite, or boat. Group ordering, split pay, locally owned. 500+ groups served.",
   ogImage: '/images/services/bach-parties/bachelorette-champagne-tower.webp',

--- a/src/components/landing/configs/corporate.ts
+++ b/src/components/landing/configs/corporate.ts
@@ -4,8 +4,8 @@ const PHONE_DISPLAY = '(737) 371-9700';
 
 export const corporateConfig: LandingConfig = {
   slug: 'austin-corporate-event-delivery',
-  metaTitle:
-    'Austin Corporate Event & Offsite Alcohol Delivery | Premium Spirits & Bar Setup | Party On Delivery',
+  // Title trimmed to <60 chars so it doesn't truncate in SERPs.
+  metaTitle: 'Austin Corporate Event Alcohol Delivery | Party On Delivery',
   metaDescription:
     'White-glove premium spirits, wine, and bar setups for Austin corporate offsites, client dinners, and team events. TABC-licensed. $1M insured. Invoices on request. Free returns.',
   ogImage: '/images/products/premium-spirits-boutique.webp',

--- a/src/components/landing/configs/wedding.ts
+++ b/src/components/landing/configs/wedding.ts
@@ -4,8 +4,8 @@ const PHONE_DISPLAY = '(737) 371-9700';
 
 export const weddingConfig: LandingConfig = {
   slug: 'austin-wedding-weekend-delivery',
-  metaTitle:
-    'Austin Wedding Weekend Alcohol Delivery | Welcome Bags, Reception & More | Party On Delivery',
+  // Title trimmed to <60 chars so it doesn't truncate in SERPs.
+  metaTitle: 'Austin Wedding Alcohol Delivery | Party On Delivery',
   metaDescription:
     'Stock the welcome reception, rehearsal dinner, ceremony, and after-party — coordinated across the whole wedding weekend. TABC-licensed, planner-friendly, sommelier-curated.',
   ogImage: '/images/services/bach-parties/bachelorette-champagne-tower.webp',


### PR DESCRIPTION
## Summary

Actions on the 4 recommendations in `docs/seo/landing-pages-audit.md` (shipped in #59). All 4 in one PR because they're small mechanical edits and ship as a coherent unit.

## Changes

### 1. Title tags trimmed below SERP truncation point

| Page | Before | After | Chars |
|------|--------|-------|------:|
| Bachelor | `Austin Bachelor Party Alcohol Delivery \| Stocked Cold, On Time \| Party On Delivery` | `Austin Bachelor Party Alcohol Delivery \| Party On Delivery` | 82 → **59** |
| Bachelorette | `Austin Bachelorette Party Alcohol Delivery \| Champagne, Cocktails & More \| Party On Delivery` | `Austin Bachelorette Alcohol Delivery \| Party On Delivery` | 96 → **57** |
| Corporate | `Austin Corporate Event & Offsite Alcohol Delivery \| Premium Spirits & Bar Setup \| Party On Delivery` | `Austin Corporate Event Alcohol Delivery \| Party On Delivery` | 107 → **60** |
| Wedding | `Austin Wedding Weekend Alcohol Delivery \| Welcome Bags, Reception & More \| Party On Delivery` | `Austin Wedding Alcohol Delivery \| Party On Delivery` | 96 → **52** |

Target keyword + brand preserved on every one. Truncating tail copy removed.

### 2. Hero eyebrow promoted from `<p>` to `<h2>`

The eyebrow text IS the target keyword phrase (e.g. `AUSTIN BACHELOR PARTY ALCOHOL DELIVERY`) but it was rendered as a styled paragraph. Same visual rendering after this PR; now in a semantic heading element search engines can weight.

### 3. `FAQPage` JSON-LD added to `LandingPageTemplate`

Built from `config.faqs` — the same Q&A rendered on the page — so the schema can't drift from visible content (Google disqualifies the entire page from rich snippets when they diverge; that was the bug PR #51 fixed elsewhere). Reuses the existing `generateFAQSchema` helper from `src/lib/seo/schemas.ts`.

After this PR, all 4 landing pages emit a single `FAQPage` JSON-LD block with their 6 visible Q&A pairs.

### 4. Cross-linking section between FAQ and Final CTA

New section `Other Austin event types we cover` renders 3 sibling landing-page cards per page (filtered by current slug). Closes the zero-cross-linking gap surfaced in the audit — every page now sends reciprocal internal link equity to its 3 siblings.

Sibling lookup table is in `LandingPageTemplate.tsx` at the top — single source of truth, easy to extend when `/austin-boat-party-delivery` ships.

## Files changed

- `src/components/landing/configs/{bachelor,bachelorette,corporate,wedding}.ts` — 1-line title trim each
- `src/components/landing/LandingPageTemplate.tsx` — eyebrow tag swap, FAQ schema, cross-link section, sibling pages lookup

## Test plan

- [x] `npx tsc --noEmit` clean for changed files
- [x] `npx next lint` on the 5 changed files — no warnings or errors
- [ ] Vercel preview: hit each of the 4 landing pages and confirm
  - Title tag: `curl -sL <preview>/austin-bachelor-party-delivery | grep -oE '<title>[^<]+' | wc -c`
  - FAQ schema present: `curl -sL <url> | grep -c '"@type":"FAQPage"'` → 1
  - Cross-link section has 3 sibling URLs
  - Hero eyebrow still styled as the yellow badge visually (now an h2)
- [ ] Post-merge: re-run on prod, confirm SERP titles update on next Google recrawl

## Refs

Closes the 4 follow-up recommendations in `docs/seo/landing-pages-audit.md`. Builds on #49, #51, #53, #55, #56, #59, #63 — the full SEO sprint cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)