### PR TITLE
fix(wedding-calc): capture email at the results moment to close the conversion leak

### DIFF
--- a/src/app/wedding-drink-calculator/CalculatorPageBody.tsx
+++ b/src/app/wedding-drink-calculator/CalculatorPageBody.tsx
@@ -12,7 +12,6 @@ import GuaranteeRow from './sections/GuaranteeRow';
 import EditorialReviews from './sections/EditorialReviews';
 import HowMathWorks from './sections/HowMathWorks';
 import FaqColumn from './sections/FaqColumn';
-import QuoteFormCard from './sections/QuoteFormCard';
 import QuoteFormSection from './sections/QuoteFormSection';
 import MobileStickyCta from './sections/MobileStickyCta';
 import type { Faq } from '@/components/landing/types';
@@ -51,21 +50,19 @@ export default function CalculatorPageBody({ faqs }: Props): ReactElement {
       {/* B. Calculator tool — get to it FAST. No duplicate H2 header
           (the hero already says "Wedding drink calculator."). The
           two-column desktop layout is self-evident so the instruction
-          line only renders on mobile where columns stack. */}
+          line only renders on mobile where columns stack.
+
+          The primary in-calculator conversion is the email-first capture
+          attached to the results (inside CalculatorClient → CalculatorResults,
+          placement="results") — it sits at the peak-intent moment instead of
+          a separate full form below. The bottom-of-page QuoteFormSection
+          remains the scroll-to-end catch-all. */}
       <section id="calculator" className="bg-white py-5 md:py-7">
         <div className="max-w-6xl mx-auto px-6">
           <p className="md:hidden text-center text-sm text-gray-600 font-light mb-4">
             Inputs first. Shopping list updates as you go.
           </p>
           <CalculatorClient onResultsComputed={setPlan} />
-
-          {/* Inline quote form — same component / same endpoint as the
-              bottom-of-page form, kept inside the calculator section so it
-              reads as the natural next step. Editorial hairline divider
-              keeps the visual rhythm consistent with the section above. */}
-          <div className="mt-16 md:mt-20 pt-12 md:pt-16 border-t border-[#2A2218]/10 max-w-3xl mx-auto">
-            <QuoteFormCard plan={plan} placement="inline" />
-          </div>
         </div>
       </section>
 

--- a/src/app/wedding-drink-calculator/CalculatorResults.tsx
+++ b/src/app/wedding-drink-calculator/CalculatorResults.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactElement } from 'react';
 import type { WeddingPlan } from '@/lib/weddingDrinkCalculator';
+import ResultsQuoteCapture from './sections/ResultsQuoteCapture';
 
 interface Props {
   plan: WeddingPlan;
@@ -84,6 +85,11 @@ export default function CalculatorResults({ plan }: Props): ReactElement {
           ))}
         </div>
       </div>
+
+      {/* Email-first capture at the peak-intent moment — converts the
+          "I have my number" moment into a real, editable quote. The full
+          list above stays free; this is the page's primary conversion. */}
+      <ResultsQuoteCapture plan={plan} />
     </div>
   );
 }

--- a/src/app/wedding-drink-calculator/sections/QuoteFormCard.tsx
+++ b/src/app/wedding-drink-calculator/sections/QuoteFormCard.tsx
@@ -2,7 +2,7 @@
 
 import { useState, type FormEvent, type ReactElement } from 'react';
 import type { WeddingPlan } from '@/lib/weddingDrinkCalculator';
