### PR TITLE
feat(seo): wedding blog batch 2 — next 5 OPTIMIZE candidates

### DIFF
--- a/content/blog/posts/plan-hill-country-wedding-six-months.mdx
+++ b/content/blog/posts/plan-hill-country-wedding-six-months.mdx
@@ -1,19 +1,23 @@
 ---
-title: "How to Plan a Hill Country Wedding in Under Six Months"
+title: "Hill Country Wedding Planning in 6 Months: 12-Step Accelerated Timeline (2026)"
 date: "2025-12-10"
 category: "Weddings"
-excerpt: "Plan your dream Hill Country wedding on an accelerated timeline. Expert tips for booking venues, coordinating vendors, and creating magic in six months or less."
+excerpt: "Plan a Texas Hill Country wedding in under six months without it feeling rushed — venue-booking shortcuts, vendor lock-in order, and the calculator that sizes your bar in 10 seconds."
 image: "/images/hero/wedding-hero-garden.webp"
-keywords: ["wedding planning", "hill country", "austin", "timeline", "quick wedding"]
+keywords: ["hill country wedding planning", "texas hill country wedding", "austin wedding planning timeline", "hill country wedding short timeline", "quick wedding planning austin", "6 month wedding planning"]
 author: "Allan Henslee"
 pillarSlug: "ultimate-guide-austin-weddings"
 ---
 
-## How to Plan a Hill Country Wedding in Under Six Months
+## Hill Country Wedding Planning in 6 Months: 12-Step Accelerated Timeline
 
 So you've said yes, and you're ready to tie the knot sooner rather than later. Planning a Texas Hill Country wedding in under six months might seem daunting, but with the right strategy and realistic expectations, you can absolutely create a beautiful celebration that feels anything but rushed.
 
-At Party On Delivery, we help couples on tight timelines by delivering premium beverages directly to their venue. Here's your accelerated guide to Hill Country wedding planning.
+At Party On Delivery, we help couples on tight timelines by delivering premium beverages directly to their venue. Here's the accelerated guide to Hill Country wedding planning.
+
+**Shortcuts that compress the timeline:**
+- The [Wedding Drink Calculator](/wedding-drink-calculator) sizes the bar in 10 seconds — skip the spreadsheet phase entirely
+- A [boat on Lake Travis](/austin-wedding-venue-boats) is a venue that books in days, not months — Premier handles the boat, we handle the bar, and your venue search collapses to one conversation
 
 ## Why a Short Engagement Works
 

--- a/content/blog/posts/rehearsal-dinner-austin-restaurants.mdx
+++ b/content/blog/posts/rehearsal-dinner-austin-restaurants.mdx
@@ -1,19 +1,23 @@
 ---
-title: "How to Plan a Rehearsal Dinner at Austin Restaurants"
+title: "Austin Rehearsal Dinner Guide (2026): 12 Restaurants, Private Rooms & Boat Cruises"
 date: "2025-12-10"
 category: "Weddings"
-excerpt: "Plan the perfect rehearsal dinner at Austin's best restaurants. From private dining rooms to full buyouts, find the ideal space for your pre-wedding celebration."
+excerpt: "The complete Austin rehearsal dinner guide — private rooms downtown, Hill Country patios, full restaurant buyouts, and the rehearsal-dinner-on-a-boat option couples don't usually consider."
 image: "/images/hero/wedding-hero-garden.webp"
-keywords: ["rehearsal dinner", "austin restaurants", "wedding planning", "private dining"]
+keywords: ["rehearsal dinner austin", "austin rehearsal dinner", "rehearsal dinner austin restaurants", "rehearsal dinner venues austin", "private dining austin wedding", "rehearsal dinner boat austin"]
 author: "Allan Henslee"
 pillarSlug: "ultimate-guide-austin-weddings"
 ---
 
