### PR TITLE
docs(codebase-docs): resync to current main — Directors + lead capture + finance

### DIFF
--- a/codebase-docs/01-overview.md
+++ b/codebase-docs/01-overview.md
@@ -3,7 +3,7 @@ title: Business Overview
 project: PartyOn2
 doc_type: codebase-reference
 section: overview
-last_generated: 2026-04-23
+last_generated: 2026-05-20
 tags: [partyondelivery, codebase, overview, business]
 ---
 
@@ -15,7 +15,7 @@ PartyOn Delivery is a premium on-demand alcohol and party-goods delivery service
 
 The site is built as a hybrid of a marketing site, an e-commerce storefront, and a set of collaborative order dashboards. Visitors can either self-serve through the standard `/order` catalog, or go through curated landing pages for their use case (weddings, bach parties, boat parties, corporate, BYOB venues, delivery-area pages). A distinctive second flow is the **Universal Order Dashboard** — a shareable, code-addressable ordering surface at `/dashboard/[code]` where a host, a partner, or an affiliate can curate a cart that guests join, add to, and pay for individually or as one invoice.
 
-Behind the storefront sits a comprehensive back-office: an ops panel for order picking / inventory / receiving shipments / distributor invoice OCR, an admin panel for customers / promotions / discounts / reports / experiments / AI assistance, and an affiliate program with magic-link auth, commission accrual, and monthly payout generation. (A points-based loyalty program was previously planned but the code was removed 2026-04-23 before launch; Postgres tables remain for data preservation only.)
+Behind the storefront sits a comprehensive back-office: an ops panel for order picking / inventory / receiving shipments / distributor invoice OCR, an admin panel for customers / promotions / discounts / reports / experiments / AI assistance, and an affiliate program with magic-link auth, commission accrual, and monthly payout generation. Three "Director" pipelines (Marketing, SEO, Operations) generate prioritized recommendation rows surfaced in a unified triage queue at `/admin/recommendations`; a Finance Director pipeline (Plaid + QuickBooks Online) is in Phase 0 scaffolding. A lead-capture + visitor-tracking system writes `Lead` / `VisitorSession` / `LeadEvent` rows from every form interaction site-wide. (A points-based loyalty program was previously planned but the code was removed 2026-04-23 before launch; Postgres tables remain for data preservation only.)
 
 ## User types
 
@@ -48,6 +48,7 @@ Behind the storefront sits a comprehensive back-office: an ops panel for order p
 - **Affiliate flow** — applicant submits at `/affiliate/apply` → admin approves → `ref=` attribution cookie set for 30 days by `src/middleware.ts` → commissions accrue via cron → monthly payout generated.
 - **Blog / SEO engine** — daily Vercel cron fires `/api/cron/generate-blog` → AI-generated MDX committed to `content/blog/posts/` → served under `/blog/*`.
 - **Inventory ops** — `/ops/inventory` + receiving flow with AI distributor-invoice OCR (`InventoryNote`, `ReceivingInvoice`, `DistributorSkuMap`).
+- **Landing-page lead capture** — anonymous visitors get a `pod_vsid` cookie + `VisitorSession` row; any captured form field upgrades them to a `Lead`; the `/austin-*-delivery` landing pages run an embedded Stripe checkout with a pre-checkout A/B upsell overlay (tracked via `DraftOrder.upsellVariantId`).
 
 ## Monetization
 

--- a/codebase-docs/02-tech-stack-and-architecture.md
+++ b/codebase-docs/02-tech-stack-and-architecture.md
@@ -3,7 +3,7 @@ title: Tech Stack and Architecture
 project: PartyOn2
 doc_type: codebase-reference
 section: architecture
-last_generated: 2026-05-03
+last_generated: 2026-05-20
 tags: [partyondelivery, codebase, architecture, stack, env]
 ---
 
@@ -23,10 +23,11 @@ tags: [partyondelivery, codebase, architecture, stack, env]
 | ORM | Prisma (`@prisma/client`, `prisma`) | 6.15.0 |
 | Auth / JWT | `jose` | 6.1.3 |
 | Password hashing | `bcryptjs` | 3.0.3 |
-| Payments | `stripe` | 20.2.0 |
+| Payments | `stripe`, `@stripe/stripe-js`, `@stripe/react-stripe-js` (embedded checkout on landing pages) | 20.2.0 / 9.5.0 / 6.3.0 |
 | Email | `resend`, `@react-email/components` | 6.9.2 / 1.0.4 |
 | SMS / webhook relay | GoHighLevel via `src/lib/webhooks/ghl.ts`; Zapier inbound | n/a (webhook URL only) |
-| Analytics | `@vercel/analytics`, `@vercel/speed-insights`, `@google-analytics/data` (GA4 Data API), Meta Pixel | 1.5.0 / 1.2.0 / 5.2.1 |
+| Analytics | `@vercel/analytics`, `@vercel/speed-insights`, `@google-analytics/data` (GA4 Data API), Meta Pixel, Microsoft Clarity (`@microsoft/clarity`) | 1.5.0 / 1.2.0 / 5.2.1 / 1.0.2 |
+| Finance integrations | `plaid`, `react-plaid-link` (bank accounts), `intuit-oauth` (QuickBooks Online) | 42.2.0 / 4.1.1 / 4.2.3 |
 | Error / observability | Vercel Analytics Drain (see `api/analytics-ingest`) | n/a |
 | Shopify integration | `@shopify/buy-button-js`, `graphql`, `graphql-request` (Admin API only) | 3.0.5 / 16.11.0 / 7.2.0 |
 | AI | `@anthropic-ai/sdk`, `@google/generative-ai`, OpenRouter (via fetch) | 0.66.0 / 0.24.1 |
