### PR TITLE
feat(seo): wedding cluster ws1 — wedding drink calculator

### DIFF
--- a/src/app/api/leads/drink-calculator/route.ts
+++ b/src/app/api/leads/drink-calculator/route.ts
@@ -3,15 +3,20 @@ import { prisma, isDatabaseConfigured } from '@/lib/database/client';
 import { z } from 'zod';
 
 /**
- * Zod schema for drink calculator lead validation
+ * Zod schema for drink calculator lead validation.
+ *
+ * Wedding scale (5-300 guests, 2-12 hours) was added 2026-05 for the
+ * public /wedding-drink-calculator page. The existing bachelor/bachelorette
+ * paths still validate against the tighter 5-50 / 2-6 range — we range-check
+ * by partyType after the base parse.
  */
 const drinkCalculatorLeadSchema = z.object({
   firstName: z.string().min(1, 'First name is required'),
   email: z.string().email('Valid email is required'),
-  guestCount: z.number().int().min(5).max(50),
-  hours: z.number().int().min(2).max(6),
+  guestCount: z.number().int().min(5).max(300),
+  hours: z.number().int().min(2).max(12),
   drinkingLevel: z.enum(['light', 'average', 'heavy']),
-  partyType: z.enum(['bachelor', 'bachelorette']),
+  partyType: z.enum(['bachelor', 'bachelorette', 'wedding']),
   drinkPreference: z.enum([
     'mostly_beer',
     'mostly_seltzers',
@@ -22,6 +27,24 @@ const drinkCalculatorLeadSchema = z.object({
   addChampagne: z.boolean().default(false),
   addCocktailKits: z.boolean().default(false),
   totalDrinks: z.number().int().min(0),
+}).superRefine((data, ctx) => {
+  // Bachelor / bachelorette retain the original tighter range.
+  if (data.partyType === 'bachelor' || data.partyType === 'bachelorette') {
+    if (data.guestCount > 50) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['guestCount'],
+        message: 'Bachelor/bachelorette guestCount must be 5-50',
+      });
+    }
+    if (data.hours > 6) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['hours'],
+        message: 'Bachelor/bachelorette hours must be 2-6',
+      });
+    }
+  }
 });
 
 export type DrinkCalculatorLeadInput = z.infer<typeof drinkCalculatorLeadSchema>;

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -63,6 +63,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     '/blog',
     '/blogs/news',
     '/weddings',
+    '/wedding-drink-calculator',
     '/boat-parties',
     '/austin-bachelor-party-delivery',
     '/austin-bachelorette-party-delivery',

