### PR TITLE
feat(checkout): add in-store pickup option

### DIFF
--- a/src/app/api/v1/checkout/route.ts
+++ b/src/app/api/v1/checkout/route.ts
@@ -99,16 +99,22 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       );
     }
 
-    // Validate minimum order
-    const validation = validateCartMinimum(cart);
-    if (!validation.valid) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: `Minimum order is $${validation.minimum}. Your cart is $${validation.current.toFixed(2)}`,
-        },
-        { status: 400 }
-      );
+    // Validate minimum order — waived for in-store pickup
+    const pickupFromAddress =
+      cart.deliveryAddress && typeof cart.deliveryAddress === 'object'
+        ? (cart.deliveryAddress as { isPickup?: boolean }).isPickup === true
+        : false;
+    if (!pickupFromAddress) {
+      const validation = validateCartMinimum(cart);
+      if (!validation.valid) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: `Minimum order is $${validation.minimum}. Your cart is $${validation.current.toFixed(2)}`,
+          },
+          { status: 400 }
+        );
+      }
     }
 
     // Validate delivery info

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -8,11 +8,25 @@ import { useCartContext } from '@/contexts/CartContext';
 import { useCustomerContext } from '@/contexts/CustomerContext';
 import CustomerAuth from '@/components/CustomerAuth';
 