@@ -47,7 +48,7 @@ tags: [partyondelivery, codebase, architecture, stack, env]
 
 ```text
 src/
-├── app/                        # Next.js App Router — 143 page.tsx, 214 route.ts
+├── app/                        # Next.js App Router — 157 page.tsx, 241 route.ts
 │   ├── (main)/                 # Route group for marketing pages (areas, press, tabc…)
 │   ├── api/
 │   │   ├── v1/                 # Primary API: auth, products, orders, cart, inventory, admin, affiliate, invoice
@@ -257,6 +258,28 @@ Grouped to match the section headers in `.env.example` at repo root. This list i
 |---|---|
 | `NEXT_PUBLIC_META_PIXEL_ID` | Facebook/Meta Pixel ID (falls back to baked-in default if unset). |
 
+### Microsoft Clarity
+| Variable | Purpose |
+|---|---|
+| `NEXT_PUBLIC_CLARITY_PROJECT_ID` | Clarity project ID (the value after `clarity.ms/tag/<id>`). Initialized client-side by `src/components/ClarityInit.tsx` in production only. Added 2026-05. |
+
+### Finance Director — QuickBooks Online (Plaid integration too)
+Added 2026-05 alongside the Finance Director pipeline (Phase 0+).
+
+| Variable | Purpose |
+|---|---|
+| `INTUIT_CLIENT_ID` | Intuit developer app client ID (QBO OAuth). |
+| `INTUIT_CLIENT_SECRET` | Intuit app client secret. |
+| `INTUIT_ENV` | `sandbox` \| `production`. |
+| `INTUIT_REDIRECT_URI` | QBO OAuth redirect — must match the value in the Intuit developer console (`/api/admin/finance/qb/callback`). |
+
+### Finance Director — Plaid
+| Variable | Purpose |
+|---|---|
+| `PLAID_CLIENT_ID` | Plaid client ID. |
+| `PLAID_SECRET` | Plaid secret (matched to env). |
+| `PLAID_ENV` | `sandbox` \| `development` \| `production`. Sandbox creds work with Plaid's `user_good` / `pass_good` fake institution. |
+
 ### Supabase (product image storage)
 | Variable | Purpose |
 |---|---|
@@ -327,6 +350,8 @@ Grouped to match the section headers in `.env.example` at repo root. This list i
 | `npm run indexnow:*` | IndexNow submission helpers. |
 | `npm run extract-bundle` | Cocktail bundle image extractor (one-off tooling). |
 | `npm run add-partner` | CLI partner onboarding. |
+| `npm run sync:marketing` / `:watch` | Mirror `RecommendationItem` rows to the Obsidian vault for the Marketing Director agent. |
+| `npm run sync:operations` / `:watch` | Mirror `OperationsRecommendation` rows to the Obsidian vault for the Operations Director agent. Added 2026-05. |
 
 ## Conventions (enforced via CLAUDE.md)
 

--- a/codebase-docs/03-routes-and-pages.md
+++ b/codebase-docs/03-routes-and-pages.md
@@ -3,7 +3,7 @@ title: Routes and Pages
 project: PartyOn2
 doc_type: codebase-reference
 section: routes
-last_generated: 2026-05-03
+last_generated: 2026-05-20
 tags: [partyondelivery, codebase, routes, api, pages]
 ---
 
@@ -45,6 +45,10 @@ Every `page.tsx` and `route.ts` discovered under `src/app/`. Paths are literal f
 | `/affiliate/dashboard/orders` | `src/app/affiliate/dashboard/orders/page.tsx` | Orders attributed to this affiliate. | — | Yes | |
 | `/aperol-spritz` | `src/app/aperol-spritz/page.tsx` | Cocktail landing. | — | No | |
 | `/atx-delivery-info` | `src/app/atx-delivery-info/page.tsx` | Delivery info. | — | No | |
+| `/austin-bachelor-party-delivery` | `src/app/austin-bachelor-party-delivery/page.tsx` | High-conversion bachelor-party landing page (Quick-Buy + Package-Builder + a-la-carte modals, embedded Stripe checkout, pre-checkout upsell overlay). Added 2026-05. | — | No | Indexable. Uses shared `LandingPageTemplate` with `bachelorConfig`. |
+| `/austin-bachelorette-party-delivery` | `src/app/austin-bachelorette-party-delivery/page.tsx` | Bachelorette equivalent of the above. | — | No | Indexable. |
+| `/austin-corporate-event-delivery` | `src/app/austin-corporate-event-delivery/page.tsx` | Corporate-event landing variant. | — | No | Indexable. |
+| `/austin-wedding-weekend-delivery` | `src/app/austin-wedding-weekend-delivery/page.tsx` | Wedding-weekend landing variant. | — | No | Indexable. |
 | `/austin-byob-venues` | `src/app/austin-byob-venues/page.tsx` | BYOB venues index. | — | No | |
 | `/austin-partners` | `src/app/austin-partners/page.tsx` | Partner overview. | — | No | |
 | `/bach-parties` | `src/app/bach-parties/page.tsx` | Bach funnel. | — | No | |
@@ -60,6 +64,7 @@ Every `page.tsx` and `route.ts` discovered under `src/app/`. Paths are literal f
 | `/boat-parties/products` | (layout only) | Shell. | — | No | |
 | `/cart/shared` | `src/app/cart/shared/page.tsx` | Shared cart (root). | — | No | |
 | `/cart/shared/[id]` | `src/app/cart/shared/[id]/page.tsx` | Shared cart by id. | `id` | No | |
+| `/s/[slug]` | `src/app/s/[slug]/route.ts` | Short-link redirect for shared carts — 302 → `/cart/shared?c=…&t=…`. Looks up `CartShareLink` by slug + bumps `viewCount`. Added 2026-05. | `slug` | No | Route handler, not a page. |
 | `/checkout` | `src/app/checkout/page.tsx` | Stripe checkout handoff. | — | Optional | Age verification required. |
 | `/checkout/success` | `src/app/checkout/success/page.tsx` | Post-payment success. | — | No | |
 | `/cocktail-kits` | `src/app/cocktail-kits/page.tsx` | Cocktail kits catalog. | — | No | |
@@ -75,7 +80,9 @@ Every `page.tsx` and `route.ts` discovered under `src/app/`. Paths are literal f
 | `/delivery-areas` | `src/app/delivery-areas/page.tsx` | Delivery coverage. | — | No | |
 | `/delivery/[location]` | `src/app/delivery/[location]/page.tsx` | Programmatic delivery-area pages. | `location` | No | |
 | `/design-example` | `src/app/design-example/page.tsx` | Design system live showcase. | — | No | Internal / reference. |
+| `/events/[slug]` | `src/app/events/[slug]/page.tsx` | Public event invite page (RSVP + BYOB order flow). Currently backed by a demo registry (`src/lib/events/demoEvents.ts`) — Prisma persistence pending. | `slug` | No | `noindex` while in demo phase. Added 2026-05. |
 | `/faqs` | `src/app/faqs/page.tsx` | FAQ. | — | No | |
+| `/flyer` | `src/app/flyer/page.tsx` | One-page marketing flyer ("The Playbook") summarising every service. Indexable. Added 2026-05. | — | No | `force-static`. Wired to lead-magnet email flow. |
 | `/gifts/cocktail-kits` | `src/app/gifts/cocktail-kits/page.tsx` | Gifting catalog. | — | No | |
 | `/gin-martini` | `src/app/gin-martini/page.tsx` | Cocktail landing. | — | No | |
 | `/group/[code]` | `src/app/group/[code]/page.tsx` | v2 group order home. | `code` | Soft | |
@@ -87,6 +94,8 @@ Every `page.tsx` and `route.ts` discovered under `src/app/`. Paths are literal f
 | `/invoices/[...slug]` | `src/app/invoices/[...slug]/page.tsx` | Legacy invoice catch-all. | `slug[]` | Token | |
 | `/[storeId]/invoices/[...slug]` | `src/app/[storeId]/invoices/[...slug]/page.tsx` | Tenant-scoped legacy invoice. | `storeId`, `slug[]` | Token | |
 | `/kegs` | `src/app/kegs/page.tsx` | Keg service. | — | No | |
+| `/landing-page-playbook` | `src/app/landing-page-playbook/page.tsx` | Internal methodology doc for replicating the landing-page system on another brand. | — | No | `noindex`. Added 2026-05. |
+| `/landing-pages` | `src/app/landing-pages/page.tsx` | Internal preview directory of all four `/austin-*-delivery` landing pages. | — | No | `noindex`. Added 2026-05. |
 | `/negroni` | `src/app/negroni/page.tsx` | Cocktail landing. | — | No | |
 | `/old-fashioned` | `src/app/old-fashioned/page.tsx` | Cocktail landing. | — | No | |
 | `/order` | `src/app/order/page.tsx` | Primary product browse. | — | No | `/products` → here. |
@@ -166,7 +175,7 @@ Every `page.tsx` and `route.ts` discovered under `src/app/`. Paths are literal f
 | `/api/v1/orders` | `.../orders/route.ts` | GET | Customer orders. | Yes |
 | `/api/v1/orders/[id]` | `.../orders/[id]/route.ts` | GET | Order detail. | Yes |
 | `/api/orders/[orderNumber]` | `src/app/api/orders/[orderNumber]/route.ts` | GET | Order lookup by number. | Token / yes |
-| `/api/cart/share` | `src/app/api/cart/share/route.ts` | POST | Create shared cart link. | No |
+| `/api/cart/share` | `src/app/api/cart/share/route.ts` | POST | Create shared cart link. Now persists a `CartShareLink` row + returns `/s/<slug>` short URL. | No |
 | `/api/cart/share/[id]` | `.../share/[id]/route.ts` | GET | Fetch shared cart. | No |
 
 ### Invoice / draft order (public-facing)
@@ -269,6 +278,7 @@ v1 `/api/group-orders/*` and v2 `/api/v2/group-orders/*` are **both live** — v
 | `/api/ops/email-preview/send` | `.../email-preview/send/route.ts` | POST | Send test email. | Ops |
 | `/api/ops/email-template-content` | `.../email-template-content/route.ts` | GET/PATCH | Edit template content. | Ops |
 | `/api/ops/orders/[id]/picks` | `.../orders/[id]/picks/route.ts` | GET/PUT | Persistent pick/pack state for the `/ops/orders` picker UI. Per `(orderId, itemKey)` row in `OrderItemPickState`; replaces prior per-browser localStorage so multiple devices see the same checkbox + short-by state. Added `86f58c77`. | Ops |
+| `/api/ops/weekly-summary` | `.../weekly-summary/route.ts` | GET | Returns the print-friendly weekly checklist JSON (PAID orders, next 7 days, cooler-by-cooler). Backs the `/weekly-summary` skill. Added 2026-05. | Ops |
 
 ### Admin API namespaces — `/api/admin/*` vs `/api/v1/admin/*`
 
@@ -330,6 +340,19 @@ These are **parallel namespaces, not a migration** — neither supersedes the ot
 |---|---|---|
 | `/api/admin/verify` | `src/app/api/admin/verify/route.ts` | Verify admin API key. |
 | `/api/admin/analytics` | `.../analytics/route.ts` | Analytics aggregates. |
+| `/api/admin/analytics/recommendations` | `.../analytics/recommendations/route.ts` | Marketing/SEO recommendation list + transitions (legacy mount; the unified queue is at `/api/admin/recommendations`). |
+| `/api/admin/recommendations` | `.../recommendations/route.ts` | Unified Marketing + SEO + Operations recommendation list. Read-only; mutations go through `[id]/{execute,snooze,dismiss}`. Added 2026-05 (Operations Director Phase 1C). |
+| `/api/admin/recommendations/[id]/execute` | `.../[id]/execute/route.ts` | Execute the recommended action (writes `actionLog` + `shippedAt`). |
+| `/api/admin/recommendations/[id]/snooze` | `.../[id]/snooze/route.ts` | Snooze until `snoozeUntil`. |
+| `/api/admin/recommendations/[id]/dismiss` | `.../[id]/dismiss/route.ts` | Dismiss with a reason — used by the operator triage queue. |
+| `/api/admin/operations/snapshot` | `.../operations/snapshot/route.ts` | One-stop JSON for the `/admin/operations` dashboard + agent: latest snapshot, 30-snapshot trend, active-rec counts, top urgent recs. Added 2026-05. |
+| `/api/admin/seo/latest-snapshot` | `.../seo/latest-snapshot/route.ts` | Latest SEMrush snapshot summary for the Brian's Stuff → SEO tab. Added 2026-05. |
+| `/api/admin/finance/qb/connect` | `.../finance/qb/connect/route.ts` | Start QuickBooks Online OAuth flow. Added 2026-05 (Finance Director Phase 0). |
+| `/api/admin/finance/qb/callback` | `.../finance/qb/callback/route.ts` | QBO OAuth callback — upserts `IntuitOAuthState`. |
+| `/api/admin/finance/qb/health` | `.../finance/qb/health/route.ts` | QBO connection health check. |
+| `/api/admin/finance/plaid/link-token` | `.../finance/plaid/link-token/route.ts` | Mint a Plaid Link token for the connect-bank flow. |
+| `/api/admin/finance/plaid/exchange` | `.../finance/plaid/exchange/route.ts` | Exchange Plaid public_token → access_token, upsert `PlaidItem`/`PlaidAccount`. |
+| `/api/admin/finance/plaid/health` | `.../finance/plaid/health/route.ts` | Plaid connection health check. |
 | `/api/admin/orders` | `.../orders/route.ts` | Legacy orders list. |
 | `/api/admin/sync` | `.../sync/route.ts` | Legacy sync. |
 | `/api/admin/experiments` | `.../experiments/route.ts` | Experiments list. |
@@ -404,6 +427,11 @@ These are **parallel namespaces, not a migration** — neither supersedes the ot
 | `/api/contact` | `src/app/api/contact/route.ts` | Contact form. |
 | `/api/newsletter` | `src/app/api/newsletter/route.ts` | Newsletter signup. |
 | `/api/leads/drink-calculator` | `.../leads/drink-calculator/route.ts` | Drink calculator lead capture. |
+| `/api/v1/landing/visitor-pixel` | `.../v1/landing/visitor-pixel/route.ts` | Page-view beacon fired from the root layout. Sets the `pod_vsid` cookie + creates/updates a `VisitorSession`, writes a `LeadEvent(PAGE_VIEW)`. Added 2026-05. |
+| `/api/v1/landing/lead-event` | `.../v1/landing/lead-event/route.ts` | Generic form-field / step / submit event. Upserts `Lead` if any identifiable field is captured. Returns `{ leadId, sessionId }`. Added 2026-05. |
+| `/api/v1/landing/quote` | `.../v1/landing/quote/route.ts` | Landing-page quote submission — converts a captured cart into a `DraftOrder` + invoice email. Added 2026-05. |
+| `/api/v1/lead-magnet` | `.../v1/lead-magnet/route.ts` | Lead-magnet (Playbook PDF) email send via Resend. Companion event row is written by the client through `/lead-event`. Added 2026-05. |
+| `/api/v1/events/abandon-nudge` | `.../v1/events/abandon-nudge/route.ts` | Sends the abandoned-RSVP email for the events flow (called by the 15-min cron). Added 2026-05. |
 | `/api/partners/inquiry` | `.../partners/inquiry/route.ts` | Partner form → Zapier. |
 | `/api/profile/upload-image` | `.../profile/upload-image/route.ts` | Avatar upload. |
 | `/api/experiments/assign` | `.../experiments/assign/route.ts` | Assign variant. |
@@ -431,8 +459,13 @@ These are **parallel namespaces, not a migration** — neither supersedes the ot
 | `/api/cron/analytics-snapshot` | `.../analytics-snapshot/route.ts` | `0 7 * * *` | Daily GA4/GSC rollup → `AnalyticsSnapshot`. |
 | `/api/cron/weekly-briefing` | `.../weekly-briefing/route.ts` | `0 13 * * 1` | Weekly Mon 13:00 UTC operator briefing email. |
 | `/api/cron/weekly-purchase-plan` | `.../weekly-purchase-plan/route.ts` | `0 13 * * 1` | Weekly Mon 13:00 UTC distributor purchase plan. |
-| `/api/cron/group-orders-v2` | `.../group-orders-v2/route.ts` | `0 */2 * * *` | Every 2h — locks expired `SubOrder` tabs (OPEN → LOCKED) and closes expired `GroupOrderV2` (ACTIVE → CLOSED). Added 2026-04-23. |
-| `/api/cron/measure-recommendations` | `.../measure-recommendations/route.ts` | `0 8 * * *` | Daily 08:00 UTC — captures the 14-day after-snapshot for shipped `MarketingRecommendation` rows (revenue/orders/AOV/margin coverage), then re-mirrors the markdown to GitHub. Added 2026-05-03. |
+| `/api/cron/group-orders-v2` | `.../group-orders-v2/route.ts` | `0 */2 * * *` | Every 2h — locks expired `SubOrder` tabs (OPEN → LOCKED) and closes expired `GroupOrderV2` (ACTIVE → CLOSED). Added 2026-04-23. Now non-destructive: never auto-closes groups on `expiresAt` alone (see commit `38150db4`). |
+| `/api/cron/measure-recommendations` | `.../measure-recommendations/route.ts` | `0 8 * * *` | Daily 08:00 UTC — captures the 14-day after-snapshot for shipped `RecommendationItem` rows (marketing/SEO). Re-mirrors markdown to GitHub. Added 2026-05-03. |
+| `/api/cron/operations-snapshot` | `.../operations-snapshot/route.ts` | `30 7 * * *` | Daily 07:30 UTC — runs 10 drift detectors + writes the day's `OperationsSnapshot` row + upserts `OperationsRecommendation` rows. Added 2026-05 (Phase 1B). |
+| `/api/cron/operations-drift-hourly` | `.../operations-drift-hourly/route.ts` | `0 * * * *` | Hourly — runs the fast drift detectors only (subset of the daily snapshot) so urgent shortages don't wait 24 h. Added 2026-05. |
+| `/api/cron/measure-operations-recommendations` | `.../measure-operations-recommendations/route.ts` | `0 8 * * *` | Daily 08:00 UTC — measures shipped `OperationsRecommendation` rows. Added 2026-05. |
+| `/api/cron/operations-briefing` | `.../operations-briefing/route.ts` | `30 13 * * 1` | Monday 13:30 UTC — emails the Operations Director weekly briefing. Added 2026-05 (Phase 1D). |
+| `/api/cron/event-abandoned-rsvps` | `.../event-abandoned-rsvps/route.ts` | `*/15 * * * *` | Every 15 min — emails an abandoned-cart nudge for lead-tracked sessions that started but didn't finish ordering. Added 2026-05. |
 
 ## Route groups & layouts
 

--- a/codebase-docs/04-customer-journey.md
+++ b/codebase-docs/04-customer-journey.md
@@ -3,7 +3,7 @@ title: Customer Journey
 project: PartyOn2
 doc_type: codebase-reference
 section: journey
-last_generated: 2026-04-23
+last_generated: 2026-05-20
 tags: [partyondelivery, codebase, journey, conversion]
 ---
 
@@ -107,6 +107,29 @@ End-to-end funnels traced with route + file references. For the full route inven
 5. Delivery confirmation — ops marks `Fulfillment.status = DELIVERED` from `/ops/orders/[id]`.
 6. Review request — `/api/v1/admin/orders/send-review-requests` can trigger review asks.
 7. Refund / amendment — `/api/v1/admin/orders/[id]/refund` or `/amend` writes `Refund` / `OrderAmendment`.
+
+## Journey H — Landing-page lead capture & embedded checkout _(added 2026-05)_
+
+**Trigger**: paid-ad or organic visit to one of the `/austin-*-delivery` landing pages (`bachelor`, `bachelorette`, `corporate`, `wedding-weekend`).
+
+1. Visitor pixel fires — `src/components/VisitorPixel.tsx` POSTs `/api/v1/landing/visitor-pixel`. First hit sets the `pod_vsid` cookie + creates `VisitorSession`; subsequent hits bump counters. A `LeadEvent(PAGE_VIEW)` is written.
+2. Visitor interacts with one of three modals (Quick-Buy, Package-Builder, A-la-carte). Every form field fires `/api/v1/landing/lead-event` on blur — the first time email/phone/name is captured, a `Lead` row is upserted and linked back to the session. `Lead.status` goes `ANONYMOUS → PARTIAL`.
+3. Pre-checkout upsell overlay shows a real-product grid. The variant arrangement is randomized + stamped on the `DraftOrder` as `upsellVariantId`; per-item attribution is `viaUpsell: true` in the items JSON.
+4. Embedded Stripe checkout runs inline via `@stripe/react-stripe-js` (no redirect). On success the modal advances; on failure the page falls back to a hosted checkout URL.
+5. Stripe webhook materializes the order as in Journey C; the `Lead` row picks up `orderId` and transitions to `CONVERTED`.
+
+**Success**: `Lead.status = CONVERTED`, `Order.upsellVariantId` informs the `/admin/brians-stuff?tab=upsell` A/B tracker.
+**Failure / edge**:
+- Visitor never identifies → session stays `ANONYMOUS`. Abandoned-cart nudge `/api/cron/event-abandoned-rsvps` (15-min cron) emails partial leads.
+- Stripe.js fails to load → graceful fallback to standard `/checkout` redirect (commit `d20b8b3f`).
+
+## Journey I — Cart sharing _(added 2026-05)_
+
+**Trigger**: user clicks "Share my cart".
+
+1. Client POSTs `/api/cart/share` with cart payload → creates a `CartShareLink` row with random 7-char `slug`. Response includes the short URL `/s/<slug>`.
+2. Recipient hits `/s/<slug>` → `src/app/s/[slug]/route.ts` looks up the slug, increments `viewCount`, 302-redirects to `/cart/shared?c=…&t=…`.
+3. `/cart/shared` parses the payload and lets the recipient claim or modify the cart.
 
 ## Journey G — Account (returning customer)
 

--- a/codebase-docs/05-data-model.md
+++ b/codebase-docs/05-data-model.md
@@ -3,13 +3,13 @@ title: Data Model
 project: PartyOn2
 doc_type: codebase-reference
 section: data-model
-last_generated: 2026-05-03
+last_generated: 2026-05-20
 tags: [partyondelivery, codebase, prisma, data-model, schema]
 ---
 
 # Data Model
 
-Source of truth: `prisma/schema.prisma`. Datasource is PostgreSQL (`POSTGRES_URL`, `POSTGRES_URL_NON_POOLING`). 77 models, 43 enums. Migrations live under `prisma/migrations/` (managed by Prisma CLI via `npm run db:migrate` / `db:push`).
+Source of truth: `prisma/schema.prisma`. Datasource is PostgreSQL (`POSTGRES_URL`, `POSTGRES_URL_NON_POOLING`). **89 models, 46 enums** (up from 77 / 43 at the 2026-05-03 sync — added: 4 Finance Director models, 2 Operations Director models, 3 Plaid models, 1 cart-share-link model, and the 3-table Lead/Visitor capture system). Migrations live under `prisma/migrations/` (managed by Prisma CLI via `npm run db:migrate` / `db:push`).
 
 > _`DeliveryZone` and `TaxRate` were removed 2026-04-23. Runtime uses hardcoded TS tables in `src/lib/delivery/rates.ts` and `src/lib/tax/rates.ts`. Postgres tables `delivery_zones` and `tax_rates` remain — drop in future migration._
 >
@@ -51,7 +51,7 @@ Source of truth: `prisma/schema.prisma`. Datasource is PostgreSQL (`POSTGRES_URL
 | | | | | 2371 | SyncLog |
 
 