--- a/src/app/wedding-drink-calculator/CalculatorClient.tsx
+++ b/src/app/wedding-drink-calculator/CalculatorClient.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useMemo, useState, type ReactElement } from 'react';
+import type { DrinkCategory } from '@/lib/drinkPlannerTypes';
+import { calculateWeddingPlan, type WeddingPlan } from '@/lib/weddingDrinkCalculator';
+import CalculatorResults from './CalculatorResults';
+
+const CATEGORY_OPTIONS: { id: DrinkCategory; label: string; hint: string }[] = [
+  { id: 'beer', label: 'Beer', hint: 'Domestic + craft mix' },
+  { id: 'wine', label: 'Wine', hint: 'Red + white split' },
+  { id: 'spirits', label: 'Spirits', hint: 'Tequila, vodka, bourbon' },
+  { id: 'seltzers', label: 'Seltzers', hint: 'High Noon, White Claw' },
+  { id: 'cocktail-kits', label: 'Cocktail Kits', hint: 'Pre-built signature drinks' },
+  { id: 'champagne', label: 'Champagne', hint: 'For toasts' },
+];
+
+const QUICK_GUEST_VALUES = [50, 75, 100, 125, 150, 200];
+const QUICK_HOUR_VALUES = [3, 4, 5, 6];
+
+/**
+ * Interactive wedding drink calculator. Wraps `calculateWeddingPlan` and
+ * renders inline results as the user adjusts inputs.
+ */
+export default function CalculatorClient(): ReactElement {
+  const [guests, setGuests] = useState(100);
+  const [hours, setHours] = useState(5);
+  const [categories, setCategories] = useState<DrinkCategory[]>(['beer', 'wine', 'spirits']);
+
+  const plan: WeddingPlan = useMemo(
+    () => calculateWeddingPlan({ guests, hours, categories }),
+    [guests, hours, categories],
+  );
+
+  const toggleCategory = (cat: DrinkCategory) => {
+    setCategories((prev) => (prev.includes(cat) ? prev.filter((c) => c !== cat) : [...prev, cat]));
+  };
+
+  return (
+    <div className="grid lg:grid-cols-5 gap-8">
+      {/* Inputs */}
+      <div className="lg:col-span-2 space-y-6">
+        <div className="card">
+          <label htmlFor="guests" className="block text-base font-semibold text-gray-900 mb-2">
+            Guest count
+          </label>
+          <p className="text-sm text-gray-600 mb-3">Drinking-age guests only.</p>
+          <input
+            id="guests"
+            type="number"
+            min={5}
+            max={300}
+            step={5}
+            value={guests}
+            onChange={(e) => setGuests(Number(e.target.value))}
+            className="input-premium w-full"
+          />
+          <div className="mt-3 flex flex-wrap gap-2">
+            {QUICK_GUEST_VALUES.map((v) => (
+              <button
+                key={v}
+                type="button"
+                onClick={() => setGuests(v)}
+                className={`px-3 py-1.5 rounded-lg text-sm font-medium tracking-[0.05em] transition-colors ${
+                  guests === v
+                    ? 'bg-brand-blue text-white'
+                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                }`}
+              >
+                {v}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="card">
+          <label htmlFor="hours" className="block text-base font-semibold text-gray-900 mb-2">
+            Reception length (hours)
+          </label>
+          <p className="text-sm text-gray-600 mb-3">Cocktail hour through last call.</p>
+          <input
+            id="hours"
+            type="number"
+            min={2}
+            max={12}
+            step={1}
+            value={hours}
+            onChange={(e) => setHours(Number(e.target.value))}
+            className="input-premium w-full"
+          />
+          <div className="mt-3 flex flex-wrap gap-2">
+            {QUICK_HOUR_VALUES.map((v) => (
+              <button
+                key={v}
+                type="button"
+                onClick={() => setHours(v)}
+                className={`px-3 py-1.5 rounded-lg text-sm font-medium tracking-[0.05em] transition-colors ${
+                  hours === v
+                    ? 'bg-brand-blue text-white'
+                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                }`}
+              >
+                {v}h
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="card">
+          <p className="block text-base font-semibold text-gray-900 mb-3">Bar style</p>
+          <div className="grid grid-cols-2 gap-2">
+            {CATEGORY_OPTIONS.map((opt) => {
+              const selected = categories.includes(opt.id);
+              return (
+                <button
+                  key={opt.id}
+                  type="button"
+                  onClick={() => toggleCategory(opt.id)}
+                  className={`text-left p-3 rounded-lg border-2 transition-colors ${
+                    selected
+                      ? 'border-brand-blue bg-brand-blue/5'
+                      : 'border-gray-200 hover:border-gray-300'
+                  }`}
+                  aria-pressed={selected}
+                >
+                  <span className="block text-base font-semibold text-gray-900">{opt.label}</span>
+                  <span className="block text-sm text-gray-600 mt-0.5">{opt.hint}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* Results */}
+      <div className="lg:col-span-3">
+        <CalculatorResults plan={plan} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/wedding-drink-calculator/CalculatorResults.tsx
+++ b/src/app/wedding-drink-calculator/CalculatorResults.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import Link from 'next/link';
+import { useState, type ReactElement, type FormEvent } from 'react';
+import type { WeddingPlan } from '@/lib/weddingDrinkCalculator';
+
+interface Props {
+  plan: WeddingPlan;
+}
+
+/**
+ * Result panel for the wedding drink calculator. Shows the bottle/case
+ * breakdown and exposes a lead-capture form that posts to
+ * /api/leads/drink-calculator with partyType=wedding.
+ *
+ * Counts only — no pricing claims (hard-stop rule).
+ */
+export default function CalculatorResults({ plan }: Props): ReactElement {
+  const [email, setEmail] = useState('');
+  const [firstName, setFirstName] = useState('');
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle');
+  const [errorMsg, setErrorMsg] = useState('');
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setStatus('submitting');
+    setErrorMsg('');
+    try {
+      const res = await fetch('/api/leads/drink-calculator', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          firstName,
+          email,
+          guestCount: plan.summary.guests,
+          hours: plan.summary.hours,
+          drinkingLevel: 'average',
+          partyType: 'wedding',
+          drinkPreference: 'good_mix',
+          addChampagne: plan.summary.categories.includes('champagne'),
+          addCocktailKits: plan.summary.categories.includes('cocktail-kits'),
+          totalDrinks: plan.totalDrinks,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body?.error ?? 'Submit failed');
+      }
+      setStatus('success');
+    } catch (err) {
+      setStatus('error');
+      setErrorMsg(err instanceof Error ? err.message : 'Submit failed');
+    }
+  };
+
+  const grouped = plan.items.reduce<Record<string, typeof plan.items>>((acc, item) => {
+    if (!acc[item.category]) acc[item.category] = [];
+    acc[item.category].push(item);
+    return acc;
+  }, {});
+
+  return (
+    <div className="space-y-6">
+      <div className="card bg-gradient-to-br from-brand-blue/5 to-white border-brand-blue/20">
+        <p className="text-sm font-semibold tracking-[0.08em] text-brand-blue uppercase mb-2">
+          Your wedding bar plan
+        </p>
+        <p className="text-4xl md:text-5xl font-heading tracking-[0.05em] text-gray-900">
+          {plan.totalDrinks.toLocaleString()} drinks
+        </p>
+        <p className="text-sm text-gray-700 mt-2">
+          For {plan.summary.guests} guests × {plan.summary.hours} hours.
+        </p>
+      </div>
+
+      <div className="card">
+        <h3 className="font-heading text-lg font-bold tracking-[0.08em] text-gray-900 mb-4">
+          Shopping list
+        </h3>
+        <div className="space-y-4">
+          {Object.entries(grouped).map(([category, items]) => (
+            <div key={category}>
+              <p className="text-sm font-semibold tracking-[0.05em] text-gray-700 uppercase mb-2">
+                {category.replace('-', ' ')}
+              </p>
+              <ul className="space-y-1">
+                {items.map((item) => (
+                  <li key={item.name} className="flex justify-between text-base text-gray-900">
+                    <span>{item.name}</span>
+                    <span className="font-semibold">
+                      {item.quantity} {item.unit}
+                      {item.quantity > 1 ? 's' : ''}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="card">
+        {status === 'success' ? (
+          <div className="text-center py-2">
+            <p className="text-base font-semibold text-gray-900 mb-2">
+              We&apos;ll email you the shopping list.
+            </p>
+            <Link href="/order?type=wedding" className="btn-primary inline-flex items-center justify-center mt-2">
+              Start Wedding Order
+            </Link>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <h3 className="font-heading text-lg font-bold tracking-[0.08em] text-gray-900">
+              Email me this plan
+            </h3>
+            <p className="text-sm text-gray-700">
+              We&apos;ll save the shopping list and follow up with delivery options. No
+              spam. No pricing yet.
+            </p>
+            <div>
+              <label htmlFor="first-name" className="block text-base font-medium text-gray-900 mb-1">
+                First name
+              </label>
+              <input
+                id="first-name"
+                type="text"
+                value={firstName}
+                onChange={(e) => setFirstName(e.target.value)}
+                required
+                className="input-premium w-full"
+              />
+            </div>
+            <div>
+              <label htmlFor="email" className="block text-base font-medium text-gray-900 mb-1">
+                Email
+              </label>
+              <input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                className="input-premium w-full"
+              />
+            </div>
+            {status === 'error' && (
+              <p className="text-sm text-red-600">{errorMsg}</p>
+            )}
+            <button
+              type="submit"
+              disabled={status === 'submitting'}
+              className="btn-cart w-full disabled:opacity-60 disabled:cursor-not-allowed"
+            >
+              {status === 'submitting' ? 'Sending...' : 'Email Me This Plan'}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/wedding-drink-calculator/page.tsx
+++ b/src/app/wedding-drink-calculator/page.tsx
@@ -1,0 +1,227 @@
+import type { Metadata } from 'next';
+import type { ReactElement } from 'react';
+import Link from 'next/link';
+import { generateFAQSchema } from '@/lib/seo/schemas';
+import Navigation from '@/components/Navigation';
+import Footer from '@/components/Footer';
+import CalculatorClient from './CalculatorClient';
+
+/**
+ * Public-facing Wedding Drink Calculator route.
+ * Target keyword: "wedding drink calculator" (vol 1,900, KD 8).
+ *
+ * Server component for SEO metadata + structured data. The interactive
+ * calculator is a client component (CalculatorClient.tsx) that reuses
+ * src/lib/weddingDrinkCalculator.ts.
+ */
+
+export const metadata: Metadata = {
+  title: 'Wedding Drink Calculator | Austin Wedding Alcohol Quantities | Party On Delivery',
+  description:
+    'Free wedding drink calculator. Get exact beer, wine, spirits, and seltzer counts for your Austin wedding reception. Built by Austin\'s alcohol-delivery team.',
+  alternates: {
+    canonical: 'https://partyondelivery.com/wedding-drink-calculator',
+  },
+  openGraph: {
+    title: 'Wedding Drink Calculator — How Much Alcohol For Your Austin Wedding?',
+    description:
+      'Plug in guest count and reception hours; get exact case + bottle counts. Free tool from Austin\'s wedding alcohol delivery team.',
+    url: 'https://partyondelivery.com/wedding-drink-calculator',
+    type: 'website',
+  },
+};
+
+const FAQS = [
+  {
+    question: 'How much alcohol do I need for my wedding?',
+    answer:
+      'A common rule for receptions of 3+ hours is guest count multiplied by hours plus one. A 100-guest, 5-hour reception works out to about 600 drinks. The calculator above applies that formula and splits the result across beer, wine, and spirits based on your bar style.',
+  },
+  {
+    question: 'How do I count guests who don\'t drink alcohol?',
+    answer:
+      'Subtract non-drinkers from your guest count before entering the number, then add a few non-alcoholic options separately. We typically suggest adding water, soda, or mocktail kits — those aren\'t in the calculator output but should be on your shopping list.',
+  },
+  {
+    question: 'What if my reception runs longer than expected?',
+    answer:
+      'Add an hour of buffer to the input. Wedding bars often slow down after dinner, but late-night guests will keep drinking. It\'s safer to round up than to run out.',
+  },
+  {
+    question: 'Does this account for signature cocktails?',
+    answer:
+      'Yes — select "Cocktail Kits" as one of the categories. The calculator reduces the spirits share and adds 3 cocktail kits sized for your crowd. Each kit serves about 16 drinks.',
+  },
+  {
+    question: 'Can you deliver this order in Austin?',
+    answer:
+      'Yes. Party On Delivery handles alcohol delivery for weddings across the Austin area. Use the order link in the result panel to start a wedding-tagged order — we\'ll review the list with you before delivery.',
+  },
+];
+
+const HOW_TO_SCHEMA = {
+  '@context': 'https://schema.org',
+  '@type': 'HowTo',
+  name: 'How to calculate alcohol for an Austin wedding reception',
+  description:
+    'Free calculator from Party On Delivery. Enter guest count and reception hours; get exact beer, wine, spirits, and seltzer counts.',
+  step: [
+    {
+      '@type': 'HowToStep',
+      name: 'Count your drinking-age guests',
+      text: 'Take your full guest list and subtract guests under 21, designated drivers, and anyone you know doesn\'t drink.',
+    },
+    {
+      '@type': 'HowToStep',
+      name: 'Multiply guests × (hours + 1)',
+      text: 'For a reception of 3+ hours, total drinks ≈ guests × (hours + 1). A 100-guest, 5-hour reception ≈ 600 drinks.',
+    },
+    {
+      '@type': 'HowToStep',
+      name: 'Split across categories',
+      text: 'A typical wedding bar splits the total roughly: spirits 50%, beer 30%, wine 15%, seltzers 5%. Adjust if you offer cocktail kits.',
+    },
+    {
+      '@type': 'HowToStep',
+      name: 'Convert drinks → bottles + cases',
+      text: 'Beer 12-packs serve 12. Wine 750ml serves 5. Liquor 750ml serves 17. Round up.',
+    },
+  ],
+};
+
+export default function WeddingDrinkCalculatorPage(): ReactElement {
+  const faqSchema = generateFAQSchema(FAQS);
+  return (
+    <>
+      <Navigation />
+      <main className="bg-white">
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(HOW_TO_SCHEMA) }}
+        />
+
+        <section className="relative bg-gradient-to-b from-gray-50 to-white mt-24 pt-12 pb-8">
+          <div className="container-custom max-w-5xl">
+            <h1 className="font-heading text-4xl md:text-5xl lg:text-6xl tracking-[0.1em] text-gray-900 text-center">
+              Wedding Drink Calculator
+            </h1>
+            <p className="mt-4 text-base md:text-lg text-gray-700 text-center max-w-3xl mx-auto">
+              How much alcohol for your Austin wedding? Enter guest count and reception
+              hours below — we’ll size beer, wine, spirits, and seltzers for you.
+              Built by Austin’s wedding alcohol delivery team.
+            </p>
+          </div>
+        </section>
+
+        <section className="bg-white py-8">
+          <div className="container-custom max-w-5xl">
+            <CalculatorClient />
+          </div>
+        </section>
+
+        <section className="bg-gray-50 section-padding">
+          <div className="container-custom max-w-4xl">
+            <h2 className="font-heading text-3xl md:text-4xl tracking-[0.1em] text-gray-900 mb-6">
+              How the math works
+            </h2>
+            <div className="prose prose-gray max-w-none text-base md:text-lg leading-relaxed">
+              <p>
+                For wedding receptions of 3 hours or more, a reliable starting point is{' '}
+                <strong>guests &times; (hours + 1)</strong>. The +1 covers the cocktail
+                hour spike at the front of the night, when most guests pick up their first
+                two drinks fast. A 100-guest, 5-hour reception comes out to around 600
+                drinks total.
+              </p>
+              <p>
+                From there we split the total roughly: <strong>spirits 50%</strong>,{' '}
+                <strong>beer 30%</strong>, <strong>wine 15%</strong>,{' '}
+                <strong>seltzers 5%</strong>. If you add cocktail kits, the spirits share
+                drops and the kits absorb part of the mix. Wedding bars tilt heavier
+                toward mixed drinks than house parties; the calculator reflects that.
+              </p>
+              <h3 className="font-heading text-2xl tracking-[0.08em] mt-8 mb-3">
+                Three common mistakes
+              </h3>
+              <ol>
+                <li>
+                  <strong>Counting kids and non-drinkers as drinkers.</strong> Subtract
+                  guests under 21 plus anyone you know doesn’t drink before entering
+                  the number. Easy way to over-order by 15-20%.
+                </li>
+                <li>
+                  <strong>Forgetting late arrivals.</strong> Out-of-town guests often
+                  arrive after the ceremony. Round hours up if you’re close to the
+                  limit; running out at 10pm is much worse than 6 unopened bottles.
+                </li>
+                <li>
+                  <strong>Skipping the ice and water.</strong> One bag of ice per 10
+                  guests is included in the result panel below. Add bottled water on the
+                  shopping list separately — it isn’t alcohol, but every wedding
+                  needs it.
+                </li>
+              </ol>
+              <h3 className="font-heading text-2xl tracking-[0.08em] mt-8 mb-3">
+                Austin-specific notes
+              </h3>
+              <p>
+                Party On Delivery is a TABC-licensed alcohol delivery company serving the
+                Austin area. We deliver to wedding venues across Lake Travis, downtown
+                Austin, Hill Country, South Austin, and the Westlake area. For deliveries
+                outside Austin city limits, lead time is usually 48 hours. We’ll
+                review your shopping list with you before delivery and answer questions
+                about quantity, brand swaps, or substitutions.
+              </p>
+              <p>
+                Wedding party order minimums and delivery windows are set per zone —
+                check the order page for specifics.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="bg-white section-padding">
+          <div className="container-custom max-w-4xl">
+            <h2 className="font-heading text-3xl md:text-4xl tracking-[0.1em] text-gray-900 mb-6">
+              Frequently asked questions
+            </h2>
+            <div className="space-y-6">
+              {FAQS.map((f) => (
+                <div key={f.question} className="card">
+                  <h3 className="font-heading text-lg font-bold tracking-[0.08em] text-gray-900 mb-2">
+                    {f.question}
+                  </h3>
+                  <p className="text-base text-gray-700 leading-relaxed">{f.answer}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="bg-gray-50 section-padding">
+          <div className="container-custom max-w-4xl text-center">
+            <h2 className="font-heading text-3xl md:text-4xl tracking-[0.1em] text-gray-900 mb-4">
+              Ready to order your wedding bar?
+            </h2>
+            <p className="text-base md:text-lg text-gray-700 mb-8 max-w-2xl mx-auto">
+              Take the result above and place a wedding-tagged order. We’ll review
+              the list with you before delivery.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/order?type=wedding" className="btn-primary inline-flex items-center justify-center">
+                Start Wedding Order
+              </Link>
+              <Link href="/weddings" className="btn-secondary inline-flex items-center justify-center">
+                Wedding Services
+              </Link>
+            </div>
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/src/app/weddings/page.tsx
+++ b/src/app/weddings/page.tsx
@@ -575,6 +575,17 @@ export default function WeddingsPage() {
           <ScrollRevealCSS duration={800} y={20}>
             <WeddingDrinkCalculator />
           </ScrollRevealCSS>
+          <ScrollRevealCSS duration={800} y={20} className="mt-12 text-center">
+            <p className="text-base md:text-lg text-gray-700 mb-4">
+              Want the detailed shopping list? Try our free public tool.
+            </p>
+            <Link
+              href="/wedding-drink-calculator"
+              className="btn-primary inline-flex items-center justify-center"
+            >
+              Wedding Drink Calculator
+            </Link>
+          </ScrollRevealCSS>
         </div>
       </section>
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -7,6 +7,7 @@ export default function Footer() {
     services: [
       { label: 'Fast Delivery', href: '/fast-delivery' },
       { label: 'Wedding Bar Service', href: '/weddings' },
+      { label: 'Wedding Drink Calculator', href: '/wedding-drink-calculator' },
       { label: 'Boat Party Packages', href: '/boat-parties' },
       { label: 'Bachelor/ette Parties', href: '/bach-parties' },
       { label: 'Keg Delivery', href: '/kegs' },

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -133,6 +133,7 @@ export default function Navigation({
 
   const services = [
     { href: '/weddings', label: 'WEDDINGS' },
+    { href: '/wedding-drink-calculator', label: 'WEDDING CALCULATOR' },
     { href: '/boat-parties', label: 'BOAT PARTIES' },
     { href: '/bach-parties', label: 'CELEBRATIONS' },
     { href: '/corporate', label: 'CORPORATE' },

--- a/src/lib/weddingDrinkCalculator.ts
+++ b/src/lib/weddingDrinkCalculator.ts
@@ -1,0 +1,205 @@
+/**
+ * Wedding Drink Calculator — public-facing tool for /wedding-drink-calculator.
+ *
+ * Reuses the same wedding-track formula and distribution ratios as
+ * src/lib/drinkPlannerLogic.ts (`guests × (hours + 1)`, beer 30% / wine 15% /
+ * spirits 50% / seltzers 5% with cocktail-kit override) but accepts raw
+ * `guests` and `hours` numbers (5-300 guests, 2-12 hours) without going
+ * through the multi-step QuizState. The two implementations must stay in
+ * sync — if you change the formula here, update drinkPlannerLogic too.
+ *
+ * Output is intentionally counts-only (no pricing claims) per the
+ * wedding-cluster build's hard-stop rules.
+ */
+
+import type { DrinkCategory } from './drinkPlannerTypes';
+
+export interface WeddingPlanInput {
+  /** Guest count, 5-300 */
+  guests: number;
+  /** Reception length in hours, 2-12 */
+  hours: number;
+  /** Drink categories the couple wants on the bar */
+  categories: DrinkCategory[];
+}
+
+export interface WeddingPlanItem {
+  /** Product nickname shown in the result panel */
+  name: string;
+  /** What to order — case, bottle, kit, etc. */
+  unit: string;
+  /** How many of `unit` to order */
+  quantity: number;
+  /** For grouping in the UI */
+  category: DrinkCategory | 'ice';
+}
+
+export interface WeddingPlan {
+  /** Total drinks at full crowd, full duration */
+  totalDrinks: number;
+  /** Per-category breakdown (counts) */
+  breakdown: Record<string, number>;
+  /** Concrete shopping list */
+  items: WeddingPlanItem[];
+  /** Input echo for the result panel */
+  summary: {
+    guests: number;
+    hours: number;
+    categories: DrinkCategory[];
+  };
+}
+
+// Servings per unit — matches drinkPlannerLogic.ts SERVINGS_PER_UNIT.
+const SERVINGS: Record<string, number> = {
+  'Miller Lite (24-pack)': 24,
+  'Modelo Especial (24-pack)': 24,
+  'Austin Beerworks Variety (12-pack)': 12,
+  'High Noon Variety (12-pack)': 12,
+  'White Claw Variety (24-pack)': 24,
+  'Dark Horse Pinot Grigio (750ml)': 5,
+  '14 Hands Cabernet Sauvignon (750ml)': 5,
+  'Espolon Tequila Blanco (750ml)': 17,
+  "Tito's Handmade Vodka (1L)": 22,
+  'Still Austin Bourbon (750ml)': 17,
+  'Lady Bird Margarita Kit': 16,
+  'Barton Springs Mojito Kit': 16,
+  'Eastside Gin & Tonic Kit': 16,
+};
+
+// Distribution weights — matches drinkPlannerLogic EVERYTHING_ELSE_*_SPLIT.
+const BASE_SPLIT: Record<string, number> = {
+  spirits: 0.5,
+  beer: 0.3,
+  seltzers: 0.05,
+  wine: 0.15,
+};
+
+const KITS_SPLIT: Record<string, number> = {
+  'cocktail-kits': 0.35,
+  spirits: 0.15,
+  beer: 0.3,
+  seltzers: 0.05,
+  wine: 0.15,
+};
+
+const ROUND_UP = (n: number) => Math.max(0, Math.ceil(n));
+
+/** Constrain inputs to the accepted ranges. */
+function clampInputs(input: WeddingPlanInput): WeddingPlanInput {
+  const guests = Math.min(300, Math.max(5, Math.round(input.guests)));
+  const hours = Math.min(12, Math.max(2, Math.round(input.hours)));
+  const categories = input.categories.length > 0
+    ? input.categories
+    : (['beer', 'wine', 'spirits'] as DrinkCategory[]);
+  return { guests, hours, categories };
+}
+
+/**
+ * Redistribute base-split weights across only the selected categories so the
+ * shares sum to 1.0. Identical to drinkPlannerLogic getSelectedShares.
+ */
+function getShares(
+  baseSplit: Record<string, number>,
+  selected: DrinkCategory[],
+): Record<string, number> {
+  let total = 0;
+  for (const cat of selected) if (baseSplit[cat] !== undefined) total += baseSplit[cat];
+  if (total === 0) {
+    const even = 1 / selected.length;
+    return Object.fromEntries(selected.map((c) => [c, even]));
+  }
+  return Object.fromEntries(selected.map((c) => [c, (baseSplit[c] ?? 0) / total]));
+}
+
+function addItems(
+  items: WeddingPlanItem[],
+  category: DrinkCategory,
+  drinks: number,
+): void {
+  switch (category) {
+    case 'beer':
+      items.push(
+        { name: 'Miller Lite (24-pack)', unit: '24-pack', quantity: ROUND_UP((drinks * 0.4) / SERVINGS['Miller Lite (24-pack)']), category: 'beer' },
+        { name: 'Modelo Especial (24-pack)', unit: '24-pack', quantity: ROUND_UP((drinks * 0.4) / SERVINGS['Modelo Especial (24-pack)']), category: 'beer' },
+        { name: 'Austin Beerworks Variety (12-pack)', unit: '12-pack', quantity: ROUND_UP((drinks * 0.2) / SERVINGS['Austin Beerworks Variety (12-pack)']), category: 'beer' },
+      );
+      return;
+    case 'seltzers':
+      items.push(
+        { name: 'High Noon Variety (12-pack)', unit: '12-pack', quantity: ROUND_UP((drinks * 0.6) / SERVINGS['High Noon Variety (12-pack)']), category: 'seltzers' },
+        { name: 'White Claw Variety (24-pack)', unit: '24-pack', quantity: ROUND_UP((drinks * 0.4) / SERVINGS['White Claw Variety (24-pack)']), category: 'seltzers' },
+      );
+      return;
+    case 'wine':
+      items.push(
+        { name: 'Dark Horse Pinot Grigio (750ml)', unit: 'bottle', quantity: ROUND_UP((drinks * 0.5) / SERVINGS['Dark Horse Pinot Grigio (750ml)']), category: 'wine' },
+        { name: '14 Hands Cabernet Sauvignon (750ml)', unit: 'bottle', quantity: ROUND_UP((drinks * 0.5) / SERVINGS['14 Hands Cabernet Sauvignon (750ml)']), category: 'wine' },
+      );
+      return;
+    case 'spirits':
+      items.push(
+        { name: 'Espolon Tequila Blanco (750ml)', unit: 'bottle', quantity: ROUND_UP((drinks * 0.4) / SERVINGS['Espolon Tequila Blanco (750ml)']), category: 'spirits' },
+        { name: "Tito's Handmade Vodka (1L)", unit: 'bottle', quantity: ROUND_UP((drinks * 0.4) / SERVINGS["Tito's Handmade Vodka (1L)"]), category: 'spirits' },
+        { name: 'Still Austin Bourbon (750ml)', unit: 'bottle', quantity: ROUND_UP((drinks * 0.2) / SERVINGS['Still Austin Bourbon (750ml)']), category: 'spirits' },
+      );
+      return;
+    case 'cocktail-kits':
+      items.push(
+        { name: 'Lady Bird Margarita Kit', unit: 'kit', quantity: Math.max(1, ROUND_UP(drinks / 16 / 3)), category: 'cocktail-kits' },
+        { name: 'Barton Springs Mojito Kit', unit: 'kit', quantity: Math.max(1, ROUND_UP(drinks / 16 / 3)), category: 'cocktail-kits' },
+        { name: 'Eastside Gin & Tonic Kit', unit: 'kit', quantity: Math.max(1, ROUND_UP(drinks / 16 / 3)), category: 'cocktail-kits' },
+      );
+      return;
+    case 'champagne':
+      items.push(
+        { name: 'Champagne / Prosecco (750ml)', unit: 'bottle', quantity: ROUND_UP(drinks / 5), category: 'champagne' },
+      );
+      return;
+  }
+}
+
+/**
+ * Calculate the wedding bar plan from raw inputs. Pure function — no I/O.
+ */
+export function calculateWeddingPlan(rawInput: WeddingPlanInput): WeddingPlan {
+  const input = clampInputs(rawInput);
+  const totalDrinks = Math.ceil(input.guests * (input.hours + 1));
+
+  const hasKits = input.categories.includes('cocktail-kits');
+  const baseSplit = hasKits ? KITS_SPLIT : BASE_SPLIT;
+
+  // Always include a small seltzer share even if not explicitly selected, to
+  // match drinkPlannerLogic behaviour. Wedding guests skew toward variety.
+  const effective: DrinkCategory[] = [...input.categories];
+  if (!effective.includes('seltzers')) effective.push('seltzers');
+
+  const shares = getShares(baseSplit, effective);
+  const breakdown: Record<string, number> = {};
+  const items: WeddingPlanItem[] = [];
+
+  for (const category of effective) {
+    const share = shares[category] ?? 0;
+    const drinks = totalDrinks * share;
+    breakdown[category] = Math.ceil(drinks);
+    addItems(items, category, drinks);
+  }
+
+  // Ice — 1 bag per 10 guests. Always include.
+  items.push({
+    name: 'Ice Bags',
+    unit: 'bag',
+    quantity: Math.max(1, Math.ceil(input.guests / 10)),
+    category: 'ice',
+  });
+
+  return {
+    totalDrinks,
+    breakdown,
+    items: items.filter((i) => i.quantity > 0),
+    summary: {
+      guests: input.guests,
+      hours: input.hours,
+      categories: input.categories,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Workstream 1 of 5. Captures the highest-ROI keyword in the dataset: \`wedding drink calculator\` (1,900 vol, KD 8).
- New public page at \`/wedding-drink-calculator\`: server component for SEO metadata, client component for the interactive calculator, results panel with bottle/case counts.
- Reuses calculation logic surfaced into \`src/lib/weddingDrinkCalculator.ts\` (extracted from existing planner code per the plan — does NOT rebuild the algorithm).
- Expands the lead-capture API to accept wedding scale (5-300 guests, 2-12 hours).
- Wires nav, footer, sitemap, and a CTA from \`/weddings\`.

## Files changed
- \`src/app/wedding-drink-calculator/{page.tsx, CalculatorClient.tsx, CalculatorResults.tsx}\` (new)
- \`src/lib/weddingDrinkCalculator.ts\` (new — wedding-specific export, reuses logic from \`drinkPlannerLogic.ts\`)
- \`src/app/api/leads/drink-calculator/route.ts\` — Zod schema expanded for \`partyType=wedding\`
- \`src/app/weddings/page.tsx\` — calculator CTA
- \`src/components/Navigation.tsx\`, \`src/components/Footer.tsx\` — links
- \`src/app/sitemap.ts\` — new route in \`staticPages\`

## Test plan
- [ ] \`curl https://partyondelivery.com/wedding-drink-calculator\` returns 200 with metadata
- [ ] Math validation: 100 guests × 5 hours → 600 drinks; category distribution sums to 100%
- [ ] Lead capture: submit test entry, verify it lands in DB
- [ ] Existing \`WeddingOrderCalculator.tsx\` on \`/weddings\` still works (coexistence per plan)
- [ ] Canonical tag self-references; appears in sitemap.xml
- [ ] HowTo + FAQPage schemas validate in Rich Results Test

## Open TODOs
- No pricing claims rendered in results (per business rules); CTA routes to \`/order\` for the actual quote.
- Coexists with \`WeddingOrderCalculator.tsx\` for 90 days per plan; revisit deprecation after data.

## Risks
- Brand-new public route — make sure nothing else in routing collides (\`/wedding-drink-calculator\` is unused prior to this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)