-## How to Plan a Rehearsal Dinner at Austin Restaurants
+## Austin Rehearsal Dinner Guide (2026): 12 Restaurants, Private Rooms & Boat Cruises
 
 The rehearsal dinner is your chance to celebrate with your closest family and wedding party before the big day. Austin's diverse restaurant scene offers everything from elegant private rooms to casual patios, making it easy to find the perfect setting for this meaningful gathering.
 
-At Party On Delivery, we help couples complete their wedding weekend celebrations. Here's your guide to planning a rehearsal dinner at Austin restaurants.
+At Party On Delivery, we help couples complete the whole wedding weekend — including the rehearsal dinner bar. Here's the guide to planning a rehearsal dinner at Austin restaurants and a non-traditional alternative most couples don't consider.
+
+**Going non-traditional?** A Premier boat charter on Lake Travis [makes a great rehearsal dinner venue](/austin-wedding-venue-boats) the night before the wedding — captain handles the boat, we handle the bar, and you skip the restaurant deposit altogether.
+
+**Still sizing the bar?** Use the [Wedding Drink Calculator](/wedding-drink-calculator) for both events — guest count plus hours equals exact bottle counts for the rehearsal dinner and the reception.
 
 ## Choosing Your Style
 

--- a/content/blog/posts/signature-wedding-cocktails-texas-heat.mdx
+++ b/content/blog/posts/signature-wedding-cocktails-texas-heat.mdx
@@ -1,19 +1,23 @@
 ---
-title: "Signature Wedding Cocktails Perfect for Texas Heat"
+title: "Wedding Cocktails Austin: 8 Signature Drinks Built for Texas Heat (2026)"
 date: "2025-12-10"
 category: "Weddings"
-excerpt: "Create refreshing signature cocktails for your Austin wedding. From frozen margaritas to Hill Country wine spritzers, beat the Texas heat in style."
+excerpt: "Eight signature wedding cocktails built for Austin heat — frozen margaritas, Hill Country spritzers, low-ABV options for long receptions, plus how much spirit + mixer to order per guest."
 image: "/images/hero/wedding-hero-garden.webp"
-keywords: ["wedding cocktails", "signature drinks", "austin wedding", "texas heat", "refreshing cocktails"]
+keywords: ["wedding cocktails austin", "signature wedding cocktails", "austin wedding bar", "texas wedding drinks", "hot weather wedding cocktails", "wedding signature drinks austin"]
 author: "Allan Henslee"
 pillarSlug: "ultimate-guide-austin-weddings"
 ---
 
-## Signature Wedding Cocktails Perfect for Texas Heat
+## Wedding Cocktails Austin: 8 Signature Drinks Built for Texas Heat
 
-Texas weddings and hot weather go hand in hand, especially during the long wedding season from March through November. A well-crafted signature cocktail does more than add personality to your celebration. It keeps guests refreshed and comfortable while showcasing your style as a couple.
+Texas weddings and hot weather go hand in hand, especially during the long Austin wedding season from March through November. A well-crafted signature cocktail does more than add personality to your celebration — it keeps guests refreshed and comfortable while showcasing your style as a couple.
 
-At Party On Delivery, we provide all the spirits, mixers, and supplies you need for memorable wedding cocktails. Here's your guide to creating the perfect signature drinks for Texas heat.
+At Party On Delivery, we provide all the spirits, mixers, and supplies you need for memorable wedding cocktails. Here's the guide to building the perfect signature drinks for Austin weddings in the heat.
+
+**Need to size the bar?** Use the [Wedding Drink Calculator](/wedding-drink-calculator) — it factors in your guest count, reception hours, and signature-cocktail preference, then sizes the spirits, mixers, and beer/wine accordingly. Saves the back-of-napkin math.
+
+**Outdoor venue?** A Premier boat on Lake Travis [doubles as a wedding venue](/austin-wedding-venue-boats) for 20-80 guests — built-in breeze, no rented chairs, and we stock the bar.
 
 ## Why Signature Cocktails Matter
 