+/** In-store pickup location — 7600 N. Lamar Blvd #A2, Austin TX 78752 */
+const STORE_PICKUP_ADDRESS = {
+  address1: '7600 N. Lamar Blvd',
+  address2: '#A2',
+  city: 'Austin',
+  province: 'TX',
+  zip: '78752',
+  country: 'US',
+} as const;
+
 export default function CheckoutPage() {
   const { cart, customCartData, loading: cartLoading, refetchCart, updateCartFromApiResponse } = useCartContext();
   const { customer, isAuthenticated } = useCustomerContext();
-  
+
   const [showAuthModal, setShowAuthModal] = useState(false);
+
+  // Fulfillment method — delivery (default) vs in-store pickup
+  const [fulfillmentMethod, setFulfillmentMethod] = useState<'delivery' | 'pickup'>('delivery');
+  const isPickup = fulfillmentMethod === 'pickup';
 
   // Delivery schedule state (inline picker)
   const [deliveryDate, setDeliveryDate] = useState<Date | null>(null);
@@ -133,7 +147,7 @@ export default function CheckoutPage() {
   const appliedDiscounts = customCartData?.appliedDiscounts ?? [];
   const hasFreeShipping = (affiliatePartner !== null && affiliatePerk === 'Free Delivery') || appliedDiscounts.some(d => d.type === 'FREE_SHIPPING' || d.freeShipping);
 
-  const effectiveDeliveryFee = hasFreeShipping ? 0 : deliveryFee;
+  const effectiveDeliveryFee = isPickup || hasFreeShipping ? 0 : deliveryFee;
 
   // Tip calculation
   const tipAmount = tipPercent !== null
@@ -218,15 +232,17 @@ export default function CheckoutPage() {
   };
 
   const handleProceedToPayment = async () => {
-    // Validate form
-    if (!billingAddress.firstName || !billingAddress.lastName || !billingAddress.email ||
-        !billingAddress.phone || !billingAddress.address1 || !billingAddress.zip) {
+    // Validate form — name/email/phone always required; street address only for delivery
+    const missingContact = !billingAddress.firstName || !billingAddress.lastName ||
+      !billingAddress.email || !billingAddress.phone;
+    const missingDeliveryAddress = !isPickup && (!billingAddress.address1 || !billingAddress.zip);
+    if (missingContact || missingDeliveryAddress) {
       alert('Please fill in all required fields');
       return;
     }
 
     if (!deliveryDate || !deliveryTime) {
-      alert('Please select a delivery date and time');
+      alert(isPickup ? 'Please select a pickup date and time' : 'Please select a delivery date and time');
       return;
     }
 
@@ -239,7 +255,17 @@ export default function CheckoutPage() {
     setCheckoutError(null);
 
     try {
-      // Save delivery info to cart
+      // Save delivery info to cart — store address + isPickup flag when picking up
+      const addressPayload = isPickup
+        ? { ...STORE_PICKUP_ADDRESS, isPickup: true }
+        : {
+            address1: billingAddress.address1,
+            address2: billingAddress.address2 || '',
+            city: billingAddress.city,
+            province: billingAddress.state,
+            zip: billingAddress.zip,
+            country: billingAddress.country,
+          };
       const deliveryResponse = await fetch('/api/v1/cart', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -247,14 +273,7 @@ export default function CheckoutPage() {
           operation: 'delivery',
           date: deliveryDate?.toISOString(),
           time: deliveryTime,
-          address: {
-            address1: billingAddress.address1,
-            address2: billingAddress.address2 || '',
-            city: billingAddress.city,
-            province: billingAddress.state,
-            zip: billingAddress.zip,
-            country: billingAddress.country,
-          },
+          address: addressPayload,
           phone: billingAddress.phone,
           instructions: deliveryInstructions,
         }),
@@ -434,7 +453,49 @@ export default function CheckoutPage() {
                 </div>
               </div>
 
-              {/* Delivery Schedule - Inline Picker */}
+              {/* Fulfillment Method Picker */}
+              <div>
+                <h2 className="font-cormorant text-2xl mb-4">How would you like your order?</h2>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <button
+                    type="button"
+                    onClick={() => setFulfillmentMethod('delivery')}
+                    className={`text-left p-5 border-2 rounded transition-colors ${
+                      !isPickup
+                        ? 'border-brand-yellow bg-yellow-50'
+                        : 'border-gray-200 bg-white hover:border-brand-yellow'
+                    }`}
+                  >
+                    <div className="flex items-center justify-between mb-1">
+                      <span className="font-semibold text-gray-900">Deliver to me</span>
+                      <span className="text-sm text-gray-600">${deliveryFee.toFixed(2)}</span>
+                    </div>
+                    <p className="text-sm text-gray-600">
+                      We&apos;ll bring it to your door. Austin-area zip codes only.
+                    </p>
+                  </button>
+
+                  <button
+                    type="button"
+                    onClick={() => setFulfillmentMethod('pickup')}
+                    className={`text-left p-5 border-2 rounded transition-colors ${
+                      isPickup
+                        ? 'border-brand-yellow bg-yellow-50'
+                        : 'border-gray-200 bg-white hover:border-brand-yellow'
+                    }`}
+                  >
+                    <div className="flex items-center justify-between mb-1">
+                      <span className="font-semibold text-gray-900">Pick up in store</span>
+                      <span className="text-sm font-semibold text-green-700">FREE</span>
+                    </div>
+                    <p className="text-sm text-gray-600">
+                      Grab it at our shop on N. Lamar. No delivery fee, no order minimum.
+                    </p>
+                  </button>
+                </div>
+              </div>
+
+              {/* Delivery / Pickup Schedule - Inline Picker */}
               <DeliveryDateTimePicker
                 selectedDate={deliveryDate}
                 selectedTime={deliveryTime}
@@ -442,9 +503,30 @@ export default function CheckoutPage() {
                 onDateChange={setDeliveryDate}
                 onTimeChange={setDeliveryTime}
                 onInstructionsChange={setDeliveryInstructions}
+                mode={isPickup ? 'pickup' : 'delivery'}
               />
 
-              {/* Delivery Address */}
+              {isPickup ? (
+                <div className="bg-white p-6 border border-gray-200">
+                  <h2 className="font-cormorant text-2xl mb-4">Pickup Location</h2>
+                  <div className="flex items-start gap-3">
+                    <svg className="w-6 h-6 text-brand-yellow flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                    </svg>
+                    <div>
+                      <p className="font-semibold text-gray-900">Party On Delivery</p>
+                      <p className="text-gray-700">
+                        7600 N. Lamar Blvd #A2<br />
+                        Austin, TX 78752
+                      </p>
+                      <p className="text-sm text-gray-500 mt-2">
+                        Bring a photo ID. We&apos;ll have your order ready at the time you select above.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              ) : (
               <div className="bg-white p-6 border border-gray-200">
                 <h2 className="font-cormorant text-2xl mb-6">Delivery Address</h2>
 
@@ -515,6 +597,7 @@ export default function CheckoutPage() {
                   </div>
                 </div>
               </div>
+              )}
             </div>
 
             {/* Right Column - Order Summary */}
@@ -675,8 +758,10 @@ export default function CheckoutPage() {
                     <span>${subtotal.toFixed(2)}</span>
                   </div>
                   <div className="flex justify-between text-sm">
-                    <span>Delivery Fee</span>
-                    {hasFreeShipping ? (
+                    <span>{isPickup ? 'Store Pickup' : 'Delivery Fee'}</span>
+                    {isPickup ? (
+                      <span className="text-green-600">FREE</span>
+                    ) : hasFreeShipping ? (
                       <span>
                         <span className="line-through text-gray-400 mr-1">${deliveryFee.toFixed(2)}</span>
                         <span className="text-green-600">$0.00</span>

--- a/src/components/checkout/DeliveryDateTimePicker.tsx
+++ b/src/components/checkout/DeliveryDateTimePicker.tsx
@@ -37,6 +37,8 @@ interface DeliveryDateTimePickerProps {
   onTimeChange: (time: string) => void;
   /** Callback when instructions change */
   onInstructionsChange: (instructions: string) => void;
+  /** Whether this is for in-store pickup vs delivery (changes copy only) */
+  mode?: 'delivery' | 'pickup';
 }
 
 /** Available time slots - 10am to 9pm, every 30 minutes */
@@ -125,7 +127,11 @@ export default function DeliveryDateTimePicker({
   onDateChange,
   onTimeChange,
   onInstructionsChange,
+  mode = 'delivery',
 }: DeliveryDateTimePickerProps): ReactElement {
+  const isPickup = mode === 'pickup';
+  const noun = isPickup ? 'pickup' : 'delivery';
+  const Noun = isPickup ? 'Pickup' : 'Delivery';
   const [isCalendarOpen, setIsCalendarOpen] = useState(false);
   const [currentMonth, setCurrentMonth] = useState(new Date());
   const [showTimeSlots, setShowTimeSlots] = useState(!!selectedDate);
@@ -213,10 +219,12 @@ export default function DeliveryDateTimePicker({
       {/* Header */}
       <div className="bg-gray-50 px-6 py-4 border-b border-gray-200">
         <h3 className="font-heading text-xl text-gray-900 tracking-[0.1em]">
-          Delivery Schedule
+          {Noun} Schedule
         </h3>
         <p className="text-sm text-gray-600 mt-1">
-          Available Monday - Saturday, 10AM - 9PM
+          {isPickup
+            ? 'Store hours: Monday - Saturday, 10AM - 9PM'
+            : 'Available Monday - Saturday, 10AM - 9PM'}
         </p>
       </div>
 
@@ -244,7 +252,7 @@ export default function DeliveryDateTimePicker({
               <span className={selectedDate ? 'text-gray-900' : 'text-gray-500'}>
                 {selectedDate
                   ? format(selectedDate, 'EEEE, MMMM d, yyyy')
-                  : 'Click to select a delivery date'
+                  : `Click to select a ${noun} date`
                 }
               </span>
               <svg
@@ -357,7 +365,7 @@ export default function DeliveryDateTimePicker({
               )
             ) : (
               <div className="text-center py-6 text-gray-500 bg-gray-50 rounded">
-                Please select a delivery date first
+                Please select a {noun} date first
               </div>
             )}
           </div>
@@ -366,14 +374,19 @@ export default function DeliveryDateTimePicker({
         {/* Special Instructions */}
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-2 tracking-[0.1em]">
-            DELIVERY INSTRUCTIONS <span className="font-normal text-gray-500">(optional)</span>
+            {isPickup ? 'PICKUP NOTES' : 'DELIVERY INSTRUCTIONS'}{' '}
+            <span className="font-normal text-gray-500">(optional)</span>
           </label>
           <textarea
             value={instructions}
             onChange={(e) => onInstructionsChange(e.target.value)}
             rows={2}
             className="w-full px-4 py-3 border border-gray-200 rounded focus:border-brand-yellow focus:ring-1 focus:ring-brand-yellow focus:outline-none transition-colors text-sm"
-            placeholder="Gate code, building entrance, special instructions..."
+            placeholder={
+              isPickup
+                ? 'Name on the order, vehicle description, anything else we should know...'
+                : 'Gate code, building entrance, special instructions...'
+            }
           />
         </div>
 
@@ -384,7 +397,7 @@ export default function DeliveryDateTimePicker({
               <svg className="w-5 h-5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
               </svg>
-              <span className="text-green-800 font-medium">Delivery scheduled</span>
+              <span className="text-green-800 font-medium">{Noun} scheduled</span>
             </div>
             <p className="text-sm text-green-700 mt-1">
               {format(selectedDate, 'EEEE, MMMM d, yyyy')} &bull; {selectedTime}

--- a/src/components/dashboard/DashboardCheckoutModal.tsx
+++ b/src/components/dashboard/DashboardCheckoutModal.tsx
@@ -54,6 +54,7 @@ export default function DashboardCheckoutModal({
   const [tipPercent, setTipPercent] = useState<number | null>(null);
   const [customTip, setCustomTip] = useState('');
 
+  const isPickup = tab.deliveryAddress?.isPickup === true;
   const hasAddress = !!tab.deliveryAddress?.address1?.trim();
 
   const subtotal = items.reduce((sum, i) => sum + i.price * i.quantity, 0);
@@ -86,7 +87,7 @@ export default function DashboardCheckoutModal({
     setError('');
 
     if (!hasAddress) {
-      setError('Delivery address is required');
+      setError(isPickup ? 'Pickup details are required' : 'Delivery address is required');
       return;
     }
 
@@ -284,10 +285,12 @@ export default function DashboardCheckoutModal({
             )}
           </div>
 
-          {/* Delivery details section */}
+          {/* Delivery / Pickup details section */}
           {hasAddress ? (
             <div className="bg-gray-50 rounded-lg px-4 py-3 space-y-1.5">
-              <p className="text-xs font-semibold uppercase tracking-wider text-gray-400">Delivery</p>
+              <p className="text-xs font-semibold uppercase tracking-wider text-gray-400">
+                {isPickup ? 'Pickup' : 'Delivery'}
+              </p>
               {(deliveryDate || deliveryTime) && (
                 <p className="text-sm text-gray-700">
                   {deliveryDate}{deliveryTime ? ` at ${deliveryTime}` : ''}
@@ -336,8 +339,10 @@ export default function DashboardCheckoutModal({
               </div>
             )}
             <div className="flex justify-between text-sm mb-1">
-              <span className="text-gray-600">Delivery Fee</span>
-              {appliedPromo?.freeDelivery ? (
+              <span className="text-gray-600">{isPickup ? 'Store Pickup' : 'Delivery Fee'}</span>
+              {isPickup ? (
+                <span className="text-green-600 font-semibold">FREE</span>
+              ) : appliedPromo?.freeDelivery ? (
                 <span className="flex items-center gap-1.5">
                   <span className="text-gray-400 line-through">${Number(tab.deliveryFee || 40).toFixed(2)}</span>
                   <span className="text-green-600 font-semibold">FREE</span>

--- a/src/components/dashboard/DeliveryDetailsModal.tsx
+++ b/src/components/dashboard/DeliveryDetailsModal.tsx
@@ -12,6 +12,16 @@ interface Props {
   onSaved: () => void;
 }
 
+/** In-store pickup location — 7600 N. Lamar Blvd #A2, Austin TX 78752 */
+const STORE_PICKUP_ADDRESS = {
+  address1: '7600 N. Lamar Blvd',
+  address2: '#A2',
+  city: 'Austin',
+  province: 'TX',
+  zip: '78752',
+  country: 'US',
+} as const;
+
 function generateTimeSlots(): string[] {
   const slots: string[] = [];
   for (let h = 10; h <= 20; h++) {
@@ -51,6 +61,12 @@ export default function DeliveryDetailsModal({
 }: Props): ReactElement {
   const addr = tab.deliveryAddress || { address1: '', address2: '', city: '', province: 'TX', zip: '', country: 'US' };
 
+  // Fulfillment method — default to whatever the tab is currently set to
+  const [fulfillmentMethod, setFulfillmentMethod] = useState<'delivery' | 'pickup'>(
+    addr.isPickup ? 'pickup' : 'delivery'
+  );
+  const isPickup = fulfillmentMethod === 'pickup';
+
   const [date, setDate] = useState(() => {
     if (!tab.deliveryDate || tab.deliveryDate === 'TBD') return '';
     if (!tab.deliveryDateConfirmed) return '';
@@ -74,19 +90,23 @@ export default function DeliveryDetailsModal({
     setError('');
 
     if (!date) {
-      setError('Please select a delivery date.');
+      setError(isPickup ? 'Please select a pickup date.' : 'Please select a delivery date.');
       return;
     }
     if (isSunday(date)) {
-      setError('We do not deliver on Sundays. Please pick another date.');
+      setError(
+        isPickup
+          ? 'We are closed on Sundays. Please pick another date.'
+          : 'We do not deliver on Sundays. Please pick another date.'
+      );
       return;
     }
     if (!time) {
-      setError('Please select a delivery time.');
+      setError(isPickup ? 'Please select a pickup time.' : 'Please select a delivery time.');
       return;
     }
 
-    // Ensure delivery is at least 4 hours from now
+    // Ensure the slot is at least 4 hours from now (give the store time to prep)
     const timeMatch = time.match(/^(\d{1,2}):(\d{2})\s*(AM|PM)/i);
     if (timeMatch) {
       let hour = parseInt(timeMatch[1], 10);
@@ -94,40 +114,51 @@ export default function DeliveryDetailsModal({
       const ampm = timeMatch[3].toUpperCase();
       if (ampm === 'PM' && hour !== 12) hour += 12;
       if (ampm === 'AM' && hour === 12) hour = 0;
-      const delivery = new Date(`${date}T${hour.toString().padStart(2, '0')}:${min.toString().padStart(2, '0')}:00`);
+      const scheduled = new Date(`${date}T${hour.toString().padStart(2, '0')}:${min.toString().padStart(2, '0')}:00`);
       const fourHoursFromNow = new Date(Date.now() + 4 * 60 * 60 * 1000);
-      if (delivery < fourHoursFromNow) {
-        setError('Delivery must be at least 4 hours from now.');
+      if (scheduled < fourHoursFromNow) {
+        setError(
+          isPickup
+            ? 'Pickup must be at least 4 hours from now.'
+            : 'Delivery must be at least 4 hours from now.'
+        );
         return;
       }
     }
-    if (!address1.trim()) {
-      setError('Please enter a delivery address.');
-      return;
-    }
-    if (!city.trim()) {
-      setError('Please enter a city.');
-      return;
-    }
-    if (!zip.trim()) {
-      setError('Please enter a zip code.');
-      return;
+
+    // Address fields are only required for delivery
+    if (!isPickup) {
+      if (!address1.trim()) {
+        setError('Please enter a delivery address.');
+        return;
+      }
+      if (!city.trim()) {
+        setError('Please enter a city.');
+        return;
+      }
+      if (!zip.trim()) {
+        setError('Please enter a zip code.');
+        return;
+      }
     }
 
     setSaving(true);
     try {
+      const deliveryAddress = isPickup
+        ? { ...STORE_PICKUP_ADDRESS, isPickup: true }
+        : {
+            address1: address1.trim(),
+            address2: address2.trim() || undefined,
+            city: city.trim(),
+            province: 'TX',
+            zip: zip.trim(),
+            country: 'US',
+          };
       await updateTabV2(shareCode, tab.id, {
         participantId,
         deliveryDate: date,
         deliveryTime: time,
-        deliveryAddress: {
-          address1: address1.trim(),
-          address2: address2.trim() || undefined,
-          city: city.trim(),
-          province: 'TX',
-          zip: zip.trim(),
-          country: 'US',
-        },
+        deliveryAddress,
         deliveryNotes: notes.trim() || undefined,
       });
       onSaved();
@@ -162,10 +193,41 @@ export default function DeliveryDetailsModal({
         </div>
 
         <form onSubmit={handleSubmit} className="p-6 space-y-4">
+          {/* Fulfillment method */}
+          <div className="grid grid-cols-2 gap-3">
+            <button
+              type="button"
+              onClick={() => setFulfillmentMethod('delivery')}
+              className={`text-left p-3 border-2 rounded-lg transition-colors ${
+                !isPickup
+                  ? 'border-brand-blue bg-blue-50'
+                  : 'border-gray-200 bg-white hover:border-gray-300'
+              }`}
+            >
+              <div className="font-semibold text-sm text-gray-900">Deliver to me</div>
+              <div className="text-xs text-gray-600 mt-0.5">Austin area</div>
+            </button>
+            <button
+              type="button"
+              onClick={() => setFulfillmentMethod('pickup')}
+              className={`text-left p-3 border-2 rounded-lg transition-colors ${
+                isPickup
+                  ? 'border-brand-blue bg-blue-50'
+                  : 'border-gray-200 bg-white hover:border-gray-300'
+              }`}
+            >
+              <div className="flex items-center justify-between">
+                <span className="font-semibold text-sm text-gray-900">Pick up in store</span>
+                <span className="text-xs font-semibold text-green-700">FREE</span>
+              </div>
+              <div className="text-xs text-gray-600 mt-0.5">7600 N. Lamar</div>
+            </button>
+          </div>
+
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">
-                Delivery Date
+                {isPickup ? 'Pickup Date' : 'Delivery Date'}
               </label>
               <input
                 type="date"
@@ -177,7 +239,7 @@ export default function DeliveryDetailsModal({
             </div>
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">
-                Delivery Time
+                {isPickup ? 'Pickup Time' : 'Delivery Time'}
               </label>
               <select
                 value={time}
@@ -192,67 +254,90 @@ export default function DeliveryDetailsModal({
             </div>
           </div>
 
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Address
-            </label>
-            <input
-              type="text"
-              value={address1}
-              onChange={(e) => setAddress1(e.target.value)}
-              placeholder="Street address"
-              className="w-full px-3 py-2.5 border-2 border-gray-200 rounded-lg text-base focus:border-brand-blue focus:ring-0 transition-all hover:border-gray-300"
-            />
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Address Line 2 <span className="text-gray-400 font-normal">(optional)</span>
-            </label>
-            <input
-              type="text"
-              value={address2}
-              onChange={(e) => setAddress2(e.target.value)}
-              placeholder="Apt, suite, unit, etc."
-              className="w-full px-3 py-2.5 border-2 border-gray-200 rounded-lg text-base focus:border-brand-blue focus:ring-0 transition-all hover:border-gray-300"
-            />
-          </div>
-
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                City
-              </label>
-              <input
-                type="text"
-                value={city}
-                onChange={(e) => setCity(e.target.value)}
-                placeholder="Austin"
-                className="w-full px-3 py-2.5 border-2 border-gray-200 rounded-lg text-base focus:border-brand-blue focus:ring-0 transition-all hover:border-gray-300"
-              />
+          {isPickup ? (
+            <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
+              <p className="text-xs font-semibold uppercase tracking-wider text-gray-400 mb-1">
+                Pickup Location
+              </p>
+              <p className="font-semibold text-gray-900">Party On Delivery</p>
+              <p className="text-sm text-gray-700">
+                7600 N. Lamar Blvd #A2<br />
+                Austin, TX 78752
+              </p>
+              <p className="text-xs text-gray-500 mt-2">
+                Bring a photo ID. Your order will be ready at the selected time.
+              </p>
             </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                Zip Code
-              </label>
-              <input
-                type="text"
-                value={zip}
-                onChange={(e) => setZip(e.target.value)}
-                placeholder="78701"
-                className="w-full px-3 py-2.5 border-2 border-gray-200 rounded-lg text-base focus:border-brand-blue focus:ring-0 transition-all hover:border-gray-300"
-              />
-            </div>
-          </div>
+          ) : (
+            <>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Address
+                </label>
+                <input
+                  type="text"
+                  value={address1}
+                  onChange={(e) => setAddress1(e.target.value)}
+                  placeholder="Street address"
+                  className="w-full px-3 py-2.5 border-2 border-gray-200 rounded-lg text-base focus:border-brand-blue focus:ring-0 transition-all hover:border-gray-300"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Address Line 2 <span className="text-gray-400 font-normal">(optional)</span>
+                </label>
+                <input
+                  type="text"
+                  value={address2}
+                  onChange={(e) => setAddress2(e.target.value)}
+                  placeholder="Apt, suite, unit, etc."
+                  className="w-full px-3 py-2.5 border-2 border-gray-200 rounded-lg text-base focus:border-brand-blue focus:ring-0 transition-all hover:border-gray-300"
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    City
+                  </label>
+                  <input
+                    type="text"
+                    value={city}
+                    onChange={(e) => setCity(e.target.value)}
+                    placeholder="Austin"
+                    className="w-full px-3 py-2.5 border-2 border-gray-200 rounded-lg text-base focus:border-brand-blue focus:ring-0 transition-all hover:border-gray-300"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Zip Code
+                  </label>
+                  <input
+                    type="text"
+                    value={zip}
+                    onChange={(e) => setZip(e.target.value)}
+                    placeholder="78701"
+                    className="w-full px-3 py-2.5 border-2 border-gray-200 rounded-lg text-base focus:border-brand-blue focus:ring-0 transition-all hover:border-gray-300"
+                  />
+                </div>
+              </div>
+            </>
+          )}
 
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">
-              Delivery Notes <span className="text-gray-400 font-normal">(optional)</span>
+              {isPickup ? 'Pickup Notes' : 'Delivery Notes'}{' '}
+              <span className="text-gray-400 font-normal">(optional)</span>
             </label>
             <textarea
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
-              placeholder="Gate code, special instructions, etc."
+              placeholder={
+                isPickup
+                  ? 'Name on the order, vehicle description, anything else we should know.'
+                  : 'Gate code, special instructions, etc.'
+              }
               rows={3}
               className="w-full px-3 py-2.5 border-2 border-gray-200 rounded-lg text-base focus:border-brand-blue focus:ring-0 transition-all hover:border-gray-300 resize-none"
             />

--- a/src/lib/inventory/services/cart-service.ts
+++ b/src/lib/inventory/services/cart-service.ts
@@ -455,11 +455,13 @@ async function recalculateCart(cartId: string): Promise<CartWithItems> {
     return sum + (parseFloat(item.price.toString()) * item.quantity);
   }, 0);
 
-  // Get zip code from delivery address if available
+  // Get zip code + pickup flag from delivery address if available
   let zipCode: string | undefined;
+  let isPickup = false;
   if (cart.deliveryAddress && typeof cart.deliveryAddress === 'object') {
-    const addr = cart.deliveryAddress as { zip?: string };
+    const addr = cart.deliveryAddress as { zip?: string; isPickup?: boolean };
     zipCode = addr.zip;
+    isPickup = addr.isPickup === true;
   }
 
   // Calculate tax using configurable rates
@@ -477,7 +479,7 @@ async function recalculateCart(cartId: string): Promise<CartWithItems> {
 
   // Calculate delivery fee based on zip code (if delivery address is set)
   let deliveryFee = parseFloat(cart.deliveryFee.toString());
-  if (hasFreeShipping) {
+  if (isPickup || hasFreeShipping) {
     deliveryFee = 0;
   } else if (zipCode && cart.deliveryAddress) {
     // Calculate delivery fee based on zone - use existing fee if manually set

--- a/src/lib/webhooks/ghl.ts
+++ b/src/lib/webhooks/ghl.ts
@@ -39,6 +39,8 @@ export interface GhlOrderPayload {
   deliveryTime: string;
   deliveryAddress: string;
   deliveryType: string;
+  /** True when the customer chose in-store pickup instead of delivery */
+  isPickup: boolean;
   deliveryInstructions: string;
   createdAt: string;
   // Dashboard link for orders placed under a GroupOrderV2 (Premier cruise,
@@ -114,7 +116,8 @@ function buildItemsSummary(
  * Build a flat GHL webhook payload from an order object.
  */
 export function buildGhlPayload(order: OrderLike, orderType: string): GhlOrderPayload {
-  const addr = (order.deliveryAddress ?? {}) as Record<string, string>;
+  const addr = (order.deliveryAddress ?? {}) as Record<string, string> & { isPickup?: boolean };
+  const isPickup = addr.isPickup === true;
   const nameParts = order.customerName.trim().split(/\s+/);
   const firstName = nameParts[0] || '';
   const lastName = nameParts.slice(1).join(' ') || '';
@@ -148,7 +151,8 @@ export function buildGhlPayload(order: OrderLike, orderType: string): GhlOrderPa
     deliveryDate: order.deliveryDate.toISOString().split('T')[0],
     deliveryTime: order.deliveryTime,
     deliveryAddress: formatAddress(addr),
-    deliveryType: order.deliveryType || 'HOUSE',
+    deliveryType: isPickup ? 'PICKUP' : (order.deliveryType || 'HOUSE'),
+    isPickup,
     deliveryInstructions: order.deliveryInstructions || '',
     createdAt: order.createdAt.toISOString(),
     dashboard_url: dashboardUrl,


### PR DESCRIPTION
## Summary
- Adds a **Pick up in store** toggle to both customer checkout flows (standalone `/checkout` page and the dashboard / group-order checkout modal).
- Pickup waives the delivery fee, the $100 order minimum (standalone only), and the post-delivery invoice (dashboard flow).
- Store address (7600 N. Lamar Blvd #A2, Austin TX 78752) is stored inside `deliveryAddress` JSON with an `isPickup: true` flag — no schema migration. The flag flows end-to-end through Cart → Order → Stripe metadata → GHL webhook so dispatch knows not to route a driver.

## How it works
- **UI (standalone)**: Two large radio cards at top of `/checkout` ("Deliver to me" / "Pick up in store — FREE"). Selecting pickup hides the address form and shows a static store-location card. The schedule picker re-labels to "Pickup Schedule".
- **UI (dashboard)**: Same two-card toggle inside `DeliveryDetailsModal`. The dashboard checkout modal then displays "Pickup" instead of "Delivery" and "Store Pickup — FREE" instead of "Billed separately".
- **Fee waiver**: `recalculateCart` checks `addr.isPickup === true` → `deliveryFee = 0`. The Stripe checkout's `if (deliveryFee > 0)` guard naturally skips the delivery line item, so no Stripe-side changes were needed for pickup orders.
- **Minimum waiver**: `/api/v1/checkout` bypasses `validateCartMinimum` when the cart's address has `isPickup: true`.
- **GHL payload**: `buildGhlPayload` adds an `isPickup: boolean` field and sets `deliveryType: "PICKUP"`.

The supporting type/service changes for the dashboard flow (`DeliveryAddressV2.isPickup`, `updateTab` fee-waiver branch) are already merged on `main`.

## Test plan
- [ ] **Standalone /checkout**: Add a single low-cost item via `/order`, go to `/checkout`, pick **Pick up in store**, confirm minimum check is waived, complete checkout, verify Stripe checkout has no delivery line item.
- [ ] **Dashboard**: Open a group dashboard, click delivery details, choose **Pick up in store**, save, then open the checkout modal and confirm it shows "Pickup" + "Store Pickup — FREE" and there is no post-delivery invoice generated.
- [ ] Verify Mon-Sat 10AM–9PM store hours enforced; Sundays rejected for pickup.
- [ ] Check `Order.deliveryAddress` JSON in DB carries `isPickup: true` after a paid pickup order.
- [ ] Verify GHL webhook payload includes `isPickup: true` and `deliveryType: "PICKUP"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)