### PR TITLE
feat(finance): internal P&L snapshot + dashboard (Phase 1C for Finance Director)

### DIFF
--- a/docs/FINANCE-DIRECTOR-AGENT-BUILDOUT.md
+++ b/docs/FINANCE-DIRECTOR-AGENT-BUILDOUT.md
@@ -140,7 +140,7 @@ This list is exhaustive — these are the financial data sources Finance can pul
 | Stripe fees per charge | Can't compute true net revenue | Phase 1A |
 | Stripe payouts → bank | Can't reconcile bank deposits | Phase 1A |
 | Stripe disputes / chargebacks | Subscribed to webhook but no handler | Phase 1A |
-| AP on `ReceivingInvoice` (total, due date, paid status) | Can't tell which distributor invoices are unpaid | Phase 1B |
+| ~~AP on `ReceivingInvoice`~~ | **REMOVED** — distributor invoices live in QuickBooks; AP visibility comes from Phase 2A (QB read), not PartyOn-side modelling. | ~~Phase 1B~~ (cancelled) |
 | Operating expenses (rent, software, fuel, contractor pay) | Lives 100% in QB / Allan's head today | Phase 2 (QB sync) |
 | Tax remittance log | Can compute liability, can't prove what's been paid | Phase 4 |
 | Contractor 1099-NEC tracking | Need annual rollup ≥$600/contractor for IRS | Phase 3 |
@@ -244,11 +244,13 @@ This is genuinely multi-quarter work. Each phase is one or more PRs.
 
 **Why first:** Until Stripe net amounts are reconciliable, nothing else is trustworthy.
 
-### Phase 1B — AP on ReceivingInvoice (1 PR)
+### Phase 1B — AP on ReceivingInvoice **(CANCELLED 2026-05-20)**
 
-- `ALTER TABLE receiving_invoices ADD COLUMN invoice_total_cents BIGINT, due_date DATE, paid_at TIMESTAMP, paid_via TEXT`
-- Receiving UI gets fields for invoice total + due date at invoice-apply time
-- New "Outstanding AP" surface in `/admin/finance/ap` showing unpaid distributor invoices with aging
+Originally scoped: add `invoice_total_cents` / `due_date` / `paid_at` / `paid_via` to `receiving_invoices` + an `/admin/finance/ap` outstanding-AP dashboard.
+
+**Cancelled** by operator. Distributor invoices arrive electronically and live in QuickBooks already — PartyOn does not duplicate AP tracking. PR #83 was closed without merging. See saved memory `finance_no_internal_ap_tracking.md`. The Director gets AP visibility through Phase 2A (QB read), not PartyOn-side modelling.
+
+**New phase sequence:** 0 → 1A → **1C** → 2A → 2B → 2C → 3 → 4 → 5 → 6 (1B removed; total of 10 phases now, not 11).
 
 ### Phase 1C — Internal P&L (1 PR)
 
@@ -316,8 +318,8 @@ Heuristics the Finance Director surfaces as recommendations. These are starting 
 | # | Signal | Detection | Severity | Inline action |
 |---|---|---|---|---|
 | 1 | **Stripe payout failed to match a bank deposit** | StripePayout marked `paid` but no corresponding PlaidTransaction within 4 banking days | high | "Investigate" → opens Stripe payout + Plaid transaction comparison view |
-| 2 | **Distributor invoice past due** | `ReceivingInvoice.dueDate < today AND paidAt IS NULL` | high → urgent at >7d past due | "Mark paid" → opens AP page with invoice highlighted |
-| 3 | **Cash runway < 30 days** | (Bank balance + outstanding AR - committed AP) / avg daily burn < 30 | urgent | "Open cash dashboard" |
+| 2 | ~~Distributor invoice past due~~ | **REMOVED** — Phase 1B cancelled. AP lives in QuickBooks; if QB exposes a "past due AP" signal in Phase 2A, re-evaluate then. | — | — |
+| 3 | **Cash runway < 30 days** | (Bank balance from Plaid + outstanding AR from `DraftOrder`) / avg daily burn < 30. **No PartyOn-side AP component** — pull committed AP from QB once Phase 2A lands if needed. | urgent | "Open cash dashboard" |
 | 4 | **Gross margin trending down** | 30-day rolling gross margin % drops > 5pp from prior 30 days | high | "Open margin analysis" |
 | 5 | **Sales tax accrual exceeds remittance pace** | Cumulative taxAmount collected − cumulative tax remitted > one quarter's expected liability | high | "Open sales-tax dashboard" |
 | 6 | **Contractor approaching 1099 threshold** | Single contractor cumulative YTD payouts > $500 (early warning before $600 IRS threshold) | normal | "Review contractor totals" |

