### PR TITLE
feat(seo): wedding cluster crosslinks — /weddings + Premier ↔ boats-as-venue

### DIFF
--- a/src/app/partners/premier-party-cruises/page.tsx
+++ b/src/app/partners/premier-party-cruises/page.tsx
@@ -197,6 +197,63 @@ function PremierPartyCruisesPageContent(): ReactElement {
       <HouseTabUpsell />
 
       {/* ============================================ */}
+      {/* SECTION 4b: WEDDING VENUE PACKAGES           */}
+      {/* Cross-link to /austin-wedding-venue-boats —  */}
+      {/* Premier boats double as a wedding venue.     */}
+      {/* ============================================ */}
+      <section className="bg-white py-16 md:py-24 border-t border-gray-200">
+        <div className="max-w-6xl mx-auto px-6 md:px-8">
+          <div className="text-center mb-10">
+            <p className="text-sm font-heading uppercase tracking-[0.08em] text-brand-blue mb-2">
+              Wedding Venue Packages
+            </p>
+            <h2 className="font-heading text-3xl md:text-4xl text-gray-900 mb-4">
+              Getting married on the lake?
+            </h2>
+            <p className="text-base text-gray-700 max-w-2xl mx-auto">
+              Premier boats also serve as a small, intimate wedding venue —
+              ceremony on the deck, rehearsal dinner the night before, brunch
+              cruise the morning after. 20-80 guests. We handle the bar.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+            {[
+              {
+                title: 'Ceremony On The Lake',
+                price: 'From $1,899',
+                blurb: 'Elopements, micro-weddings, vow renewals. 20-30 guests.',
+              },
+              {
+                title: 'Wedding Weekend',
+                price: 'From $5,999',
+                blurb: 'Rehearsal + ceremony + brunch. One boat, one weekend.',
+              },
+              {
+                title: 'Photography Cruise',
+                price: '$1,499',
+                blurb: '90-min sunset cruise for photos + the wedding party.',
+              },
+            ].map((card) => (
+              <div key={card.title} className="bg-gray-50 rounded-lg p-6 border border-gray-200">
+                <h3 className="font-heading text-lg font-bold tracking-[0.05em] text-gray-900 mb-1">
+                  {card.title}
+                </h3>
+                <p className="text-sm font-semibold text-brand-blue mb-2">{card.price}</p>
+                <p className="text-sm text-gray-700">{card.blurb}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="text-center">
+            <Button variant="primary" size="lg" href="/austin-wedding-venue-boats">
+              See Wedding Venue Packages
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      {/* ============================================ */}
       {/* SECTION 5: EXPERIENCE PROOF (Video)          */}
       {/* ============================================ */}
       <section id="experience-proof" className="bg-white py-16 md:py-24">

--- a/src/app/weddings/page.tsx
+++ b/src/app/weddings/page.tsx
@@ -419,6 +419,61 @@ export default function WeddingsPage() {
         </div>
       </section>
 
+      {/* Wedding Venue Options — cross-link to boats-as-venue */}
+      <section className="py-24 bg-white">
+        <div className="max-w-6xl mx-auto px-8">
+          <ScrollRevealCSS duration={800} y={20} className="text-center mb-12">
+            <p className="text-sm font-heading uppercase tracking-[0.08em] text-brand-yellow mb-3">
+              Need A Venue Too?
+            </p>
+            <h2 className="font-heading font-light text-4xl md:text-5xl text-gray-900 mb-4 tracking-[0.1em]">
+              Wedding Venue Options
+            </h2>
+            <div className="w-16 h-px bg-brand-yellow mx-auto mb-6" />
+            <p className="text-base text-gray-700 max-w-2xl mx-auto">
+              Already have a venue? Skip ahead. If you&apos;re still looking, Premier
+              Party Cruises boats double as a small, intimate Austin wedding venue —
+              ceremony on the deck, reception on the water, brunch the next morning.
+            </p>
+          </ScrollRevealCSS>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-4xl mx-auto">
+            <ScrollRevealCSS duration={800} y={20} className="card flex flex-col">
+              <h3 className="font-heading text-2xl text-gray-900 mb-3 tracking-[0.05em]">
+                Boats As Wedding Venue
+              </h3>
+              <p className="text-sm text-gray-700 mb-4 flex-1">
+                Lake Travis boats for ceremony, rehearsal dinner, or the morning-after
+                brunch cruise. 20-80 guests. Starts around $1,500 for the venue itself.
+              </p>
+              <Link
+                href="/austin-wedding-venue-boats"
+                className="inline-flex items-center text-sm font-semibold tracking-[0.08em] text-brand-blue hover:underline"
+              >
+                See boat venue packages →
+              </Link>
+            </ScrollRevealCSS>
+
+            <ScrollRevealCSS duration={800} y={20} delay={100} className="card flex flex-col">
+              <h3 className="font-heading text-2xl text-gray-900 mb-3 tracking-[0.05em]">
+                Already Booked Premier?
+              </h3>
+              <p className="text-sm text-gray-700 mb-4 flex-1">
+                If your wedding cruise is already on the books with Premier Party
+                Cruises, we deliver and stock the boat — free marina delivery, ice,
+                glassware, the works.
+              </p>
+              <Link
+                href="/partners/premier-party-cruises"
+                className="inline-flex items-center text-sm font-semibold tracking-[0.08em] text-brand-blue hover:underline"
+              >
+                Premier partner page →
+              </Link>
+            </ScrollRevealCSS>
+          </div>
+        </div>
+      </section>
+
       {/* Benefits */}
       <section className="py-24">
         <div className="max-w-7xl mx-auto px-8 md:px-12">


### PR DESCRIPTION
## Summary
- Deferred follow-up to the wedding cluster build. Both `/weddings/page.tsx` and `/partners/premier-party-cruises/page.tsx` were touched by sibling PRs (#81 WS1 calculator and #82 WS2 venue), so the cross-links were held until after both merged to avoid conflict. Both have merged — this PR closes the loop.
- Adds the internal-link triangle the SEO strategy depends on: `/weddings` → `/austin-wedding-venue-boats`, Premier partner page → `/austin-wedding-venue-boats`, and the venue page already links back to both.

## Files changed
- `src/app/weddings/page.tsx` — new \"Wedding Venue Options\" section between \"Choose Your Path\" and \"Benefits\", two cards (boat venue + Premier partner)
- `src/app/partners/premier-party-cruises/page.tsx` — new \"Wedding Venue Packages\" section between House Tab Upsell and Experience Proof, three-tier summary cards + CTA to `/austin-wedding-venue-boats`

## Test plan
- [ ] `/weddings` renders the new section between Choose Your Path and Benefits
- [ ] `/partners/premier-party-cruises` renders the new venue-packages section
- [ ] Both new links 200 to the boats-as-venue page
- [ ] No layout shift on mobile (cards stack)
- [ ] `npx tsc --noEmit` clean

## Risks
- Premier page is now 555 lines (was 498) — still within the soft 500-line cap because the existing exception is documented (custom partner pages). If we want to refactor, the new venue section is the natural slice-out candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)