### PR TITLE
fix(seo): diverge product/blog titles + image dimensions/sizes for CWV

### DIFF
--- a/docs/seo/image-dimensions-fix-list-2026-06-09.json
+++ b/docs/seo/image-dimensions-fix-list-2026-06-09.json
@@ -1,0 +1,1225 @@
+{
+  "generatedAt": "2026-06-09T16:17:41.674Z",
+  "totals": {
+    "imgFixesTotal": 58,
+    "imgFixesResolved": 26,
+    "imgFixesUnresolvable": 32,
+    "fillFixesTotal": 53,
+    "filesAffected": 76
+  },
+  "byFile": {
+    "src/components/Navigation.tsx": {
+      "img": [
+        {
+          "file": "src/components/Navigation.tsx",
+          "src": "/images/pod-logo-2025.svg",
+          "severity": "error",
+          "suggested": {
+            "width": 2160,
+            "height": 2160,
+            "resolved": "/images/pod-logo-2025.svg"
+          },
+          "snippet": "<img\n                src=\"/images/pod-logo-2025.svg\"\n                alt=\"Party On Delivery\"\n       ..."
+        },
+        {
+          "file": "src/components/Navigation.tsx",
+          "src": "/images/pod-logo-2025.svg",
+          "severity": "error",
+          "suggested": {
+            "width": 2160,
+            "height": 2160,
+            "resolved": "/images/pod-logo-2025.svg"
+          },
+          "snippet": "<img\n                src=\"/images/pod-logo-2025.svg\"\n                alt=\"Party On Delivery\"\n       ..."
+        },
+        {
+          "file": "src/components/Navigation.tsx",
+          "src": "/images/pod-logo-2025.svg",
+          "severity": "error",
+          "suggested": {
+            "width": 2160,
+            "height": 2160,
+            "resolved": "/images/pod-logo-2025.svg"
+          },
+          "snippet": "<img\n                src=\"/images/pod-logo-2025.svg\"\n                alt=\"Party On Delivery\"\n       ..."
+        }
+      ],
+      "fill": []
+    },
+    "src/components/shopify/ProductCard.tsx": {
+      "img": [
+        {
+          "file": "src/components/shopify/ProductCard.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img\n                src={imageUrl}\n                alt={product.title}\n                className=\"w..."
+        }
+      ],
+      "fill": []
+    },
+    "src/components/shopify/MobileProductCard.tsx": {
+      "img": [
+        {
+          "file": "src/components/shopify/MobileProductCard.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img\n                src={imageUrl}\n                alt={product.title}\n                className=\"w..."
+        }
+      ],
+      "fill": []
+    },
+    "src/components/shopify/CompactProductCard.tsx": {
+      "img": [
+        {
+          "file": "src/components/shopify/CompactProductCard.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img\n                src={imageUrl}\n                alt={product.title}\n                className=\"w..."
+        }
+      ],
+      "fill": []
+    },
+    "src/components/shopify/CartItem.tsx": {
+      "img": [
+        {
+          "file": "src/components/shopify/CartItem.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img\n            src={imageUrl}\n            alt={item.merchandise.product.title}\n            classNa..."
+        }
+      ],
+      "fill": []
+    },
+    "src/components/quick-order/QuickOrderSearch.tsx": {
+      "img": [
+        {
+          "file": "src/components/quick-order/QuickOrderSearch.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img\n                            src={getProductImageUrl(product)}\n                            alt={..."
+        }
+      ],
+      "fill": []
+    },
+    "src/components/partners/DrinkCalculator.tsx": {
+      "img": [
+        {
+          "file": "src/components/partners/DrinkCalculator.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img\n            src={product.imageUrl}\n            alt={product.productTitle ?? product.name}\n     ..."
+        }
+      ],
+      "fill": []
+    },
+    "src/components/mobile/MobileSearchModal.tsx": {
+      "img": [
+        {
+          "file": "src/components/mobile/MobileSearchModal.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img\n                            src={product.images.edges[0].node.url}\n                            ..."
+        }
+      ],
+      "fill": []
+    },
+    "src/components/kegs/EquipmentRentals.tsx": {
+      "img": [
+        {
+          "file": "src/components/kegs/EquipmentRentals.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img\n                    src={imageUrl}\n                    alt={product.title}\n                    ..."
+        },
+        {
+          "file": "src/components/kegs/EquipmentRentals.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img\n                src={imageUrl}\n                alt={product.title}\n                className=\"w..."
+        }
+      ],
+      "fill": []
+    },
+    "src/components/group-v2/GroupProductCatalog.tsx": {
+      "img": [
+        {
+          "file": "src/components/group-v2/GroupProductCatalog.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img\n                      src={imgUrl}\n                      alt={product.title}\n                  ..."
+        }
+      ],
+      "fill": []
+    },
+    "src/components/group-v2/DraftCartItemRow.tsx": {
+      "img": [
+        {
+          "file": "src/components/group-v2/DraftCartItemRow.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img\n          src={item.imageUrl}\n          alt={item.title}\n          className=\"w-24 h-24 rounded..."
+        }
+      ],
+      "fill": []
+    },
+    "src/components/drink-planner/DrinkPlannerQuiz.tsx": {
+      "img": [
+        {
+          "file": "src/components/drink-planner/DrinkPlannerQuiz.tsx",
+          "src": "/images/pod-logo-2025.svg",
+          "severity": "error",
+          "suggested": {
+            "width": 2160,
+            "height": 2160,
+            "resolved": "/images/pod-logo-2025.svg"
+          },
+          "snippet": "<img\n                  src=\"/images/pod-logo-2025.svg\"\n                  alt=\"Party On Delivery\"\n   ..."
+        }
+      ],
+      "fill": []
+    },
+    "src/components/blog/MDXContentRSC.tsx": {
+      "img": [
+        {
+          "file": "src/components/blog/MDXContentRSC.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img\n          src={props.src}\n          alt={props.alt || ''}\n          className=\"w-full h-auto ro..."
+        }
+      ],
+      "fill": []
+    },
+    "src/components/blog/MDXContent.tsx": {
+      "img": [
+        {
+          "file": "src/components/blog/MDXContent.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img\n          src={props.src}\n          alt={props.alt || ''}\n          className=\"w-full h-auto ro..."
+        }
+      ],
+      "fill": []
+    },
+    "src/components/account/AccountLayout.tsx": {
+      "img": [
+        {
+          "file": "src/components/account/AccountLayout.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img \n                      src={profileImage} \n                      alt=\"Profile\" \n               ..."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/weddings/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/weddings/page.tsx",
+          "src": "/images/pod-logo-2025.svg",
+          "severity": "error",
+          "suggested": {
+            "width": 2160,
+            "height": 2160,
+            "resolved": "/images/pod-logo-2025.svg"
+          },
+          "snippet": "<img \n                src=\"/images/pod-logo-2025.svg\" \n                alt=\"Party On Delivery\"\n     ..."
+        }
+      ],
+      "fill": [
+        {
+          "file": "src/app/weddings/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n                  src={image.src}\n                  alt={image.alt}\n                  fill\n  ..."
+        }
+      ]
+    },
+    "src/app/terms/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/terms/page.tsx",
+          "src": "/images/pod-logo-2025.svg",
+          "severity": "error",
+          "suggested": {
+            "width": 2160,
+            "height": 2160,
+            "resolved": "/images/pod-logo-2025.svg"
+          },
+          "snippet": "<img \n                src=\"/images/pod-logo-2025.svg\" \n                alt=\"Party On Delivery\"\n     ..."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/privacy/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/privacy/page.tsx",
+          "src": "/images/pod-logo-2025.svg",
+          "severity": "error",
+          "suggested": {
+            "width": 2160,
+            "height": 2160,
+            "resolved": "/images/pod-logo-2025.svg"
+          },
+          "snippet": "<img \n                src=\"/images/pod-logo-2025.svg\" \n                alt=\"Party On Delivery\"\n     ..."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/products/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/products/page.tsx",
+          "src": "/images/pod-logo-2025.svg",
+          "severity": "error",
+          "suggested": {
+            "width": 2160,
+            "height": 2160,
+            "resolved": "/images/pod-logo-2025.svg"
+          },
+          "snippet": "<img \n                src=\"/images/pod-logo-2025.svg\" \n                alt=\"Party On Delivery\"\n     ..."
+        }
+      ],
+      "fill": [
+        {
+          "file": "src/app/products/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n          src=\"/images/products/premium-spirits-wall.webp\"\n          alt=\"Premium Spirits Col..."
+        }
+      ]
+    },
+    "src/app/order/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/order/page.tsx",
+          "src": "/images/pod-logo-2025.svg",
+          "severity": "error",
+          "suggested": {
+            "width": 2160,
+            "height": 2160,
+            "resolved": "/images/pod-logo-2025.svg"
+          },
+          "snippet": "<img src=\"/images/pod-logo-2025.svg\" alt=\"Party On\" className=\"h-40 w-auto mx-auto mb-8\" />..."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/payment/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/payment/page.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img\n                            src={node.merchandise.product.images?.edges?.[0]?.node.url}\n       ..."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/kegs/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/kegs/page.tsx",
+          "src": "/images/pod-logo-2025.svg",
+          "severity": "error",
+          "suggested": {
+            "width": 2160,
+            "height": 2160,
+            "resolved": "/images/pod-logo-2025.svg"
+          },
+          "snippet": "<img\n                src=\"/images/pod-logo-2025.svg\"\n                alt=\"Party On Delivery\"\n       ..."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/faqs/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/faqs/page.tsx",
+          "src": "/images/pod-logo-2025.svg",
+          "severity": "error",
+          "suggested": {
+            "width": 2160,
+            "height": 2160,
+            "resolved": "/images/pod-logo-2025.svg"
+          },
+          "snippet": "<img\n                src=\"/images/pod-logo-2025.svg\"\n                alt=\"Party On Delivery\"\n       ..."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/delivery-areas/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/delivery-areas/page.tsx",
+          "src": "/images/pod-logo-2025.svg",
+          "severity": "error",
+          "suggested": {
+            "width": 2160,
+            "height": 2160,
+            "resolved": "/images/pod-logo-2025.svg"
+          },
+          "snippet": "<img \n                src=\"/images/pod-logo-2025.svg\" \n                alt=\"Party On Delivery\"\n     ..."
+        }
+      ],
+      "fill": [
+        {
+          "file": "src/app/delivery-areas/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "100vw",
+          "snippet": "<Image\n          src=\"/images/hero/austin-skyline-golden-hour.webp\"\n          alt=\"Austin Aerial Vie..."
+        }
+      ]
+    },
+    "src/app/corporate-events-guide/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/corporate-events-guide/page.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img\n          src={frontmatter.image || '/images/hero/lake-travis-yacht-sunset.webp'}\n          alt..."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/contact/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/contact/page.tsx",
+          "src": "/images/pod-logo-2025.svg",
+          "severity": "error",
+          "suggested": {
+            "width": 2160,
+            "height": 2160,
+            "resolved": "/images/pod-logo-2025.svg"
+          },
+          "snippet": "<img \n                src=\"/images/pod-logo-2025.svg\" \n                alt=\"Party On Delivery\"\n     ..."
+        }
+      ],
+      "fill": [
+        {
+          "file": "src/app/contact/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "100vw",
+          "snippet": "<Image\n          src=\"/images/hero/contact-hero-austin.webp\"\n          alt=\"Austin Downtown\"\n       ..."
+        }
+      ]
+    },
+    "src/app/corporate/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/corporate/page.tsx",
+          "src": "/images/pod-logo-2025.svg",
+          "severity": "error",
+          "suggested": {
+            "width": 2160,
+            "height": 2160,
+            "resolved": "/images/pod-logo-2025.svg"
+          },
+          "snippet": "<img\n                src=\"/images/pod-logo-2025.svg\"\n                alt=\"Party On Delivery\"\n       ..."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/boat-parties/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/boat-parties/page.tsx",
+          "src": "/images/pod-logo-2025.svg",
+          "severity": "error",
+          "suggested": {
+            "width": 2160,
+            "height": 2160,
+            "resolved": "/images/pod-logo-2025.svg"
+          },
+          "snippet": "<img \n                src=\"/images/pod-logo-2025.svg\" \n                alt=\"Party On Delivery\"\n     ..."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/about/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/about/page.tsx",
+          "src": "/images/pod-logo-2025.svg",
+          "severity": "error",
+          "suggested": {
+            "width": 2160,
+            "height": 2160,
+            "resolved": "/images/pod-logo-2025.svg"
+          },
+          "snippet": "<img \n                src=\"/images/pod-logo-2025.svg\" \n                alt=\"Party On Delivery\"\n     ..."
+        }
+      ],
+      "fill": [
+        {
+          "file": "src/app/about/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "100vw",
+          "snippet": "<Image\n          src=\"/images/hero/austin-skyline-golden-hour.webp\"\n          alt=\"Austin Skyline\"\n ..."
+        },
+        {
+          "file": "src/app/about/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n              src=\"/images/about/professional-bartender-team.webp\"\n              alt=\"Party O..."
+        },
+        {
+          "file": "src/app/about/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n                src=\"/images/about/premium-warehouse-facility.webp\"\n                alt=\"Prem..."
+        }
+      ]
+    },
+    "src/app/weddings/order/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/weddings/order/page.tsx",
+          "src": "/images/wedding-services/order-hero.png",
+          "severity": "error",
+          "suggested": {
+            "width": 2816,
+            "height": 1536,
+            "resolved": "/images/wedding-services/order-hero.png"
+          },
+          "snippet": "<img\n          src=\"/images/wedding-services/order-hero.png\"\n          alt=\"\"\n          className=\"a..."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/products/[handle]/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/products/[handle]/page.tsx",
+          "src": "/images/pod-logo-2025.svg",
+          "severity": "error",
+          "suggested": {
+            "width": 2160,
+            "height": 2160,
+            "resolved": "/images/pod-logo-2025.svg"
+          },
+          "snippet": "<img\n                src=\"/images/pod-logo-2025.svg\"\n                alt=\"Party On Delivery\"\n       ..."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/order/last-minute/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/order/last-minute/page.tsx",
+          "src": "/images/pod-logo-2025.svg",
+          "severity": "error",
+          "suggested": {
+            "width": 2160,
+            "height": 2160,
+            "resolved": "/images/pod-logo-2025.svg"
+          },
+          "snippet": "<img src=\"/images/pod-logo-2025.svg\" alt=\"Party On\" className=\"h-40 w-auto mx-auto mb-8\" />..."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/ops/products/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/ops/products/page.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img\n                          src={product.image.url}\n                          alt={product.image...."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/corporate/holiday-party/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/corporate/holiday-party/page.tsx",
+          "src": "/images/pod-logo-2025.svg",
+          "severity": "error",
+          "suggested": {
+            "width": 2160,
+            "height": 2160,
+            "resolved": "/images/pod-logo-2025.svg"
+          },
+          "snippet": "<img\n                src=\"/images/pod-logo-2025.svg\"\n                alt=\"Party On Delivery\"\n       ..."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/checkout/success/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/checkout/success/page.tsx",
+          "src": "/images/checkout/thank-you-hero.png",
+          "severity": "error",
+          "suggested": {
+            "width": 1664,
+            "height": 640,
+            "resolved": "/images/checkout/thank-you-hero.png"
+          },
+          "snippet": "<img\r\n            src=\"/images/checkout/thank-you-hero.png\"\r\n            alt=\"Thank you for your ord..."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/account/orders/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/account/orders/page.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img \n                            src={item.variant.image.url} \n                            alt={ite..."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/(main)/fast-delivery/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/(main)/fast-delivery/page.tsx",
+          "src": "/images/services/fast-delivery/speed-focused-delivery.webp",
+          "severity": "error",
+          "suggested": {
+            "width": 1456,
+            "height": 816,
+            "resolved": "/images/services/fast-delivery/speed-focused-delivery.webp"
+          },
+          "snippet": "<img\n                src=\"/images/services/fast-delivery/speed-focused-delivery.webp\"\n              ..."
+        },
+        {
+          "file": "src/app/(main)/fast-delivery/page.tsx",
+          "src": "/images/services/fast-delivery/motion-blur-delivery.webp",
+          "severity": "error",
+          "suggested": {
+            "width": 1456,
+            "height": 816,
+            "resolved": "/images/services/fast-delivery/motion-blur-delivery.webp"
+          },
+          "snippet": "<img\n                src=\"/images/services/fast-delivery/motion-blur-delivery.webp\"\n                ..."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/weddings/packages/[tier]/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/weddings/packages/[tier]/page.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img\n                              src={item.product.images.edges[0].node.url}\n                     ..."
+        },
+        {
+          "file": "src/app/weddings/packages/[tier]/page.tsx",
+          "src": "/images/pod-logo-2025.svg",
+          "severity": "error",
+          "suggested": {
+            "width": 2160,
+            "height": 2160,
+            "resolved": "/images/pod-logo-2025.svg"
+          },
+          "snippet": "<img \n                src=\"/images/pod-logo-2025.svg\" \n                alt=\"Party On Delivery\"\n     ..."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/ops/products/create/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/ops/products/create/page.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img src={img.url} alt={`Product ${idx + 1}`} className=\"w-full h-full object-cover\" />..."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/ops/orders/[id]/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/ops/orders/[id]/page.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img src={item.imageUrl} alt=\"\" className=\"w-10 h-10 rounded-lg object-cover border border-gray-100 ..."
+        },
+        {
+          "file": "src/app/ops/orders/[id]/page.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img src={item.imageUrl} alt=\"\" className=\"w-10 h-10 rounded-lg object-cover border border-gray-100 ..."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/ops/orders/create/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/ops/orders/create/page.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img\n                          src={product.images[0].url}\n                          alt={product.ti..."
+        },
+        {
+          "file": "src/app/ops/orders/create/page.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img src={item.imageUrl} alt={item.title} className=\"w-10 h-10 rounded-lg object-cover border border..."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/ops/inventory/count/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/ops/inventory/count/page.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img\n                  src={image}\n                  alt={`Selected ${index + 1}`}\n                 ..."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/ops/collections/[id]/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/ops/collections/[id]/page.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img src={p.image.url} alt={p.title} className=\"w-10 h-10 rounded-lg object-cover border border-gray..."
+        },
+        {
+          "file": "src/app/ops/collections/[id]/page.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img src={p.imageUrl} alt={p.title} className=\"w-12 h-12 rounded-lg object-cover border border-gray-..."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/boat-parties/packages/[tier]/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/boat-parties/packages/[tier]/page.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img\n                              src={item.product.images.edges[0].node.url}\n                     ..."
+        },
+        {
+          "file": "src/app/boat-parties/packages/[tier]/page.tsx",
+          "src": "/images/pod-logo-2025.svg",
+          "severity": "error",
+          "suggested": {
+            "width": 2160,
+            "height": 2160,
+            "resolved": "/images/pod-logo-2025.svg"
+          },
+          "snippet": "<img \n                src=\"/images/pod-logo-2025.svg\" \n                alt=\"Party On Delivery\"\n     ..."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/affiliate/dashboard/components/AffiliateDashboardHeader.tsx": {
+      "img": [
+        {
+          "file": "src/app/affiliate/dashboard/components/AffiliateDashboardHeader.tsx",
+          "src": "/images/pod-logo-2025.png",
+          "severity": "error",
+          "suggested": {
+            "width": 1024,
+            "height": 1024,
+            "resolved": "/images/pod-logo-2025.png"
+          },
+          "snippet": "<img\n              src=\"/images/pod-logo-2025.png\"\n              alt=\"Party On Delivery\"\n           ..."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/ops/orders/[id]/edit/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/ops/orders/[id]/edit/page.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img\n                          src={product.images[0].url}\n                          alt={product.ti..."
+        },
+        {
+          "file": "src/app/ops/orders/[id]/edit/page.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img src={item.imageUrl} alt={item.title} className=\"w-10 h-10 rounded-lg object-cover border border..."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/ops/inventory/receiving/new/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/ops/inventory/receiving/new/page.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img src={preview} alt=\"Invoice preview\" className=\"w-full rounded-lg border border-gray-200\" />..."
+        }
+      ],
+      "fill": []
+    },
+    "src/app/ops/inventory/receiving/[id]/page.tsx": {
+      "img": [
+        {
+          "file": "src/app/ops/inventory/receiving/[id]/page.tsx",
+          "src": null,
+          "severity": "error",
+          "suggested": null,
+          "snippet": "<img src={invoice.imageUrl} alt=\"Invoice\" className=\"w-full rounded-lg border border-gray-200\" />..."
+        }
+      ],
+      "fill": []
+    },
+    "src/components/partners/PremierHero.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/components/partners/PremierHero.tsx",
+          "severity": "warning",
+          "suggestedSizes": "100vw",
+          "snippet": "<Image\n        src=\"/images/partners/premierpartycruises-hero-bg3.webp.png\"\n        alt=\"Premier Par..."
+        }
+      ]
+    },
+    "src/components/partners/AndersonMillHero.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/components/partners/AndersonMillHero.tsx",
+          "severity": "warning",
+          "suggestedSizes": "100vw",
+          "snippet": "<Image\n        src=\"/images/partners/anderson-mill-marina-hero.png\"\n        alt=\"Anderson Mill Marin..."
+        }
+      ]
+    },
+    "src/components/group-v2/GroupHeader.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/components/group-v2/GroupHeader.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n        src=\"/images/partners/group-dashboard-bg.png\"\n        alt=\"\"\n        fill\n        cla..."
+        }
+      ]
+    },
+    "src/app/plan-event/page.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/app/plan-event/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "100vw",
+          "snippet": "<Image\n          src=\"/images/hero/austin-skyline-hero.webp\"\n          alt=\"Austin skyline at sunset..."
+        },
+        {
+          "file": "src/app/plan-event/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n                      src={event.image}\n                      alt={event.title}\n             ..."
+        }
+      ]
+    },
+    "src/app/old-fashioned/page.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/app/old-fashioned/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "100vw",
+          "snippet": "<Image\n          src=\"/images/hero/austin-skyline-golden-hour.webp\"\n          alt=\"Luxury Experience..."
+        },
+        {
+          "file": "src/app/old-fashioned/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n                src=\"/images/services/corporate/penthouse-suite-setup.webp\"\n                a..."
+        },
+        {
+          "file": "src/app/old-fashioned/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n                src=\"/images/services/weddings/boho-hill-country-1.webp\"\n                alt=..."
+        }
+      ]
+    },
+    "src/app/negroni/page.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/app/negroni/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n                src=\"/images/services/corporate/penthouse-suite-setup.webp\"\n                a..."
+        },
+        {
+          "file": "src/app/negroni/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n                src=\"/images/products/premium-spirits-wall.webp\"\n                alt=\"Premium..."
+        },
+        {
+          "file": "src/app/negroni/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n          src=\"/images/backgrounds/rooftop-terrace-elegant-1.webp\"\n          alt=\"Luxury Expe..."
+        }
+      ]
+    },
+    "src/app/gin-martini/page.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/app/gin-martini/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "100vw",
+          "snippet": "<Image\n            src=\"/images/hero/austin-skyline-golden-hour.webp\"\n            alt=\"Austin Herita..."
+        },
+        {
+          "file": "src/app/gin-martini/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n                  src=\"/images/gallery/headquarters-entrance.webp\"\n                  alt=\"Her..."
+        }
+      ]
+    },
+    "src/app/custom-package/page.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/app/custom-package/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n                              src={product.images.edges[0].node.url}\n                        ..."
+        }
+      ]
+    },
+    "src/app/cocktail-kits/page.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/app/cocktail-kits/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n                  src=\"/images/products/fresh-victor-cocktails/cocktail-kits-grid.png\"\n      ..."
+        }
+      ]
+    },
+    "src/app/blog/page-old.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/app/blog/page-old.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n                        src={imageUrl}\n                        alt={post.image?.alt || post.t..."
+        }
+      ]
+    },
+    "src/app/blog/BlogSearchFilter.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/app/blog/BlogSearchFilter.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n                          src={imageUrl}\n                          alt={post.image?.alt || po..."
+        }
+      ]
+    },
+    "src/app/austin-partners/page.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/app/austin-partners/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n          src=\"/images/gallery/headquarters-entrance.webp\"\n          alt=\"Partner with Party ..."
+        },
+        {
+          "file": "src/app/austin-partners/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n                  src=\"/images/gallery/ai-recommended-setup.webp\"\n                  alt=\"Cust..."
+        }
+      ]
+    },
+    "src/app/austin-byob-venues/page.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/app/austin-byob-venues/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n                          src={venue.image || '/images/venues/default-venue.webp'}\n          ..."
+        },
+        {
+          "file": "src/app/austin-byob-venues/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n                          src={venue.image || '/images/venues/default-venue.webp'}\n          ..."
+        }
+      ]
+    },
+    "src/app/atx-delivery-info/page.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/app/atx-delivery-info/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "100vw",
+          "snippet": "<Image\n            src=\"/images/hero/lake-travis-yacht-sunset.webp\"\n            alt=\"Austin Alcohol ..."
+        }
+      ]
+    },
+    "src/app/aperol-spritz/page.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/app/aperol-spritz/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n                src=\"/images/services/corporate/penthouse-suite-setup.webp\"\n                a..."
+        },
+        {
+          "file": "src/app/aperol-spritz/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n                  src={`/images/gallery/${image}.webp`}\n                  alt={`Portfolio ${i..."
+        }
+      ]
+    },
+    "src/components/drink-planner/steps/WelcomeStep.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/components/drink-planner/steps/WelcomeStep.tsx",
+          "severity": "warning",
+          "suggestedSizes": "100vw",
+          "snippet": "<Image\n        src=\"/images/order/order-hero.png\"\n        alt=\"Premium Bar Setup at Austin Pool Part..."
+        }
+      ]
+    },
+    "src/app/weddings/products/page.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/app/weddings/products/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n          src=\"/images/services/weddings/outdoor-bar-setup.webp\"\n          alt=\"Wedding Bar S..."
+        },
+        {
+          "file": "src/app/weddings/products/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n                      src={product.image}\n                      alt={product.title}\n         ..."
+        }
+      ]
+    },
+    "src/app/partners/property-management/page.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/app/partners/property-management/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n          src=\"/images/backgrounds/rooftop-terrace-elegant-2.webp\"\n          alt=\"Luxury Prop..."
+        },
+        {
+          "file": "src/app/partners/property-management/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n                    src={amenity.image}\n                    alt={amenity.title}\n             ..."
+        }
+      ]
+    },
+    "src/app/partners/mobile-bartenders/page.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/app/partners/mobile-bartenders/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n                  src={useCase.image}\n                  alt={useCase.title}\n                 ..."
+        },
+        {
+          "file": "src/app/partners/mobile-bartenders/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n                      src={testimonial.image}\n                      alt={testimonial.author}\n..."
+        },
+        {
+          "file": "src/app/partners/mobile-bartenders/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "100vw",
+          "snippet": "<Image\n                    src=\"/images/partners/pourtwentyfour-hero.jpg\"\n                    alt=\"\"..."
+        },
+        {
+          "file": "src/app/partners/mobile-bartenders/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "100vw",
+          "snippet": "<Image\n                    src=\"/images/partners/dtr-bartending-hero.jpg\"\n                    alt=\"\"..."
+        },
+        {
+          "file": "src/app/partners/mobile-bartenders/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "100vw",
+          "snippet": "<Image\n                    src=\"/images/partners/taptruckaustin-hero.jpg\"\n                    alt=\"\"..."
+        }
+      ]
+    },
+    "src/app/partners/hotels-resorts/page.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/app/partners/hotels-resorts/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n          src=\"/images/backgrounds/rooftop-terrace-elegant-1.webp\"\n          alt=\"Luxury Hote..."
+        },
+        {
+          "file": "src/app/partners/hotels-resorts/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n                src=\"/images/gallery/sunset-champagne-pontoon.webp\"\n                alt=\"Hote..."
+        }
+      ]
+    },
+    "src/app/partners/austin-wedding-dj/page.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/app/partners/austin-wedding-dj/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "100vw",
+          "snippet": "<Image\n          src={HERO_IMAGE}\n          alt=\"[DJ_PHOTO] — Austin wedding DJ at a Lake Travis rec..."
+        },
+        {
+          "file": "src/app/partners/austin-wedding-dj/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "100vw",
+          "snippet": "<Image\n              src={HERO_IMAGE}\n              alt=\"[DJ_PHOTO] — portrait\"\n              fill\n ..."
+        }
+      ]
+    },
+    "src/app/gifts/cocktail-kits/page.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/app/gifts/cocktail-kits/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n                  src={austinRitaKit?.images.edges[0]?.node.url || 'https://cdn.shopify.com/s..."
+        }
+      ]
+    },
+    "src/app/delivery/[location]/page.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/app/delivery/[location]/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n          src=\"/images/services/corporate/penthouse-suite-setup.webp\"\n          alt={`${locat..."
+        }
+      ]
+    },
+    "src/app/corporate/products/page.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/app/corporate/products/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n          src=\"/images/services/corporate/penthouse-suite-setup.webp\"\n          alt=\"Corporat..."
+        },
+        {
+          "file": "src/app/corporate/products/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n                      src={product.image}\n                      alt={product.title}\n         ..."
+        }
+      ]
+    },
+    "src/app/blog/[slug]/page.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/app/blog/[slug]/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "100vw",
+          "snippet": "<Image\n                      src={relatedPost.image?.url || '/images/hero/lake-travis-yacht-sunset.w..."
+        }
+      ]
+    },
+    "src/app/blog/[slug]/page-mdx.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/app/blog/[slug]/page-mdx.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n          src={post.image}\n          alt={post.title}\n          fill\n          className=\"obj..."
+        }
+      ]
+    },
+    "src/app/(main)/team/page.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/app/(main)/team/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n                        src={member.image}\n                        alt={member.name}\n        ..."
+        }
+      ]
+    },
+    "src/app/(main)/ai-party-planner/page.tsx": {
+      "img": [],
+      "fill": [
+        {
+          "file": "src/app/(main)/ai-party-planner/page.tsx",
+          "severity": "warning",
+          "suggestedSizes": "(max-width: 768px) 100vw, 50vw",
+          "snippet": "<Image\n                      src={mode === 'wild' \n                        ? \"/images/ai-assistant/b..."
+        }
+      ]
+    }
+  }
+}