-## Enums (all 43)
+## Enums (all 46)
 
 | Enum | Values |
 |---|---|
@@ -98,6 +98,9 @@ Source of truth: `prisma/schema.prisma`. Datasource is PostgreSQL (`POSTGRES_URL
 | `CallbackStatus` | (line 2130) |
 | `AgentProposalType` | (line 2262) |
 | `AgentProposalStatus` | (line 2267) |
+| `LeadStatus` | ANONYMOUS, PARTIAL, SUBMITTED, CONVERTED, ARCHIVED (added 2026-05) |
+| `LeadSourceWidget` | QUICK_BUY, PACKAGE_BUILDER, A_LA_CARTE, CALL_BOOKING, EMAIL_SIGNUP, CONTACT_FORM, DRINK_CALCULATOR, OTHER (added 2026-05) |
+| `LeadEventType` | PAGE_VIEW, FIELD_FOCUS, FIELD_BLUR, STEP_COMPLETE, CART_ADD, FORM_SUBMIT, CHECKOUT_START, CONVERSION, CUSTOM (added 2026-05) |
 
 ## ER diagram — Catalog & Inventory
 
@@ -298,6 +301,108 @@ erDiagram
 ## Domain: AI agent
 
 - **AgentConversation** (2249), **AgentProposal** (2273), **McpRequestLog** (2291) — agent sessions, proposed mutations, MCP request audit log. `AgentProposalType`, `AgentProposalStatus`.
+
+## Domain: Operations Director (added 2026-05)
+
+Phase 1B+ of the Operations Director pipeline. Schema notes live in `prisma/schema.prisma` and the long-form spec is at `docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md` §5a / §12. The Marketing/SEO equivalent is `RecommendationItem` — Operations is intentionally a parallel model rather than a unified table so the shared lib at `src/lib/recommendations/{lifecycle,measurement,card-types}.ts` can serve both.
+
+### OperationsRecommendation
+- Purpose: queue of detector-generated recommendations surfaced in `/admin/recommendations` (filtered by `domain=operations`) and `/admin/operations`.
+- Key fields: `signalKind`, `severity` (`urgent` | `high` | `normal`), `title`, `evidence Json`, `targetEntityType`, `targetEntityId`, `actionPayload Json`, `status` (default `open`), `snoozeUntil?`, `dismissReason?`, `actionLog Json[]`, `source` (default `auto-snapshot`), `shippedAt?`, `measuredAt?`, `measurementResult? Json`, **unique** `dedupeKey` (= `signalKind:targetEntityId`).
+- Indexed by `status`, `(severity, status)`, `(signalKind, status)`.
+- Touched by: `/api/cron/operations-snapshot`, `/api/cron/operations-drift-hourly`, `/api/cron/measure-operations-recommendations`, `/api/admin/recommendations/*`, `/admin/operations`, `npm run sync:operations` (Obsidian mirror).
+
+### OperationsSnapshot
+- Purpose: one row per snapshot run — powers the dashboard trend sparklines and the Monday briefing.
+- Key fields: `capturedAt`, `inventoryAccuracyPct?`, `driftEventsTotal`, `driftEventsBySignal Json`, `urgentShortagesCount`, `costCoveragePct`, `receivingLagP50Hours?`, `receivingLagP90Hours?`, `cycleCountsCompletedLast7d`, `paidOrders14dShortageCount`.
+- Indexed by `capturedAt`.
+
+### RecommendationItem — domain discriminator (existing model, new field)
+- New field `domain String @default("marketing")` (`marketing` | `seo`) + new index `(domain, status)`. SEO-director sourced rows use `source = 'seo-director'`. See ADR S0001 in the Obsidian vault.
+
+## Domain: Finance Director (added 2026-05)
+
+Phase 0 scaffolding for the Finance Director pipeline — see `docs/FINANCE-DIRECTOR-AGENT-BUILDOUT.md`. Phase 0 ships empty tables; Phase 1C+ populates and reconciles.
+
+### FinanceRecommendation
+- Mirror of `OperationsRecommendation` (same field set, same dedupe key strategy). Exists so the shared `src/lib/recommendations/*` lib serves Finance too. Phase 0 ships empty.
+
+### FinanceSnapshot
+- Purpose: one row per finance cron run. Key fields: `snapshotDate Date`, `payload Json`, `createdAt`. Indexed by `snapshotDate`. Payload schema defined per-phase.
+
+### IntuitOAuthState
+- Purpose: **single-row** singleton (`id = "singleton"`) holding the QuickBooks Online OAuth state.
+- Key fields: `realmId`, `accessToken @db.Text`, `refreshToken @db.Text`, `accessTokenExpires`, `refreshTokenExpires`, `environment` (`sandbox` | `production`), `lastRefreshedAt?`, `lastError?`.
+- Written by `/api/admin/finance/qb/callback`; refreshed in place when the access token rotates.
+
+### PlaidItem
+- Purpose: one row per linked Plaid Item (institution).
+- Key fields: unique `itemId`, `accessToken @db.Text`, `institutionId?`, `institutionName?`, `environment` (`sandbox` | `development` | `production`), `status` (`active` | `login_required` | `error` | `removed`), `lastSyncAt?`, `lastError?`.
+- Relations: → `PlaidAccount[]`, `PlaidTransaction[]` (cascade delete).
+
+### PlaidAccount
+- Purpose: one account within a Plaid Item (checking / savings / credit card).
+- Key fields: unique `accountId`, `plaidItemId` (FK), `name`, `officialName?`, `mask?`, `type` (`depository` | `credit` | `loan` | `investment`), `subtype?`, `currentBalance Decimal(15,2)`, `availableBalance Decimal(15,2)`, `isoCurrencyCode` (default `USD`).
+
+### PlaidTransaction
+- Purpose: bank transactions ingested via Plaid webhook + nightly sync. Phase 0 ships empty; Phase 2C populates and reconciles against Stripe payouts / receiving invoices / QBO.
+- Key fields: unique `transactionId`, `plaidItemId` (FK), `accountId`, `date Date`, `authorizedDate? Date`, `amount Decimal(15,2)` (positive = outflow per Plaid), `name`, `merchantName?`, `pending`, `paymentChannel?`, `category String[]`, `personalFinanceCategoryPrimary?`, `personalFinanceCategoryDetailed?`, `matchedStripePayoutId?`, `matchedReceivingInvoiceId?`, `qbTransactionId?`, `qbCategoryAssigned?`, `reconciledAt?`.
+- Indexed by `plaidItemId`, `date`, `(accountId, date)`, `reconciledAt`.
+
+```mermaid
+erDiagram
+  PlaidItem ||--o{ PlaidAccount : has
+  PlaidItem ||--o{ PlaidTransaction : ingests
+  IntuitOAuthState ||--|| Singleton : holds
+  OperationsSnapshot ||--o{ OperationsRecommendation : "informs (logical)"
+  FinanceSnapshot ||--o{ FinanceRecommendation : "informs (logical)"
+```
+
+## Domain: Lead capture & visitor tracking (added 2026-05)
+
+Three loosely-coupled tables powering the lead-tracking system surfaced at `/admin/brians-stuff?tab=leads`. A session may exist without a lead (anonymous browsing). A `Lead` is created the first time any of email/phone/name is captured; subsequent events on the same session re-attach to the lead. Re-identification across sessions is supported via `Lead.sessions[]`.
+
+### VisitorSession
+- Purpose: one row per anonymous browser session (cookie-based).
+- Key fields: unique `cookieId` (= `pod_vsid` cookie), `firstSeenAt`, `lastSeenAt`, `pageViewCount`, `eventCount`, `landingPage?`, `referrer?`, UTM bag (`utmSource/Medium/Campaign/Content/Term`), `ipAddress?`, geo (`city/region/country/postalCode`), enrichment bag (`enrichedCompany/Industry/Role/Size`), `userAgent?`, `deviceType?`, `metadata? Json`, `leadId?` (denormalized FK).
+- Relations: → `Lead?` (m:1 via leadId), `LeadEvent[]`.
+- Indexed by `leadId`, `firstSeenAt`, `lastSeenAt`.
+
+### Lead
+- Purpose: one row per identifiable person.
+- Key fields: `email?`, `phone?`, `firstName?`, `lastName?`, `status LeadStatus` (default `PARTIAL`), `sourcePage?`, `sourceWidget? LeadSourceWidget`, `lastPage?`, UTM bag (first-touch), `resumeCart? Json` (used to resume "finish your order"), `draftOrderId?`, `orderId?`, `metadata? Json`, `notes? @db.Text`.
+- Relations: → `LeadEvent[]`, `VisitorSession[]`.
+- Indexed by `email`, `phone`, `status`, `createdAt`, `draftOrderId`.
+
+### LeadEvent
+- Purpose: one row per atomic interaction (field blur, page view, form submit, step complete, etc.).
+- Key fields: `leadId?` (FK), `sessionId?` (FK), `type LeadEventType`, `page?`, `widget?`, `fieldName?`, `fieldValue? @db.Text` (truncated to 1000 chars upstream), `metadata? Json`, `occurredAt`.
+- Indexed by `leadId`, `sessionId`, `type`, `occurredAt`.
+- Written by `/api/v1/landing/visitor-pixel` (PAGE_VIEW) and `/api/v1/landing/lead-event` (everything else); read by `/admin/brians-stuff?tab=leads`.
+
+```mermaid
+erDiagram
+  VisitorSession ||--o{ LeadEvent : emits
+  Lead ||--o{ LeadEvent : emits
+  Lead ||--o{ VisitorSession : "identifies (n:m via leadId)"
+  Lead ||--o| DraftOrder : converted_to
+  Lead ||--o| Order : paid_as
+```
+
+## Domain: Shared cart links (added 2026-05)
+
+### CartShareLink
+- Purpose: short-link record for the `/s/<slug>` redirect → `/cart/shared?c=…&t=…` flow.
+- Key fields: unique `slug` (4–16 chars `[A-Za-z0-9]`), `cartData @db.Text` (base64 `c` payload), `token` (base36 `t` timestamp), `expiresAt`, `viewCount` (incremented on each `/s/<slug>` resolve).
+- Indexed by `expiresAt`.
+
+## Domain: Order tracking — Upsell A/B (existing models, new fields)
+
+### DraftOrder — new field
+- `upsellVariantId String?` — landing-page pre-checkout upsell A/B tracking. Records which arrangement of the overlay was shown. Per-item upsell attribution lives in the items JSON (each item may carry `{ ..., viaUpsell: true }`). Index on `upsellVariantId`.
+
+### SubOrder — new field
+- `deliveryDateConfirmed Boolean @default(false)` — flags that the host has manually confirmed the date on the universal dashboard.
 
 ## Domain: Boat schedule
 

--- a/codebase-docs/06-admin-features.md
+++ b/codebase-docs/06-admin-features.md
@@ -3,7 +3,7 @@ title: Admin Features
 project: PartyOn2
 doc_type: codebase-reference
 section: admin
-last_generated: 2026-05-03
+last_generated: 2026-05-20
 tags: [partyondelivery, codebase, admin, ops, affiliate, cron, webhooks]
 ---
 
@@ -40,7 +40,13 @@ Three admin surfaces live in the app: `/admin/*` (business operator), `/ops/*` (
 | `/admin/affiliates/commissions` | `.../commissions/page.tsx` | Commission ledger. |
 | `/admin/affiliates/payouts` | `.../payouts/page.tsx` | Payouts. |
 | `/admin/affiliates/embed-generator` | `.../embed-generator/page.tsx` | Embed snippet builder. |
-| `/admin/analytics/recommendations` | `.../analytics/recommendations/page.tsx` | Marketing recommendation triage queue. Reads `MarketingRecommendation` rows surfaced by the snapshot cron + Marketing Director agent; operator moves items through `open → approved → shipped` (or `rejected` / `invalidated`). |
+| `/admin/analytics/recommendations` | `.../analytics/recommendations/page.tsx` | Marketing/SEO recommendation triage queue (legacy mount — now redirects/links to the unified `/admin/recommendations`). |
+| `/admin/recommendations` | `.../recommendations/page.tsx` | **Unified triage queue** — Marketing + SEO + Operations recommendations in one view, filtered by `?domain=`. Inline execute/snooze/dismiss. Backed by `/api/admin/recommendations*`. Added 2026-05 (Operations Director Phase 1C). |
+| `/admin/operations` | `.../operations/page.tsx` | Operations Director health dashboard — latest `OperationsSnapshot`, 30-day drift trend, drift by signal, top urgent recs. Backed by `/api/admin/operations/snapshot`. Added 2026-05 (Phase 1D). |
+| `/admin/brians-stuff` | `.../brians-stuff/page.tsx` | Multi-tab admin landing — Playbook, Upsell A/B tracker, Leads, Events, Lead-magnet send list, SEO Intelligence snapshot, Enrichment docs. Tabs selected via `?tab=`. Added 2026-05. |
+| `/admin/upsell-tracker` | `.../upsell-tracker/page.tsx` | Redirect → `/admin/brians-stuff?tab=upsell`. |
+| `/admin/finance/connect-bank` | `.../finance/connect-bank/page.tsx` | Plaid Link launcher for connecting bank accounts. Added 2026-05 (Finance Director Phase 0). |
+| `/admin/finance/connect-quickbooks` | `.../finance/connect-quickbooks/page.tsx` | Starts QuickBooks Online OAuth — writes `IntuitOAuthState` on callback. Added 2026-05. |
 
 ### `/ops/*` — warehouse / fulfilment
 
@@ -95,7 +101,7 @@ Three admin surfaces live in the app: `/admin/*` (business operator), `/ops/*` (
 
 These are **parallel namespaces, not a migration** — neither supersedes the other.
 
-- **`/api/admin/*`** is admin-UI-facing and is guarded by `ADMIN_API_KEY` / admin session. Covers: `affiliates`, `analytics` (sub-routes: `ga4`, `gbp`, `vercel`, `internal`, `experiments`, `recommendations`), `experiments`, `orders`, `sync`, `verify`.
+- **`/api/admin/*`** is admin-UI-facing and is guarded by `ADMIN_API_KEY` / admin session. Covers: `affiliates`, `analytics` (sub-routes: `ga4`, `gbp`, `vercel`, `internal`, `experiments`, `recommendations`), `experiments`, `orders`, `sync`, `verify`, plus (added 2026-05) the unified `recommendations` queue, `operations/snapshot`, `seo/latest-snapshot`, and the Finance Director routes under `finance/{qb,plaid}/*`.
 - **`/api/v1/admin/*`** is ops-panel-facing. Covers: `collections`, `customers`, `dashboard`, `discounts`, `draft-orders`, `features`, `orders`, `products`, `reports`, `shortage-list`, `sync`, `unpaid-carts`. (Loyalty admin page and APIs were removed 2026-04-23.)
 - Overlap is only `orders` and `sync`; each namespace's `orders` / `sync` endpoints serve a different consumer. Do not treat either as deprecated.
 
@@ -176,6 +182,43 @@ These are **parallel namespaces, not a migration** — neither supersedes the ot
 - `/ops/boat-schedule` + `/api/ops/boat-schedule*` with sync to match orders (`ScheduleOrderMatch`).
 - Public read: `/api/public/boat-schedule*` + `/premier-boat-schedule`.
 
+### Recommendations triage (Marketing / SEO / Operations) — _added 2026-05_
+- Unified queue at `/admin/recommendations` (legacy `/admin/analytics/recommendations` redirects in).
+- Marketing/SEO rows live in `RecommendationItem` (`domain` field discriminates between `marketing` and `seo` — see ADR S0001 in the Obsidian vault).
+- Operations rows live in `OperationsRecommendation` — kept parallel to `RecommendationItem` so the shared lib at `src/lib/recommendations/{lifecycle,measurement,card-types}.ts` serves both. Long-form spec: `docs/OPERATIONS-DIRECTOR-AGENT-BUILDOUT.md`.
+- Mutations: `POST /api/admin/recommendations/[id]/{execute,snooze,dismiss}` write to `actionLog`/`shippedAt`/`snoozeUntil`/`dismissReason`.
+- Measurement: 14-day after-snapshot for both `MarketingRecommendation` (via `/api/cron/measure-recommendations`) and `OperationsRecommendation` (via `/api/cron/measure-operations-recommendations`).
+- Obsidian mirroring: `npm run sync:marketing` / `npm run sync:operations` write per-row markdown to the vault for the agent.
+
+### Operations Director — _added 2026-05_
+- Dashboard: `/admin/operations` (RSC) backed by `/api/admin/operations/snapshot`.
+- 10 drift detectors run from `/api/cron/operations-snapshot` (daily 07:30 UTC) + a fast subset at `/api/cron/operations-drift-hourly`.
+- Daily snapshot row: `OperationsSnapshot` (inventory accuracy, drift events by signal, urgent shortages, cost coverage, receiving lag p50/p90, cycle counts completed last 7d, 14-day shortage count on PAID orders).
+- Monday briefing email: `/api/cron/operations-briefing` (Mon 13:30 UTC).
+- Volume cap + severity tiering rules baked in (commit `4be754e3`).
+
+### Finance Director — _Phase 0 added 2026-05_
+- Connect flows live at `/admin/finance/connect-bank` (Plaid Link) and `/admin/finance/connect-quickbooks` (Intuit OAuth).
+- Plaid: `PlaidItem` / `PlaidAccount` / `PlaidTransaction` populated via `/api/admin/finance/plaid/{link-token,exchange,health}`. Phase 0 ships the transactions table empty; Phase 2C reconciles against Stripe payouts / `ReceivingInvoice` / QuickBooks.
+- QuickBooks Online: singleton `IntuitOAuthState` row holds the rotating access/refresh tokens. Endpoints under `/api/admin/finance/qb/{connect,callback,health}`.
+- Recommendation queue scaffold: `FinanceRecommendation` + `FinanceSnapshot` ship empty in Phase 0; populated by `/api/cron/finance-snapshot` starting Phase 1C (not yet in `vercel.json`).
+- Long-form spec: `docs/FINANCE-DIRECTOR-AGENT-BUILDOUT.md`.
+
+### Lead capture & visitor tracking (Brian's Stuff) — _added 2026-05_
+- Multi-tab admin landing at `/admin/brians-stuff` (Playbook, Upsell A/B, Leads, Events, Lead-magnet, SEO Intelligence, Enrichment docs).
+- Visitor pixel `src/components/VisitorPixel.tsx` (wrapped client-only) fires `/api/v1/landing/visitor-pixel` on every page-view → upserts `VisitorSession` keyed by the `pod_vsid` cookie + writes a `LeadEvent(PAGE_VIEW)`.
+- Form fields fire `/api/v1/landing/lead-event` on focus/blur/step/submit. A `Lead` is created the first time any of email/phone/name is captured; subsequent events on the same session re-attach. Re-identification across sessions is supported via `Lead.sessions[]`.
+- Landing-page "Get a quote" flow posts `/api/v1/landing/quote` → creates `DraftOrder` + invoice email. The Lead row is stamped with `draftOrderId`.
+- Lead magnet (flyer PDF): `/flyer` page + `/api/v1/lead-magnet` Resend send. Lead row goes to `SUBMITTED` after the modal completes.
+- Abandoned-cart nudge: `/api/cron/event-abandoned-rsvps` (every 15 min) calls `/api/v1/events/abandon-nudge` for sessions that started but didn't finish ordering.
+- Upsell A/B attribution: `DraftOrder.upsellVariantId` + per-item `viaUpsell` JSON flag; tracker view at `/admin/brians-stuff?tab=upsell`.
+- Cart sharing: short links served from `/s/[slug]` (route handler) → 302 → `/cart/shared?c=…&t=…`, backed by `CartShareLink`.
+
+### Microsoft Clarity (session replay) — _added 2026-05_
+- Initialized client-side by `src/components/ClarityInit.tsx` in production only.
+- Project ID lives in `NEXT_PUBLIC_CLARITY_PROJECT_ID`.
+- CSP `script-src` / `img-src` / `connect-src` whitelist `*.clarity.ms` (commit `ac1b7587`).
+
 ## Background jobs (Vercel cron — `vercel.json`)
 
 | Schedule (UTC) | Endpoint | Purpose |
@@ -187,7 +230,13 @@ These are **parallel namespaces, not a migration** — neither supersedes the ot
 | `0 7 * * *` (daily 07:00) | `/api/cron/analytics-snapshot` | Daily GA4/GSC rollup → `AnalyticsSnapshot`. |
 | `0 13 * * 1` (Mon 13:00) | `/api/cron/weekly-briefing` | Weekly operator briefing email. |
 | `0 13 * * 1` (Mon 13:00) | `/api/cron/weekly-purchase-plan` | Weekly distributor purchase plan (PAID orders, 14-day window). |
-| `0 */2 * * *` (every 2h) | `/api/cron/group-orders-v2` | Locks expired `SubOrder` tabs (`OPEN` → `LOCKED` when `orderDeadline` has passed) and closes expired `GroupOrderV2` (`ACTIVE` → `CLOSED` when `expiresAt` has passed). Added to `vercel.json` 2026-04-23. |
+| `0 */2 * * *` (every 2h) | `/api/cron/group-orders-v2` | Locks expired `SubOrder` tabs (`OPEN` → `LOCKED` when `orderDeadline` has passed). No longer auto-closes `GroupOrderV2` rows on `expiresAt` alone (commit `38150db4`, 2026-05). |
+| `0 8 * * *` (daily 08:00) | `/api/cron/measure-recommendations` | 14-day after-snapshot measurement for shipped Marketing/SEO `RecommendationItem` rows. |
+| `30 7 * * *` (daily 07:30) | `/api/cron/operations-snapshot` | Runs the 10 drift detectors, writes `OperationsSnapshot`, upserts `OperationsRecommendation` rows. Added 2026-05 (Operations Director Phase 1B). |
+| `0 * * * *` (hourly) | `/api/cron/operations-drift-hourly` | Fast subset of the drift detectors — keeps urgent shortages fresh between daily snapshots. Added 2026-05. |
+| `0 8 * * *` (daily 08:00) | `/api/cron/measure-operations-recommendations` | 14-day after-snapshot measurement for shipped `OperationsRecommendation` rows. Added 2026-05. |
+| `30 13 * * 1` (Mon 13:30) | `/api/cron/operations-briefing` | Weekly Operations Director briefing email. Added 2026-05 (Phase 1D). |
+| `*/15 * * * *` | `/api/cron/event-abandoned-rsvps` | Abandoned-cart nudge for the lead-capture events flow. Added 2026-05. |
 
 ### Blog automation (GitHub Actions)
 
@@ -220,6 +269,9 @@ These are **parallel namespaces, not a migration** — neither supersedes the ot
 | Supabase | aux | Auxiliary storage (`src/lib/supabase/`). |
 | Vercel Blob / KV | aux | Blob uploads + KV cache. |
 | IndexNow / Bing / Google ping | out | `scripts/indexnow-*.mjs`, `sitemap:ping` script. |
+| Plaid | in (webhook) + out (sync) | Bank-account linking for Finance Director. `PlaidItem` / `PlaidAccount` / `PlaidTransaction`. Added 2026-05. |
+| QuickBooks Online (Intuit) | OAuth + REST | Accounting bridge for Finance Director — `IntuitOAuthState` singleton. Added 2026-05. |
+| Microsoft Clarity | in (script) | Session replay + heatmaps via `@microsoft/clarity`. Added 2026-05. |
 
 ## Gaps / TODOs
 

--- a/codebase-docs/INDEX.md
+++ b/codebase-docs/INDEX.md
@@ -3,13 +3,13 @@ title: PartyOn2 Codebase Reference — Index
 project: PartyOn2
 doc_type: codebase-reference
 section: index
-last_generated: 2026-05-03
+last_generated: 2026-05-20
 tags: [partyondelivery, codebase, index, toc]
 ---
 
 # PartyOn2 Codebase Reference — Index
 
-PartyOn2 is the Next.js 15 App Router codebase that powers [partyondelivery.com](https://partyondelivery.com), a premium alcohol + party-goods delivery service for Austin, TX. The stack is Next.js 15.4 + React 19 + TypeScript 5 + Tailwind CSS 3 + Prisma 6 on a Neon Postgres database, with Stripe for payments, Resend for email, Shopify Admin API for catalog sync, an affiliate/partner program, a universal group-order "dashboard" flow, and a rich internal ops/admin panel. This reference is designed for LLM agents: every section is cross-linked, deterministic, and grounded in files that exist in the repo.
+PartyOn2 is the Next.js 15 App Router codebase that powers [partyondelivery.com](https://partyondelivery.com), a premium alcohol + party-goods delivery service for Austin, TX. The stack is Next.js 15.4 + React 19 + TypeScript 5 + Tailwind CSS 3 + Prisma 6 on a Neon Postgres database, with Stripe for payments, Resend for email, Shopify Admin API for catalog sync, an affiliate/partner program, a universal group-order "dashboard" flow, a lead-capture + visitor-tracking pixel, a Finance Director pipeline (Plaid + QuickBooks Online), an Operations Director pipeline (drift detectors + snapshot crons), and a rich internal ops/admin panel. This reference is designed for LLM agents: every section is cross-linked, deterministic, and grounded in files that exist in the repo.
 
 ## Table of contents
 
@@ -19,7 +19,7 @@ PartyOn2 is the Next.js 15 App Router codebase that powers [partyondelivery.com]
 | [[02-tech-stack-and-architecture]] | Exact versions, folder tree, App Router patterns, env vars, conventions. |
 | [[03-routes-and-pages]] | Exhaustive table of every page + every API route under `src/app/`. |
 | [[04-customer-journey]] | Discovery to post-purchase funnel with route-level references. |
-| [[05-data-model]] | Prisma schema — all 77 models + 43 enums, ER diagrams, relationships. |
+| [[05-data-model]] | Prisma schema — all 89 models + 46 enums, ER diagrams, relationships. |
 | [[06-admin-features]] | `/admin`, `/ops`, `/affiliate` panels, cron jobs, webhooks, integrations. |
 
 ## Quick facts
@@ -33,13 +33,13 @@ PartyOn2 is the Next.js 15 App Router codebase that powers [partyondelivery.com]
 | Database | Neon Postgres via `@prisma/client` 6.15.0 |
 | Hosting | Vercel (crons in `vercel.json`) |
 | Primary package | `party-on-delivery` v0.1.0 |
-| `page.tsx` files | **145** |
-| `route.ts` API files | **217** |
-| Prisma models | **77** |
-| Prisma enums | **43** |
+| `page.tsx` files | **157** |
+| `route.ts` API files | **241** |
+| Prisma models | **89** |
+| Prisma enums | **46** |
 | Blog posts in `content/blog/posts/` | **133** |
-| TS/TSX files in `src/` | **902** |
-| Approx. LOC in `src/` (TS + TSX) | **~167,379** |
+| TS/TSX files in `src/` | **1047** |
+| Approx. LOC in `src/` (TS + TSX) | **~200,613** |
 
 ## How to use this reference (for LLMs)
 


### PR DESCRIPTION
## Summary
Brings all 7 \`codebase-docs/*.md\` files current with main after 130 commits since the prior sync (#21, 2026-05-05). +266 / −27 lines.

## Counts
| | Was | Now |
|---|---|---|
| Pages | 145 | **157** |
| API routes | 217 | **241** |
| Prisma models | 77 | **89** |
| Prisma enums | 43 | **46** |

## What's newly documented
- **Operations Director** — \`OperationsRecommendation\` + \`OperationsSnapshot\`, 10 drift detectors, unified \`/admin/recommendations\` triage queue
- **Finance Director Phase 0** — Plaid + QuickBooks Online scaffolding (5 models, empty tables)
- **Lead capture & visitor tracking** — \`VisitorSession\` + \`Lead\` + \`LeadEvent\` from a site-wide pixel
- **Shared cart links** — \`CartShareLink\` + \`/s/[slug]\` short link
- **4 paid-ad landing pages** at \`/austin-*-delivery\` with embedded Stripe checkout + upsell A/B
- **Microsoft Clarity** session replay
- **Journey H** (landing-page lead capture) and **Journey I** (cart sharing) appended to the customer journey doc

## Verified before commit
- ✅ All 6 new cron schedules match \`vercel.json\` exactly
- ✅ All 6 \`/api/admin/finance/*\` routes exist on disk at documented paths
- ✅ All 12 new Prisma models have the field types listed in the doc

## Vault mirror
Also mirrored to \`/Users/allan/Projects/Obsidian/Obsidian/PartyOn2/*.md\` (vault is local, not in this PR).

## Test plan
- [ ] Skim each file's section headers
- [ ] No build impact — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)