### PR TITLE
fix(finance): bind Plaid webhook URL at link_token (no dashboard config)

### DIFF
--- a/src/app/api/admin/finance/plaid/backfill-webhooks/route.ts
+++ b/src/app/api/admin/finance/plaid/backfill-webhooks/route.ts
@@ -1,0 +1,33 @@
+/**
+ * POST /api/admin/finance/plaid/backfill-webhooks
+ *
+ * One-shot maintenance endpoint. Walks every active PlaidItem and calls
+ * /item/webhook/update on Plaid's side to point them at our webhook URL.
+ *
+ * Use after deploying the change that adds `webhook` to link_token creation
+ * (existing Items were linked before that change and have no webhook set
+ * on their Plaid Item record).
+ *
+ * Behind requireOpsAuth. Idempotent — re-running just re-sets the same URL.
+ */
+
+import { NextResponse } from 'next/server';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
+import { backfillItemWebhooks } from '@/lib/finance/plaid-client';
+
+export async function POST(): Promise<NextResponse> {
+  try {
+    const auth = await requireOpsAuth();
+    if (auth instanceof NextResponse) return auth;
+
+    const result = await backfillItemWebhooks();
+    return NextResponse.json({ success: true, data: result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('[Plaid backfill-webhooks] Error:', message);
+    return NextResponse.json(
+      { success: false, error: message },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/finance/plaid-client.ts
+++ b/src/lib/finance/plaid-client.ts
@@ -103,6 +103,23 @@ function createClient(): PlaidApi {
 }
 
 /**
+ * Public webhook URL Plaid will POST to when transactions / item events
+ * happen. Bound at link_token creation so every new Item is auto-wired —
+ * no Plaid-dashboard config required.
+ *
+ * Note: there's no team-level default webhook URL setting for the
+ * Transactions product in the Plaid dashboard (the dashboard "Webhooks"
+ * page is only for Transfer / Wallet / Bank Income product listeners).
+ * Per-Item is the supported path.
+ */
+function getWebhookUrl(): string {
+  return (
+    process.env.PLAID_WEBHOOK_URL ||
+    'https://partyondelivery.com/api/webhooks/plaid'
+  );
+}
+
+/**
  * Create a link_token the browser SDK exchanges for a public_token.
  * Phase 0 only requests `Transactions` since that's all Phase 2C uses.
  */
@@ -114,8 +131,52 @@ export async function createLinkToken(userId: string): Promise<string> {
     products: [Products.Transactions],
     country_codes: [CountryCode.Us],
     language: 'en',
+    webhook: getWebhookUrl(),
   });
   return response.data.link_token;
+}
+
+/**
+ * Update the webhook URL on an already-linked Item. Used for the one-shot
+ * backfill that wires the webhook on every existing PlaidItem (which were
+ * created before we passed `webhook` into link_token).
+ */
+export async function updateItemWebhook(accessToken: string): Promise<void> {
+  const client = createClient();
+  await client.itemWebhookUpdate({
+    access_token: accessToken,
+    webhook: getWebhookUrl(),
+  });
+}
+
+/**
+ * One-shot: walk every active PlaidItem and set its webhook URL on Plaid's
+ * side. Idempotent. Used by /api/admin/finance/plaid/backfill-webhooks once
+ * after this PR deploys, then optionally removed.
+ */
+export async function backfillItemWebhooks(): Promise<{
+  updated: number;
+  failed: number;
+  errors: string[];
+}> {
+  const { prisma } = await import('@/lib/database/client');
+  const items = await prisma.plaidItem.findMany({
+    where: { status: { in: ['active', 'error'] } },
+    select: { id: true, itemId: true, accessToken: true },
+  });
+  let updated = 0;
+  let failed = 0;
+  const errors: string[] = [];
+  for (const item of items) {
+    try {
+      await updateItemWebhook(item.accessToken);
+      updated++;
+    } catch (err) {
+      failed++;
+      errors.push(`${item.itemId}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  return { updated, failed, errors };
 }
 
 /**


### PR DESCRIPTION
## What's broken

The plan said \"set the Plaid webhook URL in dashboard.plaid.com\" but that page only accepts Transfer / Wallet / Bank Income product listeners. Transactions products take their webhook URL from the per-Item \`webhook\` field on \`/link/token/create\`, not from any team-level default.

## Fix

- \`src/lib/finance/plaid-client.ts\`:
  - \`createLinkToken\` now passes \`webhook\` so every NEW Item is auto-wired to our endpoint
  - \`updateItemWebhook(accessToken)\` — single-Item helper around \`/item/webhook/update\`
  - \`backfillItemWebhooks()\` — iterates every active PlaidItem; idempotent
- \`POST /api/admin/finance/plaid/backfill-webhooks\` — operator-triggerable one-shot to update existing Items

Reads optional \`PLAID_WEBHOOK_URL\` env override; defaults to \`https://partyondelivery.com/api/webhooks/plaid\`.

## After deploy

Allan runs the backfill once to point the already-connected sandbox Item at our endpoint:

\`\`\`bash
# Via admin session (preferred)
# Open Chrome → /admin/finance/plaid → DevTools Console → run:
fetch('/api/admin/finance/plaid/backfill-webhooks', { method: 'POST' })
  .then(r => r.json()).then(console.log)
\`\`\`

Or just click Reconnect Bank on /admin/finance/connect-bank — the new link_token call bakes the URL in.

## Verification

- \`npx tsc --noEmit\` — clean for changed files (unrelated pre-existing errors in dashboard code from main, not from this PR)
- No schema changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)