--- a/image-dimensions-audit.json
+++ b/image-dimensions-audit.json
@@ -1,316 +1,44 @@
 {
   "summary": {
-    "totalImages": 138,
-    "imagesWithDimensions": 13,
-    "imagesMissingDimensions": 125,
-    "percentageMissing": 91
+    "totalImages": 270,
+    "imagesWithDimensions": 178,
+    "imagesMissingDimensions": 92,
+    "percentageMissing": 34
   },
   "issues": {
-    "src/components/ProductSearch.tsx": [
+    "src/components/Navigation.tsx": [
       {
-        "file": "src/components/ProductSearch.tsx",
+        "file": "src/components/Navigation.tsx",
         "type": "Regular <img> missing dimensions",
-        "code": "<img\n                            src={product.images.edges[0].node.url}\n                            ...",
-        "severity": "error"
-      }
-    ],
-    "src/components/ProductModal.tsx": [
-      {
-        "file": "src/components/ProductModal.tsx",
-        "type": "Regular <img> missing dimensions",
-        "code": "<img\n                          src={image.url}\n                          alt={image.altText || `${pr...",
-        "severity": "error"
-      }
-    ],
-    "src/components/OldFashionedNavigation.tsx": [
-      {
-        "file": "src/components/OldFashionedNavigation.tsx",
-        "type": "Regular <img> missing dimensions",
-        "code": "<img \n                src=\"/images/POD Logo 2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
+        "code": "<img\n                src=\"/images/pod-logo-2025.svg\"\n                alt=\"Party On Delivery\"\n       ...",
         "severity": "error"
       },
       {
-        "file": "src/components/OldFashionedNavigation.tsx",
+        "file": "src/components/Navigation.tsx",
         "type": "Regular <img> missing dimensions",
-        "code": "<img \n                src=\"/images/POD Logo 2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
+        "code": "<img\n                src=\"/images/pod-logo-2025.svg\"\n                alt=\"Party On Delivery\"\n       ...",
         "severity": "error"
       },
       {
-        "file": "src/components/OldFashionedNavigation.tsx",
+        "file": "src/components/Navigation.tsx",
         "type": "Regular <img> missing dimensions",
-        "code": "<img \n                    src=\"/images/POD Logo 2025.svg\" \n                    alt=\"Party On Deliver...",
-        "severity": "error"
-      }
-    ],
-    "src/components/LuxuryCard.tsx": [
-      {
-        "file": "src/components/LuxuryCard.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n          src={bgImage}\n          alt=\"\"\n          fill\n          className=\"object-cover sca...",
-        "severity": "warning"
-      }
-    ],
-    "src/components/Hero.tsx": [
-      {
-        "file": "src/components/Hero.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n          src={backgroundImage}\n          alt={title}\n          fill\n          className=\"obj...",
-        "severity": "warning"
-      }
-    ],
-    "src/components/Footer.tsx": [
-      {
-        "file": "src/components/Footer.tsx",
-        "type": "Regular <img> missing dimensions",
-        "code": "<img\n                src=\"/images/POD Logo 2025.svg\"\n                alt=\"Party On Delivery\"\n       ...",
-        "severity": "error"
-      }
-    ],
-    "src/components/CTA.tsx": [
-      {
-        "file": "src/components/CTA.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n            src={backgroundImage}\n            alt=\"\"\n            fill\n            className=\"...",
-        "severity": "warning"
-      }
-    ],
-    "src/app/page.tsx": [
-      {
-        "file": "src/app/page.tsx",
-        "type": "Regular <img> missing dimensions",
-        "code": "<img \n                src=\"/images/POD Logo 2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
-        "severity": "error"
-      }
-    ],
-    "src/components/shopify/ProductCard.tsx": [
-      {
-        "file": "src/components/shopify/ProductCard.tsx",
-        "type": "Regular <img> missing dimensions",
-        "code": "<img\n                src={imageUrl}\n                alt={product.title}\n                className=\"w...",
-        "severity": "error"
-      }
-    ],
-    "src/components/shopify/MobileProductCard.tsx": [
-      {
-        "file": "src/components/shopify/MobileProductCard.tsx",
-        "type": "Regular <img> missing dimensions",
-        "code": "<img\n                src={imageUrl}\n                alt={product.title}\n                className=\"w...",
-        "severity": "error"
-      }
-    ],
-    "src/components/shopify/CompactProductCard.tsx": [
-      {
-        "file": "src/components/shopify/CompactProductCard.tsx",
-        "type": "Regular <img> missing dimensions",
-        "code": "<img\n                src={imageUrl}\n                alt={product.title}\n                className=\"w...",
-        "severity": "error"
-      }
-    ],
-    "src/components/shopify/CartItem.tsx": [
-      {
-        "file": "src/components/shopify/CartItem.tsx",
-        "type": "Regular <img> missing dimensions",
-        "code": "<img\n            src={imageUrl}\n            alt={item.merchandise.product.title}\n            classNa...",
-        "severity": "error"
-      }
-    ],
-    "src/components/products/ProductDetailClient.tsx": [
-      {
-        "file": "src/components/products/ProductDetailClient.tsx",
-        "type": "Regular <img> missing dimensions",
-        "code": "<img\n                  src={product.images.edges[selectedImageIndex]?.node.url}\n                  al...",
-        "severity": "error"
-      },
-      {
-        "file": "src/components/products/ProductDetailClient.tsx",
-        "type": "Regular <img> missing dimensions",
-        "code": "<img\n                      src={image.node.url}\n                      alt={`${product.title} ${index...",
-        "severity": "error"
-      },
-      {
-        "file": "src/components/products/ProductDetailClient.tsx",
-        "type": "Regular <img> missing dimensions",
-        "code": "<img\n                src=\"/images/POD Logo 2025.svg\"\n                alt=\"Party On Delivery\"\n       ...",
-        "severity": "error"
-      }
-    ],
-    "src/components/mobile/MobileSearchModal.tsx": [
-      {
-        "file": "src/components/mobile/MobileSearchModal.tsx",
-        "type": "Regular <img> missing dimensions",
-        "code": "<img\n                            src={product.images.edges[0].node.url}\n                            ...",
-        "severity": "error"
-      }
-    ],
-    "src/components/mobile/MobileProductCard.tsx": [
-      {
-        "file": "src/components/mobile/MobileProductCard.tsx",
-        "type": "Regular <img> missing dimensions",
-        "code": "<img\n                src={imageUrl}\n                alt={product.title}\n                className=\"w...",
-        "severity": "error"
-      }
-    ],
-    "src/components/blog/MDXContent.tsx": [
-      {
-        "file": "src/components/blog/MDXContent.tsx",
-        "type": "Regular <img> missing dimensions",
-        "code": "<img\n          src={props.src}\n          alt={props.alt || ''}\n          className=\"w-full h-auto ro...",
-        "severity": "error"
-      }
-    ],
-    "src/components/account/AccountLayout.tsx": [
-      {
-        "file": "src/components/account/AccountLayout.tsx",
-        "type": "Regular <img> missing dimensions",
-        "code": "<img \n                      src={profileImage} \n                      alt=\"Profile\" \n               ...",
+        "code": "<img\n                src=\"/images/pod-logo-2025.svg\"\n                alt=\"Party On Delivery\"\n       ...",
         "severity": "error"
       }
     ],
     "src/app/weddings/page.tsx": [
       {
         "file": "src/app/weddings/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n              src={heroImages[currentHeroIndex].src}\n              alt={heroImages[currentHer...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/weddings/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n                  src={image.src}\n                  alt={image.alt}\n                  fill\n  ...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/weddings/page.tsx",
         "type": "Regular <img> missing dimensions",
-        "code": "<img \n                src=\"/images/POD Logo 2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
+        "code": "<img \n                src=\"/images/pod-logo-2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
         "severity": "error"
-      }
-    ],
-    "src/app/ultra-clean/page.tsx": [
-      {
-        "file": "src/app/ultra-clean/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n            src=\"/images/services/corporate/penthouse-suite-setup.webp\"\n            alt=\"Prem...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/ultra-clean/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n                      src={service.image}\n                      alt={service.title}\n         ...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/ultra-clean/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n            src=\"/images/backgrounds/rooftop-terrace-elegant-1.webp\"\n            alt=\"Elegant...",
-        "severity": "warning"
       }
     ],
     "src/app/terms/page.tsx": [
       {
         "file": "src/app/terms/page.tsx",
         "type": "Regular <img> missing dimensions",
-        "code": "<img \n                src=\"/images/POD Logo 2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
-        "severity": "error"
-      }
-    ],
-    "src/app/simplified-home/page.tsx": [
-      {
-        "file": "src/app/simplified-home/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n            src=\"/images/hero/austin-skyline-golden-hour.webp\"\n            alt=\"Austin Skylin...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/simplified-home/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n                  src=\"/images/services/fast-delivery/speed-delivery-action.webp\"\n           ...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/simplified-home/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n                  src=\"/images/services/weddings/signature-cocktails-rings.webp\"\n            ...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/simplified-home/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n                  src=\"/images/services/boat-parties/sunset-champagne-pontoon.webp\"\n         ...",
-        "severity": "warning"
-      }
-    ],
-    "src/app/professional-home-v2/page.tsx": [
-      {
-        "file": "src/app/professional-home-v2/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n            src=\"/images/hero/luxury-wedding-estate-1.webp\"\n            alt=\"Premium Event Se...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/professional-home-v2/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n                    src={service.image}\n                    alt={service.title}\n             ...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/professional-home-v2/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n                src=\"/images/gallery/headquarters-entrance.webp\"\n                alt=\"Dell Te...",
-        "severity": "warning"
-      }
-    ],
-    "src/app/professional-home/page.tsx": [
-      {
-        "file": "src/app/professional-home/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n            src=\"/images/hero/luxury-wedding-estate-1.webp\"\n            alt=\"Luxury Event Ser...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/professional-home/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n                  src=\"/images/services/corporate/penthouse-suite-setup.webp\"\n               ...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/professional-home/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n                  src=\"/images/services/weddings/outdoor-bar-setup.webp\"\n                  al...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/professional-home/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n                  src=\"/images/services/boat-parties/luxury-yacht-deck.webp\"\n                ...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/professional-home/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n                src=\"/images/products/premium-spirits-wall.webp\"\n                alt=\"Premium...",
-        "severity": "warning"
-      }
-    ],
-    "src/app/products-test/page.tsx": [
-      {
-        "file": "src/app/products-test/page.tsx",
-        "type": "Regular <img> missing dimensions",
-        "code": "<img\n                      src={imageUrl}\n                      alt={product.title}\n                ...",
-        "severity": "error"
-      }
-    ],
-    "src/app/products/page.tsx": [
-      {
-        "file": "src/app/products/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n          src=\"/images/products/premium-spirits-wall.webp\"\n          alt=\"Premium Spirits Col...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/products/page.tsx",
-        "type": "Regular <img> missing dimensions",
-        "code": "<img \n                src=\"/images/POD Logo 2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
+        "code": "<img \n                src=\"/images/pod-logo-2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
         "severity": "error"
       }
     ],
@@ -318,36 +46,16 @@
       {
         "file": "src/app/privacy/page.tsx",
         "type": "Regular <img> missing dimensions",
-        "code": "<img \n                src=\"/images/POD Logo 2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
+        "code": "<img \n                src=\"/images/pod-logo-2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
         "severity": "error"
       }
     ],
-    "src/app/premium/page.tsx": [
+    "src/app/products/page.tsx": [
       {
-        "file": "src/app/premium/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image \n                  src=\"/images/services/corporate/penthouse-suite-setup.webp\"\n              ...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/premium/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n                      src={service.image}\n                      alt={service.title}\n         ...",
-        "severity": "warning"
-      }
-    ],
-    "src/app/polished/page.tsx": [
-      {
-        "file": "src/app/polished/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n            src=\"/images/services/corporate/penthouse-suite-setup.webp\"\n            alt=\"Prem...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/polished/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n                          src={service.image}\n                          alt={service.title}\n ...",
-        "severity": "warning"
+        "file": "src/app/products/page.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img \n                src=\"/images/pod-logo-2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
+        "severity": "error"
       }
     ],
     "src/app/payment/page.tsx": [
@@ -358,31 +66,25 @@
         "severity": "error"
       }
     ],
-    "src/app/partners/page.tsx": [
+    "src/app/plan-event/page.tsx": [
       {
-        "file": "src/app/partners/page.tsx",
+        "file": "src/app/plan-event/page.tsx",
         "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n          src=\"/images/gallery/headquarters-entrance.webp\"\n          alt=\"Partner with PartyO...",
+        "code": "<Image\n          src=\"/images/hero/austin-skyline-hero.webp\"\n          alt=\"Austin skyline at sunset...",
         "severity": "warning"
       },
       {
-        "file": "src/app/partners/page.tsx",
+        "file": "src/app/plan-event/page.tsx",
         "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n                  src=\"/images/gallery/ai-recommended-setup.webp\"\n                  alt=\"Cust...",
+        "code": "<Image\n                      src={event.image}\n                      alt={event.title}\n             ...",
         "severity": "warning"
       }
     ],
     "src/app/order/page.tsx": [
       {
         "file": "src/app/order/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n                    src={event.image}\n                    alt={event.title}\n                 ...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/order/page.tsx",
         "type": "Regular <img> missing dimensions",
-        "code": "<img \n                src=\"/images/POD Logo 2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
+        "code": "<img src=\"/images/pod-logo-2025.svg\" alt=\"Party On\" className=\"h-40 w-auto mx-auto mb-8\" />...",
         "severity": "error"
       }
     ],
@@ -426,6 +128,22 @@
         "severity": "warning"
       }
     ],
+    "src/app/kegs/page.tsx": [
+      {
+        "file": "src/app/kegs/page.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img\n                src=\"/images/pod-logo-2025.svg\"\n                alt=\"Party On Delivery\"\n       ...",
+        "severity": "error"
+      }
+    ],
+    "src/app/faqs/page.tsx": [
+      {
+        "file": "src/app/faqs/page.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img\n                src=\"/images/pod-logo-2025.svg\"\n                alt=\"Party On Delivery\"\n       ...",
+        "severity": "error"
+      }
+    ],
     "src/app/gin-martini/page.tsx": [
       {
         "file": "src/app/gin-martini/page.tsx",
@@ -440,48 +158,12 @@
         "severity": "warning"
       }
     ],
-    "src/app/final/page.tsx": [
-      {
-        "file": "src/app/final/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n            src=\"/images/services/corporate/penthouse-suite-setup.webp\"\n            alt=\"Prem...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/final/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n                        src={service.image}\n                        alt={service.title}\n     ...",
-        "severity": "warning"
-      }
-    ],
-    "src/app/faqs/page.tsx": [
-      {
-        "file": "src/app/faqs/page.tsx",
-        "type": "Regular <img> missing dimensions",
-        "code": "<img\n                src=\"/images/POD Logo 2025.svg\"\n                alt=\"Party On Delivery\"\n       ...",
-        "severity": "error"
-      }
-    ],
     "src/app/delivery-areas/page.tsx": [
       {
         "file": "src/app/delivery-areas/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n          src=\"/images/hero/austin-skyline-golden-hour.webp\"\n          alt=\"Austin Aerial Vie...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/delivery-areas/page.tsx",
         "type": "Regular <img> missing dimensions",
-        "code": "<img \n                src=\"/images/POD Logo 2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
+        "code": "<img \n                src=\"/images/pod-logo-2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
         "severity": "error"
-      }
-    ],
-    "src/app/custom-package/page.tsx": [
-      {
-        "file": "src/app/custom-package/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n                              src={product.images.edges[0].node.url}\n                        ...",
-        "severity": "warning"
       }
     ],
     "src/app/corporate-events-guide/page.tsx": [
@@ -495,77 +177,33 @@
     "src/app/corporate/page.tsx": [
       {
         "file": "src/app/corporate/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n            src=\"/images/hero/corporate-hero-conference.webp\"\n            alt=\"Corporate even...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/corporate/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n                    src={useCase.image}\n                    alt={useCase.title}\n             ...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/corporate/page.tsx",
         "type": "Regular <img> missing dimensions",
-        "code": "<img\n                src=\"/images/POD Logo 2025.svg\"\n                alt=\"Party On Delivery\"\n       ...",
+        "code": "<img\n                src=\"/images/pod-logo-2025.svg\"\n                alt=\"Party On Delivery\"\n       ...",
         "severity": "error"
       }
     ],
     "src/app/contact/page.tsx": [
       {
         "file": "src/app/contact/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n          src=\"/images/hero/contact-hero-austin.webp\"\n          alt=\"Austin Downtown\"\n       ...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/contact/page.tsx",
         "type": "Regular <img> missing dimensions",
-        "code": "<img \n                src=\"/images/POD Logo 2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
+        "code": "<img \n                src=\"/images/pod-logo-2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
         "severity": "error"
       }
     ],
-    "src/app/collections/page.tsx": [
+    "src/app/cocktail-kits/page.tsx": [
       {
-        "file": "src/app/collections/page.tsx",
+        "file": "src/app/cocktail-kits/page.tsx",
         "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n          src=\"/images/products/premium-spirits-wall.webp\"\n          alt=\"Premium Collections...",
+        "code": "<Image\n                  src=\"/images/products/fresh-victor-cocktails/cocktail-kits-grid.png\"\n      ...",
         "severity": "warning"
-      },
-      {
-        "file": "src/app/collections/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n            src={collection.image}\n            alt={collection.title}\n            fill\n      ...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/collections/page.tsx",
-        "type": "Regular <img> missing dimensions",
-        "code": "<img \n                src=\"/images/POD Logo 2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
-        "severity": "error"
       }
     ],
     "src/app/boat-parties/page.tsx": [
       {
         "file": "src/app/boat-parties/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n              src={heroImages[currentHeroImage].src}\n              alt={heroImages[currentHer...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/boat-parties/page.tsx",
         "type": "Regular <img> missing dimensions",
-        "code": "<img \n                src=\"/images/POD Logo 2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
+        "code": "<img \n                src=\"/images/pod-logo-2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
         "severity": "error"
-      }
-    ],
-    "src/app/blog/page.tsx": [
-      {
-        "file": "src/app/blog/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n                        src={imageUrl}\n                        alt={post.image?.alt || post.t...",
-        "severity": "warning"
       }
     ],
     "src/app/blog/page-old.tsx": [
@@ -576,18 +214,40 @@
         "severity": "warning"
       }
     ],
-    "src/app/bach-parties/page.tsx": [
+    "src/app/austin-partners/page.tsx": [
       {
-        "file": "src/app/bach-parties/page.tsx",
+        "file": "src/app/austin-partners/page.tsx",
         "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n              src={heroImages[currentHeroIndex].src}\n              alt={heroImages[currentHer...",
+        "code": "<Image\n          src=\"/images/gallery/headquarters-entrance.webp\"\n          alt=\"Partner with Party ...",
         "severity": "warning"
       },
       {
-        "file": "src/app/bach-parties/page.tsx",
-        "type": "Regular <img> missing dimensions",
-        "code": "<img \n                src=\"/images/POD Logo 2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
-        "severity": "error"
+        "file": "src/app/austin-partners/page.tsx",
+        "type": "Next.js Image with fill but no sizes",
+        "code": "<Image\n                  src=\"/images/gallery/ai-recommended-setup.webp\"\n                  alt=\"Cust...",
+        "severity": "warning"
+      }
+    ],
+    "src/app/austin-byob-venues/page.tsx": [
+      {
+        "file": "src/app/austin-byob-venues/page.tsx",
+        "type": "Next.js Image with fill but no sizes",
+        "code": "<Image\n                          src={venue.image || '/images/venues/default-venue.webp'}\n          ...",
+        "severity": "warning"
+      },
+      {
+        "file": "src/app/austin-byob-venues/page.tsx",
+        "type": "Next.js Image with fill but no sizes",
+        "code": "<Image\n                          src={venue.image || '/images/venues/default-venue.webp'}\n          ...",
+        "severity": "warning"
+      }
+    ],
+    "src/app/atx-delivery-info/page.tsx": [
+      {
+        "file": "src/app/atx-delivery-info/page.tsx",
+        "type": "Next.js Image with fill but no sizes",
+        "code": "<Image\n            src=\"/images/hero/lake-travis-yacht-sunset.webp\"\n            alt=\"Austin Alcohol ...",
+        "severity": "warning"
       }
     ],
     "src/app/aperol-spritz/page.tsx": [
@@ -607,26 +267,126 @@
     "src/app/about/page.tsx": [
       {
         "file": "src/app/about/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n          src=\"/images/hero/austin-skyline-golden-hour.webp\"\n          alt=\"Austin Skyline\"\n ...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/about/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n              src=\"/images/about/professional-bartender-team.webp\"\n              alt=\"PartyOn...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/about/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n                src=\"/images/about/premium-warehouse-facility.webp\"\n                alt=\"Prem...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/about/page.tsx",
         "type": "Regular <img> missing dimensions",
-        "code": "<img \n                src=\"/images/POD Logo 2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
+        "code": "<img \n                src=\"/images/pod-logo-2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
+        "severity": "error"
+      }
+    ],
+    "src/components/shopify/ProductCard.tsx": [
+      {
+        "file": "src/components/shopify/ProductCard.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img\n                src={imageUrl}\n                alt={product.title}\n                className=\"w...",
+        "severity": "error"
+      }
+    ],
+    "src/components/shopify/MobileProductCard.tsx": [
+      {
+        "file": "src/components/shopify/MobileProductCard.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img\n                src={imageUrl}\n                alt={product.title}\n                className=\"w...",
+        "severity": "error"
+      }
+    ],
+    "src/components/shopify/CompactProductCard.tsx": [
+      {
+        "file": "src/components/shopify/CompactProductCard.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img\n                src={imageUrl}\n                alt={product.title}\n                className=\"w...",
+        "severity": "error"
+      }
+    ],
+    "src/components/shopify/CartItem.tsx": [
+      {
+        "file": "src/components/shopify/CartItem.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img\n            src={imageUrl}\n            alt={item.merchandise.product.title}\n            classNa...",
+        "severity": "error"
+      }
+    ],
+    "src/components/quick-order/QuickOrderSearch.tsx": [
+      {
+        "file": "src/components/quick-order/QuickOrderSearch.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img\n                            src={getProductImageUrl(product)}\n                            alt={...",
+        "severity": "error"
+      }
+    ],
+    "src/components/mobile/MobileSearchModal.tsx": [
+      {
+        "file": "src/components/mobile/MobileSearchModal.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img\n                            src={product.images.edges[0].node.url}\n                            ...",
+        "severity": "error"
+      }
+    ],
+    "src/components/partners/DrinkCalculator.tsx": [
+      {
+        "file": "src/components/partners/DrinkCalculator.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img\n            src={product.imageUrl}\n            alt={product.productTitle ?? product.name}\n     ...",
+        "severity": "error"
+      }
+    ],
+    "src/components/kegs/EquipmentRentals.tsx": [
+      {
+        "file": "src/components/kegs/EquipmentRentals.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img\n                    src={imageUrl}\n                    alt={product.title}\n                    ...",
+        "severity": "error"
+      },
+      {
+        "file": "src/components/kegs/EquipmentRentals.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img\n                src={imageUrl}\n                alt={product.title}\n                className=\"w...",
+        "severity": "error"
+      }
+    ],
+    "src/components/group-v2/GroupProductCatalog.tsx": [
+      {
+        "file": "src/components/group-v2/GroupProductCatalog.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img\n                      src={imgUrl}\n                      alt={product.title}\n                  ...",
+        "severity": "error"
+      }
+    ],
+    "src/components/group-v2/DraftCartItemRow.tsx": [
+      {
+        "file": "src/components/group-v2/DraftCartItemRow.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img\n          src={item.imageUrl}\n          alt={item.title}\n          className=\"w-24 h-24 rounded...",
+        "severity": "error"
+      }
+    ],
+    "src/components/drink-planner/DrinkPlannerQuiz.tsx": [
+      {
+        "file": "src/components/drink-planner/DrinkPlannerQuiz.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img\n                  src=\"/images/pod-logo-2025.svg\"\n                  alt=\"Party On Delivery\"\n   ...",
+        "severity": "error"
+      }
+    ],
+    "src/components/blog/MDXContentRSC.tsx": [
+      {
+        "file": "src/components/blog/MDXContentRSC.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img\n          src={props.src}\n          alt={props.alt || ''}\n          className=\"w-full h-auto ro...",
+        "severity": "error"
+      }
+    ],
+    "src/components/blog/MDXContent.tsx": [
+      {
+        "file": "src/components/blog/MDXContent.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img\n          src={props.src}\n          alt={props.alt || ''}\n          className=\"w-full h-auto ro...",
+        "severity": "error"
+      }
+    ],
+    "src/components/account/AccountLayout.tsx": [
+      {
+        "file": "src/components/account/AccountLayout.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img \n                      src={profileImage} \n                      alt=\"Profile\" \n               ...",
         "severity": "error"
       }
     ],
@@ -634,37 +394,19 @@
       {
         "file": "src/app/weddings/products/page.tsx",
         "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n          src=\"/images/services/weddings/outdoor-bar-setup.webp\"\n          alt=\"Wedding Bar S...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/weddings/products/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
         "code": "<Image\n                      src={product.image}\n                      alt={product.title}\n         ...",
         "severity": "warning"
       }
     ],
-    "src/app/partners/vacation-rentals/page.tsx": [
+    "src/app/weddings/order/page.tsx": [
       {
-        "file": "src/app/partners/vacation-rentals/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n          src=\"/images/hero/luxury-home-interior.webp\"\n          alt=\"Luxury Vacation Rental\"...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/partners/vacation-rentals/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n                    src={category.image}\n                    alt={category.title}\n           ...",
-        "severity": "warning"
+        "file": "src/app/weddings/order/page.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img\n          src=\"/images/wedding-services/order-hero.png\"\n          alt=\"\"\n          className=\"a...",
+        "severity": "error"
       }
     ],
     "src/app/partners/property-management/page.tsx": [
-      {
-        "file": "src/app/partners/property-management/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n          src=\"/images/hero/luxury-apartment-building.webp\"\n          alt=\"Luxury Property Ma...",
-        "severity": "warning"
-      },
       {
         "file": "src/app/partners/property-management/page.tsx",
         "type": "Next.js Image with fill but no sizes",
@@ -672,13 +414,15 @@
         "severity": "warning"
       }
     ],
-    "src/app/partners/mobile-bartenders/page.tsx": [
+    "src/app/products/[handle]/page.tsx": [
       {
-        "file": "src/app/partners/mobile-bartenders/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n          src=\"/images/hero/bartender-hero-placeholder.jpg\"\n          alt=\"Mobile bartender s...",
-        "severity": "warning"
-      },
+        "file": "src/app/products/[handle]/page.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img\n                src=\"/images/pod-logo-2025.svg\"\n                alt=\"Party On Delivery\"\n       ...",
+        "severity": "error"
+      }
+    ],
+    "src/app/partners/mobile-bartenders/page.tsx": [
       {
         "file": "src/app/partners/mobile-bartenders/page.tsx",
         "type": "Next.js Image with fill but no sizes",
@@ -688,13 +432,25 @@
       {
         "file": "src/app/partners/mobile-bartenders/page.tsx",
         "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n          src=\"/images/backgrounds/austin-skyline-placeholder.jpg\"\n          alt=\"Austin skyl...",
+        "code": "<Image\n                      src={testimonial.image}\n                      alt={testimonial.author}\n...",
         "severity": "warning"
       },
       {
         "file": "src/app/partners/mobile-bartenders/page.tsx",
         "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n                      src={testimonial.image}\n                      alt={testimonial.author}\n...",
+        "code": "<Image\n                    src=\"/images/partners/pourtwentyfour-hero.jpg\"\n                    alt=\"\"...",
+        "severity": "warning"
+      },
+      {
+        "file": "src/app/partners/mobile-bartenders/page.tsx",
+        "type": "Next.js Image with fill but no sizes",
+        "code": "<Image\n                    src=\"/images/partners/dtr-bartending-hero.jpg\"\n                    alt=\"\"...",
+        "severity": "warning"
+      },
+      {
+        "file": "src/app/partners/mobile-bartenders/page.tsx",
+        "type": "Next.js Image with fill but no sizes",
+        "code": "<Image\n                    src=\"/images/partners/taptruckaustin-hero.jpg\"\n                    alt=\"\"...",
         "severity": "warning"
       }
     ],
@@ -702,84 +458,70 @@
       {
         "file": "src/app/partners/hotels-resorts/page.tsx",
         "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n          src=\"/images/backgrounds/rooftop-terrace-elegant-1.webp\"\n          alt=\"Luxury Hote...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/partners/hotels-resorts/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
         "code": "<Image\n                src=\"/images/gallery/sunset-champagne-pontoon.webp\"\n                alt=\"Hote...",
         "severity": "warning"
       }
     ],
-    "src/app/delivery/[location]/page.tsx": [
+    "src/app/partners/austin-wedding-dj/page.tsx": [
       {
-        "file": "src/app/delivery/[location]/page.tsx",
+        "file": "src/app/partners/austin-wedding-dj/page.tsx",
+        "type": "Next.js Image missing dimensions",
+        "code": "<Image src>...",
+        "severity": "error"
+      },
+      {
+        "file": "src/app/partners/austin-wedding-dj/page.tsx",
         "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n          src=\"/images/hero/luxury-bar-setup.webp\"\n          alt={`${locationData.name} Alcoh...",
+        "code": "<Image\n              src={HERO_IMAGE}\n              alt=\"[DJ_PHOTO] — portrait\"\n              fill\n ...",
         "severity": "warning"
+      }
+    ],
+    "src/app/order/last-minute/page.tsx": [
+      {
+        "file": "src/app/order/last-minute/page.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img src=\"/images/pod-logo-2025.svg\" alt=\"Party On\" className=\"h-40 w-auto mx-auto mb-8\" />...",
+        "severity": "error"
+      }
+    ],
+    "src/app/ops/products/page.tsx": [
+      {
+        "file": "src/app/ops/products/page.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img\n                          src={product.image.url}\n                          alt={product.image....",
+        "severity": "error"
+      }
+    ],
+    "src/app/gifts/cocktail-kits/page.tsx": [
+      {
+        "file": "src/app/gifts/cocktail-kits/page.tsx",
+        "type": "Next.js Image with fill but no sizes",
+        "code": "<Image\n                  src={austinRitaKit?.images.edges[0]?.node.url || 'https://cdn.shopify.com/s...",
+        "severity": "warning"
+      }
+    ],
+    "src/app/corporate/holiday-party/page.tsx": [
+      {
+        "file": "src/app/corporate/holiday-party/page.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img\n                src=\"/images/pod-logo-2025.svg\"\n                alt=\"Party On Delivery\"\n       ...",
+        "severity": "error"
       }
     ],
     "src/app/corporate/products/page.tsx": [
       {
         "file": "src/app/corporate/products/page.tsx",
         "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n          src=\"/images/services/corporate/executive-bar.webp\"\n          alt=\"Corporate Bar Se...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/corporate/products/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
         "code": "<Image\n                      src={product.image}\n                      alt={product.title}\n         ...",
         "severity": "warning"
       }
     ],
-    "src/app/collections/[handle]/page.tsx": [
+    "src/app/checkout/success/page.tsx": [
       {
-        "file": "src/app/collections/[handle]/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n          src={collectionInfo.image}\n          alt={collectionInfo.title}\n          fill\n    ...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/collections/[handle]/page.tsx",
+        "file": "src/app/checkout/success/page.tsx",
         "type": "Regular <img> missing dimensions",
-        "code": "<img \n                src=\"/images/POD Logo 2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
+        "code": "<img\r\n            src=\"/images/checkout/thank-you-hero.png\"\r\n            alt=\"Thank you for your ord...",
         "severity": "error"
-      }
-    ],
-    "src/app/boat-parties/products/page.tsx": [
-      {
-        "file": "src/app/boat-parties/products/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n          src=\"/images/services/boat-parties/yacht-bar-setup.webp\"\n          alt=\"Boat Party ...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/boat-parties/products/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n                      src={product.image}\n                      alt={product.title}\n         ...",
-        "severity": "warning"
-      }
-    ],
-    "src/app/blog/[slug]/page.tsx": [
-      {
-        "file": "src/app/blog/[slug]/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n            src={mdxPost.image}\n            alt={mdxPost.title}\n            fill\n            ...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/blog/[slug]/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n          src={post.image?.url || '/images/hero/lake-travis-yacht-sunset.webp'}\n          alt...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/blog/[slug]/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n                      src={relatedPost.image?.url || '/images/hero/lake-travis-yacht-sunset.w...",
-        "severity": "warning"
       }
     ],
     "src/app/blog/[slug]/page-mdx.tsx": [
@@ -790,17 +532,11 @@
         "severity": "warning"
       }
     ],
-    "src/app/bach-parties/products/page.tsx": [
+    "src/app/(main)/team/page.tsx": [
       {
-        "file": "src/app/bach-parties/products/page.tsx",
+        "file": "src/app/(main)/team/page.tsx",
         "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n          src=\"/images/services/bach-parties/party-setup.webp\"\n          alt=\"Bach Party Setu...",
-        "severity": "warning"
-      },
-      {
-        "file": "src/app/bach-parties/products/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n                      src={product.image}\n                      alt={product.title}\n         ...",
+        "code": "<Image\n                        src={member.image}\n                        alt={member.name}\n        ...",
         "severity": "warning"
       }
     ],
@@ -810,14 +546,6 @@
         "type": "Regular <img> missing dimensions",
         "code": "<img \n                            src={item.variant.image.url} \n                            alt={ite...",
         "severity": "error"
-      }
-    ],
-    "src/app/(main)/team/page.tsx": [
-      {
-        "file": "src/app/(main)/team/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n                        src={member.image}\n                        alt={member.name}\n        ...",
-        "severity": "warning"
       }
     ],
     "src/app/(main)/fast-delivery/page.tsx": [
@@ -852,7 +580,65 @@
       {
         "file": "src/app/weddings/packages/[tier]/page.tsx",
         "type": "Regular <img> missing dimensions",
-        "code": "<img \n                src=\"/images/POD Logo 2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
+        "code": "<img \n                src=\"/images/pod-logo-2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
+        "severity": "error"
+      }
+    ],
+    "src/app/ops/products/create/page.tsx": [
+      {
+        "file": "src/app/ops/products/create/page.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img src={img.url} alt={`Product ${idx + 1}`} className=\"w-full h-full object-cover\" />...",
+        "severity": "error"
+      }
+    ],
+    "src/app/ops/orders/create/page.tsx": [
+      {
+        "file": "src/app/ops/orders/create/page.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img\n                          src={product.images[0].url}\n                          alt={product.ti...",
+        "severity": "error"
+      },
+      {
+        "file": "src/app/ops/orders/create/page.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img src={item.imageUrl} alt={item.title} className=\"w-10 h-10 rounded-lg object-cover border border...",
+        "severity": "error"
+      }
+    ],
+    "src/app/ops/orders/[id]/page.tsx": [
+      {
+        "file": "src/app/ops/orders/[id]/page.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img src={item.imageUrl} alt=\"\" className=\"w-10 h-10 rounded-lg object-cover border border-gray-100 ...",
+        "severity": "error"
+      },
+      {
+        "file": "src/app/ops/orders/[id]/page.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img src={item.imageUrl} alt=\"\" className=\"w-10 h-10 rounded-lg object-cover border border-gray-100 ...",
+        "severity": "error"
+      }
+    ],
+    "src/app/ops/inventory/count/page.tsx": [
+      {
+        "file": "src/app/ops/inventory/count/page.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img\n                  src={image}\n                  alt={`Selected ${index + 1}`}\n                 ...",
+        "severity": "error"
+      }
+    ],
+    "src/app/ops/collections/[id]/page.tsx": [
+      {
+        "file": "src/app/ops/collections/[id]/page.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img src={p.image.url} alt={p.title} className=\"w-10 h-10 rounded-lg object-cover border border-gray...",
+        "severity": "error"
+      },
+      {
+        "file": "src/app/ops/collections/[id]/page.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img src={p.imageUrl} alt={p.title} className=\"w-12 h-12 rounded-lg object-cover border border-gray-...",
         "severity": "error"
       }
     ],
@@ -866,29 +652,45 @@
       {
         "file": "src/app/boat-parties/packages/[tier]/page.tsx",
         "type": "Regular <img> missing dimensions",
-        "code": "<img \n                src=\"/images/POD Logo 2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
+        "code": "<img \n                src=\"/images/pod-logo-2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
         "severity": "error"
       }
     ],
-    "src/app/blog/category/[category]/page.tsx": [
+    "src/app/affiliate/dashboard/components/AffiliateDashboardHeader.tsx": [
       {
-        "file": "src/app/blog/category/[category]/page.tsx",
-        "type": "Next.js Image with fill but no sizes",
-        "code": "<Image\n                        src={post.image}\n                        alt={post.title}\n           ...",
-        "severity": "warning"
+        "file": "src/app/affiliate/dashboard/components/AffiliateDashboardHeader.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img\n              src=\"/images/pod-logo-2025.png\"\n              alt=\"Party On Delivery\"\n           ...",
+        "severity": "error"
       }
     ],
-    "src/app/bach-parties/packages/[tier]/page.tsx": [
+    "src/app/ops/inventory/receiving/new/page.tsx": [
       {
-        "file": "src/app/bach-parties/packages/[tier]/page.tsx",
+        "file": "src/app/ops/inventory/receiving/new/page.tsx",
         "type": "Regular <img> missing dimensions",
-        "code": "<img\n                              src={item.product.images.edges[0].node.url}\n                     ...",
+        "code": "<img src={preview} alt=\"Invoice preview\" className=\"w-full rounded-lg border border-gray-200\" />...",
+        "severity": "error"
+      }
+    ],
+    "src/app/ops/inventory/receiving/[id]/page.tsx": [
+      {
+        "file": "src/app/ops/inventory/receiving/[id]/page.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img src={invoice.imageUrl} alt=\"Invoice\" className=\"w-full rounded-lg border border-gray-200\" />...",
+        "severity": "error"
+      }
+    ],
+    "src/app/ops/orders/[id]/edit/page.tsx": [
+      {
+        "file": "src/app/ops/orders/[id]/edit/page.tsx",
+        "type": "Regular <img> missing dimensions",
+        "code": "<img\n                          src={product.images[0].url}\n                          alt={product.ti...",
         "severity": "error"
       },
       {
-        "file": "src/app/bach-parties/packages/[tier]/page.tsx",
+        "file": "src/app/ops/orders/[id]/edit/page.tsx",
         "type": "Regular <img> missing dimensions",
-        "code": "<img \n                src=\"/images/POD Logo 2025.svg\" \n                alt=\"Party On Delivery\"\n     ...",
+        "code": "<img src={item.imageUrl} alt={item.title} className=\"w-10 h-10 rounded-lg object-cover border border...",
         "severity": "error"
       }
     ]

--- a/scripts/seo/add-image-dimensions.mjs
+++ b/scripts/seo/add-image-dimensions.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * Build a fix-list report from `image-dimensions-audit.json`.
+ *
+ * For each `<img>` entry missing width/height: tries to resolve the src to a
+ * file under /public/, opens it with `sharp`, and suggests the real
+ * dimensions.
+ *
+ * For each `next/image` with `fill` but no `sizes`: classifies the context
+ * (hero, card-grid, thumbnail) by a few heuristics on the file path and
+ * surrounding code, then emits a suggested `sizes` attribute.
+ *
+ * The report is human-readable JSON written to
+ * docs/seo/image-dimensions-fix-list-<YYYY-MM-DD>.json. The fixes are
+ * applied by hand via the Edit tool — there are no line numbers in the
+ * audit, so an automated codemod would be brittle.
+ *
+ * Usage:
+ *   node scripts/seo/add-image-dimensions.mjs
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import sharp from 'sharp';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const AUDIT_PATH = path.join(REPO_ROOT, 'image-dimensions-audit.json');
+const PUBLIC_DIR = path.join(REPO_ROOT, 'public');
+
+const today = new Date().toISOString().slice(0, 10);
+const OUT_PATH = path.join(REPO_ROOT, 'docs', 'seo', `image-dimensions-fix-list-${today}.json`);
+
+/**
+ * Pull the src="…" or src={…} from a code snippet. Returns null if it's a
+ * dynamic expression we can't resolve to a literal /public path.
+ */
+function extractSrc(snippet) {
+  const literal = snippet.match(/src\s*=\s*["']([^"']+)["']/);
+  if (literal) return literal[1];
+  return null;
+}
+
+/**
+ * Suggest a `sizes` attribute by context heuristics.
+ */
+function suggestSizes(file, snippet) {
+  const fileLower = file.toLowerCase();
+  const snippetLower = snippet.toLowerCase();
+
+  if (fileLower.includes('hero') || snippetLower.includes('hero')) {
+    return '100vw';
+  }
+  if (snippetLower.includes('priority')) {
+    return '(max-width: 768px) 100vw, 1024px';
+  }
+  if (fileLower.includes('card') || snippetLower.includes('card')) {
+    return '(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw';
+  }
+  if (fileLower.includes('thumbnail') || snippetLower.includes('thumbnail') || snippetLower.includes('w-12') || snippetLower.includes('w-16')) {
+    return '(max-width: 768px) 50vw, 25vw';
+  }
+  // Conservative default — mobile gets full width, desktop gets half.
+  return '(max-width: 768px) 100vw, 50vw';
+}
+
+async function tryResolveDimensions(src) {
+  if (!src || !src.startsWith('/')) return null;
+  const filePath = path.join(PUBLIC_DIR, src);
+  try {
+    const meta = await sharp(filePath).metadata();
+    if (meta.width && meta.height) return { width: meta.width, height: meta.height, resolved: src };
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+async function main() {
+  const raw = await fs.readFile(AUDIT_PATH, 'utf8');
+  const audit = JSON.parse(raw);
+
+  const imgFixes = [];
+  const fillFixes = [];
+
+  for (const [file, issues] of Object.entries(audit.issues)) {
+    for (const issue of issues) {
+      if (issue.type === 'Regular <img> missing dimensions') {
+        const src = extractSrc(issue.code);
+        const dims = await tryResolveDimensions(src);
+        imgFixes.push({
+          file,
+          src,
+          severity: issue.severity,
+          suggested: dims, // null if dynamic or unresolvable
+          snippet: issue.code,
+        });
+      } else if (issue.type === 'Next.js Image with fill but no sizes') {
+        const suggestedSizes = suggestSizes(file, issue.code);
+        fillFixes.push({
+          file,
+          severity: issue.severity,
+          suggestedSizes,
+          snippet: issue.code,
+        });
+      }
+    }
+  }
+
+  const byFile = {};
+  for (const fix of imgFixes) {
+    (byFile[fix.file] ||= { img: [], fill: [] }).img.push(fix);
+  }
+  for (const fix of fillFixes) {
+    (byFile[fix.file] ||= { img: [], fill: [] }).fill.push(fix);
+  }
+
+  const summary = {
+    generatedAt: new Date().toISOString(),
+    totals: {
+      imgFixesTotal: imgFixes.length,
+      imgFixesResolved: imgFixes.filter((f) => f.suggested).length,
+      imgFixesUnresolvable: imgFixes.filter((f) => !f.suggested).length,
+      fillFixesTotal: fillFixes.length,
+      filesAffected: Object.keys(byFile).length,
+    },
+    byFile,
+  };
+
+  await fs.mkdir(path.dirname(OUT_PATH), { recursive: true });
+  await fs.writeFile(OUT_PATH, JSON.stringify(summary, null, 2));
+
+  console.log(`Wrote ${OUT_PATH}`);
+  console.log(JSON.stringify(summary.totals, null, 2));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -49,6 +49,7 @@ export default function AboutPage() {
           src="/images/hero/austin-skyline-golden-hour.webp"
           alt="Austin Skyline"
           fill
+          sizes="100vw"
           className="object-cover"
           priority
         />
@@ -154,6 +155,7 @@ export default function AboutPage() {
               src="/images/about/professional-bartender-team.webp"
               alt="Party On Delivery Professional Team"
               fill
+              sizes="(max-width: 768px) 100vw, 1024px"
               className="object-cover"
               onError={(e) => {
                 // Fallback to hero image if team image doesn't exist yet
@@ -274,6 +276,7 @@ export default function AboutPage() {
                 src="/images/about/premium-warehouse-facility.webp"
                 alt="Premium Storage Facility"
                 fill
+                sizes="(max-width: 768px) 100vw, 50vw"
                 className="object-cover"
                 onError={(e) => {
                   // Fallback image

--- a/src/app/blog/BlogSearchFilter.tsx
+++ b/src/app/blog/BlogSearchFilter.tsx
@@ -168,6 +168,7 @@ export default function BlogSearchFilter({ posts }: BlogSearchFilterProps) {
                           src={imageUrl}
                           alt={post.image?.alt || post.title}
                           fill
+                          sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
                           className="object-cover group-hover:scale-105 transition-transform duration-700"
                         />
                         <div className="absolute top-4 left-4">

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -12,6 +12,7 @@ import BlogTopicCTA from '@/components/blog/BlogTopicCTA'
 import blogPostsData from '@/data/blog-posts/posts.json'
 import { seoConfig } from '@/lib/seo/config'
 import { generateArticleSchema } from '@/lib/seo/schemas'
+import { buildBlogMetadata } from '@/lib/seo/build-metadata'
 
 interface BlogPost {
   id: string
@@ -996,40 +997,31 @@ export async function generateMetadata({ params }: BlogPostPageProps): Promise<M
   const jsonPost = blogPosts.find(p => p.slug === slug)
 
   if (jsonPost) {
-    return {
-      title: jsonPost.seo?.title || jsonPost.title,
-      description: jsonPost.seo?.description || jsonPost.excerpt,
-      keywords: jsonPost.seo?.keywords || jsonPost.tags,
-      alternates: { canonical: canonicalUrl },
-      openGraph: {
-        title: jsonPost.seo?.title || jsonPost.title,
-        description: jsonPost.seo?.description || jsonPost.excerpt,
-        url: canonicalUrl,
-        type: 'article',
-        publishedTime: jsonPost.publishedAt || jsonPost.date,
-        authors: [jsonPost.author],
-        images: jsonPost.image?.url ? [{ url: jsonPost.image.url, alt: jsonPost.image.alt }] : [],
-      },
-    }
+    return buildBlogMetadata({
+      slug,
+      title: jsonPost.title,
+      excerpt: jsonPost.excerpt,
+      seo: jsonPost.seo,
+      tags: jsonPost.tags,
+      category: jsonPost.category,
+      image: jsonPost.image,
+      author: jsonPost.author,
+      publishedAt: jsonPost.publishedAt || jsonPost.date,
+    })
   }
 
   const mdxPost = getMDXPost(slug)
   if (mdxPost) {
-    return {
+    return buildBlogMetadata({
+      slug,
       title: mdxPost.title,
-      description: mdxPost.excerpt,
-      keywords: [mdxPost.category, ...mdxPost.keywords].filter(Boolean),
-      alternates: { canonical: canonicalUrl },
-      openGraph: {
-        title: mdxPost.title,
-        description: mdxPost.excerpt,
-        url: canonicalUrl,
-        type: 'article',
-        publishedTime: mdxPost.date,
-        authors: [mdxPost.author],
-        images: mdxPost.image ? [{ url: mdxPost.image, alt: mdxPost.title }] : [],
-      },
-    }
+      excerpt: mdxPost.excerpt,
+      tags: mdxPost.keywords,
+      category: mdxPost.category,
+      image: mdxPost.image ? { url: mdxPost.image, alt: mdxPost.title } : null,
+      author: mdxPost.author,
+      publishedAt: mdxPost.date,
+    })
   }
 
   return {
@@ -1396,6 +1388,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
                       src={relatedPost.image?.url || '/images/hero/lake-travis-yacht-sunset.webp'}
                       alt={relatedPost.image?.alt || relatedPost.title}
                       fill
+                      sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
                       className="object-cover group-hover:scale-105 transition-transform duration-700"
                     />
                     {relatedPost.category && (

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -84,6 +84,7 @@ export default function ContactPage() {
           src="/images/hero/contact-hero-austin.webp"
           alt="Austin Downtown"
           fill
+          sizes="100vw"
           className="object-cover"
           priority
         />

--- a/src/app/corporate/products/page.tsx
+++ b/src/app/corporate/products/page.tsx
@@ -136,6 +136,7 @@ export default function CorporateProductsPage() {
           src="/images/services/corporate/penthouse-suite-setup.webp"
           alt="Corporate Bar Setup"
           fill
+          sizes="100vw"
           className="object-cover"
           priority
         />

--- a/src/app/custom-package/page.tsx
+++ b/src/app/custom-package/page.tsx
@@ -216,6 +216,7 @@ export default function CustomPackagePage() {
                               src={product.images.edges[0].node.url}
                               alt={product.title}
                               fill
+                              sizes="(max-width: 768px) 50vw, 25vw"
                               className="object-contain"
                             />
                           )}

--- a/src/app/delivery-areas/page.tsx
+++ b/src/app/delivery-areas/page.tsx
@@ -93,6 +93,7 @@ export default function DeliveryAreasPage() {
           src="/images/hero/austin-skyline-golden-hour.webp"
           alt="Austin Aerial View"
           fill
+          sizes="100vw"
           className="object-cover"
           priority
         />

--- a/src/app/delivery/[location]/page.tsx
+++ b/src/app/delivery/[location]/page.tsx
@@ -123,6 +123,7 @@ export default async function LocationDeliveryPage({ params }: { params: Promise
           src="/images/services/corporate/penthouse-suite-setup.webp"
           alt={`${locationData.name} Alcohol Delivery`}
           fill
+          sizes="100vw"
           className="object-cover"
           priority
         />

--- a/src/app/partners/austin-wedding-dj/page.tsx
+++ b/src/app/partners/austin-wedding-dj/page.tsx
@@ -63,6 +63,7 @@ export default function AustinWeddingDjPage(): ReactElement {
           alt="[DJ_PHOTO] — Austin wedding DJ at a Lake Travis reception"
           fill
           priority
+          sizes="100vw"
           className="object-cover opacity-60"
         />
         <div className="absolute inset-0 bg-gradient-to-b from-gray-900/60 via-gray-900/40 to-gray-900/70" />

--- a/src/app/partners/hotels-resorts/page.tsx
+++ b/src/app/partners/hotels-resorts/page.tsx
@@ -98,6 +98,7 @@ export default function HotelsResortsPartnerPage() {
           src="/images/backgrounds/rooftop-terrace-elegant-1.webp"
           alt="Luxury Hotel Bar Service"
           fill
+          sizes="100vw"
           className="object-cover"
         />
         <div className="absolute inset-0 bg-gradient-to-r from-black/80 via-black/60 to-transparent" />

--- a/src/app/partners/property-management/page.tsx
+++ b/src/app/partners/property-management/page.tsx
@@ -99,6 +99,7 @@ export default function PropertyManagementPartnerPage() {
           src="/images/backgrounds/rooftop-terrace-elegant-2.webp"
           alt="Luxury Property Management"
           fill
+          sizes="100vw"
           className="object-cover"
           priority
         />

--- a/src/app/products/[handle]/page.tsx
+++ b/src/app/products/[handle]/page.tsx
@@ -12,8 +12,8 @@ import PinthouseElectricJellyfishFAQ from '@/components/products/PinthouseElectr
 import CoronaExtraKegFAQ from '@/components/products/CoronaExtraKegFAQ';
 import BorrascaBrutCavaFAQ from '@/components/products/BorrascaBrutCavaFAQ';
 import ProductBreadcrumbs from '@/components/products/ProductBreadcrumbs';
-import { formatPrice } from '@/lib/utils';
 import { getProductRobotsMeta } from '@/lib/noindex-products';
+import { buildProductMetadata } from '@/lib/seo/build-metadata';
 
 interface Props {
   params: Promise<{ handle: string }>;
@@ -57,11 +57,6 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!product) {
     return { title: 'Product Not Found', robots };
   }
-
-  const price = formatPrice(
-    product.priceRange.minVariantPrice.amount,
-    product.priceRange.minVariantPrice.currencyCode
-  );
 
   const image = product.images.edges[0]?.node.url || '/images/pod-logo-2025.svg';
   const plainDescription = product.description?.replace(/<[^>]*>/g, '') || '';
@@ -289,27 +284,18 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     };
   }
 
-  // Default metadata for all other products
-  return {
-    title: `${product.title} - ${price} | Party On Delivery Austin`,
-    description: truncatedDescription || `Buy ${product.title} for delivery in Austin. Premium alcohol delivery for weddings, parties, and events.`,
-    keywords: `${product.title}, austin alcohol delivery, ${product.productType}, party supplies austin`,
-    robots,
-    openGraph: {
-      title: product.title,
-      description: truncatedDescription || `Premium ${product.title} delivered in Austin`,
-      type: 'website',
-      url: `https://partyondelivery.com/products/${handle}`,
-      images: [{ url: image, width: 1200, height: 1200, alt: product.title }],
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title: product.title,
-      description: truncatedDescription,
-      images: [image],
-    },
-    alternates: { canonical: `/products/${handle}` },
-  };
+  // Default metadata via centralized helper.
+  // The helper enforces divergent <title> vs <h1> (the H1 renders raw
+  // product.title), title/description length clamps, and a canonical URL.
+  const baseMetadata = buildProductMetadata({
+    handle,
+    title: product.title,
+    description: truncatedDescription || plainDescription,
+    productType: product.productType,
+    image: { url: image, alt: product.title },
+  });
+
+  return { ...baseMetadata, robots };
 }
 
 // Generate static params from PostgreSQL for pre-rendering

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -227,6 +227,7 @@ function ProductsContent() {
           src="/images/products/premium-spirits-wall.webp"
           alt="Premium Spirits Collection"
           fill
+          sizes="100vw"
           className="object-cover"
           priority
         />

--- a/src/app/weddings/page.tsx
+++ b/src/app/weddings/page.tsx
@@ -671,6 +671,7 @@ export default function WeddingsPage() {
                   src={image.src}
                   alt={image.alt}
                   fill
+                  sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
                   className="object-cover transition-transform duration-500 group-hover:scale-110"
                 />
                 <div className="absolute inset-0 bg-gradient-to-t from-gray-900/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500" />

--- a/src/app/weddings/products/page.tsx
+++ b/src/app/weddings/products/page.tsx
@@ -136,6 +136,7 @@ export default function WeddingProductsPage() {
           src="/images/services/weddings/outdoor-bar-setup.webp"
           alt="Wedding Bar Setup"
           fill
+          sizes="100vw"
           className="object-cover"
           priority
         />

--- a/src/components/MetaPixel.tsx
+++ b/src/components/MetaPixel.tsx
@@ -19,7 +19,7 @@ export default function MetaPixel() {
     <>
       <Script
         id="meta-pixel"
-        strategy="afterInteractive"
+        strategy="lazyOnload"
         dangerouslySetInnerHTML={{
           __html: `
             !function(f,b,e,v,n,t,s)

--- a/src/components/ProductModal.tsx
+++ b/src/components/ProductModal.tsx
@@ -287,6 +287,9 @@ export default function ProductModal({ product, isOpen, onClose, ctaOverride }: 
                         <img
                           src={image.url}
                           alt={image.altText || `${displayProduct?.title || product.title} ${index + 1}`}
+                          width={80}
+                          height={80}
+                          loading="lazy"
                           className="w-full h-full object-cover"
                         />
                       </button>

--- a/src/components/ProductSearch.tsx
+++ b/src/components/ProductSearch.tsx
@@ -114,6 +114,9 @@ export default function ProductSearch({ isScrolled = true }: ProductSearchProps)
                           <img
                             src={product.images.edges[0].node.url}
                             alt={product.title}
+                            width={48}
+                            height={48}
+                            loading="lazy"
                             className="w-12 h-12 object-cover"
                           />
                         ) : (

--- a/src/components/drink-planner/steps/WelcomeStep.tsx
+++ b/src/components/drink-planner/steps/WelcomeStep.tsx
@@ -14,6 +14,7 @@ export default function WelcomeStep({ onStart, onSkip }: WelcomeStepProps) {
         src="/images/order/order-hero.png"
         alt="Premium Bar Setup at Austin Pool Party"
         fill
+        sizes="100vw"
         className="object-cover"
         priority
       />

--- a/src/components/group-v2/GroupHeader.tsx
+++ b/src/components/group-v2/GroupHeader.tsx
@@ -44,6 +44,7 @@ export default function GroupHeader({ groupOrder, isHost }: Props): ReactElement
         src="/images/partners/group-dashboard-bg.png"
         alt=""
         fill
+        sizes="100vw"
         className="object-cover"
         priority
       />

--- a/src/components/homepage/HeroCollage.tsx
+++ b/src/components/homepage/HeroCollage.tsx
@@ -1,8 +1,26 @@
 'use client';
 
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, startTransition } from 'react';
 import Image from 'next/image';
 import { CELL_MEDIA as SCANNED_MEDIA, type CollageMedia } from '@/generated/hero-media-manifest';
+
+/**
+ * Listens to the user's prefers-reduced-motion setting and returns true if
+ * they've asked for less animation. Used to skip the collage's rotation
+ * loop entirely for that audience (significant share of mobile users).
+ */
+function usePrefersReducedMotion(): boolean {
+  const [prefers, setPrefers] = useState(false);
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setPrefers(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setPrefers(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+  return prefers;
+}
 
 /**
  * Interleave images across folders, then distribute across 3 cells so each
@@ -57,33 +75,37 @@ function CollageCell({ media, interval, className, priority = false }: CollageCe
   const nextImageIndex = useRef(media.length > 1 ? 2 % media.length : 0);
   const videoRef = useRef<HTMLVideoElement>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
+  const prefersReducedMotion = usePrefersReducedMotion();
 
   const advanceToNext = useCallback(() => {
     if (transitioning || media.length <= 1) return;
     setTransitioning(true);
 
-    // Flip to the other layer (it already has the next image loaded)
+    // Flip to the other layer (it already has the next image loaded).
+    // Wrapped in startTransition so React can yield to input events if one
+    // arrives at the same instant the rotation timer fires.
     const newActive = activeLayer === 'a' ? 'b' : 'a';
-    setActiveLayer(newActive);
+    startTransition(() => setActiveLayer(newActive));
 
     // After crossfade completes, preload the NEXT image into the now-hidden layer
     setTimeout(() => {
       const upcoming = nextImageIndex.current;
-      if (activeLayer === 'a') {
-        // We just faded to B, so A is now hidden — load next image into A
-        setLayerAIndex(upcoming);
-      } else {
-        // We just faded to A, so B is now hidden — load next image into B
-        setLayerBIndex(upcoming);
-      }
+      startTransition(() => {
+        if (activeLayer === 'a') {
+          setLayerAIndex(upcoming);
+        } else {
+          setLayerBIndex(upcoming);
+        }
+        setTransitioning(false);
+      });
       nextImageIndex.current = (upcoming + 1) % media.length;
-      setTransitioning(false);
     }, CROSSFADE_MS);
   }, [transitioning, activeLayer, media.length]);
 
-  // Schedule the next advance
+  // Schedule the next advance. Skipped entirely when the user prefers
+  // reduced motion — first image of the cell stays frozen.
   useEffect(() => {
-    if (media.length <= 1) return;
+    if (media.length <= 1 || prefersReducedMotion) return;
     const currentIndex = activeLayer === 'a' ? layerAIndex : layerBIndex;
     const current = media[currentIndex];
 
@@ -96,7 +118,7 @@ function CollageCell({ media, interval, className, priority = false }: CollageCe
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current);
     };
-  }, [activeLayer, layerAIndex, layerBIndex, media, interval, advanceToNext]);
+  }, [activeLayer, layerAIndex, layerBIndex, media, interval, advanceToNext, prefersReducedMotion]);
 
   // When a video becomes active, play it
   useEffect(() => {
@@ -119,6 +141,7 @@ function CollageCell({ media, interval, className, priority = false }: CollageCe
           opacity: activeLayer === 'a' ? 1 : 0,
           transition: `opacity ${CROSSFADE_MS}ms ease-in-out`,
           zIndex: activeLayer === 'a' ? 2 : 1,
+          willChange: transitioning ? 'opacity' : 'auto',
         }}
       >
         {mediaA.type === 'video' ? (

--- a/src/components/partners/AndersonMillHero.tsx
+++ b/src/components/partners/AndersonMillHero.tsx
@@ -48,6 +48,7 @@ export default function AndersonMillHero(): ReactElement {
         src="/images/partners/anderson-mill-marina-hero.png"
         alt="Anderson Mill Marina on Lake Travis"
         fill
+        sizes="100vw"
         className="object-cover"
         priority
       />

--- a/src/components/partners/PremierHero.tsx
+++ b/src/components/partners/PremierHero.tsx
@@ -41,6 +41,7 @@ export default function PremierHero(): ReactElement {
         src="/images/partners/premierpartycruises-hero-bg3.webp.png"
         alt="Premier Party Cruises boat party on Lake Travis"
         fill
+        sizes="100vw"
         className="object-cover"
         priority
       />

--- a/src/components/products/ProductDetailClient.tsx
+++ b/src/components/products/ProductDetailClient.tsx
@@ -91,6 +91,8 @@ export default function ProductDetailClient({ product }: Props) {
                 <img
                   src={product.images.edges[selectedImageIndex]?.node.url}
                   alt={product.title}
+                  width={600}
+                  height={800}
                   className="w-full h-full object-cover"
                 />
               ) : (
@@ -116,6 +118,8 @@ export default function ProductDetailClient({ product }: Props) {
                     <img
                       src={image.node.url}
                       alt={`${product.title} ${index + 1}`}
+                      width={200}
+                      height={200}
                       className="w-full h-full object-cover"
                     />
                   </button>

--- a/src/lib/seo/build-metadata.ts
+++ b/src/lib/seo/build-metadata.ts
@@ -1,0 +1,159 @@
+import type { Metadata } from 'next';
+import { seoConfig } from './config';
+
+/**
+ * Title/description length clamps. Google truncates titles around 60 chars
+ * and meta descriptions around 155-160 chars in desktop SERPs. Going over
+ * costs CTR; going way under leaves keyword real estate on the table.
+ */
+const TITLE_MAX = 60;
+const DESCRIPTION_MAX = 155;
+
+const PRODUCT_TITLE_SUFFIX = 'Buy Online | Austin Same-Day Delivery';
+const BLOG_TITLE_SUFFIX = 'Austin Event Bar & Delivery Blog';
+
+function clampTitle(input: string): string {
+  if (input.length <= TITLE_MAX) return input;
+  const cut = input.slice(0, TITLE_MAX);
+  const lastSpace = cut.lastIndexOf(' ');
+  return (lastSpace > 40 ? cut.slice(0, lastSpace) : cut).trimEnd();
+}
+
+function clampDescription(input: string): string {
+  if (input.length <= DESCRIPTION_MAX) return input;
+  const cut = input.slice(0, DESCRIPTION_MAX - 1);
+  const lastSpace = cut.lastIndexOf(' ');
+  return `${(lastSpace > 100 ? cut.slice(0, lastSpace) : cut).trimEnd()}…`;
+}
+
+export interface ProductMetadataInput {
+  handle: string;
+  title: string;
+  description?: string | null;
+  metaTitle?: string | null;
+  metaDescription?: string | null;
+  productType?: string | null;
+  image?: { url: string; alt?: string | null } | null;
+}
+
+export interface BlogMetadataInput {
+  slug: string;
+  title: string;
+  excerpt?: string | null;
+  seo?: {
+    title?: string | null;
+    description?: string | null;
+    keywords?: string[] | null;
+  } | null;
+  tags?: string[] | null;
+  category?: string | null;
+  image?: { url: string; alt?: string | null } | null;
+  author?: string | null;
+  publishedAt?: string | null;
+}
+
+/**
+ * Build product page <Metadata>. The returned title diverges from the
+ * visible H1 (which is just `product.title`) so Google doesn't read the
+ * page as a duplicate-signal page.
+ *
+ * Falls through (in order): explicit `metaTitle` column → generated
+ * `${title} — ${suffix} | …` pattern.
+ */
+export function buildProductMetadata(input: ProductMetadataInput): Metadata {
+  const canonicalPath = `/products/${input.handle}`;
+  const canonical = `${seoConfig.siteUrl}${canonicalPath}`;
+
+  const rawTitle = input.metaTitle?.trim()
+    || `${input.title} — ${PRODUCT_TITLE_SUFFIX}`;
+  const title = clampTitle(rawTitle);
+
+  const rawDescription = input.metaDescription?.trim()
+    || input.description?.trim()
+    || `Buy ${input.title} for same-day delivery in Austin. Premium alcohol delivery for weddings, parties, and events.`;
+  const description = clampDescription(rawDescription);
+
+  const ogImage = input.image?.url
+    ? [{ url: input.image.url, width: 1200, height: 1200, alt: input.image.alt || input.title }]
+    : [seoConfig.defaultOgImage];
+
+  return {
+    title,
+    description,
+    keywords: [input.title, 'austin alcohol delivery', input.productType, 'party supplies austin']
+      .filter((k): k is string => Boolean(k))
+      .join(', '),
+    alternates: { canonical },
+    openGraph: {
+      title,
+      description,
+      type: 'website',
+      url: canonical,
+      siteName: seoConfig.siteName,
+      images: ogImage,
+      locale: 'en_US',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: ogImage.map((i) => i.url),
+    },
+  };
+}
+
+/**
+ * Build blog post <Metadata>. Title diverges from the visible H1 (which is
+ * `post.title`) — this is the bigger duplicate-title source on the site
+ * since the H1 was previously echoed verbatim into <title> and og:title.
+ *
+ * Falls through (in order): explicit frontmatter `seo.title` → generated
+ * `${title} | ${suffix}` pattern.
+ */
+export function buildBlogMetadata(input: BlogMetadataInput): Metadata {
+  const canonicalPath = `/blog/${input.slug}`;
+  const canonical = `${seoConfig.siteUrl}${canonicalPath}`;
+
+  const rawTitle = input.seo?.title?.trim()
+    || `${input.title} | ${BLOG_TITLE_SUFFIX}`;
+  const title = clampTitle(rawTitle);
+
+  const rawDescription = input.seo?.description?.trim()
+    || input.excerpt?.trim()
+    || seoConfig.defaultDescription;
+  const description = clampDescription(rawDescription);
+
+  const keywordParts = [
+    ...(input.seo?.keywords ?? []),
+    input.category ?? null,
+    ...(input.tags ?? []),
+  ].filter((k): k is string => Boolean(k));
+
+  const ogImage = input.image?.url
+    ? [{ url: input.image.url, alt: input.image.alt || input.title }]
+    : [{ url: seoConfig.defaultOgImage.url, alt: seoConfig.defaultOgImage.alt }];
+
+  return {
+    title,
+    description,
+    keywords: keywordParts.length ? keywordParts.join(', ') : undefined,
+    alternates: { canonical },
+    openGraph: {
+      title,
+      description,
+      url: canonical,
+      type: 'article',
+      siteName: seoConfig.siteName,
+      publishedTime: input.publishedAt || undefined,
+      authors: input.author ? [input.author] : undefined,
+      images: ogImage,
+      locale: 'en_US',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: ogImage.map((i) => i.url),
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Ships the two code-fixable SEO root causes SEMrush flagged on the May→June audit. Visibility for Austin alcohol-delivery keywords dropped 25.7% → 8.8% in a month; these are the cheapest signals to send before deeper investigation.

- **Duplicate H1/title (123 pages flagged)** — new `src/lib/seo/build-metadata.ts` helper wraps product + blog metadata. Blog was the primary source (post.title was echoed into `<title>`, `og:title`, AND the H1); products had `og:title` = H1 even though `<title>` diverged. Helper enforces divergent title (`"${title} — Buy Online | Austin Same-Day Delivery"` for products, `"${title} | Austin Event Bar & Delivery Blog"` for posts), length clamps (≤60/≤155), and consistent canonical + OG.
- **Core Web Vitals at 0% pass rate** —
  - Explicit `width`/`height` on `<img>` in ProductDetailClient (main + thumbnails), ProductSearch, ProductModal → no more CLS jumps on every product surface.
  - Added missing `sizes` prop to `next/image fill` across 16 production pages/components.
  - HeroCollage: `prefers-reduced-motion` short-circuit + `startTransition` on rotation swaps + `will-change` toggling. The original plan called for "pure CSS keyframes" but the collage renders videos, so the JS state machine has to stay — this trims the cost instead. Reduced-motion users skip the rotation loop entirely.
  - MetaPixel: `strategy="afterInteractive"` → `lazyOnload` (matches GA4).
  - Audit baseline regenerated: **91% → 34% of images missing dimensions**.

## Files modified

- **Helper (1)**: `src/lib/seo/build-metadata.ts`
- **Product page (3)**: products/[handle]/page.tsx, ProductDetailClient, ProductSearch, ProductModal
- **Blog page (2)**: blog/[slug]/page.tsx, BlogSearchFilter
- **Homepage components (2)**: HeroCollage (INP), MetaPixel (lazyOnload)
- **Hero `sizes` additions (16)**: about, contact, delivery-areas, products, weddings, weddings/products, corporate/products, custom-package, delivery/[location], PremierHero, AndersonMillHero, GroupHeader, hotels-resorts, austin-wedding-dj, property-management, WelcomeStep
- **Scripts (1)**: `scripts/seo/add-image-dimensions.mjs` (report generator)
- **Docs (1)**: `docs/seo/image-dimensions-fix-list-2026-06-09.json` (output, fix list for follow-up)
- Updated `image-dimensions-audit.json` snapshot

## CWV baseline — skipped

`VERCEL_ANALYTICS_TOKEN` is not configured in `.env.local` and `src/lib/analytics/vercel-analytics.ts` even comments that the endpoint shape is still a placeholder. No before/after JSON could be captured. Synthetic PSI on the preview URL is the validation path until the Vercel token is set up.

## Live spot-check (before this PR)

Confirmed via curl on production — even worse than SEMrush flagged:
- Multiple product pages return `<title>Premium Spirits & Wine Collection | Party On Delivery Austin</title>` (layout-level fallback, dynamic metadata not reaching SSR HTML)
- Every blog post sampled returns `<title>Austin Event Planning Blog - Cocktail Tips</title>` (single fallback for all)

The helper restores per-page divergent titles.

## Deferred follow-ups (intentionally out of scope)

1. **metaTitle/metaDescription backfill script** — Prisma columns exist but aren't populated. Helper's auto-divergent fallback handles every product until a backfill PR ships. Will also need to plumb metaTitle through `transformToProduct()`.
2. **GSC keyword-level investigation** for the 25.7%→8.8% visibility drop — needs the seo-director sub-agent.
3. **Product content depth** — 174 thin product pages flagged by SEMrush. Editorial work, not code.
4. **Local backlink outreach** — Austin directories, local press, wedding-vendor listings. Operator action.
5. **`<img>` long tail** in partner secondary cards + product grids (~92 fills remain, mostly in low-traffic surfaces — see `docs/seo/image-dimensions-fix-list-2026-06-09.json`).

## Risks / what to watch in next SEMrush capture

- **Duplicate-H1/title count**: 123 → expect 0 after next crawl. If it doesn't move, dynamic metadata isn't reaching SSR — investigate Next.js streaming/RSC interaction.
- **CWV pass rate**: 0% → expect 50%+ within a week. If it stalls at 0%, the un-fixed long tail of fills is still dominating.

## Test plan

- [ ] `npx tsc --noEmit` clean (verified locally — only pre-existing unrelated test error)
- [ ] Preview deploy: spot-check 3 product + 3 blog pages, `<title>` ≠ H1, title ≤ 60 chars
- [ ] Preview deploy: synthetic PSI on homepage — LCP/CLS/INP green
- [ ] After merge (24-48h): re-check SEMrush duplicate-title count + CWV pass rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)