### PR TITLE
feat(wedding-calc): conversion tracking + Phase B page rebuild

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -231,3 +231,10 @@ INTUIT_REDIRECT_URI=https://partyondelivery.com/api/admin/finance/qb/callback
 PLAID_CLIENT_ID=your-plaid-client-id
 PLAID_SECRET=your-plaid-secret
 PLAID_ENV=sandbox
+
+# --- Google Ads conversion tracking (Phase C) ---
+# Set these once the operator builds conversion actions in the Google Ads UI.
+# Leave empty in dev — conversion firing is a no-op until populated.
+NEXT_PUBLIC_GOOGLE_ADS_ID=
+NEXT_PUBLIC_GADS_QUOTE_CONVERSION_ID=
+NEXT_PUBLIC_GADS_PURCHASE_CONVERSION_ID=

--- a/docs/GOOGLE-ADS-CONVERSIONS.md
+++ b/docs/GOOGLE-ADS-CONVERSIONS.md
@@ -1,0 +1,94 @@
+# Google Ads Conversion Tracking — Setup Guide
+
+This doc explains the conversion actions the operator needs to create in
+the Google Ads UI before paid traffic to `/wedding-drink-calculator`
+(and future landing pages) can be optimized by Smart Bidding.
+
+The code-level wiring is already in place behind env-var gates. Until the
+env vars below are populated in Vercel, conversion firing is a silent
+no-op — safe to deploy unset.
+
+## The three env vars
+
+| Env var | Holds | Used by |
+|---|---|---|
+| `NEXT_PUBLIC_GOOGLE_ADS_ID` | The account-level tag id, format `AW-XXXXXXXXX` | `src/components/GoogleAdsTag.tsx` (loads gtag.js) |
+| `NEXT_PUBLIC_GADS_QUOTE_CONVERSION_ID` | Full conversion label for the Quote Lead action, format `AW-XXXXXXXXX/abc123def456` | `src/app/wedding-drink-calculator/sections/QuoteFormSection.tsx` |
+| `NEXT_PUBLIC_GADS_PURCHASE_CONVERSION_ID` | Full conversion label for the Invoice Purchase action, format `AW-XXXXXXXXX/abc123def456` | `src/app/checkout/success/page.tsx` |
+
+**Important**: the conversion-id env vars must hold the FULL label
+(`AW-XXXXXXXXX/abc123def456`), not just the suffix after the slash.
+That's the value you paste into `send_to` on `gtag('event', 'conversion', ...)`.
+
+## Conversion actions to create in Google Ads
+
+In Google Ads UI: **Tools & Settings → Measurement → Conversions → + New conversion action → Website**.
+
+Create these three actions. For each, capture the resulting "Conversion ID + label" pair
+(under "Tag setup → Use Google tag → install yourself") — that's the value the env var holds.
+
+### 1. Quote Lead
+
+- **Conversion name**: `Wedding Bar Quote Submitted`
+- **Category**: Submit lead form
+- **Value**: Don't use a value for this conversion action (we send `value: 0` from code)
+- **Count**: One (one conversion per click — quote forms aren't a repeat action)
+- **Click-through conversion window**: 30 days
+- **Attribution model**: Data-driven (fall back to Last click if traffic is too low)
+- **Includes "Conversions" column**: Yes (Smart Bidding will optimize toward this)
+
+Once created, paste `NEXT_PUBLIC_GADS_QUOTE_CONVERSION_ID=AW-XXXXXXXXX/quote-label-here` into Vercel.
+
+### 2. Invoice Purchase
+
+- **Conversion name**: `Invoice Purchase (Stripe)`
+- **Category**: Purchase
+- **Value**: Use different values for each conversion (code passes the `value` from the Stripe session amount)
+- **Count**: Every (purchases can repeat)
+- **Click-through conversion window**: 30 days
+- **Attribution model**: Data-driven
+- **Includes "Conversions" column**: Yes
+- **Enhanced conversions**: Recommended once live — code already passes `transaction_id` for dedup
+
+Once created, paste `NEXT_PUBLIC_GADS_PURCHASE_CONVERSION_ID=AW-XXXXXXXXX/purchase-label-here` into Vercel.
+
+### 3. Phone Call
+
+- **Conversion name**: `Wedding Calculator Phone Call`
+- **Category**: Phone call lead
+- **Method**: Calls from ads using call extensions (set up via Google's "Call from ads" — no code change needed)
+- **Minimum call length**: 60 seconds (filters out misdials)
+- **Count**: One
+
+No env var for this one — Google Ads tracks call-extension conversions natively.
+It's listed here so the operator remembers to enable it in the same setup pass.
+
+## GA4 ↔ Google Ads link (redundancy)
+
+In parallel with the direct conversion firing above, link the GA4 property to
+Google Ads (**Google Ads UI → Tools & Settings → Linked accounts → Google Analytics (GA4)**).
+That gives Google Ads access to GA4-defined `generate_lead` and `purchase`
+events as importable conversions. If the direct `gtag('event', 'conversion')`
+calls ever drift or block, the GA4 import keeps Smart Bidding fed.
+
+Set the direct-fired action as **primary** and the GA4-imported version as
+**secondary** for the same conversion category, so they don't double-count.
+
+## Verifying it works
+
+1. Once env vars are set in Vercel and a build is deployed, open the
+   calculator page in Chrome with the [Google Tag Assistant](https://tagassistant.google.com/)
+   extension. Confirm gtag.js loads with the `AW-` id.
+2. Submit a test quote. Tag Assistant should show a `conversion` hit
+   with `send_to` matching `NEXT_PUBLIC_GADS_QUOTE_CONVERSION_ID`.
+3. Run a Stripe test checkout and land on `/checkout/success`. Tag Assistant
+   should show a second `conversion` hit with the purchase id and `value`.
+4. In Google Ads UI, the conversion action status will flip from
+   "No recent conversions" to "Recording conversions" within ~3 hours of the first fire.
+
+## References
+
+- [Set up conversion tracking for your website](https://support.google.com/google-ads/answer/6095821)
+- [Use the Google tag for conversion tracking](https://support.google.com/google-ads/answer/12002338)
+- [Link Google Analytics 4 to Google Ads](https://support.google.com/google-ads/answer/9379420)
+- [Enhanced conversions for web](https://support.google.com/google-ads/answer/9888656)

--- a/docs/wedding-calculator-upgrade-spec.md
+++ b/docs/wedding-calculator-upgrade-spec.md
@@ -1,0 +1,276 @@
+# Wedding Drink Calculator — Wes + Hormozi Upgrade Spec (Phase B)
+
+_Last updated: 2026-05-24. Source: Wes + Hormozi audit deliverable (agent transcript `a8064e71a595bdae7`), plan file `/Users/allan/.claude/plans/actually-the-pages-i-distributed-swan.md`._
+
+## Why this exists
+
+The `/wedding-drink-calculator` page is the first Google Ads landing target for Party On Delivery. It has proven organic demand (~400 clicks/mo at avg position ~14) but was built for SEO, not for ad conversion. The audit scored it 3/14 on the Wes McDowell 16-checklist and 8/20 on Hormozi's Value Equation. **Recommendation was UPGRADE, not REBUILD** — the calculator mechanics, FAQ, and Schema.org structured data are all solid; the conversion layers around them are missing.
+
+This doc is the consolidated implementation spec — audit findings + operator decisions, ready to execute in a fresh session.
+
+## Operator decisions (locked 2026-05-24)
+
+| Question | Decision |
+|---|---|
+| Guarantee copy | "If we're late, we'll refund your delivery fee. No questions asked." (delivery-fee refund — lower exposure than free setup) |
+| Hero image | `/images/services/weddings/outdoor-bar-setup.webp` (distinct from wedding-weekend page) |
+| Sample packages | 3 reception-bar tiers by guest count: 50 / 100 / 150 (middle featured = 100-guest "MOST BOOKED"). New static recipes, not the weekend-oriented packages from `wedding.ts`. |
+| Primary CTA strategy | Single quote form (Wes "one conversion goal"). REPLACES both existing CTAs ("Start Wedding Order" + "Wedding Services"). Quote form POSTs to existing `/api/v1/landing/quote` endpoint with `occasion='wedding'`. |
+| Cross-link | New page should link to `/austin-wedding-weekend-delivery` from a small "Need the full weekend coordinator?" callout near the sample packages section. |
+
+## Critical files
+
+**Read these first:**
+- `/Users/allan/.claude/plans/actually-the-pages-i-distributed-swan.md` — the approved plan
+- `src/app/landing-page-playbook/content.ts` — Wes principles (sections 1 + 7 are the rubric)
+- `src/app/wedding-drink-calculator/page.tsx` — current state (227 lines, server component)
+- `src/app/wedding-drink-calculator/CalculatorClient.tsx` — interactive calculator (client component)
+- `src/components/landing/configs/wedding.ts` — for reviews data + theme colors
+- `src/components/landing/LandingPageTemplate.tsx` — source for component extraction
+- `src/components/landing/QuickBuyModal.tsx` (792 lines) — modal pattern reference
+- `src/app/api/v1/landing/quote/route.ts` — quote-submission endpoint (no changes needed, calculator just POSTs to this)
+- `docs/AD-CAMPAIGN-UTM-CONVENTION.md` — UTM tagging the page must support
+- `2026-05-14-ad-creatives-and-pinterest.md` (Obsidian vault) — Campaign 4 wedding ad copy for message-match
+
+**Files to modify:**
+- `src/app/wedding-drink-calculator/page.tsx` — major restructure (see Page structure below)
+- `src/app/wedding-drink-calculator/CalculatorClient.tsx` — surface calculator state to parent OR hook into quote form
+- `src/components/landing/sections/` — NEW directory for extracted Wes section components (see Component Extraction below)
+
+**Files NOT to modify (compliance fixes already shipped):**
+- The 21+/TABC compliance badge strip is already added to the calculator hero (lines 117–138 after the subhead). Don't remove it.
+- `LandingPageTemplate.tsx` line 672 already has the `/tabc` Link. Don't remove it.
+- `heroTrustBadges` arrays on bachelor/bachelorette/corporate configs are now populated. Don't reset to `[]`.
+- All 4 Wes configs have `quoteInbox: 'info@partyondelivery.com'`. Don't revert.
+
+## Component extraction (per audit recommendation)
+
+Extract 3 reusable section components from `LandingPageTemplate.tsx` into a new directory `src/components/landing/sections/`:
+
+1. **`PainSolutionSection.tsx`** — accepts `{ headline, body, theme }` props. Source: `LandingPageTemplate.tsx` lines ~370–415 (the pain section).
+2. **`PackageCardGrid.tsx`** — accepts `{ packages: Package[], theme, onCardClick? }` props. Source: lines ~417–550 (the packages grid). Should support a `featured: true` package being scaled 1.03× and bordered in brand color.
+3. **`ReviewsSection.tsx`** — accepts `{ reviews: Review[], theme, eyebrow?, headline? }` props. Source: lines ~570–620 (the social proof section).
+
+Do NOT extract the hero or modal — too much config coupling.
+
+After extraction:
+- `LandingPageTemplate.tsx` should import and render these instead of inlining the markup
+- The calculator page imports them directly without instantiating the full template
+
+Pre-flight: run `npx tsc --noEmit` + `npx next lint` after extraction, before adding new content to the calculator. The extraction should be a no-op visually for the 4 Wes pages.
+
+## Page structure after upgrade
+
+Section order top → bottom:
+
+### A. Hero (replaces lines 107–139, keeps the 21+ compliance strip at lines 117–138)
+
+Add a full-bleed hero image section following the standard pattern from `CLAUDE.md`: `h-[60vh] md:h-[70vh] mt-24`. Background image: `/images/services/weddings/outdoor-bar-setup.webp`.
+
+Proposed copy (message-matched to Campaign 4):
+- **Eyebrow**: `AUSTIN WEDDING BAR DELIVERY`
+- **H1 (two lines)**: "Your Wedding Bar." / "Calculated. Delivered. Done." (second line in champagne gold `#C8A96A`)
+- **Subhead**: "Plug in your guest count. Get exact quantities for beer, wine, spirits, and bubbly. Then let Austin's wedding alcohol delivery team handle the rest."
+- **Primary CTA**: "Get My Wedding Bar Quote →" — scrolls to the calculator section (or to the quote form below results)
+
+KEEP the 4-badge compliance strip already in place under the subhead. Move it from the gray-gradient hero into the new full-bleed hero (overlay on the image with semi-transparent background).
+
+### B. Calculator tool — keep `CalculatorClient` exactly as-is
+
+The calculator mechanics are not the problem. The `<CalculatorClient />` component stays put. If the calculator's result state needs to feed the quote form (Section I), pass a callback down (`onResultsComputed: (state) => void`).
+
+### C. Pain → Solution (new section, between calculator and "How the math works")
+
+Use the extracted `<PainSolutionSection>` component.
+
+- **Headline**: "The Costco run is not your wedding-day job."
+- **Body**: "You're planning a wedding, not managing a liquor inventory. Give us your guest count — we've already done the math. Beer, wine, spirits, champagne for the toast, ice, mixers. Delivered cold to your venue. Reviewed with you before delivery so nothing's missing."
+
+### D. 3 Sample Reception Bar Packages (new section, after Pain)
+
+Use the extracted `<PackageCardGrid>` component with 3 hardcoded reception-bar packages:
+
+```ts
+const RECEPTION_PACKAGES: Package[] = [
+  {
+    name: 'Intimate Reception',
+    serves: 'Reception bar for 50 guests',
+    price: '$899',
+    save: 'Save $80 in supplies',
+    blurb: 'A clean bar for backyard, Hill Country, or boutique-venue weddings.',
+    items: [
+      'House red + white wine (×6 bottles)',
+      'Veuve Clicquot for the toast (×3 bottles)',
+      'Beer + seltzer variety case',
+      'Premium spirits well kit (vodka, tequila, whiskey)',
+      'Mixers, ice, citrus, garnishes',
+      'Cups, napkins, opener — included free ($80 value)',
+    ],
+    image: '/images/services/weddings/boho-hill-country-2.webp',
+    featured: false,
+  },
+  {
+    name: 'Reception Bar Standard',
+    serves: 'Reception bar for 100 guests',
+    price: '$1,799',
+    save: 'Save $140 in supplies',
+    blurb: 'The most-booked package — full bar for a 100-guest reception, no upcharge.',
+    items: [
+      'Curated red + white wine (×12 bottles)',
+      'Champagne toast for the room (×6 bottles)',
+      'Beer + seltzer variety (3 cases)',
+      'Premium spirits (vodka, tequila, whiskey, gin)',
+      'Signature cocktail kit (your pick)',
+      'Mixers, ice, citrus, garnishes',
+      'Glassware-grade cups + bar tools ($140 value, bundled free)',
+    ],
+    image: '/images/services/weddings/outdoor-bar-setup-travis.webp',
+    featured: true,  // MIDDLE FEATURED — Wes pattern
+  },
+  {
+    name: 'Full Reception + Toast',
+    serves: 'Reception bar for 150 guests',
+    price: '$2,499',
+    save: 'Save $200 in supplies',
+    blurb: 'For larger receptions — premium pour, sommelier-curated wines, full toast.',
+    items: [
+      'Sommelier-curated red + white wine (×18 bottles)',
+      'Champagne toast service (×9 bottles)',
+      'Beer + seltzer variety (4 cases)',
+      'Premium spirits across 5 categories',
+      'Signature cocktail kits (×2)',
+      'Mixers, ice, citrus, garnishes, fresh herbs',
+      'Premium bar setup ($200 value, bundled free)',
+    ],
+    image: '/images/services/weddings/signature-cocktails-closeup.webp',
+    featured: false,
+  },
+];
+```
+
+Add a small cross-link CTA below the package grid: "Need full-weekend coordination (welcome reception → ceremony → after-party)? → Build your weekend at /austin-wedding-weekend-delivery"
+
+**Compliance note**: All prices and "Save $X" values are placeholders for Allan to confirm before deploy. Match real margins from `getOccasionPackages('wedding')` if needed.
+
+### E. Hormozi Guarantee Row (new, between packages and reviews)
+
+A single centered callout block:
+
+> **If we're late, we'll refund your delivery fee. No questions asked.**
+> Call or text **(737) 371-9700** the day of your wedding if anything's off — we'll make it right.
+
+Style as a brand-blue strip with white text + the brand-yellow trust badge feel. Single line emphasized, second line smaller.
+
+### F. Named Reviews (new section, after guarantee)
+
+Use the extracted `<ReviewsSection>` component. Source data: `src/components/landing/configs/wedding.ts` `reviews` array. Should render:
+- Caroline H. — Wedding Planner, Austin
+- Megan & Tom S. — Hill Country wedding
+- Jules R. — MOH + planner liaison
+
+These are already in `weddingConfig.reviews` — import and pass through.
+
+### G. "How the math works" — keep existing section (lines 126–184)
+
+Don't touch. Good SEO content. Moves down the page but stays.
+
+### H. FAQ — keep existing 5 + add 2 (lines 186–203)
+
+Add to FAQS array:
+- Question: "Can I return bottles we didn't open?" / Answer: "Yes — we can take back unopened cases for a partial refund (depending on volume) or leave everything with you. Your call. Decision made at delivery."
+- Question: "Do you set up the bar or just deliver?" / Answer: "Both options. Standard delivery drops everything at your venue. White-glove setup includes ice, bar tools, glassware, garnish prep, and a coordinator handoff with your venue staff. Add white-glove on the quote form."
+
+Update the `HOW_TO_SCHEMA` and `FAQS` exports to include the new questions.
+
+### I. Quote Form — REPLACES the existing final CTA section (lines 204–222)
+
+New section, 3-field form (4 fields if delivery date is required by Stripe — see existing endpoint validation):
+- Name (required)
+- Email (required)
+- Phone (recommended — used for delivery-day reach)
+- Hidden: guestCount (auto-populated from calculator state)
+- Hidden: occasion = 'wedding'
+- Hidden: items array (auto-populated from calculator output — converted to product handles)
+- Hidden: deliveryDate (default to 30 days out, user can change on the invoice page)
+
+Submit handler:
+```ts
+const response = await fetch('/api/v1/landing/quote', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    mode: 'quote',
+    occasion: 'wedding',
+    customerName: formName,
+    customerEmail: formEmail,
+    customerPhone: formPhone,
+    groupSize: calculatorGuestCount,
+    deliveryDate: defaultDeliveryDate.toISOString().slice(0, 10),
+    items: calculatorOutputItems, // [{ handle, qty }, ...]
+  }),
+});
+```
+
+On success: show "Quote sent! Check your inbox for the editable invoice." + redirect to `invoiceUrl` from response. On error: show error message + phone number to call.
+
+Primary CTA button: "Get My Wedding Bar Quote →"
+
+**Important**: the calculator currently outputs quantities by category (beer, wine, spirits, seltzer), NOT by product handle. The CalculatorClient may need a small extension to map computed quantities → product handles. Use `getCuratedCatalog().productById` or a hard-coded recommendation table. If this is complex, ship Phase B with the form posting just `groupSize` + `customerNotes` (= calculator JSON summary) and let admin manually fill the items in the draft order. Document this as a follow-up.
+
+### J. Mobile sticky CTA (new, `md:hidden`)
+
+Match the pattern at `LandingPageTemplate.tsx` lines 681–699. Single button: "Get My Wedding Bar Quote →" — scrolls to the quote form section.
+
+### K. Schema.org JSON-LD — KEEP
+
+Both `FAQPage` and `HowTo` schemas at lines 93–105 stay verbatim. Update `FAQS` for the schema generator after adding the 2 new FAQs in section H.
+
+## Verification before merging
+
+```bash
+npx tsc --noEmit  # no new type errors
+npx next lint     # no new lint errors
+npm run test:run  # no broken tests
+```
+
+Then locally (`npm run dev`):
+1. Visit `/wedding-drink-calculator` on desktop. Verify:
+   - New hero with eyebrow + 2-line headline + outdoor-bar-setup.webp image
+   - 21+ compliance strip still visible
+   - Calculator works (enter 100 guests, 5 hours — expect ~600 drinks total)
+   - 3 packages render with middle featured
+   - Named reviews show Caroline H., Megan & Tom S., Jules R.
+   - Guarantee row visible
+   - Quote form below results
+   - "How the math works" + FAQ still present (now with 7 FAQs not 5)
+   - TABC link in footer
+2. Submit a test quote with mode=quote. Confirm:
+   - Invoice email received at the form's email address
+   - `Order.landingPage = '/wedding-drink-calculator'`
+   - `Order.utmCampaign = 'wedding-bar-delivery'` (set test URL with UTMs first)
+   - `Order.segment = 'wedding'`
+3. Test on mobile viewport (`<768px`): hero loads, sticky CTA appears, quote form usable
+4. Run Lighthouse on the page — Performance score should not drop more than 5 points from current baseline. Document baseline first (current LCP/CLS) before changes.
+5. Monitor GSC for 7 days post-deploy — position for "wedding drink calculator" should not drop more than 2 positions. If it does, the calculator may have moved too far down the page.
+
+## Out of scope (Phase 2+)
+
+- Bachelor/bachelorette/corporate page upgrades (they were 12–13/15 already — small polish only)
+- Component-level Hormozi additions to Wes pages (urgency badges on package cards)
+- The `📞`/`💬` emoji replacement in `LandingPageTemplate.tsx` (CLAUDE.md violation but not blocking)
+- The "Austin Bach Babes" review attribution fix on bachelorette.ts (needs operator to source real name)
+- Splitting `'bach'` segment into separate bachelor/bachelorette labels (medium refactor — defer until campaign-level reporting needs it)
+
+## When Phase B is done
+
+Move to Phase C (Google Ads campaign build). See plan file for spec.
+
+## Phase B follow-up: ops admin UI shows deliveryNotes?
+
+**Resolved 2026-05-26**: no action needed. The DraftOrders table in ops
+links each row directly to `/ops/orders/[id]/edit`, which already renders
+`deliveryNotes` as a textarea (line 1304). When an operator opens a
+landing-quote draft order, the calculator summary is visible in the Notes
+field. Post-payment Order detail page doesn't display deliveryNotes, but
+by that stage the operator has already converted the draft, so the
+summary's window of relevance has closed.

--- a/src/app/checkout/success/page.tsx
+++ b/src/app/checkout/success/page.tsx
@@ -113,6 +113,17 @@ function CheckoutSuccessContent() {
               currency: data.data.currency?.toUpperCase() || 'USD',
               content_name: 'Stripe Order',
             });
+            if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
+              const conversionId = process.env.NEXT_PUBLIC_GADS_PURCHASE_CONVERSION_ID;
+              if (conversionId) {
+                window.gtag('event', 'conversion', {
+                  send_to: conversionId,
+                  value: amount,
+                  currency: data.data.currency?.toUpperCase() || 'USD',
+                  transaction_id: sessionId,
+                });
+              }
+            }
           }
         } catch (error) {
           console.error('Failed to fetch session:', error);
@@ -137,6 +148,17 @@ function CheckoutSuccessContent() {
         currency: 'USD',
         content_name: orderName || order || 'Order',
       });
+      if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
+        const conversionId = process.env.NEXT_PUBLIC_GADS_PURCHASE_CONVERSION_ID;
+        if (conversionId) {
+          window.gtag('event', 'conversion', {
+            send_to: conversionId,
+            value: orderTotal ? parseFloat(orderTotal) : 0,
+            currency: 'USD',
+            transaction_id: orderName || order || 'Unknown',
+          });
+        }
+      }
     }
 
     if (isAuthenticated) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { CustomerProvider } from "@/contexts/CustomerContext";
 import ClientLayoutWrapper from "@/components/ClientLayoutWrapper";
 import { structuredData } from "./structured-data";
 import GoogleAnalytics from "@/components/GoogleAnalytics";
+import GoogleAdsTag from "@/components/GoogleAdsTag";
 import MetaPixel from "@/components/MetaPixel";
 import ClarityInit from "@/components/ClarityInit";
 import AttributionTracker from "@/components/AttributionTracker";
@@ -118,6 +119,7 @@ export default function RootLayout({
         <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
 
         <GoogleAnalytics />
+        <GoogleAdsTag />
         <MetaPixel />
         <AttributionTracker />
         <script

--- a/src/app/wedding-drink-calculator/CalculatorClient.tsx
+++ b/src/app/wedding-drink-calculator/CalculatorClient.tsx
@@ -1,9 +1,15 @@
 'use client';
 
-import { useMemo, useState, type ReactElement } from 'react';
+import { useEffect, useMemo, useState, type ReactElement } from 'react';
 import type { DrinkCategory } from '@/lib/drinkPlannerTypes';
 import { calculateWeddingPlan, type WeddingPlan } from '@/lib/weddingDrinkCalculator';
 import CalculatorResults from './CalculatorResults';
+
+type Props = {
+  /** Fires whenever the computed plan changes — used by the quote-form section
+      below the calculator to populate hidden items + guest count. */
+  onResultsComputed?: (plan: WeddingPlan) => void;
+};
 
 const CATEGORY_OPTIONS: { id: DrinkCategory; label: string; hint: string }[] = [
   { id: 'beer', label: 'Beer', hint: 'Domestic + craft mix' },
@@ -21,7 +27,7 @@ const QUICK_HOUR_VALUES = [3, 4, 5, 6];
  * Interactive wedding drink calculator. Wraps `calculateWeddingPlan` and
  * renders inline results as the user adjusts inputs.
  */
-export default function CalculatorClient(): ReactElement {
+export default function CalculatorClient({ onResultsComputed }: Props = {}): ReactElement {
   const [guests, setGuests] = useState(100);
   const [hours, setHours] = useState(5);
   const [categories, setCategories] = useState<DrinkCategory[]>(['beer', 'wine', 'spirits']);
@@ -30,6 +36,10 @@ export default function CalculatorClient(): ReactElement {
     () => calculateWeddingPlan({ guests, hours, categories }),
     [guests, hours, categories],
   );
+
+  useEffect(() => {
+    onResultsComputed?.(plan);
+  }, [plan, onResultsComputed]);
 
   const toggleCategory = (cat: DrinkCategory) => {
     setCategories((prev) => (prev.includes(cat) ? prev.filter((c) => c !== cat) : [...prev, cat]));

--- a/src/app/wedding-drink-calculator/CalculatorPageBody.tsx
+++ b/src/app/wedding-drink-calculator/CalculatorPageBody.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import Link from 'next/link';
+import { useState, type ReactElement } from 'react';
+import type { WeddingPlan } from '@/lib/weddingDrinkCalculator';
+import { trackCTAClick } from '@/lib/analytics/ga4-events';
+import PackageCardGrid from '@/components/landing/sections/PackageCardGrid';
+import ReviewsSection from '@/components/landing/sections/ReviewsSection';
+import { weddingConfig } from '@/components/landing/configs/wedding';
+import CalculatorClient from './CalculatorClient';
+import CalculatorHero from './sections/CalculatorHero';
+import WhyYouNeedUs from './sections/WhyYouNeedUs';
+import GuaranteeRow from './sections/GuaranteeRow';
+import HowMathWorks from './sections/HowMathWorks';
+import QuoteFormSection from './sections/QuoteFormSection';
+import MobileStickyCta from './sections/MobileStickyCta';
+import { RECEPTION_PACKAGES, WEDDING_THEME } from './sections/receptionPackages';
+import type { Faq } from '@/components/landing/types';
+
+type Props = {
+  faqs: Faq[];
+};
+
+/**
+ * Top-level interactive body for /wedding-drink-calculator. Owns the
+ * calculator-plan state so the quote form section near the bottom of the
+ * page can populate hidden item handles + guest count when the visitor
+ * submits.
+ */
+export default function CalculatorPageBody({ faqs }: Props): ReactElement {
+  const [plan, setPlan] = useState<WeddingPlan | null>(null);
+
+  const scrollToQuoteForm = () => {
+    trackCTAClick(
+      'Get My Wedding Bar Quote',
+      '#quote-form',
+      'wedding_calc_package',
+    );
+    const el = document.getElementById('quote-form');
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  return (
+    <>
+      <CalculatorHero />
+
+      {/* B. Calculator tool — unchanged mechanics, plus result-state callback */}
+      <section id="calculator" className="bg-white py-12">
+        <div className="container-custom max-w-5xl">
+          <CalculatorClient onResultsComputed={setPlan} />
+        </div>
+      </section>
+
+      {/* C. Why you need us — three facts couples don't realize + refund promise */}
+      <WhyYouNeedUs />
+
+      {/* D. 3 Sample Reception Bar Packages */}
+      <PackageCardGrid
+        packages={RECEPTION_PACKAGES}
+        theme={WEDDING_THEME}
+        eyebrow="SAMPLE RECEPTION BAR PACKAGES · 100 GUESTS"
+        headline="Three tiers. Same 100-guest reception. Pick your level."
+        blurb="Same crowd, three price points — so you can compare apples to apples. Final quote scales to your actual guest count + bar style."
+        primaryCtaLabel="Get My Wedding Bar Quote →"
+        onPrimaryCta={scrollToQuoteForm}
+        footer={
+          <div className="text-center mt-12">
+            <p className="text-base text-gray-600 mb-3">
+              Need full-weekend coordination (welcome reception → ceremony → after-party)?
+            </p>
+            <Link
+              href="/austin-wedding-weekend-delivery"
+              className="inline-flex items-center font-semibold text-brand-blue hover:underline"
+            >
+              Build your weekend at /austin-wedding-weekend-delivery →
+            </Link>
+          </div>
+        }
+      />
+
+      {/* E. Hormozi Guarantee Row */}
+      <GuaranteeRow />
+
+      {/* F. Named Reviews */}
+      <ReviewsSection
+        reviews={weddingConfig.reviews}
+        theme={WEDDING_THEME}
+        eyebrow="★★★★★ 5.0 ON GOOGLE"
+        headline="The vendor every Austin wedding planner books first."
+      />
+
+      {/* G. How the math works — kept verbatim for SEO */}
+      <HowMathWorks />
+
+      {/* H. FAQ — 5 original + 2 new */}
+      <section className="bg-white section-padding">
+        <div className="container-custom max-w-4xl">
+          <h2 className="font-heading text-3xl md:text-4xl tracking-[0.1em] text-gray-900 mb-6">
+            Frequently asked questions
+          </h2>
+          <div className="space-y-6">
+            {faqs.map((f) => (
+              <div key={f.q} className="card">
+                <h3 className="font-heading text-lg font-bold tracking-[0.08em] text-gray-900 mb-2">
+                  {f.q}
+                </h3>
+                <p className="text-base text-gray-700 leading-relaxed">{f.a}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* I. Quote Form — single conversion goal */}
+      <QuoteFormSection plan={plan} />
+
+      {/* J. Mobile sticky CTA */}
+      <MobileStickyCta />
+    </>
+  );
+}

--- a/src/app/wedding-drink-calculator/page.tsx
+++ b/src/app/wedding-drink-calculator/page.tsx
@@ -1,18 +1,17 @@
 import type { Metadata } from 'next';
 import type { ReactElement } from 'react';
-import Link from 'next/link';
 import { generateFAQSchema } from '@/lib/seo/schemas';
 import Navigation from '@/components/Navigation';
 import Footer from '@/components/Footer';
-import CalculatorClient from './CalculatorClient';
+import CalculatorPageBody from './CalculatorPageBody';
 
 /**
  * Public-facing Wedding Drink Calculator route.
  * Target keyword: "wedding drink calculator" (vol 1,900, KD 8).
  *
  * Server component for SEO metadata + structured data. The interactive
- * calculator is a client component (CalculatorClient.tsx) that reuses
- * src/lib/weddingDrinkCalculator.ts.
+ * calculator, quote form, and Wes/Hormozi sections live in
+ * CalculatorPageBody (client) which shares state between them.
  */
 
 export const metadata: Metadata = {
@@ -33,29 +32,39 @@ export const metadata: Metadata = {
 
 const FAQS = [
   {
-    question: 'How much alcohol do I need for my wedding?',
-    answer:
+    q: 'How much alcohol do I need for my wedding?',
+    a:
       'A common rule for receptions of 3+ hours is guest count multiplied by hours plus one. A 100-guest, 5-hour reception works out to about 600 drinks. The calculator above applies that formula and splits the result across beer, wine, and spirits based on your bar style.',
   },
   {
-    question: 'How do I count guests who don\'t drink alcohol?',
-    answer:
+    q: 'How do I count guests who don\'t drink alcohol?',
+    a:
       'Subtract non-drinkers from your guest count before entering the number, then add a few non-alcoholic options separately. We typically suggest adding water, soda, or mocktail kits — those aren\'t in the calculator output but should be on your shopping list.',
   },
   {
-    question: 'What if my reception runs longer than expected?',
-    answer:
+    q: 'What if my reception runs longer than expected?',
+    a:
       'Add an hour of buffer to the input. Wedding bars often slow down after dinner, but late-night guests will keep drinking. It\'s safer to round up than to run out.',
   },
   {
-    question: 'Does this account for signature cocktails?',
-    answer:
+    q: 'Does this account for signature cocktails?',
+    a:
       'Yes — select "Cocktail Kits" as one of the categories. The calculator reduces the spirits share and adds 3 cocktail kits sized for your crowd. Each kit serves about 16 drinks.',
   },
   {
-    question: 'Can you deliver this order in Austin?',
-    answer:
-      'Yes. Party On Delivery handles alcohol delivery for weddings across the Austin area. Use the order link in the result panel to start a wedding-tagged order — we\'ll review the list with you before delivery.',
+    q: 'Can you deliver this order in Austin?',
+    a:
+      'Yes. Party On Delivery handles alcohol delivery for weddings across the Austin area. Use the quote form below the calculator to start a wedding-tagged order — we\'ll review the list with you before delivery.',
+  },
+  {
+    q: 'Can I return bottles we didn\'t open?',
+    a:
+      'Yes — we can take back unopened cases for a partial refund (depending on volume) or leave everything with you. Your call. Decision made at delivery.',
+  },
+  {
+    q: 'Do you set up the bar or just deliver?',
+    a:
+      'Both options. Standard delivery drops everything at your venue, on time and cold. We can also coordinate timing and handoff with your bartender or venue staff so the run-of-show stays clean — just note what level of support you need on the quote form.',
   },
 ];
 
@@ -90,7 +99,9 @@ const HOW_TO_SCHEMA = {
 };
 
 export default function WeddingDrinkCalculatorPage(): ReactElement {
-  const faqSchema = generateFAQSchema(FAQS);
+  const faqSchema = generateFAQSchema(
+    FAQS.map((f) => ({ question: f.q, answer: f.a })),
+  );
   return (
     <>
       <Navigation />
@@ -104,122 +115,7 @@ export default function WeddingDrinkCalculatorPage(): ReactElement {
           dangerouslySetInnerHTML={{ __html: JSON.stringify(HOW_TO_SCHEMA) }}
         />
 
-        <section className="relative bg-gradient-to-b from-gray-50 to-white mt-24 pt-12 pb-8">
-          <div className="container-custom max-w-5xl">
-            <h1 className="font-heading text-4xl md:text-5xl lg:text-6xl tracking-[0.1em] text-gray-900 text-center">
-              Wedding Drink Calculator
-            </h1>
-            <p className="mt-4 text-base md:text-lg text-gray-700 text-center max-w-3xl mx-auto">
-              How much alcohol for your Austin wedding? Enter guest count and reception
-              hours below — we’ll size beer, wine, spirits, and seltzers for you.
-              Built by Austin’s wedding alcohol delivery team.
-            </p>
-          </div>
-        </section>
-
-        <section className="bg-white py-8">
-          <div className="container-custom max-w-5xl">
-            <CalculatorClient />
-          </div>
-        </section>
-
-        <section className="bg-gray-50 section-padding">
-          <div className="container-custom max-w-4xl">
-            <h2 className="font-heading text-3xl md:text-4xl tracking-[0.1em] text-gray-900 mb-6">
-              How the math works
-            </h2>
-            <div className="prose prose-gray max-w-none text-base md:text-lg leading-relaxed">
-              <p>
-                For wedding receptions of 3 hours or more, a reliable starting point is{' '}
-                <strong>guests &times; (hours + 1)</strong>. The +1 covers the cocktail
-                hour spike at the front of the night, when most guests pick up their first
-                two drinks fast. A 100-guest, 5-hour reception comes out to around 600
-                drinks total.
-              </p>
-              <p>
-                From there we split the total roughly: <strong>spirits 50%</strong>,{' '}
-                <strong>beer 30%</strong>, <strong>wine 15%</strong>,{' '}
-                <strong>seltzers 5%</strong>. If you add cocktail kits, the spirits share
-                drops and the kits absorb part of the mix. Wedding bars tilt heavier
-                toward mixed drinks than house parties; the calculator reflects that.
-              </p>
-              <h3 className="font-heading text-2xl tracking-[0.08em] mt-8 mb-3">
-                Three common mistakes
-              </h3>
-              <ol>
-                <li>
-                  <strong>Counting kids and non-drinkers as drinkers.</strong> Subtract
-                  guests under 21 plus anyone you know doesn’t drink before entering
-                  the number. Easy way to over-order by 15-20%.
-                </li>
-                <li>
-                  <strong>Forgetting late arrivals.</strong> Out-of-town guests often
-                  arrive after the ceremony. Round hours up if you’re close to the
-                  limit; running out at 10pm is much worse than 6 unopened bottles.
-                </li>
-                <li>
-                  <strong>Skipping the ice and water.</strong> One bag of ice per 10
-                  guests is included in the result panel below. Add bottled water on the
-                  shopping list separately — it isn’t alcohol, but every wedding
-                  needs it.
-                </li>
-              </ol>
-              <h3 className="font-heading text-2xl tracking-[0.08em] mt-8 mb-3">
-                Austin-specific notes
-              </h3>
-              <p>
-                Party On Delivery is a TABC-licensed alcohol delivery company serving the
-                Austin area. We deliver to wedding venues across Lake Travis, downtown
-                Austin, Hill Country, South Austin, and the Westlake area. For deliveries
-                outside Austin city limits, lead time is usually 48 hours. We’ll
-                review your shopping list with you before delivery and answer questions
-                about quantity, brand swaps, or substitutions.
-              </p>
-              <p>
-                Wedding party order minimums and delivery windows are set per zone —
-                check the order page for specifics.
-              </p>
-            </div>
-          </div>
-        </section>
-
-        <section className="bg-white section-padding">
-          <div className="container-custom max-w-4xl">
-            <h2 className="font-heading text-3xl md:text-4xl tracking-[0.1em] text-gray-900 mb-6">
-              Frequently asked questions
-            </h2>
-            <div className="space-y-6">
-              {FAQS.map((f) => (
-                <div key={f.question} className="card">
-                  <h3 className="font-heading text-lg font-bold tracking-[0.08em] text-gray-900 mb-2">
-                    {f.question}
-                  </h3>
-                  <p className="text-base text-gray-700 leading-relaxed">{f.answer}</p>
-                </div>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        <section className="bg-gray-50 section-padding">
-          <div className="container-custom max-w-4xl text-center">
-            <h2 className="font-heading text-3xl md:text-4xl tracking-[0.1em] text-gray-900 mb-4">
-              Ready to order your wedding bar?
-            </h2>
-            <p className="text-base md:text-lg text-gray-700 mb-8 max-w-2xl mx-auto">
-              Take the result above and place a wedding-tagged order. We’ll review
-              the list with you before delivery.
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link href="/order?type=wedding" className="btn-primary inline-flex items-center justify-center">
-                Start Wedding Order
-              </Link>
-              <Link href="/weddings" className="btn-secondary inline-flex items-center justify-center">
-                Wedding Services
-              </Link>
-            </div>
-          </div>
-        </section>
+        <CalculatorPageBody faqs={FAQS} />
       </main>
       <Footer />
     </>

--- a/src/app/wedding-drink-calculator/sections/CalculatorHero.tsx
+++ b/src/app/wedding-drink-calculator/sections/CalculatorHero.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import type { ReactElement } from 'react';
+import { trackCTAClick } from '@/lib/analytics/ga4-events';
+
+/**
+ * Full-bleed hero for /wedding-drink-calculator. Follows the `mt-24 h-[60vh]
+ * md:h-[70vh]` pattern from CLAUDE.md. Keeps the 4-badge TABC/21+ compliance
+ * strip required by Google Ads alcohol policy.
+ */
+export default function CalculatorHero(): ReactElement {
+  const handleHeroCta = () => {
+    trackCTAClick('Show me the calculator', '#calculator', 'wedding_calc_hero');
+  };
+
+  return (
+    <section className="relative h-[60vh] md:h-[70vh] mt-16 flex items-center justify-center overflow-hidden">
+      <Image
+        src="/images/services/weddings/outdoor-bar-setup.webp"
+        alt="Outdoor wedding bar setup at an Austin reception"
+        fill
+        className="object-cover"
+        priority
+        sizes="100vw"
+      />
+      <div className="absolute inset-0 bg-gradient-to-b from-gray-900/65 via-gray-900/45 to-gray-900/65" />
+
+      <div className="relative z-10 text-center text-white max-w-4xl mx-auto px-6">
+        <p className="text-xs sm:text-sm font-semibold tracking-[0.18em] text-[#F2D34F] mb-4">
+          AUSTIN WEDDING BAR DELIVERY
+        </p>
+        <h1 className="font-heading font-bold text-4xl sm:text-5xl md:text-6xl leading-[1.05] tracking-tight mb-5">
+          Your Wedding Bar.
+          <span className="block text-[#C8A96A]">Calculated. Delivered. Done.</span>
+        </h1>
+        <p className="text-base sm:text-lg md:text-xl text-white/90 max-w-2xl mx-auto leading-relaxed mb-7">
+          Plug in your guest count. Get exact quantities for beer, wine, spirits,
+          and bubbly. Then let Austin&apos;s wedding alcohol delivery team handle the rest.
+        </p>
+
+        <a
+          href="#calculator"
+          onClick={handleHeroCta}
+          className="inline-flex items-center justify-center font-bold text-base sm:text-lg px-8 py-4 rounded-lg tracking-wide bg-[#F2D34F] text-gray-900 hover:bg-[#FACC15] transition-colors shadow-xl"
+        >
+          Show Me The Calculator ↓
+        </a>
+
+        {/* Compliance + trust strip — required for Google Ads alcohol policy.
+            Surfaces TABC license and 21+ disclosure above the fold. */}
+        <ul className="mt-8 flex flex-wrap items-center justify-center gap-2 sm:gap-3 text-sm">
+          <li>
+            <Link
+              href="/tabc"
+              className="inline-flex items-center gap-1.5 rounded-full bg-white/15 backdrop-blur px-3 py-1.5 font-semibold text-white hover:bg-white/25 border border-white/25"
+            >
+              ✓ TABC-Licensed Retailer
+            </Link>
+          </li>
+          <li className="inline-flex items-center gap-1.5 rounded-full bg-white/10 backdrop-blur px-3 py-1.5 font-semibold text-white border border-white/20">
+            ✓ Must Be 21+ to Order
+          </li>
+          <li className="inline-flex items-center gap-1.5 rounded-full bg-white/10 backdrop-blur px-3 py-1.5 font-semibold text-white border border-white/20">
+            ★ 5.0 on Google · 98+ reviews
+          </li>
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/src/app/wedding-drink-calculator/sections/GuaranteeRow.tsx
+++ b/src/app/wedding-drink-calculator/sections/GuaranteeRow.tsx
@@ -1,0 +1,32 @@
+import type { ReactElement } from 'react';
+
+/**
+ * Hormozi risk-reversal strip. Deep-espresso band with champagne-gold
+ * headline — matches the wedding palette already established on the page
+ * (no more brand-blue clashing with the gold theme).
+ */
+export default function GuaranteeRow(): ReactElement {
+  return (
+    <section className="py-14" style={{ background: '#2A2218' }}>
+      <div className="max-w-3xl mx-auto px-6 text-center text-white">
+        <p
+          className="font-heading text-2xl md:text-3xl font-bold tracking-[0.05em] mb-3"
+          style={{ color: '#C8A96A' }}
+        >
+          If we&apos;re late, we&apos;ll refund your delivery fee. No questions asked.
+        </p>
+        <p className="text-base md:text-lg text-white/90">
+          Call or text{' '}
+          <a
+            href="tel:7373719700"
+            className="font-bold underline hover:text-[#F2D34F]"
+            style={{ color: '#C8A96A' }}
+          >
+            (737) 371-9700
+          </a>{' '}
+          the day of your wedding if anything&apos;s off — we&apos;ll make it right.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/app/wedding-drink-calculator/sections/HowMathWorks.tsx
+++ b/src/app/wedding-drink-calculator/sections/HowMathWorks.tsx
@@ -1,0 +1,70 @@
+import type { ReactElement } from 'react';
+
+/**
+ * "How the math works" content section. Kept verbatim from the original
+ * server-rendered page — solid SEO content for the long-tail keyword
+ * cluster around "how much alcohol for X guest wedding".
+ */
+export default function HowMathWorks(): ReactElement {
+  return (
+    <section className="bg-gray-50 section-padding">
+      <div className="container-custom max-w-4xl">
+        <h2 className="font-heading text-3xl md:text-4xl tracking-[0.1em] text-gray-900 mb-6">
+          How the math works
+        </h2>
+        <div className="prose prose-gray max-w-none text-base md:text-lg leading-relaxed">
+          <p>
+            For wedding receptions of 3 hours or more, a reliable starting point is{' '}
+            <strong>guests &times; (hours + 1)</strong>. The +1 covers the cocktail
+            hour spike at the front of the night, when most guests pick up their first
+            two drinks fast. A 100-guest, 5-hour reception comes out to around 600
+            drinks total.
+          </p>
+          <p>
+            From there we split the total roughly: <strong>spirits 50%</strong>,{' '}
+            <strong>beer 30%</strong>, <strong>wine 15%</strong>,{' '}
+            <strong>seltzers 5%</strong>. If you add cocktail kits, the spirits share
+            drops and the kits absorb part of the mix. Wedding bars tilt heavier
+            toward mixed drinks than house parties; the calculator reflects that.
+          </p>
+          <h3 className="font-heading text-2xl tracking-[0.08em] mt-8 mb-3">
+            Three common mistakes
+          </h3>
+          <ol>
+            <li>
+              <strong>Counting kids and non-drinkers as drinkers.</strong> Subtract
+              guests under 21 plus anyone you know doesn&apos;t drink before entering
+              the number. Easy way to over-order by 15-20%.
+            </li>
+            <li>
+              <strong>Forgetting late arrivals.</strong> Out-of-town guests often
+              arrive after the ceremony. Round hours up if you&apos;re close to the
+              limit; running out at 10pm is much worse than 6 unopened bottles.
+            </li>
+            <li>
+              <strong>Skipping the ice and water.</strong> One bag of ice per 10
+              guests is included in the result panel below. Add bottled water on the
+              shopping list separately — it isn&apos;t alcohol, but every wedding
+              needs it.
+            </li>
+          </ol>
+          <h3 className="font-heading text-2xl tracking-[0.08em] mt-8 mb-3">
+            Austin-specific notes
+          </h3>
+          <p>
+            Party On Delivery is a TABC-licensed alcohol delivery company serving the
+            Austin area. We deliver to wedding venues across Lake Travis, downtown
+            Austin, Hill Country, South Austin, and the Westlake area. For deliveries
+            outside Austin city limits, lead time is usually 48 hours. We&apos;ll
+            review your shopping list with you before delivery and answer questions
+            about quantity, brand swaps, or substitutions.
+          </p>
+          <p>
+            Wedding party order minimums and delivery windows are set per zone —
+            check the order page for specifics.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/wedding-drink-calculator/sections/MobileStickyCta.tsx
+++ b/src/app/wedding-drink-calculator/sections/MobileStickyCta.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import type { ReactElement } from 'react';
+import { trackCTAClick } from '@/lib/analytics/ga4-events';
+
+/**
+ * Mobile sticky CTA — only shown on <md viewports. Tapping scrolls to the
+ * quote form section. Matches the height/spacing pattern from the Wes
+ * landing template so the spacer below avoids covering trailing content.
+ */
+export default function MobileStickyCta(): ReactElement {
+  const handleClick = () => {
+    trackCTAClick(
+      'Get My Wedding Bar Quote',
+      '#quote-form',
+      'wedding_calc_sticky',
+    );
+    const el = document.getElementById('quote-form');
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  return (
+    <>
+      <div className="md:hidden fixed bottom-0 inset-x-0 z-40 bg-white border-t border-gray-200 px-4 py-3 shadow-2xl">
+        <button
+          type="button"
+          onClick={handleClick}
+          className="w-full inline-flex items-center justify-center font-bold py-3 rounded-lg text-sm tracking-[0.05em] bg-[#F2D34F] text-gray-900"
+        >
+          Get My Wedding Bar Quote →
+        </button>
+      </div>
+      <div className="md:hidden h-16" aria-hidden />
+    </>
+  );
+}

--- a/src/app/wedding-drink-calculator/sections/QuoteFormSection.tsx
+++ b/src/app/wedding-drink-calculator/sections/QuoteFormSection.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+import { useState, type FormEvent, type ReactElement } from 'react';
+import type { WeddingPlan } from '@/lib/weddingDrinkCalculator';
+import { trackMetaEvent } from '@/components/MetaPixel';
+
+type Props = {
+  /** Latest computed plan from the calculator above; null until first render. */
+  plan: WeddingPlan | null;
+};
+
+/**
+ * Maps a calculator output item name to the underlying product handle in
+ * Postgres. Handles were grepped out of src/lib/landing/getOccasionPackages.ts
+ * (the curated catalog used by the Wes-template Quick-Buy modal).
+ *
+ * Items not in this map fall through — admin reviews the draft order and
+ * adds them manually. We always send `bag-of-ice-7-lbs` as the fallback so
+ * the API's `items.min(1)` validation always passes.
+ */
+const ITEM_NAME_TO_HANDLE: Record<string, string> = {
+  'Miller Lite (24-pack)': 'miller-lite-24-pack-12oz-can',
+  'Modelo Especial (24-pack)': 'modelo-especial-24pack-12oz-cans',
+  'Austin Beerworks Variety (12-pack)': 'austin-beerworks-variety-pack-12-pack-12oz-can',
+  'High Noon Variety (12-pack)':
+    'high-noon-vodka-soda-combo-3-each-grapefruit-9-pineapple-9-black-cherry-9-watermelon-9-355ml-12-pack',
+  'White Claw Variety (24-pack)': 'white-claw-variety-24-pack-12oz-can',
+  'Dark Horse Pinot Grigio (750ml)': 'dark-horse-pinot-grigio-750ml-bottle',
+  '14 Hands Cabernet Sauvignon (750ml)': '14-hands-cabernet-sauvignon',
+  'Espolon Tequila Blanco (750ml)': 'espolon-tequila-blanco-80-1l',
+  "Tito's Handmade Vodka (1L)": 'titos-handmade-vodka-80-1lt',
+  'Still Austin Bourbon (750ml)': 'jameson-irish-whiskey-1',
+  'Champagne / Prosecco (750ml)': 'chandon-california-brut-750ml',
+  'Ice Bags': 'bag-of-ice-7-lbs',
+};
+
+/**
+ * Section I — the single conversion goal. Replaces the dual CTA section
+ * from the old page. Posts to /api/v1/landing/quote with the calculator
+ * state baked in.
+ */
+export default function QuoteFormSection({ plan }: Props): ReactElement {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle');
+  const [errorMsg, setErrorMsg] = useState('');
+  const [invoiceUrl, setInvoiceUrl] = useState<string | null>(null);
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setStatus('submitting');
+    setErrorMsg('');
+
+    // Map calculator output → product handles where we can. Always include
+    // bag-of-ice as a safety net so the API's items.min(1) check passes
+    // even if every shopping-list item failed to map.
+    const items: { handle: string; qty: number }[] = [];
+    const unmappedNames: string[] = [];
+    if (plan) {
+      for (const item of plan.items) {
+        const handle = ITEM_NAME_TO_HANDLE[item.name];
+        if (handle) items.push({ handle, qty: item.quantity });
+        else unmappedNames.push(`${item.quantity}× ${item.name}`);
+      }
+    }
+    if (items.length === 0) {
+      items.push({ handle: 'bag-of-ice-7-lbs', qty: 4 });
+    }
+
+    // Default delivery date = 30 days out. Customer can edit on the invoice page.
+    const deliveryDate = new Date();
+    deliveryDate.setDate(deliveryDate.getDate() + 30);
+
+    // Stash the full calculator summary in admin-visible notes so an operator
+    // can sanity-check the auto-mapped line items, swap brands, and add any
+    // items that didn't map (cocktail kits today, future skus tomorrow).
+    const summary = plan
+      ? [
+          `Calculator state: ${plan.summary.guests} guests × ${plan.summary.hours} hours = ${plan.totalDrinks} drinks.`,
+          `Categories: ${plan.summary.categories.join(', ')}.`,
+          unmappedNames.length > 0
+            ? `Unmapped items (operator to add): ${unmappedNames.join('; ')}.`
+            : '',
+        ]
+          .filter(Boolean)
+          .join(' ')
+      : 'No calculator state captured.';
+
+    try {
+      const res = await fetch('/api/v1/landing/quote', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          mode: 'quote',
+          occasion: 'wedding',
+          customerName: name,
+          customerEmail: email,
+          customerPhone: phone,
+          groupSize: plan?.summary.guests ?? 100,
+          deliveryDate: deliveryDate.toISOString().slice(0, 10),
+          items,
+          deliveryNotes: summary,
+        }),
+      });
+      const body = await res.json();
+      if (!res.ok || !body.success) {
+        throw new Error(body.error || 'Submit failed');
+      }
+      setInvoiceUrl(body.invoiceUrl ?? null);
+      setStatus('success');
+
+      // Conversion firing — Meta + GA4 + Google Ads. All three are guarded
+      // so a missing pixel / env var is a silent no-op rather than a throw.
+      trackMetaEvent('Lead', {
+        content_name: 'Wedding Bar Quote',
+        content_category: 'wedding-drink-calculator',
+      });
+
+      if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
+        window.gtag('event', 'generate_lead', {
+          form_id: 'wedding-bar-quote',
+          page_location: window.location.href,
+          value: plan?.totalDrinks ?? 0,
+        });
+
+        const conversionId = process.env.NEXT_PUBLIC_GADS_QUOTE_CONVERSION_ID;
+        if (conversionId) {
+          window.gtag('event', 'conversion', {
+            send_to: conversionId,
+            value: 0,
+            currency: 'USD',
+          });
+        }
+      }
+    } catch (err) {
+      setStatus('error');
+      setErrorMsg(err instanceof Error ? err.message : 'Submit failed');
+    }
+  };
+
+  return (
+    <section id="quote-form" className="bg-gray-50 section-padding">
+      <div className="container-custom max-w-3xl">
+        <div className="text-center mb-8">
+          <h2 className="font-heading text-3xl md:text-4xl tracking-[0.1em] text-gray-900 mb-3">
+            Get Your Wedding Bar Quote
+          </h2>
+          <p className="text-base md:text-lg text-gray-700 max-w-2xl mx-auto">
+            We&apos;ll email an editable invoice within 15 minutes — built from the
+            calculator above. Adjust quantities, brands, and delivery details
+            before you pay. No credit card to start.
+          </p>
+        </div>
+
+        {status === 'success' ? (
+          <div className="card border-brand-blue/40 bg-white text-center py-10">
+            <h3 className="font-heading text-2xl text-gray-900 mb-3">
+              Quote sent! Check your inbox.
+            </h3>
+            <p className="text-base text-gray-700 mb-6">
+              We emailed your editable invoice to{' '}
+              <strong className="text-gray-900">{email}</strong>. You can review
+              and adjust before you pay.
+            </p>
+            {invoiceUrl && (
+              <a
+                href={invoiceUrl}
+                className="btn-primary inline-flex items-center justify-center"
+              >
+                Open My Invoice →
+              </a>
+            )}
+            <p className="text-sm text-gray-600 mt-6">
+              Questions? Call or text{' '}
+              <a href="tel:7373719700" className="font-semibold text-brand-blue">
+                (737) 371-9700
+              </a>
+              .
+            </p>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="card bg-white space-y-5">
+            <div>
+              <label htmlFor="qf-name" className="block text-base font-semibold text-gray-900 mb-1">
+                Your name <span className="text-red-600">*</span>
+              </label>
+              <input
+                id="qf-name"
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                required
+                autoComplete="name"
+                className="input-premium w-full"
+              />
+            </div>
+            <div>
+              <label htmlFor="qf-email" className="block text-base font-semibold text-gray-900 mb-1">
+                Email <span className="text-red-600">*</span>
+              </label>
+              <input
+                id="qf-email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                autoComplete="email"
+                className="input-premium w-full"
+              />
+            </div>
+            <div>
+              <label htmlFor="qf-phone" className="block text-base font-semibold text-gray-900 mb-1">
+                Phone <span className="text-sm font-normal text-gray-600">(used for delivery-day reach)</span>
+              </label>
+              <input
+                id="qf-phone"
+                type="tel"
+                value={phone}
+                onChange={(e) => setPhone(e.target.value)}
+                autoComplete="tel"
+                className="input-premium w-full"
+              />
+            </div>
+
+            {plan && (
+              <p className="text-sm text-gray-600 border-l-2 border-brand-blue/40 pl-3">
+                Based on your inputs above: <strong>{plan.summary.guests} guests</strong>{' '}
+                × <strong>{plan.summary.hours} hours</strong> = ~{plan.totalDrinks} drinks
+                across {plan.summary.categories.join(', ')}.
+              </p>
+            )}
+
+            {status === 'error' && (
+              <p className="text-sm text-red-600">
+                {errorMsg}. Try again or call{' '}
+                <a href="tel:7373719700" className="font-semibold underline">
+                  (737) 371-9700
+                </a>
+                .
+              </p>
+            )}
+
+            <button
+              type="submit"
+              disabled={status === 'submitting'}
+              className="btn-cart w-full disabled:opacity-60 disabled:cursor-not-allowed"
+            >
+              {status === 'submitting' ? 'Sending…' : 'Get My Wedding Bar Quote →'}
+            </button>
+
+            <p className="text-xs text-gray-500 text-center">
+              No spam. TABC-licensed retailer. Must be 21+ at delivery.
+            </p>
+          </form>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/app/wedding-drink-calculator/sections/WhyYouNeedUs.tsx
+++ b/src/app/wedding-drink-calculator/sections/WhyYouNeedUs.tsx
@@ -1,0 +1,90 @@
+import type { ReactElement } from 'react';
+
+/**
+ * Replaces the generic "Pain → Solution" block on the calculator. Most
+ * couples don't realize the structural reasons they can't just "have the
+ * bartender bring it" or "have Total Wine deliver to the venue" — this
+ * section lays out the facts so they understand why a TABC-licensed
+ * delivery partner like POD is the only path that actually works.
+ *
+ * Three concrete facts + the refund promise = removes the over-ordering
+ * objection the calculator itself triggers (people see "600 drinks" and
+ * worry they'll be stuck with cases).
+ */
+export default function WhyYouNeedUs(): ReactElement {
+  return (
+    <section className="py-20" style={{ background: '#FBF6EC' }}>
+      <div className="max-w-4xl mx-auto px-4 sm:px-6">
+        <p
+          className="text-center font-semibold tracking-[0.18em] text-sm mb-4"
+          style={{ color: '#7E5A40' }}
+        >
+          THINGS NO ONE TELLS YOU
+        </p>
+        <h2
+          className="font-heading text-3xl md:text-5xl font-bold text-center mb-10 leading-tight"
+          style={{ color: '#2A2218' }}
+        >
+          Why your wedding alcohol is harder than it looks.
+        </h2>
+
+        <div className="space-y-6 text-base md:text-lg text-gray-800 leading-relaxed">
+          <div className="bg-white rounded-xl p-6 border border-gray-200 shadow-sm">
+            <p className="font-bold mb-2" style={{ color: '#2A2218' }}>
+              1. Most mobile bartenders are &ldquo;dry hire.&rdquo;
+            </p>
+            <p>
+              They&apos;ll pour for you all night, but they can&apos;t legally bring
+              the alcohol. Texas law requires a TABC-licensed retailer for
+              the delivery itself — so your bartender shows up with shakers
+              and shows out with shakers, and the alcohol is your problem.
+            </p>
+          </div>
+
+          <div className="bg-white rounded-xl p-6 border border-gray-200 shadow-sm">
+            <p className="font-bold mb-2" style={{ color: '#2A2218' }}>
+              2. Total Wine and Spec&apos;s probably won&apos;t deliver to your venue.
+            </p>
+            <p>
+              Most venues aren&apos;t on their delivery routes. And even if
+              they&apos;ll go to the address, the delivery window won&apos;t match your
+              coordinator&apos;s timeline — you&apos;ll get a four-hour window on a
+              random weekday, not &ldquo;4pm Saturday, dock entrance, cold.&rdquo; Don&apos;t
+              find out at the last minute that the run-of-show falls apart.
+            </p>
+          </div>
+
+          <div className="bg-white rounded-xl p-6 border border-gray-200 shadow-sm">
+            <p className="font-bold mb-2" style={{ color: '#2A2218' }}>
+              3. So most couples end up doing a Costco run themselves.
+            </p>
+            <p>
+              That&apos;s the trap. The week of your wedding, you and your
+              partner are loading carts at Spec&apos;s, fighting traffic to
+              Wimberley, icing it all down in your Airbnb bathtub. Not how
+              you should be spending the 72 hours before the ceremony.
+            </p>
+          </div>
+
+          <div
+            className="rounded-xl p-6 shadow-sm border-2"
+            style={{
+              background: '#FBF6EC',
+              borderColor: '#C8A96A',
+            }}
+          >
+            <p className="font-bold mb-2" style={{ color: '#2A2218' }}>
+              The over-ordering fix: 100% refund on up to 25% of your order.
+            </p>
+            <p style={{ color: '#2A2218' }}>
+              Order extra so you don&apos;t run out — drop the unopened cases back
+              at our store the day after the wedding and we refund up to a
+              quarter of the total, same day. No restocking fees, no
+              questions. You can&apos;t run out, and you can&apos;t over-pay.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/wedding-drink-calculator/sections/receptionPackages.ts
+++ b/src/app/wedding-drink-calculator/sections/receptionPackages.ts
@@ -1,0 +1,79 @@
+import type { Package, ThemeColors } from '@/components/landing/types';
+
+/**
+ * Static reception-bar recipes for /wedding-drink-calculator. All three
+ * tiers are sized for the same 100-guest reception — they differ on
+ * quality and inclusions, not on headcount. Letting visitors compare
+ * apples-to-apples on price is the Wes "three packages, middle featured"
+ * pattern executed properly.
+ *
+ * Item lists are deliberately quality/style descriptors only — no bottle
+ * counts, no case counts, no non-consumables (cups, glassware, bar tools).
+ * Operator's call: keeps the focus on the alcohol and avoids advertising
+ * inclusions we may not always carry.
+ *
+ * Prices are operator-set marketing bundles; actual checkout happens via
+ * the quote form (admin builds the final invoice line items).
+ */
+export const RECEPTION_PACKAGES: Package[] = [
+  {
+    name: 'Beer & Wine',
+    serves: '100 guests',
+    price: '$1,199',
+    save: 'Best price',
+    blurb: 'A clean, classic bar for couples keeping it simple — no spirits, no surprises.',
+    items: [
+      'House red + white wine',
+      'Beer + seltzer variety',
+      'Add Prosecco for the toast (+$199)',
+    ],
+    image: '/images/services/weddings/boho-hill-country-2.webp',
+    featured: false,
+  },
+  {
+    name: 'Standard Bar',
+    serves: '100 guests',
+    price: '$1,799',
+    save: 'Most booked',
+    blurb: 'Full open bar — beer, wine, spirits, signature cocktail, champagne for toasts. The default for most Austin weddings.',
+    items: [
+      'Curated red + white wine',
+      'Champagne toast for the room',
+      'Beer + seltzer variety',
+      'Premium spirits — vodka, tequila, whiskey, gin',
+      'One signature cocktail kit (your pick)',
+    ],
+    image: '/images/services/weddings/outdoor-bar-setup-travis.webp',
+    featured: true,
+  },
+  {
+    name: 'Top Shelf + Toast',
+    serves: '100 guests',
+    price: '$2,199',
+    save: 'Premium tier',
+    blurb: 'Top-shelf spirits, sommelier-curated wines, and Veuve for the toast — the upgrade most planners recommend for ranches and Hill Country venues.',
+    items: [
+      'Sommelier-curated red + white wine',
+      'Veuve Clicquot for the toast',
+      'Beer + seltzer variety',
+      'Top-shelf spirits — Casamigos, Grey Goose, Woodford Reserve',
+      'Two signature cocktail kits',
+    ],
+    image: '/images/services/weddings/signature-cocktails-closeup.webp',
+    featured: false,
+  },
+];
+
+/**
+ * Wedding-themed palette for the section components on the calculator page.
+ * Champagne gold over deep espresso — matches `weddingConfig.theme` so the
+ * extracted Wes section components blend with the rest of the site.
+ */
+export const WEDDING_THEME: ThemeColors = {
+  primary: '#C8A96A',
+  primaryHover: '#B59456',
+  primaryText: '#2A2218',
+  navy: '#2A2218',
+  cream: '#FBF6EC',
+  blue: '#7E5A40',
+};

--- a/src/components/GoogleAdsTag.tsx
+++ b/src/components/GoogleAdsTag.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import Script from 'next/script';
+
+/**
+ * Google Ads global site tag (gtag.js for an AW-XXXXXXXXX account).
+ *
+ * Loaded alongside GoogleAnalytics so the same window.gtag function
+ * services both GA4 and Google Ads. GA4 is responsible for declaring
+ * the gtag function + dataLayer; this component only calls gtag('config').
+ *
+ * No-ops if NEXT_PUBLIC_GOOGLE_ADS_ID is unset OR we are not in production.
+ * That way dev sessions don't load tracking and missing env vars in any
+ * environment are a silent no-op rather than a runtime error.
+ */
+export default function GoogleAdsTag() {
+  const adsId = process.env.NEXT_PUBLIC_GOOGLE_ADS_ID;
+
+  if (!adsId || process.env.NODE_ENV !== 'production') {
+    return null;
+  }
+
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${adsId}`}
+        strategy="lazyOnload"
+      />
+      <Script id="google-ads-tag" strategy="lazyOnload">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          window.gtag = window.gtag || function(){ window.dataLayer.push(arguments); };
+          gtag('config', '${adsId}');
+        `}
+      </Script>
+    </>
+  );
+}

--- a/src/components/landing/sections/PackageCardGrid.tsx
+++ b/src/components/landing/sections/PackageCardGrid.tsx
@@ -1,0 +1,374 @@
+'use client';
+
+import { useState, type ReactElement, type ReactNode } from 'react';
+import Image from 'next/image';
+import type { Package, PackageLineItem, ThemeColors } from '../types';
+
+type Props = {
+  packages: Package[];
+  theme: ThemeColors;
+  /** Eyebrow shown above the grid. Optional. */
+  eyebrow?: string;
+  /** Headline shown above the grid. Optional. */
+  headline?: string;
+  /** Subhead shown above the grid. Optional. */
+  blurb?: string;
+  /** Optional content rendered below the grid (e.g. the "Need something custom?" line). */
+  footer?: ReactNode;
+  /**
+   * Primary CTA shown on every card. Defaults to "BUY THIS PACKAGE NOW →".
+   * Wes-template pages pass an `onBuyNow` that opens QuickBuyModal; the
+   * wedding calculator passes a scroll-to-quote-form handler with a custom
+   * label.
+   */
+  primaryCtaLabel?: string;
+  onPrimaryCta: (pkg: Package) => void;
+  /**
+   * Optional secondary CTA (e.g. "Build my own") shown below the primary.
+   * If `onSecondaryCta` is omitted the secondary button is not rendered.
+   */
+  secondaryCtaLabel?: string;
+  onSecondaryCta?: () => void;
+};
+
+export default function PackageCardGrid({
+  packages,
+  theme: T,
+  eyebrow,
+  headline,
+  blurb,
+  primaryCtaLabel = 'BUY THIS PACKAGE NOW →',
+  onPrimaryCta,
+  secondaryCtaLabel,
+  onSecondaryCta,
+  footer,
+}: Props): ReactElement {
+  return (
+    <section id="packages" className="py-24 md:py-28 bg-white">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6">
+        {(eyebrow || headline || blurb) && (
+          <div className="text-center mb-20 max-w-3xl mx-auto">
+            {eyebrow && (
+              <p
+                className="font-bold tracking-[0.15em] text-sm mb-4"
+                style={{ color: T.blue }}
+              >
+                {eyebrow}
+              </p>
+            )}
+            {headline && (
+              <h2
+                className="font-heading text-4xl md:text-5xl font-bold mb-6 leading-tight"
+                style={{ color: T.navy }}
+              >
+                {headline}
+              </h2>
+            )}
+            {blurb && (
+              <p className="text-lg text-gray-600 leading-relaxed">{blurb}</p>
+            )}
+          </div>
+        )}
+
+        <div className="grid md:grid-cols-3 gap-6 lg:gap-8">
+          {packages.map((pkg) => (
+            <PackageCard
+              key={pkg.name}
+              pkg={pkg}
+              theme={T}
+              primaryCtaLabel={primaryCtaLabel}
+              onPrimaryCta={onPrimaryCta}
+              secondaryCtaLabel={secondaryCtaLabel}
+              onSecondaryCta={onSecondaryCta}
+            />
+          ))}
+        </div>
+
+        {footer}
+      </div>
+    </section>
+  );
+}
+
+function PackageCard({
+  pkg,
+  theme: T,
+  primaryCtaLabel,
+  onPrimaryCta,
+  secondaryCtaLabel,
+  onSecondaryCta,
+}: {
+  pkg: Package;
+  theme: ThemeColors;
+  primaryCtaLabel: string;
+  onPrimaryCta: (pkg: Package) => void;
+  secondaryCtaLabel?: string;
+  onSecondaryCta?: () => void;
+}): ReactElement {
+  const [open, setOpen] = useState(false);
+
+  const isLive = !!pkg.lineItems && pkg.packagePrice != null;
+
+  const priceLabel = isLive ? `$${pkg.packagePrice}` : pkg.price ?? '';
+  const saveLabel = isLive
+    ? `Save $${pkg.freebiesValue ?? 0}`
+    : pkg.save ?? '';
+
+  const alcoholItems = (pkg.lineItems ?? []).filter((i) => !i.freebie);
+  const freebieItems = (pkg.lineItems ?? []).filter((i) => i.freebie);
+
+  return (
+    <div
+      className="relative rounded-2xl overflow-hidden flex flex-col bg-white border-2 transition-all"
+      style={{
+        borderColor: pkg.featured ? T.primary : '#E5E7EB',
+        boxShadow: pkg.featured
+          ? '0 25px 50px -12px rgba(0,0,0,0.18)'
+          : '0 1px 3px rgba(0,0,0,0.05)',
+        transform: pkg.featured ? 'scale(1.03)' : 'none',
+      }}
+    >
+      {pkg.featured && (
+        <div
+          className="absolute top-4 right-4 z-10 text-xs font-bold tracking-widest px-3 py-1 rounded-full"
+          style={{ background: T.primary, color: T.primaryText }}
+        >
+          MOST BOOKED
+        </div>
+      )}
+      <div className="relative w-full flex-shrink-0" style={{ height: '208px' }}>
+        <Image
+          src={pkg.image}
+          alt={pkg.name}
+          fill
+          sizes="(min-width: 768px) 33vw, 100vw"
+          className="object-cover"
+        />
+      </div>
+      <div className="p-6 flex flex-col flex-1">
+        <div className="flex items-start justify-between gap-3 mb-2">
+          <h3 className="font-heading text-2xl font-bold leading-tight" style={{ color: T.navy }}>
+            {pkg.name}
+          </h3>
+          {saveLabel && (
+            <span
+              className="text-xs font-bold px-2 py-1 rounded whitespace-nowrap"
+              style={{ background: '#10B98119', color: '#047857' }}
+            >
+              {saveLabel}
+            </span>
+          )}
+        </div>
+        <div className="flex items-baseline gap-2 mb-3">
+          <span className="font-heading text-4xl font-bold" style={{ color: T.blue }}>
+            {priceLabel}
+          </span>
+          <span className="text-sm text-gray-500">{pkg.serves}</span>
+        </div>
+        <p className="text-gray-600 mb-4 leading-relaxed">{pkg.blurb}</p>
+
+        {isLive && pkg.lineItems && pkg.lineItems.length > 0 && (
+          <ul className="mb-4 space-y-1.5 text-sm text-gray-700">
+            {summarizeAlcohol(alcoholItems).map((line, i) => (
+              <li key={`sum-${i}`} className="flex items-start gap-2">
+                <span className="mt-0.5 font-bold" style={{ color: T.primary }}>
+                  ✓
+                </span>
+                <span>{line}</span>
+              </li>
+            ))}
+            {freebieItems.length > 0 && (
+              <li className="flex items-start gap-2">
+                <span className="mt-0.5 font-bold" style={{ color: '#047857' }}>
+                  ★
+                </span>
+                <span style={{ color: '#047857' }}>
+                  <strong>Free party bundle:</strong>{' '}
+                  {freebieItems
+                    .map((f) => f.name.split(' • ')[0].replace(/^\d+\s*/, ''))
+                    .slice(0, 4)
+                    .join(', ')}
+                  {freebieItems.length > 4 ? '…' : ''}
+                </span>
+              </li>
+            )}
+          </ul>
+        )}
+
+        {isLive ? (
+          <div className="mb-5 flex-1">
+            <button
+              type="button"
+              onClick={() => setOpen((o) => !o)}
+              className="w-full flex items-center justify-between text-left font-bold text-sm py-2 border-b transition-colors"
+              style={{ color: T.navy, borderColor: '#E5E7EB' }}
+              aria-expanded={open}
+            >
+              <span>
+                {open ? 'Hide' : 'See'} what&apos;s inside ({pkg.lineItems!.length} items)
+              </span>
+              <span className="text-xs" style={{ color: T.blue }}>
+                {open ? '▲' : '▼'}
+              </span>
+            </button>
+            {open && (
+              <div className="mt-3 space-y-3 text-sm">
+                <div>
+                  <div className="text-[10px] font-bold tracking-widest text-gray-500 mb-1.5">
+                    INCLUDED ALCOHOL
+                  </div>
+                  <ul className="space-y-1.5">
+                    {alcoholItems.map((it, i) => (
+                      <li
+                        key={`a-${i}`}
+                        className="flex justify-between gap-3 text-gray-700"
+                      >
+                        <span className="flex-1">
+                          <span className="font-semibold" style={{ color: T.navy }}>
+                            {it.qty}×
+                          </span>{' '}
+                          {it.name}
+                        </span>
+                        <span className="text-gray-500 whitespace-nowrap">
+                          ${(it.unitPrice * it.qty).toFixed(2)}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+                {freebieItems.length > 0 && (
+                  <div className="pt-2 border-t" style={{ borderColor: '#E5E7EB' }}>
+                    <div
+                      className="text-[10px] font-bold tracking-widest mb-1.5"
+                      style={{ color: '#047857' }}
+                    >
+                      FREE PARTY SUPPLIES (BUNDLED IN)
+                    </div>
+                    <ul className="space-y-1.5">
+                      {freebieItems.map((it, i) => (
+                        <li
+                          key={`f-${i}`}
+                          className="flex justify-between gap-3 text-gray-700"
+                        >
+                          <span className="flex-1">
+                            <span className="font-semibold" style={{ color: T.navy }}>
+                              {it.qty}×
+                            </span>{' '}
+                            {it.name}
+                          </span>
+                          <span className="whitespace-nowrap font-semibold" style={{ color: '#047857' }}>
+                            FREE (${(it.unitPrice * it.qty).toFixed(2)})
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        ) : pkg.items ? (
+          <ul className="space-y-2 mb-7 text-sm text-gray-700 flex-1">
+            {pkg.items.map((item) => (
+              <li key={item} className="flex items-start gap-2">
+                <span className="mt-0.5 font-bold" style={{ color: T.primary }}>
+                  ✓
+                </span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+
+        <div className="flex flex-col gap-2">
+          <button
+            type="button"
+            onClick={() => onPrimaryCta(pkg)}
+            className="block text-center font-bold py-4 px-6 rounded-md tracking-wide transition-all w-full hover:scale-[1.01] shadow-md"
+            style={{ background: T.primary, color: T.primaryText }}
+          >
+            {primaryCtaLabel}
+          </button>
+          {secondaryCtaLabel && onSecondaryCta && (
+            <button
+              type="button"
+              onClick={onSecondaryCta}
+              className="block text-center font-bold py-3 px-6 rounded-md tracking-wide transition-colors w-full"
+              style={{
+                background: '#FFFFFF',
+                color: T.navy,
+                border: `2px solid ${T.navy}`,
+              }}
+            >
+              {secondaryCtaLabel}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function summarizeAlcohol(items: PackageLineItem[]): string[] {
+  const out: string[] = [];
+  type Bucket = { qty: number; cans: number; bottles: number };
+  const buckets: Record<string, Bucket> = {
+    beer: { qty: 0, cans: 0, bottles: 0 },
+    seltzer: { qty: 0, cans: 0, bottles: 0 },
+    spirits: { qty: 0, cans: 0, bottles: 0 },
+    wine: { qty: 0, cans: 0, bottles: 0 },
+    mixer: { qty: 0, cans: 0, bottles: 0 },
+  };
+
+  for (const it of items) {
+    const t = it.name.toLowerCase();
+    const packMatch = it.name.match(/(\d+)\s*pack/i);
+    const cans = packMatch ? parseInt(packMatch[1], 10) * it.qty : 0;
+    if (
+      /\b(beer|ipa|lager|hefe|pilsner|modelo|miller|coors|corona|michelob|lone star)\b/.test(t)
+    ) {
+      buckets.beer.qty += it.qty;
+      buckets.beer.cans += cans;
+    } else if (/\b(seltzer|high noon|white claw|truly|surfside)\b/.test(t)) {
+      buckets.seltzer.qty += it.qty;
+      buckets.seltzer.cans += cans;
+    } else if (
+      /\b(vodka|tequila|whiskey|whisky|bourbon|gin|rum|jameson|tito|espolon|casamigos|jack daniels|bulleit)\b/.test(t)
+    ) {
+      buckets.spirits.qty += it.qty;
+      buckets.spirits.bottles += it.qty;
+    } else if (
+      /\b(wine|champagne|prosecco|rosé|rose|sauv|cab|pinot|veuve|chandon|whispering angel|josh cellars|14 hands|bogle|oyster bay|dark horse)\b/.test(t)
+    ) {
+      buckets.wine.qty += it.qty;
+      buckets.wine.bottles += it.qty;
+    } else {
+      buckets.mixer.qty += it.qty;
+    }
+  }
+
+  if (buckets.beer.qty + buckets.seltzer.qty > 0) {
+    const totalPacks = buckets.beer.qty + buckets.seltzer.qty;
+    const totalCans = buckets.beer.cans + buckets.seltzer.cans;
+    const label = buckets.seltzer.qty > 0 && buckets.beer.qty > 0
+      ? 'beer + seltzer packs'
+      : buckets.seltzer.qty > 0
+        ? 'hard-seltzer packs'
+        : 'beer packs';
+    out.push(
+      totalCans > 0
+        ? `${totalPacks} ${label} (${totalCans} cans)`
+        : `${totalPacks} ${label}`,
+    );
+  }
+  if (buckets.spirits.qty > 0) {
+    out.push(`${buckets.spirits.qty} premium spirit bottle${buckets.spirits.qty !== 1 ? 's' : ''}`);
+  }
+  if (buckets.wine.qty > 0) {
+    out.push(`${buckets.wine.qty} bottle${buckets.wine.qty !== 1 ? 's' : ''} of wine + champagne`);
+  }
+  if (buckets.mixer.qty > 0) {
+    out.push('Mixers, juices, and chasers');
+  }
+  return out.slice(0, 4);
+}

--- a/src/components/landing/sections/PainSolutionSection.tsx
+++ b/src/components/landing/sections/PainSolutionSection.tsx
@@ -1,0 +1,24 @@
+import type { ReactElement } from 'react';
+import type { ThemeColors } from '../types';
+
+type Props = {
+  headline: string;
+  body: string;
+  theme: ThemeColors;
+};
+
+export default function PainSolutionSection({ headline, body, theme: T }: Props): ReactElement {
+  return (
+    <section className="py-20" style={{ background: T.cream }}>
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 text-center">
+        <h2
+          className="font-heading text-3xl md:text-5xl font-bold mb-6 leading-tight"
+          style={{ color: T.navy }}
+        >
+          {headline}
+        </h2>
+        <p className="text-lg md:text-xl text-gray-700 leading-relaxed">{body}</p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/landing/sections/ReviewsSection.tsx
+++ b/src/components/landing/sections/ReviewsSection.tsx
@@ -1,0 +1,58 @@
+import type { ReactElement } from 'react';
+import type { Review, ThemeColors } from '../types';
+
+type Props = {
+  reviews: Review[];
+  theme: ThemeColors;
+  eyebrow?: string;
+  headline?: string;
+};
+
+export default function ReviewsSection({
+  reviews,
+  theme: T,
+  eyebrow,
+  headline,
+}: Props): ReactElement {
+  return (
+    <section className="py-20 text-white" style={{ background: T.navy }}>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6">
+        {(eyebrow || headline) && (
+          <div className="text-center mb-14">
+            {eyebrow && (
+              <p
+                className="font-bold tracking-[0.15em] text-sm mb-3"
+                style={{ color: T.primary }}
+              >
+                {eyebrow}
+              </p>
+            )}
+            {headline && (
+              <h2 className="font-heading text-4xl md:text-5xl font-bold mb-4">
+                {headline}
+              </h2>
+            )}
+          </div>
+        )}
+        <div className="grid md:grid-cols-3 gap-6">
+          {reviews.map((r) => (
+            <div
+              key={r.author}
+              className="bg-white/5 backdrop-blur rounded-xl p-7"
+              style={{ border: '1px solid rgba(255,255,255,0.1)' }}
+            >
+              <div className="text-lg mb-3" style={{ color: T.primary }}>
+                ★★★★★
+              </div>
+              <p className="text-gray-100 leading-relaxed mb-5">&ldquo;{r.quote}&rdquo;</p>
+              <div className="text-sm">
+                <div className="font-bold text-white">{r.author}</div>
+                <div className="opacity-70">{r.detail}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/analytics/ga4-events.ts
+++ b/src/lib/analytics/ga4-events.ts
@@ -43,7 +43,16 @@ function isGtagAvailable(): boolean {
 export function trackCTAClick(
   buttonText: string,
   buttonUrl: string,
-  section: 'hero' | 'choose_path' | 'services' | 'footer_cta' | 'navigation' | 'group_order_strip',
+  section:
+    | 'hero'
+    | 'choose_path'
+    | 'services'
+    | 'footer_cta'
+    | 'navigation'
+    | 'group_order_strip'
+    | 'wedding_calc_hero'
+    | 'wedding_calc_package'
+    | 'wedding_calc_sticky',
   experimentId?: string,
   variantId?: string
 ): void {

--- a/src/lib/leadMagnet/config.ts
+++ b/src/lib/leadMagnet/config.ts
@@ -83,8 +83,8 @@ export const LEAD_MAGNETS: LeadMagnet[] = [
       '/',
       '/austin-bachelor-party-delivery',
       '/austin-bachelorette-party-delivery',
-      '/austin-corporate-party-delivery',
-      '/austin-wedding-delivery',
+      '/austin-corporate-event-delivery',
+      '/austin-wedding-weekend-delivery',
       '/services/*',
       '/flyer',
     ],
@@ -98,6 +98,7 @@ export const LEAD_MAGNETS: LeadMagnet[] = [
       '/api/*',
       '/partners/*',
       '/affiliate/*',
+      '/wedding-drink-calculator',
     ],
     triggers: [
       { type: 'time', seconds: 25 },


### PR DESCRIPTION
## Summary

- Ships Phase B wedding-calculator rebuild (hero, packages, guarantee row, named reviews, expanded FAQ, single quote form, mobile sticky CTA) to production
- Adds Phase C Google Ads conversion tracking — env-var-gated, no-op until vars populated in Vercel
- Fixes stale lead-magnet route names + excludes calculator page from playbook popup

Cherry-picked from dev commit \`e4071223\` to avoid bundling unrelated dev-only work (finance phases, other SEO landings) into this release.

## Test plan

- [ ] Vercel preview build succeeds
- [ ] Visit /wedding-drink-calculator on preview: hero loads, calculator works, 3 packages render, quote form submits
- [ ] tsc clean (verified locally — only pre-existing test error)
- [ ] After merge: submit one test quote on live site to fire \`generate_lead\` GA4 event
- [ ] Then in Google Ads, select \`generate_lead\` in the conversion wizard (see docs/GOOGLE-ADS-CONVERSIONS.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)