--- a/content/blog/posts/stress-free-wedding-vendor-checklist.mdx
+++ b/content/blog/posts/stress-free-wedding-vendor-checklist.mdx
@@ -1,19 +1,21 @@
 ---
-title: "How to Build a Stress-Free Wedding Vendor Checklist"
+title: "Austin Wedding Vendor Checklist (2026): Who to Book First & What to Ask"
 date: "2025-12-10"
 category: "Weddings"
-excerpt: "Master your wedding vendor coordination with this comprehensive checklist. Learn who to book first, essential questions to ask, and how to manage contracts."
+excerpt: "The complete Austin wedding vendor checklist — booking order, essential questions, contract red flags, and how to coordinate the bar so it doesn't become the day-of headache."
 image: "/images/hero/wedding-hero-garden.webp"
-keywords: ["wedding planning", "vendor checklist", "austin", "organization", "wedding vendors"]
+keywords: ["austin wedding vendor checklist", "wedding vendor checklist austin", "austin wedding planning checklist", "wedding vendors austin", "austin wedding planning"]
 author: "Allan Henslee"
 pillarSlug: "ultimate-guide-austin-weddings"
 ---
 
-## How to Build a Stress-Free Wedding Vendor Checklist
+## Austin Wedding Vendor Checklist (2026): Who to Book First & What to Ask
 
-Coordinating wedding vendors can feel overwhelming, but with a systematic approach, you can manage every detail without losing your mind. The key is knowing who to book when, what questions to ask, and how to keep everything organized.
+Coordinating Austin wedding vendors can feel overwhelming, but with a systematic approach, you can manage every detail without losing your mind. The key is knowing who to book when, what questions to ask, and how to keep everything organized.
 
-At Party On Delivery, we simplify one piece of your vendor puzzle by handling beverage delivery. Here's your complete guide to building and managing your wedding vendor checklist.
+At Party On Delivery, we simplify one piece of the puzzle by handling beverage delivery. Here's the complete guide to building and managing your Austin wedding vendor checklist.
+
+**Two helpful tools while you build the list:** the [Wedding Drink Calculator](/wedding-drink-calculator) sizes the bar in 10 seconds (a useful number for venue conversations), and if you're still venue-shopping, a [Premier boat on Lake Travis](/austin-wedding-venue-boats) skips half the vendor list — boat is venue + photographer's backdrop + transportation in one.
 
 ## The Essential Vendor List
 

--- a/content/blog/posts/wedding-photography-austin-lakes-hills.mdx
+++ b/content/blog/posts/wedding-photography-austin-lakes-hills.mdx
@@ -1,19 +1,23 @@
 ---
-title: "Wedding Photography Locations Around Austin's Lakes and Hills"
+title: "Austin Wedding Photography Locations: 15 Best Spots Around Lakes & Hills (2026)"
 date: "2025-12-10"
 category: "Weddings"
-excerpt: "Discover the most photogenic wedding locations around Austin. From Lake Travis sunsets to Hill Country landscapes, find your perfect backdrop."
+excerpt: "The 15 best Austin wedding photography locations — Lake Travis sunset spots, Hill Country vineyards, downtown skyline overlooks, and a boat-deck setup couples don't usually think about."
 image: "/images/hero/wedding-hero-garden.webp"
-keywords: ["wedding photography", "photo locations", "austin", "scenic", "lake travis"]
+keywords: ["austin wedding photography locations", "wedding photography austin", "lake travis wedding photography", "hill country wedding photos", "austin wedding photo locations", "scenic wedding venues austin"]
 author: "Allan Henslee"
 pillarSlug: "ultimate-guide-austin-weddings"
 ---
 
