### PR TITLE
feat(leads): fire generate_lead across landing pages (occasion-tagged)

### DIFF
--- a/src/app/wedding-drink-calculator/sections/submitWeddingQuote.ts
+++ b/src/app/wedding-drink-calculator/sections/submitWeddingQuote.ts
@@ -1,5 +1,5 @@
 import type { WeddingPlan } from '@/lib/weddingDrinkCalculator';
-import { trackMetaEvent } from '@/components/MetaPixel';
+import { fireLeadConversion } from '@/lib/leads/fireLeadConversion';
 
 /**
  * Where on the page a wedding-bar quote was submitted. Sent as the
@@ -116,37 +116,13 @@ export async function submitWeddingQuote({
     throw new Error(body.error || 'Submit failed');
   }
 
-  fireQuoteConversion(plan, placement);
-  return { invoiceUrl: body.invoiceUrl ?? null };
-}
-
-/**
- * Conversion firing — Meta + GA4 + Google Ads. All gated so missing
- * pixels / env vars are silent no-ops. The `placement` flows into the
- * GA4 generate_lead event so conversion rate can be split by entry point.
- */
-function fireQuoteConversion(plan: WeddingPlan | null, placement: QuotePlacement): void {
-  trackMetaEvent('Lead', {
-    content_name: 'Wedding Bar Quote',
-    content_category: 'wedding-drink-calculator',
+  // Centralized lead-conversion firing (Meta + GA4 generate_lead + Ads).
+  // occasion="wedding" + placement let GA4 split conversion by occasion
+  // and by entry point within the page.
+  fireLeadConversion({
+    occasion: 'wedding',
     placement,
+    value: plan?.totalDrinks ?? 0,
   });
-
-  if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
-    window.gtag('event', 'generate_lead', {
-      form_id: 'wedding-bar-quote',
-      placement,
-      page_location: window.location.href,
-      value: plan?.totalDrinks ?? 0,
-    });
-
-    const conversionId = process.env.NEXT_PUBLIC_GADS_QUOTE_CONVERSION_ID;
-    if (conversionId) {
-      window.gtag('event', 'conversion', {
-        send_to: conversionId,
-        value: 0,
-        currency: 'USD',
-      });
-    }
-  }
+  return { invoiceUrl: body.invoiceUrl ?? null };
 }

--- a/src/components/landing/PackageBuilderModal.tsx
+++ b/src/components/landing/PackageBuilderModal.tsx
@@ -7,6 +7,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import Image from 'next/image';
 import { useLeadCapture } from '@/lib/leads/client';
+import { fireLeadConversion } from '@/lib/leads/fireLeadConversion';
 import { trackFunnelStep } from '@/lib/experiments/funnelTrack';
 import type { FunnelStep } from '@/lib/experiments/funnelSteps';
 import type {
@@ -444,6 +445,12 @@ export default function PackageBuilderModal({
       if (!res.ok || !json.ok) {
         throw new Error(json.error || 'Failed to create your order. Try again.');
       }
+
+      // Fire the lead conversion (Meta + GA4 generate_lead + Ads) BEFORE
+      // the redirect — tagged with this page's occasion so each landing
+      // campaign optimizes toward its own leads. Synchronous; the gtag/fbq
+      // beacons are queued before navigation.
+      fireLeadConversion({ occasion, placement: 'package-builder', value: people });
 
       // Stash host participant id so the dashboard recognizes the
       // visitor as the order owner.

--- a/src/lib/leads/fireLeadConversion.ts
+++ b/src/lib/leads/fireLeadConversion.ts
@@ -1,0 +1,71 @@
+import { trackMetaEvent } from '@/components/MetaPixel';
+
+/**
+ * Occasion that generated the lead. Flows into the GA4 `generate_lead`
+ * event as a parameter so a SINGLE event name powers per-occasion key
+ * events / Google Ads conversion actions (Lead – Bachelor, Lead – Wedding,
+ * …) — there is deliberately NOT a separate event name per landing page.
+ * GA4 derives per-occasion key events from this param; Google Ads imports
+ * those as distinct conversion actions and each campaign optimizes toward
+ * its own.
+ */
+export type LeadOccasion =
+  | 'wedding'
+  | 'bachelor'
+  | 'bachelorette'
+  | 'corporate'
+  | 'boat'
+  | 'house'
+  // Allow any future occasion string without widening to plain `string`
+  // (keeps editor autocomplete on the known set).
+  | (string & {});
+
+type FireLeadConversionArgs = {
+  /** Which landing occasion produced the lead. */
+  occasion: LeadOccasion;
+  /** Where on the page it fired — e.g. 'results', 'inline', 'bottom',
+      'package-builder'. Lets GA4 split conversion by entry point. */
+  placement: string;
+  /** Optional numeric value (e.g. estimated drink count). Defaults to 0. */
+  value?: number;
+};
+
+/**
+ * Fires the cross-network "a lead was generated" conversion in one place:
+ * Meta `Lead` + GA4 `generate_lead` + (env-gated) Google Ads direct-fire
+ * `conversion`. Every call is guarded so a missing pixel / env var is a
+ * silent no-op.
+ *
+ * Shared by every quote/lead entry point (wedding calculator + landing-page
+ * package builder) so the event schema stays identical everywhere and a new
+ * landing page becomes trackable just by calling this on submit success.
+ */
+export function fireLeadConversion({
+  occasion,
+  placement,
+  value = 0,
+}: FireLeadConversionArgs): void {
+  trackMetaEvent('Lead', {
+    content_name: `${occasion} quote`,
+    content_category: occasion,
+    placement,
+  });
+
+  if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
+    window.gtag('event', 'generate_lead', {
+      occasion,
+      placement,
+      page_location: window.location.href,
+      value,
+    });
+
+    const conversionId = process.env.NEXT_PUBLIC_GADS_QUOTE_CONVERSION_ID;
+    if (conversionId) {
+      window.gtag('event', 'conversion', {
+        send_to: conversionId,
+        value: 0,
+        currency: 'USD',
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Why
Only `/wedding-drink-calculator` fired a GA4 `generate_lead` conversion. The bachelor/bachelorette/corporate landing pages create a real order via the shared package builder but fired **nothing** to GA4 — so a Google Ads campaign on any of them would see **0 conversions** (the wedding campaign's pre-fix problem). This is the **prerequisite** for launching the bachelor campaign with measurable spend.

## What
One generic `generate_lead` event everywhere, distinguished by an **`occasion`** parameter — *not* a separate event name per page. GA4 derives per-occasion key events from the param; Google Ads imports those as distinct conversion actions so each campaign optimizes toward its own page's leads.

- **New** `src/lib/leads/fireLeadConversion.ts` — centralizes Meta `Lead` + GA4 `generate_lead` (`occasion` + `placement` + `value`) + env-gated Ads `conversion`. All guarded (missing pixel/env = silent no-op).
- **PackageBuilderModal** — fires it on successful `/quote/start` (occasion from the page, `placement="package-builder"`) before the dashboard redirect.
- **submitWeddingQuote** — now uses the shared helper, backfilling `occasion="wedding"` so wedding leads are consistently tagged (replaces inline firing + `form_id`).

`QuickBuyModal` is intentionally **untouched** — it's a pay-now path, so its conversion is a **purchase** (tracked on checkout success), not a lead.

## Verify
`tsc --noEmit` clean (the one error is a pre-existing unrelated test); ESLint clean on touched files (the `productById` warning is pre-existing). Post-deploy: submit the bachelor package builder → confirm `generate_lead` with `occasion=bachelor` in GA4 Realtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)