-import { trackMetaEvent } from '@/components/MetaPixel';
+import { submitWeddingQuote } from './submitWeddingQuote';
 
 type Props = {
   /** Latest computed plan from the calculator above; null until first render. */
@@ -17,28 +17,6 @@ type Props = {
   heading?: string;
   /** Optional subhead override. */
   subhead?: string;
-};
-
-/**
- * Maps a calculator output item name to the underlying product handle in
- * Postgres. Items not in this map fall through — admin reviews the draft
- * order and adds them manually. We always send `bag-of-ice-7-lbs` as the
- * fallback so the API's `items.min(1)` validation always passes.
- */
-const ITEM_NAME_TO_HANDLE: Record<string, string> = {
-  'Miller Lite (24-pack)': 'miller-lite-24-pack-12oz-can',
-  'Modelo Especial (24-pack)': 'modelo-especial-24pack-12oz-cans',
-  'Austin Beerworks Variety (12-pack)': 'austin-beerworks-variety-pack-12-pack-12oz-can',
-  'High Noon Variety (12-pack)':
-    'high-noon-vodka-soda-combo-3-each-grapefruit-9-pineapple-9-black-cherry-9-watermelon-9-355ml-12-pack',
-  'White Claw Variety (24-pack)': 'white-claw-variety-24-pack-12oz-can',
-  'Dark Horse Pinot Grigio (750ml)': 'dark-horse-pinot-grigio-750ml-bottle',
-  '14 Hands Cabernet Sauvignon (750ml)': '14-hands-cabernet-sauvignon',
-  'Espolon Tequila Blanco (750ml)': 'espolon-tequila-blanco-80-1l',
-  "Tito's Handmade Vodka (1L)": 'titos-handmade-vodka-80-1lt',
-  'Still Austin Bourbon (750ml)': 'jameson-irish-whiskey-1',
-  'Champagne / Prosecco (750ml)': 'chandon-california-brut-750ml',
-  'Ice Bags': 'bag-of-ice-7-lbs',
 };
 
 /**
@@ -72,83 +50,16 @@ export default function QuoteFormCard({
     setStatus('submitting');
     setErrorMsg('');
 
-    const items: { handle: string; qty: number }[] = [];
-    const unmappedNames: string[] = [];
-    if (plan) {
-      for (const item of plan.items) {
-        const handle = ITEM_NAME_TO_HANDLE[item.name];
-        if (handle) items.push({ handle, qty: item.quantity });
-        else unmappedNames.push(`${item.quantity}× ${item.name}`);
-      }
-    }
-    if (items.length === 0) {
-      items.push({ handle: 'bag-of-ice-7-lbs', qty: 4 });
-    }
-
-    const deliveryDate = new Date();
-    deliveryDate.setDate(deliveryDate.getDate() + 30);
-
-    const summary = plan
-      ? [
-          `Calculator state: ${plan.summary.guests} guests × ${plan.summary.hours} hours = ${plan.totalDrinks} drinks.`,
-          `Categories: ${plan.summary.categories.join(', ')}.`,
-          `Submitted from: ${placement === 'inline' ? 'calculator inline form' : 'bottom-of-page form'}.`,
-          unmappedNames.length > 0
-            ? `Unmapped items (operator to add): ${unmappedNames.join('; ')}.`
-            : '',
-        ]
-          .filter(Boolean)
-          .join(' ')
-      : `No calculator state captured. Submitted from ${placement === 'inline' ? 'calculator inline form' : 'bottom-of-page form'}.`;
-
     try {
-      const res = await fetch('/api/v1/landing/quote', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          mode: 'quote',
-          occasion: 'wedding',
-          customerName: name,
-          customerEmail: email,
-          customerPhone: phone,
-          groupSize: plan?.summary.guests ?? 100,
-          deliveryDate: deliveryDate.toISOString().slice(0, 10),
-          items,
-          deliveryNotes: summary,
-        }),
-      });
-      const body = await res.json();
-      if (!res.ok || !body.success) {
-        throw new Error(body.error || 'Submit failed');
-      }
-      setInvoiceUrl(body.invoiceUrl ?? null);
-      setStatus('success');
-
-      // Conversion firing — Meta + GA4 + Google Ads. All gated so missing
-      // pixels / env vars are silent no-ops.
-      trackMetaEvent('Lead', {
-        content_name: 'Wedding Bar Quote',
-        content_category: 'wedding-drink-calculator',
+      const { invoiceUrl: url } = await submitWeddingQuote({
+        plan,
+        customerName: name,
+        customerEmail: email,
+        customerPhone: phone,
         placement,
       });
-
-      if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
-        window.gtag('event', 'generate_lead', {
-          form_id: 'wedding-bar-quote',
-          placement,
-          page_location: window.location.href,
-          value: plan?.totalDrinks ?? 0,
-        });
-
-        const conversionId = process.env.NEXT_PUBLIC_GADS_QUOTE_CONVERSION_ID;
-        if (conversionId) {
-          window.gtag('event', 'conversion', {
-            send_to: conversionId,
-            value: 0,
-            currency: 'USD',
-          });
-        }
-      }
+      setInvoiceUrl(url);
+      setStatus('success');
     } catch (err) {
       setStatus('error');
       setErrorMsg(err instanceof Error ? err.message : 'Submit failed');

--- a/src/app/wedding-drink-calculator/sections/ResultsQuoteCapture.tsx
+++ b/src/app/wedding-drink-calculator/sections/ResultsQuoteCapture.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useState, type FormEvent, type ReactElement } from 'react';
+import type { WeddingPlan } from '@/lib/weddingDrinkCalculator';
+import { submitWeddingQuote } from './submitWeddingQuote';
+
+type Props = {
+  /** Current calculator plan — submitted with the quote so the emailed
+      invoice matches exactly what the visitor is looking at. */
+  plan: WeddingPlan | null;
+};
+
+/**
+ * Soft, email-first capture attached directly to the calculator results —
+ * the peak-intent moment. The full count + shopping list stay free; this
+ * converts the "I have my number" moment into a real, editable quote
+ * instead of letting the visitor leave with the list and never come back.
+ *
+ * Posts to the SAME endpoint as QuoteFormCard (a real draft order, not a
+ * dead-end lead) and fires generate_lead with placement="results", so GA4
+ * can show how much of conversion this entry point drives. This is the
+ * deliberate, clearly-labeled replacement for the in-result capture removed
+ * 2026-05-27 — the copy here makes it unambiguous what happens next, which
+ * is exactly what the earlier version got wrong.
+ */
+export default function ResultsQuoteCapture({ plan }: Props): ReactElement {
+  const [email, setEmail] = useState('');
+  const [firstName, setFirstName] = useState('');
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle');
+  const [errorMsg, setErrorMsg] = useState('');
+  const [invoiceUrl, setInvoiceUrl] = useState<string | null>(null);
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setStatus('submitting');
+    setErrorMsg('');
+
+    // Name is optional here (email-first). Fall back to the email local-part
+    // so the draft order isn't nameless — the operator reviews it anyway.
+    const customerName =
+      firstName.trim() || email.split('@')[0]?.trim() || 'Wedding guest';
+
+    try {
+      const { invoiceUrl: url } = await submitWeddingQuote({
+        plan,
+        customerName,
+        customerEmail: email,
+        placement: 'results',
+      });
+      setInvoiceUrl(url);
+      setStatus('success');
+    } catch (err) {
+      setStatus('error');
+      setErrorMsg(err instanceof Error ? err.message : 'Submit failed');
+    }
+  };
+
+  if (status === 'success') {
+    return (
+      <div className="mt-5 pt-5 border-t border-[#2A2218]/10">
+        <p className="font-heading text-lg text-[#2A2218] italic mb-1">
+          Sent — check your inbox.
+        </p>
+        <p className="text-sm text-gray-700 font-light mb-3">
+          We emailed this exact list to{' '}
+          <strong className="text-[#2A2218]">{email}</strong> as an editable
+          invoice. Adjust quantities, brands, and delivery before you pay.
+        </p>
+        {invoiceUrl && (
+          <a
+            href={invoiceUrl}
+            className="inline-flex items-center justify-center gap-2 bg-[#C8A96A] text-[#1a1410] hover:bg-[#d8b97a] transition-colors duration-300 px-6 py-2.5 text-xs tracking-[0.25em] uppercase font-medium rounded-lg"
+          >
+            Open My Invoice →
+          </a>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="mt-5 pt-5 border-t border-[#2A2218]/10"
+    >
+      <p className="text-xs tracking-[0.4em] uppercase text-[#7E5A40] mb-1 font-light">
+        Want this as a ready-to-order list?
+      </p>
+      <p className="text-sm text-gray-700 font-light mb-3">
+        We&apos;ll email this exact plan as an editable invoice — adjust it
+        before you pay. No card to start.
+      </p>
+
+      <div className="flex flex-col sm:flex-row gap-2">
+        <input
+          type="text"
+          value={firstName}
+          onChange={(e) => setFirstName(e.target.value)}
+          autoComplete="given-name"
+          placeholder="First name (optional)"
+          aria-label="First name (optional)"
+          className="input-premium w-full sm:w-40"
+        />
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          autoComplete="email"
+          placeholder="you@email.com"
+          aria-label="Email"
+          className="input-premium w-full flex-1"
+        />
+        <button
+          type="submit"
+          disabled={status === 'submitting'}
+          className="btn-cart whitespace-nowrap disabled:opacity-60 disabled:cursor-not-allowed"
+        >
+          {status === 'submitting' ? 'Sending…' : 'Email me my list →'}
+        </button>
+      </div>
+
+      {status === 'error' && (
+        <p className="text-sm text-red-600 mt-2">
+          {errorMsg}. Try again or call{' '}
+          <a href="tel:7373719700" className="font-semibold underline">
+            (737) 371-9700
+          </a>
+          .
+        </p>
+      )}
+
+      <p className="text-xs text-gray-500 mt-2 font-light">
+        No spam. TABC-licensed retailer. Must be 21+ at delivery.
+      </p>
+    </form>
+  );
+}

--- a/src/app/wedding-drink-calculator/sections/submitWeddingQuote.ts
+++ b/src/app/wedding-drink-calculator/sections/submitWeddingQuote.ts
@@ -1,0 +1,152 @@
+import type { WeddingPlan } from '@/lib/weddingDrinkCalculator';
+import { trackMetaEvent } from '@/components/MetaPixel';
+
+/**
+ * Where on the page a wedding-bar quote was submitted. Sent as the
+ * `placement` parameter on the generate_lead event so GA4 can split
+ * conversion rate by placement:
+ *   - results  — soft capture attached to the calculator output (peak intent)
+ *   - inline   — full form directly below the calculator
+ *   - bottom   — end-of-page hard CTA
+ */
+export type QuotePlacement = 'results' | 'inline' | 'bottom';
+
+const PLACEMENT_LABEL: Record<QuotePlacement, string> = {
+  results: 'calculator results capture',
+  inline: 'calculator inline form',
+  bottom: 'bottom-of-page form',
+};
+
+/**
+ * Maps a calculator output item name to the underlying product handle in
+ * Postgres. Items not in this map fall through — admin reviews the draft
+ * order and adds them manually. We always send `bag-of-ice-7-lbs` as the
+ * fallback so the API's `items.min(1)` validation always passes.
+ */
+const ITEM_NAME_TO_HANDLE: Record<string, string> = {
+  'Miller Lite (24-pack)': 'miller-lite-24-pack-12oz-can',
+  'Modelo Especial (24-pack)': 'modelo-especial-24pack-12oz-cans',
+  'Austin Beerworks Variety (12-pack)': 'austin-beerworks-variety-pack-12-pack-12oz-can',
+  'High Noon Variety (12-pack)':
+    'high-noon-vodka-soda-combo-3-each-grapefruit-9-pineapple-9-black-cherry-9-watermelon-9-355ml-12-pack',
+  'White Claw Variety (24-pack)': 'white-claw-variety-24-pack-12oz-can',
+  'Dark Horse Pinot Grigio (750ml)': 'dark-horse-pinot-grigio-750ml-bottle',
+  '14 Hands Cabernet Sauvignon (750ml)': '14-hands-cabernet-sauvignon',
+  'Espolon Tequila Blanco (750ml)': 'espolon-tequila-blanco-80-1l',
+  "Tito's Handmade Vodka (1L)": 'titos-handmade-vodka-80-1lt',
+  'Still Austin Bourbon (750ml)': 'jameson-irish-whiskey-1',
+  'Champagne / Prosecco (750ml)': 'chandon-california-brut-750ml',
+  'Ice Bags': 'bag-of-ice-7-lbs',
+};
+
+export type SubmitWeddingQuoteArgs = {
+  /** Latest computed plan from the calculator; null if the visitor never
+      touched the inputs (defaults applied server-side). */
+  plan: WeddingPlan | null;
+  /** Customer name. May be empty for the email-first results capture —
+      callers should fall back to the email local-part before calling. */
+  customerName: string;
+  customerEmail: string;
+  customerPhone?: string;
+  placement: QuotePlacement;
+};
+
+/**
+ * Posts a wedding-bar quote to /api/v1/landing/quote and, on success,
+ * fires the conversion events (Meta Lead + GA4 generate_lead + optional
+ * Google Ads direct-fire conversion). Shared by every quote entry point
+ * on /wedding-drink-calculator so item mapping + tracking stay identical.
+ *
+ * Throws on a failed/!ok response so callers can render an error state.
+ */
+export async function submitWeddingQuote({
+  plan,
+  customerName,
+  customerEmail,
+  customerPhone,
+  placement,
+}: SubmitWeddingQuoteArgs): Promise<{ invoiceUrl: string | null }> {
+  const items: { handle: string; qty: number }[] = [];
+  const unmappedNames: string[] = [];
+  if (plan) {
+    for (const item of plan.items) {
+      const handle = ITEM_NAME_TO_HANDLE[item.name];
+      if (handle) items.push({ handle, qty: item.quantity });
+      else unmappedNames.push(`${item.quantity}× ${item.name}`);
+    }
+  }
+  if (items.length === 0) {
+    items.push({ handle: 'bag-of-ice-7-lbs', qty: 4 });
+  }
+
+  const deliveryDate = new Date();
+  deliveryDate.setDate(deliveryDate.getDate() + 30);
+
+  const placementLabel = PLACEMENT_LABEL[placement];
+  const summary = plan
+    ? [
+        `Calculator state: ${plan.summary.guests} guests × ${plan.summary.hours} hours = ${plan.totalDrinks} drinks.`,
+        `Categories: ${plan.summary.categories.join(', ')}.`,
+        `Submitted from: ${placementLabel}.`,
+        unmappedNames.length > 0
+          ? `Unmapped items (operator to add): ${unmappedNames.join('; ')}.`
+          : '',
+      ]
+        .filter(Boolean)
+        .join(' ')
+    : `No calculator state captured. Submitted from ${placementLabel}.`;
+
+  const res = await fetch('/api/v1/landing/quote', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      mode: 'quote',
+      occasion: 'wedding',
+      customerName,
+      customerEmail,
+      customerPhone: customerPhone ?? '',
+      groupSize: plan?.summary.guests ?? 100,
+      deliveryDate: deliveryDate.toISOString().slice(0, 10),
+      items,
+      deliveryNotes: summary,
+    }),
+  });
+  const body = await res.json();
+  if (!res.ok || !body.success) {
+    throw new Error(body.error || 'Submit failed');
+  }
+
+  fireQuoteConversion(plan, placement);
+  return { invoiceUrl: body.invoiceUrl ?? null };
+}
+
+/**
+ * Conversion firing — Meta + GA4 + Google Ads. All gated so missing
+ * pixels / env vars are silent no-ops. The `placement` flows into the
+ * GA4 generate_lead event so conversion rate can be split by entry point.
+ */
+function fireQuoteConversion(plan: WeddingPlan | null, placement: QuotePlacement): void {
+  trackMetaEvent('Lead', {
+    content_name: 'Wedding Bar Quote',
+    content_category: 'wedding-drink-calculator',
+    placement,
+  });
+
+  if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
+    window.gtag('event', 'generate_lead', {
+      form_id: 'wedding-bar-quote',
+      placement,
+      page_location: window.location.href,
+      value: plan?.totalDrinks ?? 0,
+    });
+
+    const conversionId = process.env.NEXT_PUBLIC_GADS_QUOTE_CONVERSION_ID;
+    if (conversionId) {
+      window.gtag('event', 'conversion', {
+        send_to: conversionId,
+        value: 0,
+        currency: 'USD',
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Why
The `/wedding-drink-calculator` campaign (Wedding · Search · ATX) is live but converting at **0% past the click**. Audit of the lead funnel: over ~3 weeks, **338 page views → 6 form-touches → 0 submits → 0 orders**. The page gives away the full free shopping list, then asks for the email in a *separate* form below — so visitors get their number and leave.

## What
Moves the ask to the **peak-intent moment**: a soft, email-first capture directly under the calculated shopping list — *"Email me this list as an editable quote — no card to start."*

- Posts to the **same real quote endpoint** as the full form (a genuine editable draft, **not** the dead-end lead removed 2026-05-27 that caused user confusion).
- Fires `generate_lead` with `placement="results"` so GA4 (→ Google Ads import) can split conversion by entry point.
- Email required, first name optional (falls back to email local-part → no nameless drafts).

## Changes
- **New** `submitWeddingQuote.ts` — shared submit + conversion-firing, reused by every quote entry point.
- **New** `ResultsQuoteCapture.tsx` — the capture component.
- `CalculatorResults` — renders it under the shopping list.
- `QuoteFormCard` — now uses the shared submit fn (no behavior change).
- `CalculatorPageBody` — removes the now-redundant inline full form; bottom-of-page form stays as the scroll-to-end catch-all.

## Verification
`tsc --noEmit` clean (one pre-existing unrelated test error), `next lint` clean, scroll anchors (`#quote-form`) intact. Post-deploy: confirm a `leads` row with `placement=results` + `generate_lead` in GA4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)