--- a/src/app/admin/finance/page.tsx
+++ b/src/app/admin/finance/page.tsx
@@ -1,0 +1,345 @@
+'use client';
+
+import { useEffect, useState, ReactElement } from 'react';
+import Link from 'next/link';
+
+interface PlSnapshotPayload {
+  date: string;
+  windowFromIso: string;
+  windowToIso: string;
+  paidOrderCount: number;
+  refundCount: number;
+  grossRevenueCents: number;
+  subtotalCents: number;
+  taxCollectedCents: number;
+  deliveryFeesCents: number;
+  tipsCents: number;
+  discountAmountCents: number;
+  refundedAmountCents: number;
+  cogsCents: number;
+  marginCoveragePct: number;
+  stripeChargeAmountCents: number;
+  stripeFeesCents: number;
+  netReceivedCents: number;
+  stripeFeeCoveragePct: number;
+  netRevenueCents: number;
+  grossProfitCents: number;
+  grossMarginPct: number;
+  salesTaxAccrualCents: number;
+  affiliateCommissionAccrualCents: number;
+  refundedTodayCount: number;
+  commissionsCreatedTodayCount: number;
+  commissionsCreatedTodayCents: number;
+}
+
+interface StoredSnapshot {
+  id: string;
+  snapshotDate: string;
+  payload: PlSnapshotPayload;
+  createdAt: string;
+}
+
+type ApiResponse<T> = { success: true; data: T } | { success: false; error: string };
+
+function formatCents(cents: number): string {
+  return `$${(cents / 100).toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+function pct(n: number): string {
+  return `${n.toFixed(1)}%`;
+}
+
+export default function FinanceDashboardPage(): ReactElement {
+  const [snapshots, setSnapshots] = useState<StoredSnapshot[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load(): Promise<void> {
+      setLoading(true);
+      try {
+        const res = await fetch('/api/admin/finance/snapshot?limit=30');
+        const body = (await res.json()) as ApiResponse<StoredSnapshot[]>;
+        if (body.success) {
+          setSnapshots(body.data);
+          setError(null);
+        } else {
+          setError(body.error);
+        }
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to load snapshots');
+      } finally {
+        setLoading(false);
+      }
+    }
+    void load();
+  }, []);
+
+  const latest = snapshots[0];
+  const prior = snapshots[1];
+
+  return (
+    <div className="p-4 md:p-8">
+      <div className="mb-6 flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-black">Finance — Internal P&amp;L</h1>
+          <p className="text-gray-600 text-sm">
+            Phase 1C of the Finance Director. Built from PartyOn data only;
+            QuickBooks OpEx joins in Phase 2A.
+          </p>
+        </div>
+        <div className="flex gap-2 text-sm">
+          <Link
+            href="/admin/finance/connect-quickbooks"
+            className="px-3 py-1.5 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+          >
+            QuickBooks
+          </Link>
+          <Link
+            href="/admin/finance/connect-bank"
+            className="px-3 py-1.5 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+          >
+            Bank
+          </Link>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mb-4 p-3 rounded-md text-sm border bg-red-50 border-red-200 text-red-800">
+          Error: {error}
+        </div>
+      )}
+
+      {loading ? (
+        <p className="text-gray-600 text-sm">Loading…</p>
+      ) : snapshots.length === 0 ? (
+        <div className="bg-white border border-gray-200 rounded-lg p-6 text-sm">
+          <p className="text-gray-700 mb-2">
+            No finance snapshots yet. The daily cron fires at 07:45 UTC.
+          </p>
+          <p className="text-gray-500 text-xs">
+            To trigger one manually (admin only): hit{' '}
+            <code className="bg-gray-100 px-1 rounded">GET /api/cron/finance-snapshot?date=YYYY-MM-DD</code>{' '}
+            with the cron bearer token.
+          </p>
+        </div>
+      ) : !latest ? null : (
+        <>
+          <div className="text-xs text-gray-500 mb-3">
+            Latest: <span className="font-medium">{latest.snapshotDate}</span> · captured{' '}
+            {new Date(latest.createdAt).toLocaleString()}
+          </div>
+
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+            <Kpi
+              label="Gross revenue"
+              value={formatCents(latest.payload.grossRevenueCents)}
+              delta={
+                prior
+                  ? deltaCents(latest.payload.grossRevenueCents, prior.payload.grossRevenueCents)
+                  : null
+              }
+              sub={`${latest.payload.paidOrderCount} orders`}
+            />
+            <Kpi
+              label="Net revenue"
+              value={formatCents(latest.payload.netRevenueCents)}
+              sub={`after refunds + Stripe fees (${pct(latest.payload.stripeFeeCoveragePct)} coverage)`}
+            />
+            <Kpi
+              label="Gross profit"
+              value={formatCents(latest.payload.grossProfitCents)}
+              sub={`${pct(latest.payload.grossMarginPct)} margin · cost coverage ${pct(latest.payload.marginCoveragePct)}`}
+            />
+            <Kpi
+              label="Refunds"
+              value={formatCents(latest.payload.refundedAmountCents)}
+              sub={`${latest.payload.refundedTodayCount} refunds`}
+              alert={latest.payload.refundedAmountCents > 0}
+            />
+          </div>
+
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6">
+            <Card title="Revenue breakdown (window)">
+              <Row label="Subtotal" value={formatCents(latest.payload.subtotalCents)} />
+              <Row
+                label="Discounts"
+                value={`-${formatCents(latest.payload.discountAmountCents)}`}
+              />
+              <Row label="Delivery fees" value={formatCents(latest.payload.deliveryFeesCents)} />
+              <Row label="Tips" value={formatCents(latest.payload.tipsCents)} />
+              <Row label="Tax collected" value={formatCents(latest.payload.taxCollectedCents)} />
+              <Divider />
+              <Row
+                label="Gross revenue"
+                value={formatCents(latest.payload.grossRevenueCents)}
+                bold
+              />
+            </Card>
+
+            <Card title="Stripe (net)">
+              <Row
+                label="Charge amount"
+                value={formatCents(latest.payload.stripeChargeAmountCents)}
+              />
+              <Row label="Stripe fees" value={`-${formatCents(latest.payload.stripeFeesCents)}`} />
+              <Row label="Net received" value={formatCents(latest.payload.netReceivedCents)} />
+              <Divider />
+              <Row
+                label="Fee coverage"
+                value={pct(latest.payload.stripeFeeCoveragePct)}
+                sub={
+                  latest.payload.stripeFeeCoveragePct < 100
+                    ? 'Run backfill-stripe-history to fill the gap'
+                    : null
+                }
+              />
+            </Card>
+
+            <Card title="Accruals (cumulative)">
+              <Row
+                label="Sales tax accrual"
+                value={formatCents(latest.payload.salesTaxAccrualCents)}
+                sub="Phase 4 will track remittance against this"
+              />
+              <Row
+                label="Affiliate commissions held"
+                value={formatCents(latest.payload.affiliateCommissionAccrualCents)}
+                sub={`HELD + APPROVED commissions outstanding`}
+              />
+              <Divider />
+              <Row
+                label="Today's new commissions"
+                value={formatCents(latest.payload.commissionsCreatedTodayCents)}
+                sub={`${latest.payload.commissionsCreatedTodayCount} created`}
+              />
+            </Card>
+          </div>
+
+          {snapshots.length > 1 && (
+            <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+              <table className="w-full text-sm">
+                <thead className="bg-gray-50 text-gray-700">
+                  <tr>
+                    <th className="text-left p-3">Date</th>
+                    <th className="text-right p-3">Orders</th>
+                    <th className="text-right p-3">Gross</th>
+                    <th className="text-right p-3">Refunds</th>
+                    <th className="text-right p-3">Stripe fees</th>
+                    <th className="text-right p-3">Net</th>
+                    <th className="text-right p-3">Gross profit</th>
+                    <th className="text-right p-3">Margin %</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {snapshots.map((s) => (
+                    <tr key={s.id} className="border-t border-gray-100">
+                      <td className="p-3 text-gray-800">{s.snapshotDate}</td>
+                      <td className="p-3 text-right tabular-nums">{s.payload.paidOrderCount}</td>
+                      <td className="p-3 text-right tabular-nums">
+                        {formatCents(s.payload.grossRevenueCents)}
+                      </td>
+                      <td className="p-3 text-right tabular-nums text-red-700">
+                        {s.payload.refundedAmountCents > 0
+                          ? `-${formatCents(s.payload.refundedAmountCents)}`
+                          : '—'}
+                      </td>
+                      <td className="p-3 text-right tabular-nums text-gray-600">
+                        {formatCents(s.payload.stripeFeesCents)}
+                      </td>
+                      <td className="p-3 text-right tabular-nums">
+                        {formatCents(s.payload.netRevenueCents)}
+                      </td>
+                      <td className="p-3 text-right tabular-nums">
+                        {formatCents(s.payload.grossProfitCents)}
+                      </td>
+                      <td className="p-3 text-right tabular-nums">{pct(s.payload.grossMarginPct)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function deltaCents(now: number, prior: number): { dirCents: number; pct: number } | null {
+  if (prior === 0) return null;
+  const diff = now - prior;
+  return { dirCents: diff, pct: (diff / prior) * 100 };
+}
+
+function Kpi({
+  label,
+  value,
+  sub,
+  delta,
+  alert,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  delta?: { dirCents: number; pct: number } | null;
+  alert?: boolean;
+}): ReactElement {
+  return (
+    <div
+      className={`p-4 rounded-lg border ${alert ? 'bg-red-50 border-red-200' : 'bg-white border-gray-200'}`}
+    >
+      <div className="text-gray-600 text-xs">{label}</div>
+      <div className="text-2xl font-bold tabular-nums">{value}</div>
+      {delta && (
+        <div
+          className={`text-xs mt-0.5 ${
+            delta.dirCents >= 0 ? 'text-green-700' : 'text-red-700'
+          }`}
+        >
+          {delta.dirCents >= 0 ? '+' : ''}
+          {delta.pct.toFixed(1)}% vs prior day
+        </div>
+      )}
+      {sub && <div className="text-gray-500 text-xs mt-1">{sub}</div>}
+    </div>
+  );
+}
+
+function Card({ title, children }: { title: string; children: React.ReactNode }): ReactElement {
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-4">
+      <h3 className="font-semibold text-gray-900 mb-3 text-sm">{title}</h3>
+      <div className="space-y-1.5 text-sm">{children}</div>
+    </div>
+  );
+}
+
+function Row({
+  label,
+  value,
+  sub,
+  bold,
+}: {
+  label: string;
+  value: string;
+  sub?: string | null;
+  bold?: boolean;
+}): ReactElement {
+  return (
+    <div>
+      <div className={`flex justify-between items-baseline ${bold ? 'font-semibold' : ''}`}>
+        <span className="text-gray-700">{label}</span>
+        <span className="tabular-nums">{value}</span>
+      </div>
+      {sub && <div className="text-xs text-gray-500">{sub}</div>}
+    </div>
+  );
+}
+
+function Divider(): ReactElement {
+  return <div className="border-t border-gray-100 my-2" />;
+}

--- a/src/app/api/admin/finance/snapshot/route.ts
+++ b/src/app/api/admin/finance/snapshot/route.ts
@@ -1,0 +1,39 @@
+/**
+ * GET /api/admin/finance/snapshot
+ *
+ * Returns the most recent N FinanceSnapshot rows for the /admin/finance
+ * dashboard. Use ?limit=N (default 30, max 365) or ?date=YYYY-MM-DD for
+ * a single-day lookup.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
+import { getSnapshotByDate, listRecentSnapshots } from '@/lib/finance/snapshot';
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const auth = await requireOpsAuth();
+    if (auth instanceof NextResponse) return auth;
+
+    const date = request.nextUrl.searchParams.get('date');
+    if (date) {
+      const snap = await getSnapshotByDate(date);
+      return NextResponse.json({ success: true, data: snap });
+    }
+
+    const limitParam = request.nextUrl.searchParams.get('limit');
+    let limit = limitParam ? Number.parseInt(limitParam, 10) : 30;
+    if (!Number.isFinite(limit) || limit < 1) limit = 30;
+    if (limit > 365) limit = 365;
+
+    const snapshots = await listRecentSnapshots(limit);
+    return NextResponse.json({ success: true, data: snapshots });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('[Finance Snapshot] Error:', message);
+    return NextResponse.json(
+      { success: false, error: message },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/cron/finance-snapshot/route.ts
+++ b/src/app/api/cron/finance-snapshot/route.ts
@@ -1,0 +1,54 @@
+/**
+ * GET /api/cron/finance-snapshot
+ *
+ * Phase 1C — daily P&L snapshot at 07:45 UTC (after Marketing 07:00,
+ * Ops 07:30, Finance Stripe sync 07:15). Computes yesterday's revenue
+ * minus known costs, plus cumulative sales-tax + affiliate-commission
+ * accruals, and persists a FinanceSnapshot row.
+ *
+ * Re-runnable: writes by snapshot_date so a backfill of Stripe fees
+ * earlier in the day can be reflected by re-firing the cron.
+ *
+ * Bearer auth: `Authorization: Bearer ${CRON_SECRET}`.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { computeDailyPL, yesterdayWindow } from '@/lib/finance/pl-calculation';
+import { writeFinanceSnapshot } from '@/lib/finance/snapshot';
+
+export const maxDuration = 60;
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = request.headers.get('authorization');
+  if (auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const startedAt = new Date();
+
+  // Allow operator/admin to backfill a specific date via ?date=YYYY-MM-DD.
+  const dateParam = request.nextUrl.searchParams.get('date');
+  let payload;
+  if (dateParam) {
+    const from = new Date(`${dateParam}T00:00:00Z`);
+    if (Number.isNaN(from.getTime())) {
+      return NextResponse.json(
+        { success: false, error: 'date must be YYYY-MM-DD' },
+        { status: 400 }
+      );
+    }
+    const to = new Date(from.getTime() + 86_400_000);
+    payload = await computeDailyPL({ from, to });
+  } else {
+    payload = await computeDailyPL(yesterdayWindow(startedAt));
+  }
+
+  const snapshot = await writeFinanceSnapshot(payload);
+  const durationMs = Date.now() - startedAt.getTime();
+
+  console.log('[finance-snapshot] wrote snapshot for', snapshot.snapshotDate, 'in', durationMs, 'ms');
+  return NextResponse.json({
+    success: true,
+    data: { snapshot, durationMs },
+  });
+}

--- a/src/lib/finance/pl-calculation.ts
+++ b/src/lib/finance/pl-calculation.ts
@@ -1,0 +1,263 @@
+/**
+ * P&L (Profit & Loss) computation — Phase 1C of the Finance Director.
+ *
+ * Computes a one-day "internal" P&L snapshot from PartyOn data only. No
+ * QuickBooks integration here — that comes in Phase 2A and adds OpEx on
+ * top of this snapshot. Phase 1C answers: "what did we make yesterday,
+ * minus the costs we actually know about?"
+ *
+ * Inputs (per `[from, to)` window — `to` is exclusive):
+ *   - `orders` rows where `created_at` falls in the window AND
+ *     `financial_status = 'PAID'`.
+ *   - `refunds` rows by `created_at`.
+ *   - `affiliate_commissions` rows by `created_at`.
+ *   - Stripe net snapshots if available (`net_received_cents`).
+ *
+ * Outputs (all in cents — match Stripe's native unit, avoid floats):
+ *   - gross revenue, refunds, discounts, tax, delivery fees, tips
+ *   - COGS (where known) + margin coverage %
+ *   - Stripe fees + net received (where snapshotted)
+ *   - sales-tax accrual (cumulative collected up to `to`)
+ *   - affiliate commission accrual (HELD + APPROVED at `to`)
+ *
+ * Used by /api/cron/finance-snapshot to persist the daily row.
+ */
+
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/database/client';
+
+const ONE_DAY_MS = 86_400_000;
+
+export interface PlWindow {
+  /** Window start (inclusive) — typically yesterday 00:00 UTC. */
+  from: Date;
+  /** Window end (exclusive) — typically today 00:00 UTC. */
+  to: Date;
+}
+
+export interface PlSnapshotPayload {
+  /** ISO date "YYYY-MM-DD" of the day the window covers. */
+  date: string;
+  windowFromIso: string;
+  windowToIso: string;
+
+  // Order counts
+  paidOrderCount: number;
+  refundCount: number;
+
+  // Revenue (all cents)
+  grossRevenueCents: number;
+  subtotalCents: number;
+  taxCollectedCents: number;
+  deliveryFeesCents: number;
+  tipsCents: number;
+  discountAmountCents: number;
+  refundedAmountCents: number;
+
+  // Cost (where snapshotted on OrderItems)
+  cogsCents: number;
+  /** % of orders in the window that have margin data populated (0–100). */
+  marginCoveragePct: number;
+
+  // Stripe net (where snapshotted via Phase 1A pipeline)
+  stripeChargeAmountCents: number;
+  stripeFeesCents: number;
+  netReceivedCents: number;
+  /** % of paid orders in window that have stripeFeesCents populated (0–100). */
+  stripeFeeCoveragePct: number;
+
+  // Derived
+  /** grossRevenue − refunds − stripeFees. Approximation when fee coverage < 100%. */
+  netRevenueCents: number;
+  /** netRevenue − cogs (where known). */
+  grossProfitCents: number;
+  grossMarginPct: number;
+
+  // Accruals (cumulative as of `to`)
+  salesTaxAccrualCents: number;
+  affiliateCommissionAccrualCents: number;
+
+  // Counts for Director context
+  refundedTodayCount: number;
+  commissionsCreatedTodayCount: number;
+  commissionsCreatedTodayCents: number;
+}
+
+/**
+ * Default window = yesterday (UTC).
+ */
+export function yesterdayWindow(now = new Date()): PlWindow {
+  const todayMidnightUtc = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  );
+  return {
+    from: new Date(todayMidnightUtc.getTime() - ONE_DAY_MS),
+    to: todayMidnightUtc,
+  };
+}
+
+function decToCents(d: Prisma.Decimal | null | undefined): number {
+  if (d === null || d === undefined) return 0;
+  // .toFixed(2) keeps precision tight; * 100 + round avoids float drift.
+  return Math.round(Number(d) * 100);
+}
+
+export async function computeDailyPL(window: PlWindow): Promise<PlSnapshotPayload> {
+  const { from, to } = window;
+
+  // ---- Revenue side -----------------------------------------------------
+  const paidOrders = await prisma.order.findMany({
+    where: {
+      createdAt: { gte: from, lt: to },
+      financialStatus: 'PAID',
+    },
+    select: {
+      id: true,
+      subtotal: true,
+      taxAmount: true,
+      deliveryFee: true,
+      tipAmount: true,
+      total: true,
+      discountAmount: true,
+      marginAmount: true,
+      marginCoveragePct: true,
+      stripeChargeAmountCents: true,
+      stripeFeesCents: true,
+      netReceivedCents: true,
+    },
+  });
+
+  let subtotalCents = 0;
+  let taxCollectedCents = 0;
+  let deliveryFeesCents = 0;
+  let tipsCents = 0;
+  let grossRevenueCents = 0;
+  let discountAmountCents = 0;
+  let stripeChargeAmountCents = 0;
+  let stripeFeesCents = 0;
+  let netReceivedCents = 0;
+  let cogsCents = 0;
+  let ordersWithMargin = 0;
+  let ordersWithStripeFees = 0;
+
+  for (const o of paidOrders) {
+    subtotalCents += decToCents(o.subtotal);
+    taxCollectedCents += decToCents(o.taxAmount);
+    deliveryFeesCents += decToCents(o.deliveryFee);
+    tipsCents += decToCents(o.tipAmount);
+    grossRevenueCents += decToCents(o.total);
+    discountAmountCents += decToCents(o.discountAmount);
+    if (o.marginAmount !== null) {
+      // marginAmount = revenue − cogs (in dollars). Derive cogs ≈ subtotal − marginAmount.
+      const subCents = decToCents(o.subtotal);
+      const marginCents = decToCents(o.marginAmount);
+      cogsCents += Math.max(0, subCents - marginCents);
+      ordersWithMargin++;
+    }
+    if (o.stripeChargeAmountCents !== null) {
+      stripeChargeAmountCents += o.stripeChargeAmountCents;
+    }
+    if (o.stripeFeesCents !== null) {
+      stripeFeesCents += o.stripeFeesCents;
+      ordersWithStripeFees++;
+    }
+    if (o.netReceivedCents !== null) {
+      netReceivedCents += o.netReceivedCents;
+    }
+  }
+
+  const paidOrderCount = paidOrders.length;
+  const marginCoveragePct =
+    paidOrderCount > 0 ? Math.round((ordersWithMargin / paidOrderCount) * 100) : 0;
+  const stripeFeeCoveragePct =
+    paidOrderCount > 0 ? Math.round((ordersWithStripeFees / paidOrderCount) * 100) : 0;
+
+  // ---- Refunds ----------------------------------------------------------
+  const refunds = await prisma.refund.findMany({
+    where: { createdAt: { gte: from, lt: to } },
+    select: { amount: true },
+  });
+  const refundedAmountCents = refunds.reduce((s, r) => s + decToCents(r.amount), 0);
+  const refundCount = refunds.length;
+
+  // ---- Affiliate commissions created today ------------------------------
+  const commissionsToday = await prisma.affiliateCommission.findMany({
+    where: { createdAt: { gte: from, lt: to } },
+    select: { commissionAmountCents: true },
+  });
+  const commissionsCreatedTodayCents = commissionsToday.reduce(
+    (s, c) => s + c.commissionAmountCents,
+    0
+  );
+
+  // ---- Accruals at `to` -------------------------------------------------
+  const accrualAt = to;
+
+  // Sales tax accrual = cumulative tax collected on PAID orders.
+  // No remittance log yet (Phase 4), so this is the running total.
+  const taxRow = await prisma.order.aggregate({
+    where: {
+      createdAt: { lt: accrualAt },
+      financialStatus: 'PAID',
+    },
+    _sum: { taxAmount: true },
+  });
+  const salesTaxAccrualCents = decToCents(taxRow._sum.taxAmount as Prisma.Decimal | null);
+
+  // Affiliate commission accrual = HELD + APPROVED commissions at `to`.
+  // Excludes PAID (already paid out) and VOID (cancelled).
+  const commissionAccrual = await prisma.affiliateCommission.aggregate({
+    where: {
+      createdAt: { lt: accrualAt },
+      status: { in: ['HELD', 'APPROVED'] },
+    },
+    _sum: { commissionAmountCents: true },
+  });
+  const affiliateCommissionAccrualCents =
+    commissionAccrual._sum.commissionAmountCents ?? 0;
+
+  // ---- Derived numbers --------------------------------------------------
+  const netRevenueCents = Math.max(
+    0,
+    grossRevenueCents - refundedAmountCents - stripeFeesCents
+  );
+  const grossProfitCents = netRevenueCents - cogsCents;
+  const grossMarginPct =
+    netRevenueCents > 0 ? Math.round((grossProfitCents / netRevenueCents) * 10000) / 100 : 0;
+
+  return {
+    date: from.toISOString().slice(0, 10),
+    windowFromIso: from.toISOString(),
+    windowToIso: to.toISOString(),
+
+    paidOrderCount,
+    refundCount,
+
+    grossRevenueCents,
+    subtotalCents,
+    taxCollectedCents,
+    deliveryFeesCents,
+    tipsCents,
+    discountAmountCents,
+    refundedAmountCents,
+
+    cogsCents,
+    marginCoveragePct,
+
+    stripeChargeAmountCents,
+    stripeFeesCents,
+    netReceivedCents,
+    stripeFeeCoveragePct,
+
+    netRevenueCents,
+    grossProfitCents,
+    grossMarginPct,
+
+    salesTaxAccrualCents,
+    affiliateCommissionAccrualCents,
+
+    refundedTodayCount: refundCount,
+    commissionsCreatedTodayCount: commissionsToday.length,
+    commissionsCreatedTodayCents,
+  };
+}

--- a/src/lib/finance/snapshot.ts
+++ b/src/lib/finance/snapshot.ts
@@ -1,0 +1,86 @@
+/**
+ * FinanceSnapshot writer + reader — Phase 1C.
+ *
+ * Wraps the FinanceSnapshot model behind a tiny service surface so the
+ * cron, the admin read API, and (eventually) the Director's briefing
+ * payload all go through the same shape. Payload type lives in
+ * `./pl-calculation.ts`.
+ */
+
+import { prisma } from '@/lib/database/client';
+import type { PlSnapshotPayload } from './pl-calculation';
+
+export interface StoredFinanceSnapshot {
+  id: string;
+  snapshotDate: string; // YYYY-MM-DD
+  payload: PlSnapshotPayload;
+  createdAt: string;
+}
+
+/**
+ * Idempotent write: if a snapshot already exists for the given date we
+ * overwrite the payload in place (the cron may re-run after a backfill
+ * or after Stripe fee snapshots catch up).
+ */
+export async function writeFinanceSnapshot(
+  payload: PlSnapshotPayload
+): Promise<StoredFinanceSnapshot> {
+  const snapshotDate = new Date(`${payload.date}T00:00:00Z`);
+  const existing = await prisma.financeSnapshot.findFirst({
+    where: { snapshotDate },
+    orderBy: { createdAt: 'desc' },
+  });
+  let row;
+  if (existing) {
+    row = await prisma.financeSnapshot.update({
+      where: { id: existing.id },
+      data: { payload: payload as unknown as object },
+    });
+  } else {
+    row = await prisma.financeSnapshot.create({
+      data: { snapshotDate, payload: payload as unknown as object },
+    });
+  }
+  return {
+    id: row.id,
+    snapshotDate: payload.date,
+    payload,
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+/**
+ * Load the most recent N snapshots (most recent first). Used by the
+ * dashboard trend chart + Director briefings.
+ */
+export async function listRecentSnapshots(
+  limit = 30
+): Promise<StoredFinanceSnapshot[]> {
+  const rows = await prisma.financeSnapshot.findMany({
+    orderBy: { snapshotDate: 'desc' },
+    take: limit,
+  });
+  return rows.map((r) => ({
+    id: r.id,
+    snapshotDate: r.snapshotDate.toISOString().slice(0, 10),
+    payload: r.payload as unknown as PlSnapshotPayload,
+    createdAt: r.createdAt.toISOString(),
+  }));
+}
+
+export async function getSnapshotByDate(
+  date: string // YYYY-MM-DD
+): Promise<StoredFinanceSnapshot | null> {
+  const snapshotDate = new Date(`${date}T00:00:00Z`);
+  const row = await prisma.financeSnapshot.findFirst({
+    where: { snapshotDate },
+    orderBy: { createdAt: 'desc' },
+  });
+  if (!row) return null;
+  return {
+    id: row.id,
+    snapshotDate: date,
+    payload: row.payload as unknown as PlSnapshotPayload,
+    createdAt: row.createdAt.toISOString(),
+  };
+}

--- a/vercel.json
+++ b/vercel.json
@@ -51,6 +51,10 @@
     {
       "path": "/api/cron/finance-stripe-sync",
       "schedule": "15 7 * * *"
+    },
+    {
+      "path": "/api/cron/finance-snapshot",
+      "schedule": "45 7 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Phase 1C — internal P&L

First user-visible Finance surface. Daily snapshot of revenue − refunds − Stripe fees − COGS (where known), plus cumulative sales-tax + affiliate-commission accruals. **PartyOn data only** — QuickBooks OpEx joins this in Phase 2A.

**Also marks Phase 1B as cancelled** in the in-repo brief per operator decision 2026-05-20 (distributor invoices live in QuickBooks, not PartyOn). Closed PR #83 without merging. New phase sequence: 0 → 1A → 1C → 2A → 2B → 2C → 3 → 4 → 5 → 6.

## Code

**Computation**
- `src/lib/finance/pl-calculation.ts` — `computeDailyPL(window)` pulls PAID orders + refunds + affiliate commissions for a `[from, to)` window and derives:
  - revenue: gross, subtotal, tax, delivery, tips, discounts, refunds
  - cost: COGS (where `OrderItem.unitCost` is populated) + margin coverage %
  - Stripe net (via Phase 1A's `Order.stripeFeesCents` / `netReceivedCents`) + fee coverage %
  - cumulative accruals at `to`: sales tax (no remittance log yet) + held/approved affiliate commissions
- `src/lib/finance/snapshot.ts` — `writeFinanceSnapshot` (upsert by snapshot_date), `listRecentSnapshots`, `getSnapshotByDate`
- All amounts in cents (Stripe's native unit; no float drift)

**API**
- `GET /api/cron/finance-snapshot` — daily at 07:45 UTC. Idempotent (re-running overwrites the day's row). Supports `?date=YYYY-MM-DD` for backfill. Behind `CRON_SECRET` bearer.
- `GET /api/admin/finance/snapshot?limit=N` or `?date=YYYY-MM-DD` — read API. Behind `requireOpsAuth`.

**UI**
- `/admin/finance` — Internal P&L dashboard. 4 KPI cards (gross, net, gross profit + margin, refunds), 3 detail cards (revenue breakdown / Stripe net / cumulative accruals), 30-day trend table.

**Wiring**
- `vercel.json` — new daily cron at 07:45 UTC.

## Verification

- Typecheck clean (only pre-existing `group-v2-payments.test.ts` error)
- Lint: no new warnings in any new files
- 166/172 tests pass (same 6 pre-existing failures unchanged)

## Operator steps after merge

```bash
# 1. Wait for next deploy. Then trigger the first snapshot manually
#    (yesterday's window):
curl -H "Authorization: Bearer $CRON_SECRET" \
     https://partyondelivery.com/api/cron/finance-snapshot

# 2. Visit https://partyondelivery.com/admin/finance — should show the
#    first snapshot's KPIs.

# 3. Backfill the last 30 days one-by-one (optional, useful for the
#    trend table to populate):
for d in $(seq 1 30); do
  date=$(date -u -v-${d}d +%Y-%m-%d 2>/dev/null || date -u -d "${d} days ago" +%Y-%m-%d)
  curl -H "Authorization: Bearer $CRON_SECRET" \
       "https://partyondelivery.com/api/cron/finance-snapshot?date=${date}"
done
```

## What's next

Phase 2A — QuickBooks: read OpEx. Weekly cron pulls QB expense transactions for the trailing 30 days; surfaces them as "OpEx by category" on the dashboard. Internal P&L becomes: revenue − COGS − OpEx (from QB) = net income.

## Test plan

- [ ] After deploy, trigger the cron manually. Confirm a `finance_snapshots` row exists.
- [ ] Open `/admin/finance`. Cards render without error. Numbers look right (compare gross revenue card to a quick `SELECT SUM(total) FROM orders WHERE created_at::date = 'yesterday' AND financial_status = 'PAID'`).
- [ ] Margin coverage % matches what's plausible given current `ProductVariant.costPerUnit` coverage (~20%).
- [ ] Stripe fee coverage % shows 0% on first run (no fees snapshotted yet); rises after running `scripts/finance/backfill-stripe-history.ts`.
- [ ] Backfill 2–3 prior days; trend table shows multiple rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)