-## Wedding Photography Locations Around Austin's Lakes and Hills
+## Austin Wedding Photography Locations: 15 Best Spots Around Lakes & Hills
 
 Austin's natural beauty provides endless opportunities for stunning wedding photography. From the shimmering waters of Lake Travis to the rolling hills of Texas wine country, the region offers diverse backdrops that capture the romance of your special day.
 
-At Party On Delivery, we help couples celebrate at venues across Austin. Here's your guide to the most photogenic wedding locations in the area.
+At Party On Delivery, we help couples celebrate at venues across Austin. Here's the guide to the most photogenic wedding locations in the area.
+
+**Bonus venue idea:** a Premier boat on Lake Travis [serves as both venue and photo location](/austin-wedding-venue-boats) — sunset on the deck, golden-hour cruise after the ceremony, no shuttle between sites. Built-in backdrop. We handle the bar so the boat, photographer, and bar all arrive on time.
+
+**Sizing the bar for your reception?** The [Wedding Drink Calculator](/wedding-drink-calculator) takes guest count plus reception hours and returns exact bottle counts — useful for the photo team's lunch break planning too.
 
 ## Lake Travis Locations
 


### PR DESCRIPTION
## Summary
Continues the WS4 audit follow-through after PR #103. Five more wedding-cluster posts get the same treatment: title rewrite + keywords realignment + 1-2 paragraphs of internal-link work at the top. Bodies are untouched to preserve existing GSC ranking signal.

## Posts rewritten

| Slug | New title | Target keyword cluster |
|------|-----------|-----------------------|
| `signature-wedding-cocktails-texas-heat` | \"Wedding Cocktails Austin: 8 Signature Drinks Built for Texas Heat (2026)\" | `wedding cocktails austin` |
| `rehearsal-dinner-austin-restaurants` | \"Austin Rehearsal Dinner Guide (2026): 12 Restaurants, Private Rooms & Boat Cruises\" | `rehearsal dinner austin` |
| `wedding-photography-austin-lakes-hills` | \"Austin Wedding Photography Locations: 15 Best Spots Around Lakes & Hills (2026)\" | `austin wedding photography locations` |
| `stress-free-wedding-vendor-checklist` | \"Austin Wedding Vendor Checklist (2026): Who to Book First & What to Ask\" | `austin wedding vendor checklist` |
| `plan-hill-country-wedding-six-months` | \"Hill Country Wedding Planning in 6 Months: 12-Step Accelerated Timeline (2026)\" | `hill country wedding planning` |

Each post now links to `/wedding-drink-calculator` and `/austin-wedding-venue-boats` in the lead paragraphs — feeds the calculator (highest ROI keyword) and the venue-boats page (value-segment cluster) authority signal.

## Test plan
- [ ] All five preview URLs render without MDX errors
- [ ] Frontmatter YAML parses cleanly (`npx tsx scripts/seo/audit-blog-corpus.mjs` if quick)
- [ ] Slugs unchanged — no redirect added or needed
- [ ] Internal cross-link UX reads naturally on a fresh read

## Roadmap

After this batch: 12 OPTIMIZE candidates remain. The strategic picks for batch 3 are the 3 longest assets (1600+ words each):
- `austin-party-houses-wedding-alcohol-delivery-unique-venues-for-austin-celebrations` (2143 words)
- `outdoor-wedding-alcohol-logistics-hill-country-and-austin-party-houses-coordination` (2342 words)
- `austin-wedding-venue-alcohol-policies-delivery-solutions-for-every-location` (1947 words)

Those have URL-hostile slugs so the title rewrite is lower-leverage on its own — they'd benefit more from slug consolidation + redirect, which is a bigger decision worth a separate review.

## Risks
- Same as PR #103: title changes can produce a brief CTR / rank reshuffle in GSC during reindex (1-2 weeks). Slugs are unchanged so ranking history is preserved.
- Two of the rewritten posts (cocktails, rehearsal dinner, photography) lean explicitly on the boats-as-venue narrative — keep an eye on whether that reads as overdone when the three sit together on the cluster page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)