### PR TITLE
feat(finance): Phase 5 — agent + recommendations + weekly briefing (recovery)

### DIFF
--- a/.claude/agents/finance-director.md
+++ b/.claude/agents/finance-director.md
@@ -1,0 +1,111 @@
+---
+name: finance-director
+description: Senior CFO-level analyst for Party On Delivery. Reviews the daily P&L snapshot, QuickBooks + Plaid + Stripe connection state, active finance recommendations, and weekly cash position. Use whenever the user asks "what's my net income," "is cash runway OK," "are there unmatched bank transactions," "what changed in margin this week," "are QB journals posting," or for weekly finance review.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+# Finance Director — Party On Delivery
+
+You are the senior CFO-level analyst for **Party On Delivery**, a premium alcohol delivery + party coordination service in Austin, TX. Your job is to read the daily P&L snapshot, the QuickBooks + Plaid + Stripe data the integrations bring in, and the active finance recommendation queue — then tell the operator what's most load-bearing this week.
+
+**Two writes happen autonomously under your authority:**
+1. **`qb-categorize` action** on Plaid transactions (per autonomy decision #4)
+2. **Daily QB sales journal post** at 08:00 UTC (per updated autonomy decision 2026-05-21 — see saved memory `finance_autonomous_qb_sales_journals.md`)
+
+Everything else (payment moves, AP, tax filings) requires operator click via the inline-action contract on each rec card.
+
+---
+
+## Business context (always true)
+
+- **External source-of-truth split is intentional.** PartyOn owns operational + customer + revenue data. QuickBooks owns AP, OpEx, journal entries. Plaid owns bank deposits/outflows. The Finance Director's job is to **read from both** and reconcile, not to replicate QB. (Saved memory `finance_no_internal_ap_tracking.md`.)
+- **Cost coverage gates affiliate-margin decisions.** Marketing's ADR M0001 says affiliate ROI / margin-leak decisions are blocked until cost coverage hits ≥70%. Currently ~20%. **Never propose "pause affiliate X" or "reprice SKU Y" recommendations** — those belong to Marketing and are gated on Ops's coverage push. Finance complements with P&L + tax-side decisions.
+- **TX sales tax** is 8.25% hardcoded. Per-order tax in `Order.taxAmount`. No remittance log yet (Phase 4) — accruals show cumulative collected.
+- **Group orders** — when surfacing a rec that targets an `Order` with `groupOrderV2Id`, resolve and display the manifest name via `scripts/ops/_group-label.mjs:resolveGroupLabel()`. Don't just show `Order.customerName` (that's the payer, not the boat manifest name). Saved memory `group_order_manifest_name_rule.md`.
+- **Stripe is the only payment processor.** Refunds, payouts, fees, disputes all come through `/api/webhooks/stripe`. Per-charge fees stored in `Order.stripeFeesCents` once the BalanceTransaction is fetched.
+- **Sandbox vs production.** Phase 0–2C run against Intuit + Plaid **sandbox**. When you cite numbers from snapshots, note whether the connections are sandbox or production (check the `intuit_oauth_state.environment` and `plaid_items.environment` columns) — sandbox numbers are fictional.
+
+## Autonomy tiers
+
+| Tier | Examples | Authority |
+|---|---|---|
+| **Autonomous (you can recommend with no operator click)** | (1) auto-categorize a Plaid transaction in QB · (2) daily sales-journal post to QB | Already wired; just confirm the audit log on each entry. Operator has a kill switch + per-entry reverse button. |
+| Recommend-only | every other inline action on a rec card (mark paid, investigate unmatched, retry failed journal) | Always recommend-only — operator clicks. |
+| **Hard stop** | direct DB writes, Stripe Transfers, ACH payouts, tax filings, marking distributor invoices paid | Never propose — flag as out of scope. |
+
+## First action every invocation
+
+1. **Pull live state.** Read these in order:
+   - **Latest P&L snapshot** — `SELECT * FROM finance_snapshots ORDER BY snapshot_date DESC LIMIT 1` (or fetch from `/api/admin/finance/snapshot?limit=1` with ops auth)
+   - **Active recs** — `SELECT * FROM finance_recommendations WHERE status IN ('open','approved') ORDER BY severity, updated_at DESC LIMIT 50`
+   - **Connection state** — `intuit_oauth_state` + `plaid_items` rows (look for `last_error`, `status='login_required'`)
+   - **Pending/failed journals** — `qb_journal_entries WHERE status IN ('PENDING_APPROVAL','FAILED')`
+
+2. **Read this week's briefing if it exists.** Path: `docs/finance/weekly/YYYY-Www.md` (committed by the Monday cron at 14:00 UTC).
+
+3. **Skim recent operator decisions** — saved memory under `~/.claude/projects/-Users-allan-Projects-Party-On-Delivery-Website-PartyOn2/memory/` with `finance_` prefix.
+
+## Signals you watch (Phase 5)
+
+The daily detector pass runs at 07:45 UTC and writes `finance_recommendations` rows. Your job is to interpret them in context, not re-derive them.
+
+| # | Signal | Source | Severity heuristic |
+|---|---|---|---|
+| 1 | Stripe payout unmatched to bank deposit | `stripe_payouts` left joined to `plaid_transactions` | urgent if >10d, else high |
+| 3 | Cash runway < 30 days | bank balance + AR / daily-avg OpEx | urgent if <14d, else high |
+| 4 | Gross margin trending down | snapshot history, 30d vs prior 30d | urgent if >10pp drop, else high |
+| 7 | OpEx category spiking | `qb_expenses` 30d vs trailing 90d | high if >3x, else normal |
+| 8 | Affiliate commission aging >30d | `affiliate_commissions` HELD/APPROVED | normal |
+| 9 | Discount over-use | `Order.discountCode` aggregates, $500/wk threshold | normal |
+| 10 | Untouched bank transaction >7d | `plaid_transactions.reconciledAt IS NULL` | normal |
+| 11 | QB sync error | `intuit_oauth_state.lastError IS NOT NULL` | urgent |
+| 12 | Plaid sync error | `plaid_items.status IN ('login_required','error')` | urgent |
+
+**Signal #2 (distributor invoice past due) was removed** — Phase 1B cancelled (saved memory `finance_no_internal_ap_tracking.md`).
+
+**Signals #5 (sales tax accrual) and #6 (contractor 1099 threshold) are deferred** — they need data Phase 3 + Phase 4 will add. If the operator asks about them, say so explicitly.
+
+## When the operator asks "what should I work on next"
+
+Walk the queue in this order:
+1. Any **urgent** sync errors (#11, #12) — broken integrations starve every other signal
+2. Any **urgent** cash runway alert (#3) — this is the actual existential signal
+3. Any **urgent** unmatched Stripe payout (#1) — bank reconciliation breaking is high-priority
+4. Then high-severity items in queue order
+5. Then a short summary of what's been **clean** for >30 days (so the operator knows the boring things are still working)
+
+## When the operator asks about a specific number
+
+Always cite the source. Don't paraphrase a snapshot — quote the field. Examples:
+- "Net income yesterday was **$2,074.35** (gross $2,106.15 − daily OpEx avg $31.80; from `finance_snapshots.payload.netIncomeCents`, snapshot date 2026-06-11)"
+- "Cash runway is **42 days** (bank $X + AR $Y ÷ daily OpEx avg $Z)"
+
+## What you DO NOT do
+
+- Auto-apply expense categorizations beyond the `qb-categorize` autonomous action — operator click required for everything else
+- Propose recommendations that touch affiliate ROI / margin until cost coverage ≥70% (gated by Marketing's ADR M0001)
+- Reach into prod database directly with raw SQL inside a session — use the read APIs and the admin endpoints
+- Propose AP / distributor-invoice tracking — that lives in QuickBooks, not PartyOn
+- Forecast tax remittance until Phase 4 ships — you can only quote the accrual
+
+## Output format
+
+When the operator asks for the weekly review, produce sections in this order:
+
+1. **Headline number** — net income trend (delta vs prior week)
+2. **Urgent items** — bullet list with one-line rationale + the recommended action
+3. **High-priority items** — bullet list
+4. **What's clean** — one paragraph noting the things that have been stable >30 days
+5. **What you can't answer yet** — list of signals/questions that depend on Phase 3 / Phase 4 data (so the operator knows what's not yet measurable)
+
+Match the operator's CLAUDE.md communication style: plain language, jargon only when it's the right word, short examples over long explanations.
+
+## Reference paths
+
+- Brief: `docs/FINANCE-DIRECTOR-AGENT-BUILDOUT.md`
+- Detectors: `src/lib/finance/detectors/signals-a.ts`
+- P&L computation: `src/lib/finance/pl-calculation.ts`
+- Sales journal autonomous post: `src/lib/finance/qb-journal-service.ts`
+- Dashboard: `/admin/finance` (admin-auth required)
+- Triage queue: `/admin/recommendations?domain=finance`

--- a/src/app/admin/recommendations/_components/domain-chips.tsx
+++ b/src/app/admin/recommendations/_components/domain-chips.tsx
@@ -9,7 +9,7 @@
 
 import type { ReactElement } from 'react';
 
-export type DomainChipValue = 'all' | 'marketing' | 'operations' | 'seo';
+export type DomainChipValue = 'all' | 'marketing' | 'operations' | 'finance' | 'seo';
 
 export interface DomainChip {
   value: DomainChipValue;
@@ -19,7 +19,7 @@ export interface DomainChip {
 export interface DomainChipsProps {
   chips: DomainChip[];
   current: DomainChipValue;
-  counts?: Record<'marketing' | 'seo' | 'operations', number>;
+  counts?: Record<'marketing' | 'seo' | 'operations' | 'finance', number>;
   onChange: (value: DomainChipValue) => void;
 }
 
@@ -39,7 +39,9 @@ export function DomainChips({
           const isActive = current === chip.value;
           const count =
             chip.value === 'all'
-              ? (counts ? counts.marketing + counts.seo + counts.operations : null)
+              ? counts
+                ? counts.marketing + counts.seo + counts.operations + counts.finance
+                : null
               : (counts?.[chip.value] ?? null);
           return (
             <button

--- a/src/app/admin/recommendations/page.tsx
+++ b/src/app/admin/recommendations/page.tsx
@@ -19,8 +19,8 @@ import { useQueueMutations } from './_components/use-queue-mutations';
 
 type QueueResponse = {
   data: RecommendationCardData[];
-  counts: Record<'marketing' | 'seo' | 'operations', number>;
-  detectorRanAt: Record<'marketing' | 'seo' | 'operations', string | null>;
+  counts: Record<'marketing' | 'seo' | 'operations' | 'finance', number>;
+  detectorRanAt: Record<'marketing' | 'seo' | 'operations' | 'finance', string | null>;
 };
 
 const PAGE_SIZE = 50;
@@ -29,6 +29,7 @@ const CHIPS: DomainChip[] = [
   { value: 'all', label: 'All' },
   { value: 'marketing', label: 'Marketing' },
   { value: 'operations', label: 'Operations' },
+  { value: 'finance', label: 'Finance' },
   { value: 'seo', label: 'SEO' },
 ];
 

--- a/src/app/api/admin/recommendations/[id]/execute/route.ts
+++ b/src/app/api/admin/recommendations/[id]/execute/route.ts
@@ -165,10 +165,19 @@ export async function POST(
 
 async function loadActionPayload(
   id: string,
-  domain: 'ops' | 'marketing-seo'
+  domain: 'ops' | 'marketing-seo' | 'finance'
 ): Promise<ActionPayload | null> {
   if (domain === 'ops') {
     const row = await prisma.operationsRecommendation.findUnique({
+      where: { id },
+      select: { actionPayload: true },
+    });
+    const raw = row?.actionPayload;
+    if (!raw || typeof raw !== 'object') return null;
+    return raw as unknown as ActionPayload;
+  }
+  if (domain === 'finance') {
+    const row = await prisma.financeRecommendation.findUnique({
       where: { id },
       select: { actionPayload: true },
     });

--- a/src/app/api/admin/recommendations/route.ts
+++ b/src/app/api/admin/recommendations/route.ts
@@ -22,7 +22,7 @@ import type { RecommendationStatus } from '@/lib/recommendations/lifecycle';
 
 export const dynamic = 'force-dynamic';
 
-const DOMAINS: DomainFilter[] = ['all', 'marketing', 'seo', 'operations'];
+const DOMAINS: DomainFilter[] = ['all', 'marketing', 'seo', 'operations', 'finance'];
 const STATUSES: RecommendationStatus[] = [
   'open', 'approved', 'shipped', 'rejected', 'invalidated', 'snoozed',
 ];

--- a/src/app/api/cron/finance-snapshot/route.ts
+++ b/src/app/api/cron/finance-snapshot/route.ts
@@ -15,6 +15,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { computeDailyPL, yesterdayWindow } from '@/lib/finance/pl-calculation';
 import { writeFinanceSnapshot } from '@/lib/finance/snapshot';
+import { generateAll as generateFinanceRecs } from '@/lib/finance/recommendations';
 
 export const maxDuration = 60;
 
@@ -44,11 +45,29 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   }
 
   const snapshot = await writeFinanceSnapshot(payload);
-  const durationMs = Date.now() - startedAt.getTime();
 
-  console.log('[finance-snapshot] wrote snapshot for', snapshot.snapshotDate, 'in', durationMs, 'ms');
+  // Phase 5 — generate Finance Director recommendations off the fresh snapshot.
+  // Failures here don't block the snapshot write; we log + surface in the response.
+  let recsResult: Awaited<ReturnType<typeof generateFinanceRecs>> | null = null;
+  let recsError: string | null = null;
+  try {
+    recsResult = await generateFinanceRecs(payload, startedAt);
+  } catch (err) {
+    recsError = err instanceof Error ? err.message : String(err);
+    console.error('[finance-snapshot] recommendation generation failed:', recsError);
+  }
+
+  const durationMs = Date.now() - startedAt.getTime();
+  console.log(
+    '[finance-snapshot] wrote snapshot for',
+    snapshot.snapshotDate,
+    'in',
+    durationMs,
+    'ms; recs:',
+    recsResult ? JSON.stringify(recsResult.upsert) : '(failed)'
+  );
   return NextResponse.json({
     success: true,
-    data: { snapshot, durationMs },
+    data: { snapshot, durationMs, recommendations: recsResult, recsError },
   });
 }

--- a/src/app/api/cron/finance-weekly-briefing/route.ts
+++ b/src/app/api/cron/finance-weekly-briefing/route.ts
@@ -1,0 +1,84 @@
+/**
+ * Finance Director — weekly briefing cron.
+ *
+ * Schedule: Monday 14:00 UTC (9:00am Central). Runs after Marketing's 13:00
+ * and Operations' 13:30 so the operator gets all three director briefings
+ * back-to-back in the morning email window.
+ *
+ * Deterministic email + payload + GitHub commit to
+ * docs/finance/weekly/YYYY-Www.md. No LLM narrative pass yet (mirrors
+ * Phase 1D pattern from Operations Director).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { resend } from '@/lib/email/resend-client';
+import { putFileToRepo } from '@/lib/github/put-file';
+import { buildFinanceBriefingPayload } from '@/lib/finance/briefing-payload';
+import { renderFinanceBriefingMarkdown } from '@/lib/finance/briefing-markdown';
+import {
+  renderFinanceBriefingEmail,
+  renderFinanceBriefingText,
+} from '@/lib/email/templates/finance-briefing';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 120;
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = request.headers.get('authorization');
+  if (auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const now = new Date();
+  const payload = await buildFinanceBriefingPayload(now);
+
+  // Deliver email — fails soft so the cron stays green.
+  const recipient =
+    process.env.FINANCE_BRIEFING_TO ||
+    process.env.OPS_BRIEFING_TO ||
+    process.env.MARKETING_BRIEFING_TO ||
+    'allan@partyondelivery.com';
+
+  let email: { sent: boolean; error?: string } = { sent: false, error: 'not attempted' };
+  if (!resend) {
+    email = { sent: false, error: 'RESEND_API_KEY not configured' };
+  } else {
+    try {
+      const html = renderFinanceBriefingEmail(payload);
+      const text = renderFinanceBriefingText(payload);
+      const fromEmail = process.env.RESEND_FROM_EMAIL || 'orders@partyondelivery.com';
+      await resend.emails.send({
+        from: `Party On Delivery — Finance Director <${fromEmail}>`,
+        to: recipient,
+        subject: `Finance weekly briefing — ${payload.weekLabel}`,
+        html,
+        text,
+      });
+      email = { sent: true };
+    } catch (err) {
+      email = { sent: false, error: err instanceof Error ? err.message : String(err) };
+      console.error('[finance-briefing] email send failed:', err);
+    }
+  }
+
+  // Commit deterministic markdown to GitHub for the (future) Obsidian sync.
+  const markdown = renderFinanceBriefingMarkdown(payload);
+  const commit = await putFileToRepo({
+    path: `docs/finance/weekly/${payload.weekLabel}.md`,
+    content: markdown,
+    message: `chore(finance): weekly briefing ${payload.weekLabel}`,
+  }).catch((err) => ({ committed: false, error: err instanceof Error ? err.message : String(err) }));
+
+  return NextResponse.json({
+    ok: true,
+    week: payload.weekLabel,
+    snapshotDate: payload.snapshotDate,
+    counts: {
+      urgent: payload.urgentRecs.length,
+      high: payload.highRecs.length,
+      normal: payload.normalRecCount,
+    },
+    delivery: { email, recipient, commit },
+    payload,
+  });
+}

--- a/src/lib/email/templates/finance-briefing.ts
+++ b/src/lib/email/templates/finance-briefing.ts
@@ -1,0 +1,230 @@
+/**
+ * Finance Director — weekly briefing email template.
+ *
+ * Same cream-paper / gold-accent aesthetic as marketing-briefing and
+ * operations-briefing. Heavier on numbers, lighter on prose.
+ */
+
+import type {
+  FinanceBriefingPayload,
+  FinanceBriefingRec,
+  FinanceBriefingStat,
+} from '@/lib/finance/briefing-payload';
+
+const COLORS = {
+  paper: '#FBFAF5',
+  ink: '#0a0a0a',
+  inkBody: '#1a1a1a',
+  inkMute: '#3a3a3a',
+  hairline: '#e7e3d6',
+  goldAccent: '#7a6a1f',
+  gold: '#D4AF37',
+  blue: '#0B74B8',
+  good: '#15803d',
+  caution: '#d97706',
+  urgent: '#dc2626',
+  muteText: '#6b6b6b',
+};
+
+function esc(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function severityColor(s: string): string {
+  if (s === 'urgent') return COLORS.urgent;
+  if (s === 'high') return COLORS.caution;
+  return COLORS.muteText;
+}
+
+function renderStat(stat: FinanceBriefingStat): string {
+  const delta = stat.delta
+    ? `<div style="font-size:11px;color:${
+        stat.delta.direction === 'up'
+          ? COLORS.good
+          : stat.delta.direction === 'down'
+            ? COLORS.urgent
+            : COLORS.muteText
+      };">${stat.delta.direction === 'up' ? '↑' : stat.delta.direction === 'down' ? '↓' : '→'} ${stat.delta.pct.toFixed(1)}% vs prior wk</div>`
+    : '';
+  const sub = stat.sub
+    ? `<div style="font-size:11px;color:${COLORS.muteText};margin-top:2px;">${esc(stat.sub)}</div>`
+    : '';
+  return `
+    <td valign="top" style="padding:14px 16px;border-bottom:1px solid ${COLORS.hairline};">
+      <div style="font-size:11px;color:${COLORS.muteText};text-transform:uppercase;letter-spacing:0.08em;font-weight:600;">${esc(stat.label)}</div>
+      <div style="font-size:24px;color:${COLORS.ink};font-weight:700;margin-top:4px;line-height:1.1;">${esc(stat.value)}</div>
+      ${delta}
+      ${sub}
+    </td>`;
+}
+
+function renderRecRow(r: FinanceBriefingRec): string {
+  const sev = severityColor(r.severity);
+  const linkOpen = r.href
+    ? `<a href="${esc(r.href)}" style="color:${COLORS.blue};text-decoration:none;">`
+    : '';
+  const linkClose = r.href ? '</a>' : '';
+  const summary = r.summary
+    ? `<div style="font-size:12px;color:${COLORS.muteText};margin-top:3px;">${esc(r.summary)}</div>`
+    : '';
+  return `
+    <tr>
+      <td valign="top" style="padding:10px 0;border-bottom:1px solid ${COLORS.hairline};">
+        <span style="display:inline-block;font-size:10px;color:${sev};text-transform:uppercase;letter-spacing:0.1em;font-weight:700;margin-right:8px;">${esc(r.severity)}</span>
+        ${linkOpen}<span style="font-size:14px;color:${COLORS.inkBody};">${esc(r.title)}</span>${linkClose}
+        ${summary}
+      </td>
+    </tr>`;
+}
+
+export function renderFinanceBriefingEmail(d: FinanceBriefingPayload): string {
+  const statRows: string[] = [];
+  for (let i = 0; i < d.stats.length; i += 2) {
+    const pair = d.stats.slice(i, i + 2);
+    statRows.push(`<tr>${pair.map(renderStat).join('')}${pair.length < 2 ? '<td></td>' : ''}</tr>`);
+  }
+
+  const urgentBlock =
+    d.urgentRecs.length > 0
+      ? `
+    <div style="background:${COLORS.paper};border-left:3px solid ${COLORS.urgent};padding:12px 16px;margin:0 0 24px 0;">
+      <div style="font-size:11px;color:${COLORS.urgent};text-transform:uppercase;letter-spacing:0.1em;font-weight:700;margin-bottom:8px;">Urgent (${d.urgentRecs.length})</div>
+      <table cellpadding="0" cellspacing="0" border="0" width="100%">
+        ${d.urgentRecs.map(renderRecRow).join('')}
+      </table>
+    </div>`
+      : '';
+
+  const highBlock =
+    d.highRecs.length > 0
+      ? `
+    <div style="margin:0 0 24px 0;">
+      <h2 style="font-size:14px;color:${COLORS.ink};text-transform:uppercase;letter-spacing:0.1em;margin:0 0 12px 0;">High priority (${d.highRecs.length})</h2>
+      <table cellpadding="0" cellspacing="0" border="0" width="100%">
+        ${d.highRecs.map(renderRecRow).join('')}
+      </table>
+    </div>`
+      : '';
+
+  const okState =
+    d.urgentRecs.length === 0 && d.highRecs.length === 0
+      ? `
+    <div style="background:${COLORS.paper};border-left:3px solid ${COLORS.good};padding:12px 16px;margin:0 0 24px 0;">
+      <div style="font-size:13px;color:${COLORS.good};">✓ No urgent or high-priority issues. ${d.normalRecCount > 0 ? `${d.normalRecCount} watch items in the queue.` : 'All clean.'}</div>
+    </div>`
+      : '';
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Finance Director — ${esc(d.weekLabel)}</title>
+</head>
+<body style="margin:0;padding:0;background:#f6f3ea;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table cellpadding="0" cellspacing="0" border="0" width="100%" style="background:#f6f3ea;padding:32px 0;">
+    <tr>
+      <td align="center">
+        <table cellpadding="0" cellspacing="0" border="0" width="600" style="background:#ffffff;border:1px solid ${COLORS.hairline};">
+          <!-- header -->
+          <tr>
+            <td style="padding:28px 32px 8px 32px;border-bottom:1px solid ${COLORS.hairline};">
+              <div style="font-size:11px;color:${COLORS.goldAccent};text-transform:uppercase;letter-spacing:0.15em;font-weight:600;">Finance Director · weekly briefing</div>
+              <h1 style="font-size:22px;color:${COLORS.ink};margin:8px 0 4px 0;font-weight:700;">${esc(d.weekLabel)}</h1>
+              <div style="font-size:12px;color:${COLORS.muteText};">Snapshot: ${esc(d.snapshotDate)} · generated ${esc(new Date(d.generatedAtIso).toUTCString())}</div>
+            </td>
+          </tr>
+
+          <!-- stats grid -->
+          ${
+            d.stats.length > 0
+              ? `<tr><td><table cellpadding="0" cellspacing="0" border="0" width="100%">${statRows.join('')}</table></td></tr>`
+              : ''
+          }
+
+          <!-- body -->
+          <tr>
+            <td style="padding:24px 32px;">
+              ${okState}
+              ${urgentBlock}
+              ${highBlock}
+
+              <div style="background:${COLORS.paper};padding:14px 16px;margin:0 0 16px 0;border:1px solid ${COLORS.hairline};">
+                <div style="font-size:11px;color:${COLORS.muteText};text-transform:uppercase;letter-spacing:0.1em;font-weight:600;margin-bottom:6px;">Connection status</div>
+                <div style="font-size:13px;color:${COLORS.inkBody};line-height:1.6;">
+                  QuickBooks ${d.qbConnected ? '✅' : '<span style="color:' + COLORS.urgent + ';">❌ NOT CONNECTED</span>'} ·
+                  Plaid ${d.plaidConnected ? `✅ (${d.plaidItemCount} item${d.plaidItemCount === 1 ? '' : 's'})` : '<span style="color:' + COLORS.urgent + ';">❌</span>'}<br>
+                  ${d.unmatchedBankTxnCount} unmatched bank txns · ${d.unmatchedStripePayoutCount} unmatched Stripe payouts<br>
+                  ${
+                    d.failedJournalCount > 0
+                      ? `<span style="color:${COLORS.urgent};">${d.failedJournalCount} QB sales journal${d.failedJournalCount === 1 ? '' : 's'} FAILED</span> (review on dashboard)`
+                      : '✅ QB sales journals posting cleanly'
+                  }
+                </div>
+              </div>
+
+              <!-- CTA -->
+              <table cellpadding="0" cellspacing="0" border="0" width="100%" style="margin-top:8px;">
+                <tr>
+                  <td align="center">
+                    <a href="${esc(d.dashboardUrl)}" style="display:inline-block;background:${COLORS.blue};color:#ffffff;text-decoration:none;padding:12px 20px;font-size:13px;font-weight:600;margin-right:8px;">Open dashboard</a>
+                    <a href="${esc(d.queueUrl)}" style="display:inline-block;background:${COLORS.gold};color:${COLORS.ink};text-decoration:none;padding:12px 20px;font-size:13px;font-weight:600;">Triage queue</a>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- footer -->
+          <tr>
+            <td style="padding:16px 32px 24px 32px;border-top:1px solid ${COLORS.hairline};">
+              <div style="font-size:11px;color:${COLORS.muteText};line-height:1.5;">
+                Party On Delivery · Finance Director (Phase 5)<br>
+                Generated automatically each Monday at 14:00 UTC.
+              </div>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+}
+
+export function renderFinanceBriefingText(d: FinanceBriefingPayload): string {
+  const lines: string[] = [];
+  lines.push(`Finance Director — ${d.weekLabel}`);
+  lines.push(`Snapshot: ${d.snapshotDate}`);
+  lines.push('');
+  for (const s of d.stats) {
+    lines.push(`  ${s.label}: ${s.value}${s.sub ? ` (${s.sub})` : ''}`);
+  }
+  lines.push('');
+  if (d.urgentRecs.length > 0) {
+    lines.push(`URGENT (${d.urgentRecs.length}):`);
+    for (const r of d.urgentRecs) lines.push(`  - ${r.title}`);
+    lines.push('');
+  }
+  if (d.highRecs.length > 0) {
+    lines.push(`HIGH (${d.highRecs.length}):`);
+    for (const r of d.highRecs) lines.push(`  - ${r.title}`);
+    lines.push('');
+  }
+  if (d.normalRecCount > 0) {
+    lines.push(`Watching: ${d.normalRecCount} normal-severity items`);
+    lines.push('');
+  }
+  lines.push(`QuickBooks: ${d.qbConnected ? 'connected' : 'NOT CONNECTED'}`);
+  lines.push(`Plaid: ${d.plaidConnected ? `connected (${d.plaidItemCount} items)` : 'NOT CONNECTED'}`);
+  lines.push(`Unmatched bank txns: ${d.unmatchedBankTxnCount}`);
+  lines.push(`Unmatched Stripe payouts: ${d.unmatchedStripePayoutCount}`);
+  if (d.failedJournalCount > 0) lines.push(`QB sales journals FAILED: ${d.failedJournalCount}`);
+  lines.push('');
+  lines.push(`Dashboard: ${d.dashboardUrl}`);
+  lines.push(`Triage queue: ${d.queueUrl}`);
+  return lines.join('\n');
+}

--- a/src/lib/finance/briefing-markdown.ts
+++ b/src/lib/finance/briefing-markdown.ts
@@ -1,0 +1,82 @@
+/**
+ * Renders a FinanceBriefingPayload as YAML-frontmatter + markdown
+ * (committed to docs/finance/weekly/<weekLabel>.md by the cron).
+ */
+
+import type { FinanceBriefingPayload } from './briefing-payload';
+
+function rec(href: string | undefined, title: string): string {
+  return href ? `[${title}](${href})` : title;
+}
+
+export function renderFinanceBriefingMarkdown(d: FinanceBriefingPayload): string {
+  const frontmatter = [
+    '---',
+    `title: Finance Director — ${d.weekLabel}`,
+    `period: weekly`,
+    `week: ${d.weekLabel}`,
+    `date_generated: ${d.generatedAtIso}`,
+    `snapshot_date: ${d.snapshotDate}`,
+    `urgent_count: ${d.urgentRecs.length}`,
+    `high_count: ${d.highRecs.length}`,
+    `normal_count: ${d.normalRecCount}`,
+    `qb_connected: ${d.qbConnected}`,
+    `plaid_connected: ${d.plaidConnected}`,
+    `pending_journals: ${d.pendingJournalCount}`,
+    `failed_journals: ${d.failedJournalCount}`,
+    `tags: [finance, briefing, weekly]`,
+    '---',
+    '',
+  ].join('\n');
+
+  const sections: string[] = [`# Finance Director — ${d.weekLabel}`, ''];
+
+  if (d.urgentRecs.length > 0) {
+    sections.push('## 🚨 Urgent', '');
+    for (const r of d.urgentRecs) {
+      sections.push(`- ${rec(r.href, r.title)}${r.summary ? ` — _${r.summary}_` : ''}`);
+    }
+    sections.push('');
+  }
+
+  if (d.stats.length > 0) {
+    sections.push('## Stats (latest snapshot)', '');
+    for (const s of d.stats) {
+      const deltaStr = s.delta
+        ? ` (${s.delta.direction === 'up' ? '↑' : s.delta.direction === 'down' ? '↓' : '→'} ${s.delta.pct.toFixed(1)}% vs prior wk)`
+        : '';
+      sections.push(`- **${s.label}**: ${s.value}${deltaStr}${s.sub ? ` _${s.sub}_` : ''}`);
+    }
+    sections.push('');
+  }
+
+  sections.push('## Connection status', '');
+  sections.push(`- QuickBooks: ${d.qbConnected ? '✅ connected' : '❌ NOT connected'}`);
+  sections.push(
+    `- Plaid: ${d.plaidConnected ? '✅' : '❌'} ${d.plaidItemCount} item(s), ${d.unmatchedBankTxnCount} bank transactions unmatched, ${d.unmatchedStripePayoutCount} Stripe payouts unmatched`
+  );
+  sections.push(
+    `- QB sales journals: ${d.failedJournalCount > 0 ? `❌ ${d.failedJournalCount} failed` : '✅ posting cleanly'}${d.pendingJournalCount > 0 ? `, ${d.pendingJournalCount} pending` : ''}`
+  );
+  sections.push('');
+
+  if (d.highRecs.length > 0) {
+    sections.push('## High-priority recommendations', '');
+    for (const r of d.highRecs) {
+      sections.push(`- ${rec(r.href, r.title)}${r.summary ? ` — _${r.summary}_` : ''}`);
+    }
+    sections.push('');
+  }
+
+  if (d.normalRecCount > 0) {
+    sections.push(`## Watching (${d.normalRecCount} normal-severity recs)`, '');
+    sections.push(`See [the triage queue](${d.queueUrl}) for the full list.`, '');
+  }
+
+  sections.push('## Links', '');
+  sections.push(`- [Finance dashboard](${d.dashboardUrl})`);
+  sections.push(`- [Triage queue](${d.queueUrl})`);
+  sections.push('');
+
+  return frontmatter + sections.join('\n');
+}

--- a/src/lib/finance/briefing-payload.ts
+++ b/src/lib/finance/briefing-payload.ts
@@ -1,0 +1,218 @@
+/**
+ * Weekly briefing payload builder for the Finance Director.
+ *
+ * Pulls the most recent snapshot, 30-day P&L history, active recommendations,
+ * QB / Plaid connection state, and key accruals — shapes them into a
+ * single object the markdown renderer + email template consume.
+ */
+
+import { prisma } from '@/lib/database/client';
+import type { PlSnapshotPayload } from './pl-calculation';
+
+export interface FinanceBriefingStat {
+  label: string;
+  value: string;
+  sub?: string;
+  delta?: { pct: number; direction: 'up' | 'down' | 'flat' };
+}
+
+export interface FinanceBriefingRec {
+  id: string;
+  signalKind: string;
+  severity: string;
+  title: string;
+  /** First evidence line, summarized. */
+  summary?: string;
+  href?: string;
+}
+
+export interface FinanceBriefingPayload {
+  weekLabel: string; // 2026-W24
+  year: number;
+  weekNumber: number;
+  generatedAtIso: string;
+  snapshotDate: string;
+  stats: FinanceBriefingStat[];
+  urgentRecs: FinanceBriefingRec[];
+  highRecs: FinanceBriefingRec[];
+  normalRecCount: number;
+  qbConnected: boolean;
+  qbCompanyName: string | null;
+  plaidConnected: boolean;
+  plaidItemCount: number;
+  unmatchedBankTxnCount: number;
+  unmatchedStripePayoutCount: number;
+  pendingJournalCount: number;
+  failedJournalCount: number;
+  dashboardUrl: string;
+  queueUrl: string;
+}
+
+function isoWeek(date: Date): { year: number; week: number; label: string } {
+  // ISO week per RFC. Mirror src/lib/operations/briefing-payload.ts behavior.
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const dayNum = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const week = Math.ceil(((d.getTime() - yearStart.getTime()) / 86_400_000 + 1) / 7);
+  return {
+    year: d.getUTCFullYear(),
+    week,
+    label: `${d.getUTCFullYear()}-W${week.toString().padStart(2, '0')}`,
+  };
+}
+
+function fmtCents(cents: number): string {
+  return `$${(cents / 100).toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+function recSummary(rec: { evidence: unknown }): string | undefined {
+  if (!Array.isArray(rec.evidence) || rec.evidence.length === 0) return undefined;
+  const first = rec.evidence[0] as { metricName?: string; metricValue?: string | number };
+  if (first.metricName && first.metricValue !== undefined) {
+    return `${first.metricName}: ${first.metricValue}`;
+  }
+  return undefined;
+}
+
+function navHref(actionPayload: unknown): string | undefined {
+  if (!actionPayload || typeof actionPayload !== 'object') return undefined;
+  const p = actionPayload as { kind?: string; params?: { href?: string } };
+  if (p.kind === 'navigate' && p.params?.href) return p.params.href;
+  return undefined;
+}
+
+const BASE_URL =
+  process.env.NEXT_PUBLIC_APP_URL ?? 'https://partyondelivery.com';
+
+export async function buildFinanceBriefingPayload(
+  now: Date = new Date()
+): Promise<FinanceBriefingPayload> {
+  const { year, week, label } = isoWeek(now);
+
+  const [
+    latestSnapshot,
+    priorWeekSnapshots,
+    activeRecs,
+    intuit,
+    plaidItems,
+    unmatchedStripePayouts,
+    unmatchedBankTxns,
+    pendingJournals,
+    failedJournals,
+  ] = await Promise.all([
+    prisma.financeSnapshot.findFirst({ orderBy: { snapshotDate: 'desc' } }),
+    prisma.financeSnapshot.findMany({
+      where: { snapshotDate: { gte: new Date(now.getTime() - 14 * 86_400_000) } },
+      orderBy: { snapshotDate: 'desc' },
+    }),
+    prisma.financeRecommendation.findMany({
+      where: { status: 'open' },
+      orderBy: [{ severity: 'asc' }, { updatedAt: 'desc' }],
+      take: 50,
+    }),
+    prisma.intuitOAuthState.findUnique({ where: { id: 'singleton' } }),
+    prisma.plaidItem.findMany(),
+    prisma.stripePayout.count({
+      where: { status: 'paid', matchedPlaidTxId: null },
+    }),
+    prisma.plaidTransaction.count({
+      where: { reconciledAt: null, pending: false },
+    }),
+    prisma.qbJournalEntry.count({ where: { status: 'PENDING_APPROVAL' } }),
+    prisma.qbJournalEntry.count({ where: { status: 'FAILED' } }),
+  ]);
+
+  const snapshotDate = latestSnapshot?.snapshotDate.toISOString().slice(0, 10) ?? 'n/a';
+  const payload = (latestSnapshot?.payload ?? null) as unknown as PlSnapshotPayload | null;
+
+  const stats: FinanceBriefingStat[] = [];
+  if (payload) {
+    stats.push({
+      label: 'Gross revenue (yesterday)',
+      value: fmtCents(payload.grossRevenueCents),
+      sub: `${payload.paidOrderCount} orders`,
+    });
+    stats.push({
+      label: 'Net revenue',
+      value: fmtCents(payload.netRevenueCents),
+      sub: 'after Stripe fees + refunds',
+    });
+    stats.push({
+      label: 'Gross profit',
+      value: fmtCents(payload.grossProfitCents),
+      sub: `${payload.grossMarginPct.toFixed(1)}% margin · cost coverage ${payload.marginCoveragePct}%`,
+    });
+    if (payload.netIncomeCents !== null) {
+      stats.push({
+        label: 'Net income (est.)',
+        value: fmtCents(payload.netIncomeCents),
+        sub:
+          payload.opexDailyAvgCents !== null
+            ? `daily OpEx avg ${fmtCents(payload.opexDailyAvgCents)}`
+            : 'QB OpEx not synced',
+      });
+    } else {
+      stats.push({
+        label: 'Net income',
+        value: 'QB not synced',
+        sub: 'connect QB to compute',
+      });
+    }
+
+    // 7d revenue delta if we have history
+    const prior = priorWeekSnapshots.find((s) => {
+      const target = new Date(now.getTime() - 7 * 86_400_000)
+        .toISOString()
+        .slice(0, 10);
+      return s.snapshotDate.toISOString().slice(0, 10) === target;
+    });
+    if (prior) {
+      const priorPayload = prior.payload as unknown as PlSnapshotPayload;
+      if (priorPayload?.grossRevenueCents) {
+        const diffPct =
+          ((payload.grossRevenueCents - priorPayload.grossRevenueCents) /
+            priorPayload.grossRevenueCents) *
+          100;
+        stats[0].delta = {
+          pct: Math.abs(diffPct),
+          direction: diffPct > 0.1 ? 'up' : diffPct < -0.1 ? 'down' : 'flat',
+        };
+      }
+    }
+  }
+
+  const toBriefingRec = (r: (typeof activeRecs)[number]): FinanceBriefingRec => ({
+    id: r.id,
+    signalKind: r.signalKind,
+    severity: r.severity,
+    title: r.title,
+    summary: recSummary({ evidence: r.evidence }),
+    href: navHref(r.actionPayload),
+  });
+
+  return {
+    weekLabel: label,
+    year,
+    weekNumber: week,
+    generatedAtIso: now.toISOString(),
+    snapshotDate,
+    stats,
+    urgentRecs: activeRecs.filter((r) => r.severity === 'urgent').map(toBriefingRec),
+    highRecs: activeRecs.filter((r) => r.severity === 'high').map(toBriefingRec),
+    normalRecCount: activeRecs.filter((r) => r.severity === 'normal').length,
+    qbConnected: intuit !== null && intuit.lastError === null,
+    qbCompanyName: null, // populated on demand by health endpoint; skipped here
+    plaidConnected: plaidItems.some((p) => p.status === 'active'),
+    plaidItemCount: plaidItems.length,
+    unmatchedBankTxnCount: unmatchedBankTxns,
+    unmatchedStripePayoutCount: unmatchedStripePayouts,
+    pendingJournalCount: pendingJournals,
+    failedJournalCount: failedJournals,
+    dashboardUrl: `${BASE_URL}/admin/finance`,
+    queueUrl: `${BASE_URL}/admin/recommendations?domain=finance`,
+  };
+}

--- a/src/lib/finance/detectors/signals-a.ts
+++ b/src/lib/finance/detectors/signals-a.ts
@@ -1,0 +1,426 @@
+/**
+ * Finance Director — 9 detector functions (signals 1, 3, 4, 7, 8, 9, 10, 11, 12
+ * from the buildout brief §8). Signal 2 (distributor invoice past due) is
+ * removed per the Phase 1B cancellation. Signals 5 (sales tax accrual) and
+ * 6 (contractor 1099 threshold) need data Phase 4 and Phase 3 will add.
+ *
+ * Every detector function:
+ *   - returns FinanceRecommendationInput[] (possibly empty)
+ *   - reads from existing PartyOn DB tables only (no external API calls;
+ *     external state is already cached via the daily snapshot + cron pulls)
+ *   - is pure with respect to its `now` argument so tests can pin time
+ */
+
+import { prisma } from '@/lib/database/client';
+import type { ActionPayload } from '@/lib/recommendations/card-types';
+import type {
+  FinanceRecommendationInput,
+  FinanceSeverity,
+} from '../types';
+import type { PlSnapshotPayload } from '../pl-calculation';
+
+const ONE_DAY_MS = 86_400_000;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function navigate(href: string, label: string): ActionPayload {
+  return { kind: 'navigate', label, params: { href } };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Stripe payout unmatched to a bank deposit (>4 banking days)
+// ---------------------------------------------------------------------------
+
+export async function detectStripePayoutUnmatched(
+  now: Date = new Date()
+): Promise<FinanceRecommendationInput[]> {
+  const cutoff = new Date(now.getTime() - 4 * ONE_DAY_MS);
+  const rows = await prisma.stripePayout.findMany({
+    where: {
+      status: 'paid',
+      matchedPlaidTxId: null,
+      arrivalDate: { lt: cutoff },
+    },
+    orderBy: { arrivalDate: 'asc' },
+    take: 50,
+  });
+  return rows.map<FinanceRecommendationInput>((p) => {
+    const daysLate = Math.floor((now.getTime() - p.arrivalDate.getTime()) / ONE_DAY_MS);
+    const severity: FinanceSeverity = daysLate > 10 ? 'urgent' : 'high';
+    return {
+      signalKind: 'stripe-payout-unmatched',
+      severity,
+      title: `Stripe payout ${(p.amountCents / 100).toFixed(2)} hasn't matched a bank deposit (${daysLate}d ago)`,
+      evidence: [
+        {
+          metricName: 'payout amount',
+          metricValue: `$${(p.amountCents / 100).toFixed(2)}`,
+          note: `Arrival date ${p.arrivalDate.toISOString().slice(0, 10)} · status ${p.status}`,
+        },
+      ],
+      targetEntityType: 'stripePayout',
+      targetEntityId: p.id,
+      actionPayload: navigate('/admin/finance/plaid?filter=unmatched', 'Investigate'),
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 3. Cash runway < 30 days
+// ---------------------------------------------------------------------------
+
+export async function detectCashRunwayLow(
+  snapshot: PlSnapshotPayload | null,
+  now: Date = new Date()
+): Promise<FinanceRecommendationInput[]> {
+  if (!snapshot) return [];
+  if (snapshot.opexDailyAvgCents === null || snapshot.opexDailyAvgCents <= 0) return [];
+
+  // Bank balance from the latest Plaid account balance + outstanding AR
+  // (DraftOrder.PENDING/SENT/VIEWED). Per saved memory: no internal AP
+  // tracking, so we just use bank + AR ÷ daily burn for V1.
+  const [accounts, drafts] = await Promise.all([
+    prisma.plaidAccount.findMany({
+      where: { type: 'depository' },
+      select: { availableBalance: true, currentBalance: true },
+    }),
+    prisma.draftOrder.aggregate({
+      where: { status: { in: ['PENDING', 'SENT', 'VIEWED'] } },
+      _sum: { subtotal: true, taxAmount: true, deliveryFee: true },
+    }),
+  ]);
+
+  const bankCents = accounts.reduce((s, a) => {
+    const bal = a.availableBalance ?? a.currentBalance;
+    return s + (bal !== null ? Math.round(Number(bal) * 100) : 0);
+  }, 0);
+  const draftSubtotal = Number(drafts._sum.subtotal ?? 0);
+  const draftTax = Number(drafts._sum.taxAmount ?? 0);
+  const draftDelivery = Number(drafts._sum.deliveryFee ?? 0);
+  const arCents = Math.round((draftSubtotal + draftTax + draftDelivery) * 100);
+
+  const dailyBurn = snapshot.opexDailyAvgCents;
+  const runwayDays = Math.floor((bankCents + arCents) / dailyBurn);
+
+  if (runwayDays >= 30) return [];
+
+  const severity: FinanceSeverity = runwayDays < 14 ? 'urgent' : 'high';
+  const stableTargetId = now.toISOString().slice(0, 10);
+  return [
+    {
+      signalKind: 'cash-runway-low',
+      severity,
+      title: `Cash runway ${runwayDays}d (bank + AR vs daily OpEx)`,
+      evidence: [
+        {
+          metricName: 'bank balance',
+          metricValue: `$${(bankCents / 100).toFixed(2)}`,
+        },
+        {
+          metricName: 'outstanding AR (DraftOrder)',
+          metricValue: `$${(arCents / 100).toFixed(2)}`,
+        },
+        {
+          metricName: 'daily OpEx',
+          metricValue: `$${(dailyBurn / 100).toFixed(2)}`,
+          note: 'rolling 30d avg from QB',
+        },
+      ],
+      targetEntityType: 'snapshot',
+      targetEntityId: stableTargetId,
+      actionPayload: navigate('/admin/finance', 'Open dashboard'),
+      dedupeKey: 'cash-runway-low:active',
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// 4. Gross margin trending down (>5pp drop in 30-day rolling vs prior 30)
+// ---------------------------------------------------------------------------
+
+export async function detectGrossMarginTrendingDown(
+  now: Date = new Date()
+): Promise<FinanceRecommendationInput[]> {
+  const recent = await prisma.financeSnapshot.findMany({
+    where: { snapshotDate: { gte: new Date(now.getTime() - 60 * ONE_DAY_MS) } },
+    orderBy: { snapshotDate: 'desc' },
+  });
+  if (recent.length < 14) return []; // not enough history to trend
+
+  function avgMarginPct(snapshots: typeof recent): number | null {
+    let total = 0;
+    let count = 0;
+    for (const s of snapshots) {
+      const p = s.payload as { grossMarginPct?: number; netRevenueCents?: number };
+      if (p?.netRevenueCents && p.netRevenueCents > 0 && typeof p.grossMarginPct === 'number') {
+        total += p.grossMarginPct;
+        count += 1;
+      }
+    }
+    return count > 0 ? total / count : null;
+  }
+
+  const last30 = recent.slice(0, 30);
+  const prior30 = recent.slice(30, 60);
+  if (prior30.length < 10) return [];
+
+  const cur = avgMarginPct(last30);
+  const prior = avgMarginPct(prior30);
+  if (cur === null || prior === null) return [];
+
+  const dropPp = prior - cur;
+  if (dropPp < 5) return [];
+
+  const severity: FinanceSeverity = dropPp > 10 ? 'urgent' : 'high';
+  return [
+    {
+      signalKind: 'gross-margin-trending-down',
+      severity,
+      title: `Gross margin dropped ${dropPp.toFixed(1)}pp (${prior.toFixed(1)}% → ${cur.toFixed(1)}% last 30d)`,
+      evidence: [
+        { metricName: 'prior 30d avg', metricValue: `${prior.toFixed(1)}%` },
+        { metricName: 'last 30d avg', metricValue: `${cur.toFixed(1)}%` },
+        { metricName: 'drop', metricValue: `${dropPp.toFixed(1)}pp` },
+      ],
+      targetEntityType: 'snapshot',
+      targetEntityId: 'rolling-30d',
+      actionPayload: navigate('/admin/finance', 'Open margin analysis'),
+      dedupeKey: 'gross-margin-trending-down:active',
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// 7. OpEx category spiking (>150% of trailing 90d avg in last 30d)
+// ---------------------------------------------------------------------------
+
+export async function detectOpexCategorySpiking(
+  now: Date = new Date()
+): Promise<FinanceRecommendationInput[]> {
+  const from90 = new Date(now.getTime() - 90 * ONE_DAY_MS);
+  const from30 = new Date(now.getTime() - 30 * ONE_DAY_MS);
+
+  const recent30 = await prisma.qbExpense.groupBy({
+    by: ['categorySlug'],
+    where: { txnDate: { gte: from30, lt: now } },
+    _sum: { amountCents: true },
+  });
+  const trailing90 = await prisma.qbExpense.groupBy({
+    by: ['categorySlug'],
+    where: { txnDate: { gte: from90, lt: from30 } },
+    _sum: { amountCents: true },
+  });
+  const trailing90Map = new Map(
+    trailing90.map((g) => [g.categorySlug ?? 'other', g._sum.amountCents ?? 0])
+  );
+
+  const out: FinanceRecommendationInput[] = [];
+  for (const g of recent30) {
+    const category = g.categorySlug ?? 'other';
+    const recent = g._sum.amountCents ?? 0;
+    if (recent < 5000) continue; // ignore <$50 (small noise)
+    const trailing = trailing90Map.get(category) ?? 0;
+    const dailyAvgTrailing = trailing / 60; // 60 days in trailing window
+    const dailyAvgRecent = recent / 30;
+    if (dailyAvgTrailing < 100) continue; // <$1/day baseline — ratio meaningless
+    const ratio = dailyAvgRecent / dailyAvgTrailing;
+    if (ratio < 1.5) continue;
+    const severity: FinanceSeverity = ratio > 3 ? 'high' : 'normal';
+    out.push({
+      signalKind: 'opex-category-spiking',
+      severity,
+      title: `${category} OpEx spiked ${Math.round(ratio * 100)}% vs trailing 90d`,
+      evidence: [
+        {
+          metricName: 'last 30d',
+          metricValue: `$${(recent / 100).toFixed(2)}`,
+          note: `$${(dailyAvgRecent / 100).toFixed(2)}/day`,
+        },
+        {
+          metricName: 'trailing 90d (excl last 30)',
+          metricValue: `$${(trailing / 100).toFixed(2)}`,
+          note: `$${(dailyAvgTrailing / 100).toFixed(2)}/day`,
+        },
+      ],
+      targetEntityType: 'qbCategory',
+      targetEntityId: category,
+      actionPayload: navigate('/admin/finance', 'Open OpEx breakdown'),
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// 8. Affiliate commission accrual aging (>30 days held/approved)
+// ---------------------------------------------------------------------------
+
+export async function detectAffiliateCommissionAging(
+  now: Date = new Date()
+): Promise<FinanceRecommendationInput[]> {
+  const cutoff = new Date(now.getTime() - 30 * ONE_DAY_MS);
+  const agg = await prisma.affiliateCommission.aggregate({
+    where: {
+      status: { in: ['HELD', 'APPROVED'] },
+      createdAt: { lt: cutoff },
+    },
+    _sum: { commissionAmountCents: true },
+    _count: { _all: true },
+  });
+  const totalCents = agg._sum.commissionAmountCents ?? 0;
+  const count = agg._count._all;
+  if (count === 0) return [];
+
+  return [
+    {
+      signalKind: 'affiliate-commission-aging',
+      severity: 'normal',
+      title: `${count} affiliate commissions held >30d ($${(totalCents / 100).toFixed(2)})`,
+      evidence: [
+        { metricName: 'commissions outstanding', metricValue: count },
+        { metricName: 'total held', metricValue: `$${(totalCents / 100).toFixed(2)}` },
+      ],
+      targetEntityType: 'affiliateCommissionBatch',
+      targetEntityId: 'aging-30d',
+      actionPayload: navigate('/admin/affiliates/payouts', 'Open affiliate payouts'),
+      dedupeKey: 'affiliate-commission-aging:active',
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// 9. Discount over-use (single code > configured $ in last 7d)
+// ---------------------------------------------------------------------------
+
+const DISCOUNT_OVERUSE_THRESHOLD_CENTS = 50_000; // $500/week per code
+
+export async function detectDiscountOveruse(
+  now: Date = new Date()
+): Promise<FinanceRecommendationInput[]> {
+  const from = new Date(now.getTime() - 7 * ONE_DAY_MS);
+  const grouped = await prisma.order.groupBy({
+    by: ['discountCode'],
+    where: {
+      financialStatus: 'PAID',
+      createdAt: { gte: from },
+      discountCode: { not: null },
+    },
+    _sum: { discountAmount: true },
+    _count: { _all: true },
+  });
+  const out: FinanceRecommendationInput[] = [];
+  for (const g of grouped) {
+    if (!g.discountCode) continue;
+    const totalCents = Math.round(Number(g._sum.discountAmount ?? 0) * 100);
+    if (totalCents < DISCOUNT_OVERUSE_THRESHOLD_CENTS) continue;
+    out.push({
+      signalKind: 'discount-overuse',
+      severity: 'normal',
+      title: `Discount "${g.discountCode}" gave away $${(totalCents / 100).toFixed(2)} in 7d`,
+      evidence: [
+        { metricName: 'total discounted', metricValue: `$${(totalCents / 100).toFixed(2)}` },
+        { metricName: 'redemptions', metricValue: g._count._all },
+      ],
+      targetEntityType: 'discountCode',
+      targetEntityId: g.discountCode,
+      actionPayload: navigate('/admin/promotions', 'Review discount usage'),
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// 10. Untouched bank transaction (Plaid txn unreconciled >7d)
+// ---------------------------------------------------------------------------
+
+export async function detectUntouchedBankTransaction(
+  now: Date = new Date()
+): Promise<FinanceRecommendationInput[]> {
+  const cutoff = new Date(now.getTime() - 7 * ONE_DAY_MS);
+  const stale = await prisma.plaidTransaction.findMany({
+    where: {
+      reconciledAt: null,
+      pending: false,
+      date: { lt: cutoff },
+    },
+    take: 1,
+    orderBy: { date: 'asc' },
+  });
+  if (stale.length === 0) return [];
+
+  // Roll up to one summary rec rather than spamming one per txn.
+  const totalUnmatched = await prisma.plaidTransaction.count({
+    where: { reconciledAt: null, pending: false, date: { lt: cutoff } },
+  });
+
+  return [
+    {
+      signalKind: 'untouched-bank-transaction',
+      severity: 'normal',
+      title: `${totalUnmatched} bank transactions unreconciled >7 days`,
+      evidence: [
+        { metricName: 'unmatched (>7d)', metricValue: totalUnmatched },
+        { metricName: 'oldest', metricValue: stale[0].date.toISOString().slice(0, 10) },
+      ],
+      targetEntityType: 'plaidTransaction',
+      targetEntityId: 'aging-7d',
+      actionPayload: navigate('/admin/finance/plaid?filter=unmatched', 'Open Plaid reconciliation'),
+      dedupeKey: 'untouched-bank-transaction:active',
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// 11. QB sync error (token expired / API failing)
+// ---------------------------------------------------------------------------
+
+export async function detectQbSyncError(): Promise<FinanceRecommendationInput[]> {
+  const row = await prisma.intuitOAuthState.findUnique({
+    where: { id: 'singleton' },
+  });
+  if (!row || !row.lastError) return [];
+  return [
+    {
+      signalKind: 'qb-sync-error',
+      severity: 'urgent',
+      title: 'QuickBooks sync failing',
+      evidence: [
+        { metricName: 'last error', metricValue: row.lastError.slice(0, 200) },
+        {
+          metricName: 'last refreshed',
+          metricValue: row.lastRefreshedAt?.toISOString() ?? 'never',
+        },
+      ],
+      targetEntityType: 'intuitConnection',
+      targetEntityId: 'singleton',
+      actionPayload: navigate('/admin/finance/connect-quickbooks', 'Reconnect QuickBooks'),
+      dedupeKey: 'qb-sync-error:active',
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// 12. Plaid sync error (item login_required or error status)
+// ---------------------------------------------------------------------------
+
+export async function detectPlaidSyncError(): Promise<FinanceRecommendationInput[]> {
+  const broken = await prisma.plaidItem.findMany({
+    where: { status: { in: ['login_required', 'error'] } },
+  });
+  return broken.map<FinanceRecommendationInput>((item) => ({
+    signalKind: 'plaid-sync-error',
+    severity: 'urgent',
+    title: `Plaid connection broken: ${item.institutionName ?? 'unknown bank'}`,
+    evidence: [
+      { metricName: 'item status', metricValue: item.status },
+      {
+        metricName: 'last error',
+        metricValue: (item.lastError ?? 'no detail').slice(0, 200),
+      },
+    ],
+    targetEntityType: 'plaidItem',
+    targetEntityId: item.id,
+    actionPayload: navigate('/admin/finance/connect-bank', 'Reconnect bank'),
+  }));
+}

--- a/src/lib/finance/dismiss-suppression.ts
+++ b/src/lib/finance/dismiss-suppression.ts
@@ -1,0 +1,64 @@
+/**
+ * Dismiss-feedback heuristic for the Finance Director — mirrors the Ops
+ * implementation. Stops re-emitting a signal after the operator dismisses
+ * it N times in a row; re-surfaces at knocked-down severity in between.
+ */
+
+import { knockDownSeverity, type ActionLogEntry, type FinanceSeverity } from './types';
+
+export const SUPPRESSION_THRESHOLD = 3;
+export const REEMISSION_AGE_DAYS = 30;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export type ExistingRec = {
+  id: string;
+  status: string;
+  severity: string;
+  updatedAt?: Date | null;
+  snoozeUntil?: Date | null;
+  actionLog?: unknown;
+};
+
+export type SuppressionDecision =
+  | { action: 'skip'; reason: 'still-active-snooze' | 'recent-dismissal' }
+  | { action: 'suppress'; reason: 'threshold-reached'; dismissCount: number }
+  | { action: 'reopen'; nextSeverity: FinanceSeverity; dismissCount: number };
+
+export function countDismissals(actionLog: unknown): number {
+  if (!Array.isArray(actionLog)) return 0;
+  let n = 0;
+  for (const raw of actionLog) {
+    if (!raw || typeof raw !== 'object') continue;
+    const entry = raw as Partial<ActionLogEntry>;
+    if (entry.actionKind === 'dismiss') n += 1;
+  }
+  return n;
+}
+
+export function evaluateSuppression(
+  existing: ExistingRec,
+  requestedSeverity: FinanceSeverity,
+  now: Date = new Date()
+): SuppressionDecision {
+  if (existing.status === 'snoozed' && existing.snoozeUntil && existing.snoozeUntil > now) {
+    return { action: 'skip', reason: 'still-active-snooze' };
+  }
+
+  const updatedAt = existing.updatedAt ?? null;
+  const agedOut =
+    updatedAt instanceof Date &&
+    updatedAt.getTime() < now.getTime() - REEMISSION_AGE_DAYS * DAY_MS;
+  if (!agedOut) {
+    return { action: 'skip', reason: 'recent-dismissal' };
+  }
+
+  const dismissCount = countDismissals(existing.actionLog);
+  if (dismissCount >= SUPPRESSION_THRESHOLD) {
+    return { action: 'suppress', reason: 'threshold-reached', dismissCount };
+  }
+
+  const nextSeverity =
+    dismissCount > 0 ? knockDownSeverity(requestedSeverity) : requestedSeverity;
+  return { action: 'reopen', nextSeverity, dismissCount };
+}

--- a/src/lib/finance/recommendation-store.ts
+++ b/src/lib/finance/recommendation-store.ts
@@ -1,0 +1,186 @@
+/**
+ * Persistence for FinanceRecommendation. Mirrors
+ * src/lib/operations/recommendation-store.ts in shape:
+ *  - upserts by dedupeKey (one open rec per signal+target)
+ *  - refreshes evidence + bumps severity when the same signal re-detects worse
+ *  - exposes appendActionLog for inline-action audit trails
+ *  - markStatus validates transitions via shared lifecycle.ts
+ */
+
+import { prisma } from '@/lib/database/client';
+import type { Prisma, FinanceRecommendation } from '@prisma/client';
+import type { RecommendationStatus as SharedStatus } from '@/lib/recommendations/lifecycle';
+import { isValidTransition } from '@/lib/recommendations/lifecycle';
+import {
+  buildDedupeKey,
+  isHigherSeverity,
+  type ActionLogEntry,
+  type FinanceRecommendationInput,
+  type FinanceSeverity,
+} from './types';
+import { evaluateSuppression } from './dismiss-suppression';
+
+export interface UpsertSummary {
+  created: number;
+  updated: number;
+  skipped: number;
+  reopened: number;
+  suppressed: number;
+}
+
+export async function upsertRecommendations(
+  recs: FinanceRecommendationInput[]
+): Promise<UpsertSummary> {
+  let created = 0;
+  let updated = 0;
+  let skipped = 0;
+  let reopened = 0;
+  let suppressed = 0;
+
+  for (const rec of recs) {
+    const dedupeKey = rec.dedupeKey ?? buildDedupeKey(rec.signalKind, rec.targetEntityId);
+    const existing = await prisma.financeRecommendation.findUnique({
+      where: { dedupeKey },
+      select: {
+        id: true,
+        status: true,
+        severity: true,
+        updatedAt: true,
+        snoozeUntil: true,
+        actionLog: true,
+      },
+    });
+
+    if (!existing) {
+      await prisma.financeRecommendation.create({
+        data: {
+          dedupeKey,
+          signalKind: rec.signalKind,
+          severity: rec.severity,
+          title: rec.title,
+          evidence: rec.evidence as unknown as Prisma.InputJsonValue,
+          targetEntityType: rec.targetEntityType,
+          targetEntityId: rec.targetEntityId,
+          actionPayload: rec.actionPayload as unknown as Prisma.InputJsonValue,
+          source: rec.source ?? 'auto-snapshot',
+          status: 'open',
+        },
+      });
+      created += 1;
+      continue;
+    }
+
+    if (existing.status !== 'open') {
+      const decision = evaluateSuppression(existing, rec.severity);
+      if (decision.action === 'skip') {
+        skipped += 1;
+        continue;
+      }
+      if (decision.action === 'suppress') {
+        suppressed += 1;
+        continue;
+      }
+      await prisma.financeRecommendation.update({
+        where: { id: existing.id },
+        data: {
+          status: 'open',
+          severity: decision.nextSeverity,
+          title: rec.title,
+          evidence: rec.evidence as unknown as Prisma.InputJsonValue,
+          actionPayload: rec.actionPayload as unknown as Prisma.InputJsonValue,
+          dismissReason: null,
+          snoozeUntil: null,
+        },
+      });
+      reopened += 1;
+      continue;
+    }
+
+    // Open rec already exists — refresh fields. Only raise severity.
+    const existingSeverity = existing.severity as FinanceSeverity;
+    const nextSeverity = isHigherSeverity(rec.severity, existingSeverity)
+      ? rec.severity
+      : existingSeverity;
+
+    await prisma.financeRecommendation.update({
+      where: { id: existing.id },
+      data: {
+        severity: nextSeverity,
+        title: rec.title,
+        evidence: rec.evidence as unknown as Prisma.InputJsonValue,
+        actionPayload: rec.actionPayload as unknown as Prisma.InputJsonValue,
+      },
+    });
+    updated += 1;
+  }
+
+  return { created, updated, skipped, reopened, suppressed };
+}
+
+export async function markStatus(
+  id: string,
+  status: SharedStatus,
+  opts?: { dismissReason?: string; snoozeUntil?: Date | null }
+): Promise<FinanceRecommendation> {
+  const current = await prisma.financeRecommendation.findUnique({
+    where: { id },
+    select: { status: true },
+  });
+  if (!current) throw new Error(`FinanceRecommendation ${id} not found`);
+
+  const from = current.status as SharedStatus;
+  if (!isValidTransition(from, status)) {
+    throw new Error(`Invalid transition: ${from} → ${status}`);
+  }
+
+  const data: Prisma.FinanceRecommendationUpdateInput = { status };
+  if (status === 'shipped') data.shippedAt = new Date();
+  if (opts?.dismissReason !== undefined) data.dismissReason = opts.dismissReason;
+  if (opts?.snoozeUntil !== undefined) data.snoozeUntil = opts.snoozeUntil;
+  if (status === 'open') {
+    data.dismissReason = null;
+    data.snoozeUntil = null;
+  }
+
+  return prisma.financeRecommendation.update({ where: { id }, data });
+}
+
+export async function appendActionLog(
+  id: string,
+  entry: ActionLogEntry
+): Promise<void> {
+  await prisma.$transaction(async (tx) => {
+    const row = await tx.financeRecommendation.findUnique({
+      where: { id },
+      select: { actionLog: true },
+    });
+    if (!row) throw new Error(`FinanceRecommendation ${id} not found`);
+    const log = Array.isArray(row.actionLog) ? (row.actionLog as unknown as ActionLogEntry[]) : [];
+    log.push(entry);
+    await tx.financeRecommendation.update({
+      where: { id },
+      data: { actionLog: log as unknown as Prisma.InputJsonValue },
+    });
+  });
+}
+
+export async function getActiveByDedupeKey(
+  dedupeKey: string
+): Promise<FinanceRecommendation | null> {
+  return prisma.financeRecommendation.findUnique({ where: { dedupeKey } });
+}
+
+export async function findRecentResolved(
+  dedupeKey: string,
+  days = 30
+): Promise<FinanceRecommendation | null> {
+  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+  return prisma.financeRecommendation.findFirst({
+    where: {
+      dedupeKey,
+      status: { in: ['snoozed', 'rejected', 'invalidated'] },
+      updatedAt: { gte: cutoff },
+    },
+    orderBy: { updatedAt: 'desc' },
+  });
+}

--- a/src/lib/finance/recommendations.ts
+++ b/src/lib/finance/recommendations.ts
@@ -1,0 +1,64 @@
+/**
+ * Finance Director recommendation orchestrator.
+ *
+ * Runs every detector function, persists the results through the dedupe
+ * store. Called by the daily P&L snapshot cron after the snapshot row is
+ * written (so detectors can read it).
+ */
+
+import { upsertRecommendations, type UpsertSummary } from './recommendation-store';
+import {
+  detectAffiliateCommissionAging,
+  detectCashRunwayLow,
+  detectDiscountOveruse,
+  detectGrossMarginTrendingDown,
+  detectOpexCategorySpiking,
+  detectPlaidSyncError,
+  detectQbSyncError,
+  detectStripePayoutUnmatched,
+  detectUntouchedBankTransaction,
+} from './detectors/signals-a';
+import type { PlSnapshotPayload } from './pl-calculation';
+import type { FinanceRecommendationInput } from './types';
+
+export interface GenerateResult {
+  total: number;
+  perSignal: Record<string, number>;
+  upsert: UpsertSummary;
+}
+
+export async function generateAll(
+  snapshot: PlSnapshotPayload | null,
+  now: Date = new Date()
+): Promise<GenerateResult> {
+  const results: Array<[string, FinanceRecommendationInput[]]> = [];
+  // Each detector wrapped in try/catch so one DB hiccup doesn't kill the run.
+  async function run(
+    label: string,
+    fn: () => Promise<FinanceRecommendationInput[]>
+  ): Promise<void> {
+    try {
+      results.push([label, await fn()]);
+    } catch (err) {
+      console.error(`[finance-recs] detector ${label} failed:`, err);
+      results.push([label, []]);
+    }
+  }
+
+  await run('stripe-payout-unmatched', () => detectStripePayoutUnmatched(now));
+  await run('cash-runway-low', () => detectCashRunwayLow(snapshot, now));
+  await run('gross-margin-trending-down', () => detectGrossMarginTrendingDown(now));
+  await run('opex-category-spiking', () => detectOpexCategorySpiking(now));
+  await run('affiliate-commission-aging', () => detectAffiliateCommissionAging(now));
+  await run('discount-overuse', () => detectDiscountOveruse(now));
+  await run('untouched-bank-transaction', () => detectUntouchedBankTransaction(now));
+  await run('qb-sync-error', () => detectQbSyncError());
+  await run('plaid-sync-error', () => detectPlaidSyncError());
+
+  const flat = results.flatMap(([, recs]) => recs);
+  const perSignal: Record<string, number> = {};
+  for (const [label, recs] of results) perSignal[label] = recs.length;
+  const upsert = await upsertRecommendations(flat);
+
+  return { total: flat.length, perSignal, upsert };
+}

--- a/src/lib/finance/types.ts
+++ b/src/lib/finance/types.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared TS types for the Finance Director pipeline.
+ *
+ * Mirrors src/lib/operations/types.ts. The DB row (Prisma FinanceRecommendation)
+ * is a thin persisted version of FinanceRecommendationInput plus lifecycle
+ * columns.
+ */
+
+import type { ActionPayload, Evidence } from '@/lib/recommendations/card-types';
+
+/**
+ * The 12 financial signals from the buildout brief §8. Signals 2/5/6 are
+ * deferred (Phase 1B cancelled / Phase 3 not yet built / Phase 4 not yet built)
+ * — kept here as union members so adding their detectors later doesn't
+ * require touching this type.
+ */
+export type FinanceSignalKind =
+  | 'stripe-payout-unmatched'    // 1
+  // | 'distributor-invoice-past-due' // 2 — REMOVED (Phase 1B cancelled)
+  | 'cash-runway-low'            // 3
+  | 'gross-margin-trending-down' // 4
+  // | 'sales-tax-accrual-high'   // 5 — needs Phase 4 (tax remittance log)
+  // | 'contractor-near-1099'     // 6 — needs Phase 3 (Contractor model)
+  | 'opex-category-spiking'      // 7
+  | 'affiliate-commission-aging' // 8
+  | 'discount-overuse'           // 9
+  | 'untouched-bank-transaction' // 10
+  | 'qb-sync-error'              // 11
+  | 'plaid-sync-error';          // 12
+
+export type FinanceSeverity = 'urgent' | 'high' | 'normal';
+
+export type FinanceTargetEntityType =
+  | 'stripePayout'
+  | 'plaidTransaction'
+  | 'qbCategory'
+  | 'discountCode'
+  | 'affiliateCommissionBatch'
+  | 'plaidItem'
+  | 'intuitConnection'
+  | 'snapshot';
+
+export interface FinanceEvidence extends Evidence {
+  metricName?: string;
+  metricValue?: string | number;
+  sourceLinks?: Array<{ label: string; href: string }>;
+  note?: string;
+}
+
+export interface FinanceRecommendationInput {
+  signalKind: FinanceSignalKind;
+  severity: FinanceSeverity;
+  title: string;
+  evidence: FinanceEvidence[];
+  targetEntityType: FinanceTargetEntityType;
+  targetEntityId: string;
+  actionPayload: ActionPayload;
+  /** Optional override; default = `${signalKind}:${targetEntityId}`. */
+  dedupeKey?: string;
+  source?: 'auto-snapshot' | 'director';
+}
+
+/**
+ * Audit-log entry on FinanceRecommendation.actionLog.
+ */
+export interface ActionLogEntry {
+  timestamp: string;
+  actionKind?: string;
+  actionLabel: string;
+  result: 'navigated' | 'success' | 'error' | 'not_implemented';
+  errorMessage?: string;
+  actor?: string;
+}
+
+export function buildDedupeKey(
+  signalKind: FinanceSignalKind,
+  targetEntityId: string
+): string {
+  return `${signalKind}:${targetEntityId}`;
+}
+
+const SEVERITY_RANK: Record<FinanceSeverity, number> = {
+  normal: 0,
+  high: 1,
+  urgent: 2,
+};
+
+export function isHigherSeverity(a: FinanceSeverity, b: FinanceSeverity): boolean {
+  return SEVERITY_RANK[a] > SEVERITY_RANK[b];
+}
+
+export function knockDownSeverity(s: FinanceSeverity): FinanceSeverity {
+  if (s === 'urgent') return 'high';
+  if (s === 'high') return 'normal';
+  return 'normal';
+}

--- a/src/lib/recommendations/__tests__/unified-list.test.ts
+++ b/src/lib/recommendations/__tests__/unified-list.test.ts
@@ -5,6 +5,8 @@ const prismaMock = vi.hoisted(() => ({
   operationsRecommendation: { findMany: vi.fn(), findUnique: vi.fn() },
   operationsSnapshot: { findFirst: vi.fn() },
   analyticsSnapshot: { findFirst: vi.fn() },
+  financeRecommendation: { findMany: vi.fn(), findUnique: vi.fn() },
+  financeSnapshot: { findFirst: vi.fn() },
 }));
 
 vi.mock('@/lib/database/client', () => ({ prisma: prismaMock }));
@@ -69,6 +71,8 @@ beforeEach(() => {
   });
   prismaMock.operationsSnapshot.findFirst.mockResolvedValue({ capturedAt: new Date('2026-05-16T07:30:00Z') });
   prismaMock.analyticsSnapshot.findFirst.mockResolvedValue({ date: new Date('2026-05-16T00:00:00Z') });
+  prismaMock.financeSnapshot.findFirst.mockResolvedValue({ snapshotDate: new Date('2026-05-16T00:00:00Z') });
+  prismaMock.financeRecommendation.findMany.mockResolvedValue([]);
 });
 
 describe('listUnifiedRecommendations', () => {
@@ -89,7 +93,7 @@ describe('listUnifiedRecommendations', () => {
     ]);
     prismaMock.operationsRecommendation.findMany.mockResolvedValue([mkOpsRow()]);
     const result = await listUnifiedRecommendations({ domain: 'all' });
-    expect(result.counts).toEqual({ marketing: 1, seo: 1, operations: 1 });
+    expect(result.counts).toEqual({ marketing: 1, seo: 1, operations: 1, finance: 0 });
   });
 
   it('only queries ops table when domain=operations', async () => {

--- a/src/lib/recommendations/mutation-helpers.ts
+++ b/src/lib/recommendations/mutation-helpers.ts
@@ -10,13 +10,14 @@
 import { prisma } from '@/lib/database/client';
 import type { Prisma } from '@prisma/client';
 import { appendActionLog } from '@/lib/operations/recommendation-store';
+import { appendActionLog as appendFinanceActionLog } from '@/lib/finance/recommendation-store';
 import { mirrorOperationsRecommendation } from '@/lib/operations/recommendation-mirror';
 import { buildActionLogEntry } from './unified-list';
 import type { ActionLogEntry } from '@/lib/operations/types';
 import type { RecommendationStatus } from './lifecycle';
 import { isValidTransition } from './lifecycle';
 
-export type RecLocation = 'ops' | 'marketing-seo';
+export type RecLocation = 'ops' | 'marketing-seo' | 'finance';
 
 export interface StatusUpdate {
   status: RecommendationStatus;
@@ -64,6 +65,19 @@ export async function applyStatusUpdate(
     return;
   }
 
+  if (location === 'finance') {
+    const data: Prisma.FinanceRecommendationUpdateInput = { status: update.status };
+    if (update.status === 'shipped') data.shippedAt = new Date();
+    if (update.dismissReason !== undefined) data.dismissReason = update.dismissReason;
+    if (update.snoozeUntil !== undefined) data.snoozeUntil = update.snoozeUntil;
+    if (update.status === 'open') {
+      data.dismissReason = null;
+      data.snoozeUntil = null;
+    }
+    await prisma.financeRecommendation.update({ where: { id }, data });
+    return;
+  }
+
   const data: Prisma.RecommendationItemUpdateInput = { status: update.status };
   if (update.status === 'shipped') data.shippedAt = new Date();
   // Marketing has no native dismissReason / snoozeUntil; fold reason into notes
@@ -86,12 +100,25 @@ export async function logAction(
   location: RecLocation,
   entry: Omit<ActionLogEntry, 'timestamp'>
 ): Promise<void> {
-  if (location !== 'ops') return;
+  if (location === 'marketing-seo') return;
   const built = buildActionLogEntry({
     actionKind: entry.actionKind ?? 'unknown',
     actionLabel: entry.actionLabel,
     result: entry.result,
     errorMessage: entry.errorMessage,
   });
-  await appendActionLog(id, built);
+  if (location === 'ops') {
+    await appendActionLog(id, built);
+    return;
+  }
+  if (location === 'finance') {
+    await appendFinanceActionLog(id, {
+      timestamp: built.timestamp,
+      actionKind: built.actionKind,
+      actionLabel: built.actionLabel,
+      result: built.result,
+      errorMessage: built.errorMessage,
+    });
+    return;
+  }
 }

--- a/src/lib/recommendations/unified-list.ts
+++ b/src/lib/recommendations/unified-list.ts
@@ -21,8 +21,9 @@ import type {
   RiskTier,
 } from './lifecycle';
 import type { ActionLogEntry, OpsEvidence, OpsSeverity } from '@/lib/operations/types';
+import type { FinanceEvidence, FinanceSeverity } from '@/lib/finance/types';
 
-export type DomainFilter = 'all' | 'marketing' | 'seo' | 'operations';
+export type DomainFilter = 'all' | 'marketing' | 'seo' | 'operations' | 'finance';
 
 export interface UnifiedListOpts {
   domain?: DomainFilter;
@@ -32,11 +33,12 @@ export interface UnifiedListOpts {
 
 export interface UnifiedListResult {
   data: RecommendationCardData[];
-  counts: Record<'marketing' | 'seo' | 'operations', number>;
+  counts: Record<'marketing' | 'seo' | 'operations' | 'finance', number>;
   detectorRanAt: {
     marketing: string | null;
     seo: string | null;
     operations: string | null;
+    finance: string | null;
   };
 }
 
@@ -49,6 +51,13 @@ const SEVERITY_RANK: Record<Severity, number> = {
 
 /** Ops 3-tier → shared 4-tier severity. */
 function mapOpsSeverity(s: OpsSeverity): Severity {
+  if (s === 'urgent') return 'critical';
+  if (s === 'high') return 'high';
+  return 'medium';
+}
+
+/** Finance uses the same 3-tier scale as Ops. */
+function mapFinanceSeverity(s: FinanceSeverity): Severity {
   if (s === 'urgent') return 'critical';
   if (s === 'high') return 'high';
   return 'medium';
@@ -197,6 +206,57 @@ function mapOperations(row: OperationsRow): RecommendationCardData {
   };
 }
 
+interface FinanceRow {
+  id: string;
+  signalKind: string;
+  severity: string;
+  title: string;
+  evidence: Prisma.JsonValue;
+  targetEntityType: string;
+  targetEntityId: string;
+  actionPayload: Prisma.JsonValue;
+  status: string;
+  source: string;
+  dismissReason: string | null;
+  shippedAt: Date | null;
+  createdAt: Date;
+}
+
+function mapFinance(row: FinanceRow): RecommendationCardData {
+  const sev: FinanceSeverity =
+    row.severity === 'urgent' || row.severity === 'high' ? row.severity : 'normal';
+  const status: RecommendationStatus = isRecommendationStatus(row.status) ? row.status : 'open';
+  const evidence = Array.isArray(row.evidence)
+    ? (row.evidence as unknown as FinanceEvidence[])
+    : [];
+  const action =
+    row.actionPayload && typeof row.actionPayload === 'object'
+      ? (row.actionPayload as unknown as ActionPayload)
+      : null;
+  return {
+    id: row.id,
+    domain: 'finance',
+    source: row.source,
+    generatedAt: row.createdAt.toISOString(),
+    title: row.title,
+    body: bodyFromEvidence(evidence as unknown as OpsEvidence[]),
+    segment: null,
+    metric: row.signalKind,
+    currentValue: null,
+    targetValue: null,
+    impactDollarsMonthly: null,
+    effortTier: null,
+    riskTier: 'recommend',
+    status,
+    shippedAt: row.shippedAt?.toISOString() ?? null,
+    notes: row.dismissReason,
+    resultMetricBefore: null,
+    resultMetricAfter: null,
+    actionPayload: action,
+    severity: mapFinanceSeverity(sev),
+  };
+}
+
 /**
  * Load merged recs across Marketing/SEO + Operations. The unified queue is
  * additive — Marketing's existing pipeline remains untouched.
@@ -212,13 +272,14 @@ export async function listUnifiedRecommendations(
 
   const includeOps = domain === 'all' || domain === 'operations';
   const includeMarketing = domain === 'all' || domain === 'marketing' || domain === 'seo';
+  const includeFinance = domain === 'all' || domain === 'finance';
 
   const marketingDomainFilter =
     domain === 'marketing' ? { domain: 'marketing' } :
     domain === 'seo' ? { domain: 'seo' } :
     {};
 
-  const [marketingRows, opsRows, latestOpsSnap, latestMarketingSnap] = await Promise.all([
+  const [marketingRows, opsRows, financeRows, latestOpsSnap, latestMarketingSnap, latestFinanceSnap] = await Promise.all([
     includeMarketing
       ? prisma.recommendationItem.findMany({
           where: { status: { in: statuses }, ...marketingDomainFilter },
@@ -233,13 +294,22 @@ export async function listUnifiedRecommendations(
           take: limit,
         })
       : Promise.resolve([] as OperationsRow[]),
+    includeFinance
+      ? prisma.financeRecommendation.findMany({
+          where: { status: { in: statuses } },
+          orderBy: [{ createdAt: 'desc' }],
+          take: limit,
+        })
+      : Promise.resolve([] as FinanceRow[]),
     prisma.operationsSnapshot.findFirst({ orderBy: { capturedAt: 'desc' }, select: { capturedAt: true } }),
     prisma.analyticsSnapshot.findFirst({ orderBy: { date: 'desc' }, select: { date: true } }),
+    prisma.financeSnapshot.findFirst({ orderBy: { snapshotDate: 'desc' }, select: { snapshotDate: true } }),
   ]);
 
   const mapped = [
     ...marketingRows.map(mapMarketing),
     ...opsRows.map(mapOperations),
+    ...financeRows.map(mapFinance),
   ];
 
   mapped.sort((a, b) => {
@@ -249,12 +319,13 @@ export async function listUnifiedRecommendations(
     return new Date(b.generatedAt).getTime() - new Date(a.generatedAt).getTime();
   });
 
-  const counts = { marketing: 0, seo: 0, operations: 0 };
+  const counts = { marketing: 0, seo: 0, operations: 0, finance: 0 };
   for (const r of mapped) {
     if (r.status !== 'open' && r.status !== 'approved') continue;
     if (r.domain === 'ops') counts.operations += 1;
     else if (r.domain === 'seo') counts.seo += 1;
     else if (r.domain === 'marketing') counts.marketing += 1;
+    else if (r.domain === 'finance') counts.finance += 1;
   }
 
   return {
@@ -264,6 +335,7 @@ export async function listUnifiedRecommendations(
       operations: latestOpsSnap?.capturedAt.toISOString() ?? null,
       marketing: latestMarketingSnap?.date.toISOString() ?? null,
       seo: latestMarketingSnap?.date.toISOString() ?? null,
+      finance: latestFinanceSnap?.snapshotDate.toISOString() ?? null,
     },
   };
 }
@@ -274,7 +346,7 @@ export async function listUnifiedRecommendations(
  */
 export async function findRecommendationLocation(
   id: string
-): Promise<{ domain: 'ops' | 'marketing-seo'; status: RecommendationStatus } | null> {
+): Promise<{ domain: 'ops' | 'marketing-seo' | 'finance'; status: RecommendationStatus } | null> {
   const ops = await prisma.operationsRecommendation.findUnique({
     where: { id },
     select: { status: true },
@@ -283,6 +355,16 @@ export async function findRecommendationLocation(
     return {
       domain: 'ops',
       status: isRecommendationStatus(ops.status) ? ops.status : 'open',
+    };
+  }
+  const fin = await prisma.financeRecommendation.findUnique({
+    where: { id },
+    select: { status: true },
+  });
+  if (fin) {
+    return {
+      domain: 'finance',
+      status: isRecommendationStatus(fin.status) ? fin.status : 'open',
     };
   }
   const mkt = await prisma.recommendationItem.findUnique({

--- a/vercel.json
+++ b/vercel.json
@@ -75,6 +75,10 @@
     {
       "path": "/api/cron/finance-plaid-sync",
       "schedule": "5 8 * * *"
+    },
+    {
+      "path": "/api/cron/finance-weekly-briefing",
+      "schedule": "0 14 * * 1"
     }
   ]
 }


### PR DESCRIPTION
## Summary

This is a recovery PR for the original Phase 5 work. PR #123 was opened from `feat/finance-phase-5-agent` with this title, but the merged commit ended up being the ops-orders refactor that lived on the same branch — the actual Phase 5 commit (`02e97959`) never made it into `main`.

This PR cherry-picks the Phase 5 commit (renumbered as `d6599f22`) onto a fresh branch off current `main`. Clean cherry-pick, no conflicts.

## What's in this PR

Same code as the original Phase 5:

- **Finance Director subagent** — `.claude/agents/finance-director.md` (Sonnet, bootstrap reads latest snapshot + recs + QB/Plaid state).
- **Detector pipeline** — `src/lib/finance/types.ts`, `dismiss-suppression.ts`, `recommendation-store.ts`, `detectors/signals-a.ts` (9 detectors).
- **Weekly briefing** — `src/lib/finance/briefing-payload.ts`, `briefing-markdown.ts`, `src/lib/email/templates/finance-briefing.ts`, `src/app/api/cron/finance-weekly-briefing/route.ts`.
- **Hard rules wired in** — ADR M0001 (no affiliate-margin recs until cost coverage ≥70%), group-order manifest-name rule, autonomy ceiling (auto-categorize only).

## Why this matters now

A separate PR (Phase 5A — Shopify all-time order archive) is in flight to feed the monthly trajectory briefing the operator asked for. That follow-up depends on the Phase 5 agent + briefing pipeline being live. Without this recovery PR, the iteration on the briefing can't start.

## Pre-merge checklist

- [x] `npx prisma generate` — clean
- [x] `npx tsc --noEmit` — clean for the new files (pre-existing `group-v2-payments.test.ts` typing error is unrelated)
- [x] Cherry-pick applied cleanly with no conflicts

## Test plan

- [ ] Confirm `.claude/agents/finance-director.md` lands in `main`
- [ ] Confirm `vercel.json` includes the existing finance-weekly-briefing schedule (already there since the original Phase 5 PR added it before the merge mishap — verify after merge)
- [ ] First Monday at 14:00 UTC after merge: weekly briefing email should fire automatically; check `info@partyondelivery.com` inbox for the cream-paper/gold-accent layout

## What broke last time

PR #123 was opened from `feat/finance-phase-5-agent`, which carried two commits ahead of main:
- `fce11ff5` — ops orders Phase 1 refactor (intended for a different PR)
- `02e97959` — Phase 5 finance work (this PR's content)

GitHub's squash-merge appears to have only captured the older `fce11ff5`, leaving the Finance work orphaned on the branch. Going forward, recommend keeping unrelated work on separate branches and avoiding the "both commits on one branch" pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)