### PR TITLE
feat(finance): Phase 5A — Shopify all-time order archive

### DIFF
--- a/docs/FINANCE-DIRECTOR-AGENT-BUILDOUT.md
+++ b/docs/FINANCE-DIRECTOR-AGENT-BUILDOUT.md
@@ -309,6 +309,20 @@ Originally scoped: add `invoice_total_cents` / `due_date` / `paid_at` / `paid_vi
 - Obsidian sync: `scripts/finance/sync-obsidian.mjs` + PreToolUse hook in `.claude/settings.json`
 - Vault shell: `Programs/Finance-Director.md` + `Memory/Finance/{Briefings,Recommendations,Decisions,MonthlyClose,Open-Questions.md,README.md}`
 
+### Phase 5A — Shopify all-time order archive (post-merge trajectory work)
+
+- Splits out from Phase 5 follow-up: the monthly close email needs multi-year
+  history that doesn't live in the Order table (which only goes back ~5 months).
+- New `ShopifyOrderArchive` table — thin financial snapshot of every Shopify
+  order ever processed (totals, refunds, line items, landing page, tags).
+- New `ShopifyArchiveSyncState` singleton tracks last full backfill + last
+  incremental cursor.
+- One-shot backfill script `scripts/finance/backfill-shopify-archive.ts` walks
+  the Admin GraphQL `orders` connection from inception.
+- Daily safety-net cron `/api/cron/finance-shopify-archive-sync` (07:00 UTC)
+  re-pulls anything Shopify updated in the last 36h.
+- Idempotent upsert keyed by Shopify order GID.
+
 ### Phase 6 — Auto-categorize graduation (post-trust)
 
 Only after the operator has reviewed Phase 5 briefings for 4+ weeks and feels confident, graduate the Director's auto-categorize behavior from "one-by-one with reversal button" to "batch auto-categorize with weekly audit summary." This is a config flag, not new code.

--- a/prisma/migrations/manual/2026-06-12-finance-phase-5a-shopify-archive.sql
+++ b/prisma/migrations/manual/2026-06-12-finance-phase-5a-shopify-archive.sql
@@ -1,0 +1,80 @@
+-- Finance Director — Phase 5A: Shopify order archive
+--
+-- Stores a thin financial snapshot of every Shopify order ever processed so
+-- the monthly trajectory rollups (Phase 5C) can cover the full history of the
+-- business, not just the ~5 months currently in the Order table.
+--
+-- This is NOT a replacement for the Order table. Order rows are still the
+-- system of record for fulfillment / picking / refunds / accounting. This
+-- archive holds the minimum financial + attribution fields needed for
+-- multi-year trajectory math.
+--
+-- Run against prod manually:
+--     psql "$DATABASE_URL" -f prisma/migrations/manual/2026-06-12-finance-phase-5a-shopify-archive.sql
+--     npx prisma generate
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS shopify_order_archive (
+  id                       TEXT PRIMARY KEY,
+  shopify_order_id         TEXT NOT NULL,
+  shopify_order_name       TEXT,
+  processed_at             TIMESTAMP(3) NOT NULL,
+  shopify_created_at       TIMESTAMP(3) NOT NULL,
+  total_price_cents        INTEGER NOT NULL,
+  subtotal_price_cents     INTEGER NOT NULL,
+  total_tax_cents          INTEGER NOT NULL DEFAULT 0,
+  total_shipping_cents     INTEGER NOT NULL DEFAULT 0,
+  total_discounts_cents    INTEGER NOT NULL DEFAULT 0,
+  total_refunds_cents      INTEGER NOT NULL DEFAULT 0,
+  currency                 TEXT NOT NULL DEFAULT 'USD',
+  financial_status         TEXT,
+  fulfillment_status       TEXT,
+  customer_email           TEXT,
+  shopify_customer_id      TEXT,
+  landing_page             TEXT,
+  referring_site           TEXT,
+  source_identifier        TEXT,
+  source_name              TEXT,
+  /// Denormalised line items: [{ sku, title, productId, variantId, quantity, priceCents }].
+  /// Kept inline so the monthly rollup builder can compute top-SKUs without
+  /// fanning out a per-order join.
+  line_items               JSONB NOT NULL DEFAULT '[]'::jsonb,
+  /// Shopify-side tag list (e.g. "boat-delivery", "wedding").
+  tags                     TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  note                     TEXT,
+  /// Optional full payload snapshot for debugging. NULL once we trust the sync.
+  raw_payload              JSONB,
+  synced_at                TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  created_at               TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at               TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS shopify_order_archive_shopify_order_id_key
+  ON shopify_order_archive (shopify_order_id);
+CREATE INDEX IF NOT EXISTS shopify_order_archive_processed_at_idx
+  ON shopify_order_archive (processed_at);
+CREATE INDEX IF NOT EXISTS shopify_order_archive_financial_status_idx
+  ON shopify_order_archive (financial_status);
+CREATE INDEX IF NOT EXISTS shopify_order_archive_customer_email_idx
+  ON shopify_order_archive (customer_email);
+CREATE INDEX IF NOT EXISTS shopify_order_archive_shopify_customer_id_idx
+  ON shopify_order_archive (shopify_customer_id);
+
+-- Operational notes used by the backfill script + safety-net cron to
+-- remember the last-seen Shopify updated_at cursor, so the daily cron can
+-- pull only what changed since the last successful run.
+CREATE TABLE IF NOT EXISTS shopify_archive_sync_state (
+  id                       TEXT PRIMARY KEY DEFAULT 'singleton',
+  last_full_backfill_at    TIMESTAMP(3),
+  last_incremental_at      TIMESTAMP(3),
+  last_cursor_updated_at   TIMESTAMP(3),
+  last_error               TEXT,
+  total_orders_archived    INTEGER NOT NULL DEFAULT 0,
+  updated_at               TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO shopify_archive_sync_state (id) VALUES ('singleton')
+  ON CONFLICT (id) DO NOTHING;
+
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2779,6 +2779,62 @@ model QbExpense {
   @@map("qb_expenses")
 }
 
+/// Thin financial snapshot of every Shopify order ever processed (Phase 5A).
+/// Powers multi-year monthly rollups for the Finance Director trajectory
+/// briefing. NOT a replacement for Order — Order is still the system of
+/// record for fulfillment / picking / refunds. This holds only the fields
+/// needed for trajectory math + segment classification.
+model ShopifyOrderArchive {
+  id                    String   @id @default(cuid())
+  shopifyOrderId        String   @unique @map("shopify_order_id")
+  shopifyOrderName      String?  @map("shopify_order_name")
+  processedAt           DateTime @map("processed_at")
+  shopifyCreatedAt      DateTime @map("shopify_created_at")
+  totalPriceCents       Int      @map("total_price_cents")
+  subtotalPriceCents    Int      @map("subtotal_price_cents")
+  totalTaxCents         Int      @default(0) @map("total_tax_cents")
+  totalShippingCents    Int      @default(0) @map("total_shipping_cents")
+  totalDiscountsCents   Int      @default(0) @map("total_discounts_cents")
+  totalRefundsCents     Int      @default(0) @map("total_refunds_cents")
+  currency              String   @default("USD")
+  financialStatus       String?  @map("financial_status")
+  fulfillmentStatus     String?  @map("fulfillment_status")
+  customerEmail         String?  @map("customer_email")
+  shopifyCustomerId     String?  @map("shopify_customer_id")
+  landingPage           String?  @map("landing_page") @db.Text
+  referringSite         String?  @map("referring_site") @db.Text
+  sourceIdentifier      String?  @map("source_identifier")
+  sourceName            String?  @map("source_name")
+  /// Denormalised line items: [{ sku, title, productId, variantId, quantity, priceCents }].
+  lineItems             Json     @default("[]") @map("line_items")
+  tags                  String[] @default([])
+  note                  String?  @db.Text
+  rawPayload            Json?    @map("raw_payload")
+  syncedAt              DateTime @default(now()) @map("synced_at")
+  createdAt             DateTime @default(now()) @map("created_at")
+  updatedAt             DateTime @updatedAt @map("updated_at")
+
+  @@index([processedAt])
+  @@index([financialStatus])
+  @@index([customerEmail])
+  @@index([shopifyCustomerId])
+  @@map("shopify_order_archive")
+}
+
+/// Single-row tracker for the Shopify archive backfill + safety-net cron
+/// (Phase 5A). Lets the daily cron pull only what changed since last run.
+model ShopifyArchiveSyncState {
+  id                     String    @id @default("singleton")
+  lastFullBackfillAt     DateTime? @map("last_full_backfill_at")
+  lastIncrementalAt      DateTime? @map("last_incremental_at")
+  lastCursorUpdatedAt    DateTime? @map("last_cursor_updated_at")
+  lastError              String?   @map("last_error") @db.Text
+  totalOrdersArchived    Int       @default(0) @map("total_orders_archived")
+  updatedAt              DateTime  @updatedAt @map("updated_at")
+
+  @@map("shopify_archive_sync_state")
+}
+
 /// Per-day sales journal entries posted from PartyOn → QuickBooks (Phase 2B).
 /// Drafted by the daily cron, REQUIRE operator approval before posting
 /// (autonomy decision #4 — only qb-categorize bypasses operator click).

--- a/scripts/finance/backfill-shopify-archive.ts
+++ b/scripts/finance/backfill-shopify-archive.ts
@@ -1,0 +1,45 @@
+/**
+ * One-shot Shopify order archive backfill (Finance Director Phase 5A).
+ *
+ * Walks the Shopify Admin GraphQL `orders` connection from inception to today
+ * and upserts every order into the shopify_order_archive table. Idempotent —
+ * safe to re-run.
+ *
+ * Usage:
+ *   set -a && source .env.local && set +a
+ *   npx tsx scripts/finance/backfill-shopify-archive.ts [--max-pages=N]
+ *
+ * Per saved memory `reference_worktree_env_and_github_token.md`, scripts/ is
+ * outside the `@/` path alias — but `tsx` honours the root tsconfig paths
+ * when traversing into src/, so re-using the service module here works.
+ */
+
+import { syncAllOrders } from '../../src/lib/finance/shopify-archive-service';
+import { prisma } from '../../src/lib/database/client';
+
+const argv = process.argv.slice(2);
+const maxPagesArg = argv.find((a) => a.startsWith('--max-pages='));
+const maxPages = maxPagesArg ? Number.parseInt(maxPagesArg.split('=')[1] ?? '', 10) : undefined;
+
+async function main(): Promise<void> {
+  console.log(
+    `[backfill-shopify-archive] starting full backfill${
+      maxPages ? ` (max ${maxPages} pages)` : ''
+    }...`
+  );
+  const started = Date.now();
+  const report = await syncAllOrders({ maxPages });
+  const seconds = ((Date.now() - started) / 1000).toFixed(1);
+  console.log('[backfill-shopify-archive] done in', seconds, 'seconds');
+  console.log(JSON.stringify(report, null, 2));
+  if (report.errors.length > 0) {
+    process.exitCode = 1;
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error('[backfill-shopify-archive] FAILED:', err);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/app/api/cron/finance-shopify-archive-sync/route.ts
+++ b/src/app/api/cron/finance-shopify-archive-sync/route.ts
@@ -1,0 +1,87 @@
+/**
+ * GET /api/cron/finance-shopify-archive-sync
+ *
+ * Phase 5A — daily safety net that re-pulls anything Shopify updated since
+ * yesterday (orders, refunds, fulfillment status changes) into
+ * shopify_order_archive. Runs at 07:00 UTC, ahead of the daily snapshot at
+ * 07:45 UTC so the rollup builder (Phase 5C) reads from a fresh archive.
+ *
+ * Bearer auth: requires `Authorization: Bearer ${CRON_SECRET}` header.
+ *
+ * Notes
+ *   - The one-shot full backfill lives in scripts/finance/backfill-shopify-archive.ts.
+ *     This cron is incremental only.
+ *   - The 36-hour lookback window is intentional overlap so we don't lose
+ *     orders updated near the previous run's tail.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  syncOrdersSince,
+  getSyncState,
+} from '@/lib/finance/shopify-archive-service';
+
+export const maxDuration = 300; // 5 min — incremental sync is fast but allow room
+
+const LOOKBACK_HOURS = 36;
+
+interface SyncReport {
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  ordersUpserted: number;
+  pagesFetched: number;
+  lastProcessedAt: string | null;
+  cursorWindowStartIso: string;
+  errors: string[];
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = request.headers.get('authorization');
+  if (auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const startedAt = new Date();
+  const state = await getSyncState();
+  const cursor =
+    state?.lastIncrementalAt ??
+    state?.lastFullBackfillAt ??
+    new Date(startedAt.getTime() - LOOKBACK_HOURS * 60 * 60 * 1000);
+  // Always overlap by LOOKBACK_HOURS so refunds + status changes near the
+  // boundary still get picked up.
+  const windowStart = new Date(
+    Math.min(
+      cursor.getTime() - LOOKBACK_HOURS * 60 * 60 * 1000,
+      startedAt.getTime() - LOOKBACK_HOURS * 60 * 60 * 1000
+    )
+  );
+
+  const report: SyncReport = {
+    startedAt: startedAt.toISOString(),
+    finishedAt: '',
+    durationMs: 0,
+    ordersUpserted: 0,
+    pagesFetched: 0,
+    lastProcessedAt: null,
+    cursorWindowStartIso: windowStart.toISOString(),
+    errors: [],
+  };
+
+  try {
+    const result = await syncOrdersSince(windowStart);
+    report.ordersUpserted = result.ordersUpserted;
+    report.pagesFetched = result.pagesFetched;
+    report.lastProcessedAt = result.lastProcessedAt;
+    report.errors.push(...result.errors);
+  } catch (err) {
+    report.errors.push(err instanceof Error ? err.message : String(err));
+  }
+
+  const finishedAt = new Date();
+  report.finishedAt = finishedAt.toISOString();
+  report.durationMs = finishedAt.getTime() - startedAt.getTime();
+
+  console.log('[finance-shopify-archive-sync] report:', JSON.stringify(report));
+  return NextResponse.json({ success: report.errors.length === 0, data: report });
+}

--- a/src/lib/finance/shopify-archive-service.ts
+++ b/src/lib/finance/shopify-archive-service.ts
@@ -1,0 +1,312 @@
+/**
+ * Shopify order archive service (Finance Director Phase 5A).
+ *
+ * Pulls a thin financial snapshot of every Shopify order — paginated via the
+ * Admin GraphQL API — into the shopify_order_archive table so the monthly
+ * rollup builder (Phase 5C) has access to the full history of the business.
+ *
+ * Two entry points:
+ *   - syncAllOrders()          — full backfill from inception, no upper bound
+ *   - syncOrdersSince(date)    — incremental, used by the daily safety-net cron
+ *
+ * Both share the same upsert path so they stay idempotent. Rate-limited via
+ * the existing paginatedAdminQuery 500 ms inter-page sleep.
+ */
+
+import { prisma } from '@/lib/database/client';
+import { adminGraphQL } from '@/lib/shopify/sync/admin-client';
+
+const PAGE_SIZE = 50;
+const INTER_PAGE_SLEEP_MS = 500;
+
+interface ShopifyMoney {
+  shopMoney: { amount: string; currencyCode: string };
+}
+
+interface ShopifyAdminOrderNode {
+  id: string;
+  name: string | null;
+  createdAt: string;
+  processedAt: string | null;
+  displayFinancialStatus: string | null;
+  displayFulfillmentStatus: string | null;
+  currentTotalPriceSet: ShopifyMoney;
+  currentSubtotalPriceSet: ShopifyMoney;
+  currentTotalTaxSet: ShopifyMoney;
+  totalShippingPriceSet: ShopifyMoney;
+  currentTotalDiscountsSet: ShopifyMoney;
+  totalRefundedSet: ShopifyMoney;
+  customer: { id: string | null; email: string | null } | null;
+  sourceIdentifier: string | null;
+  sourceName: string | null;
+  tags: string[];
+  note: string | null;
+  lineItems: {
+    edges: {
+      node: {
+        sku: string | null;
+        title: string | null;
+        quantity: number;
+        product: { id: string | null } | null;
+        variant: { id: string | null } | null;
+        originalUnitPriceSet: ShopifyMoney;
+      };
+    }[];
+  };
+}
+
+interface OrdersPageResponse {
+  orders: {
+    edges: { node: ShopifyAdminOrderNode }[];
+    pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  };
+}
+
+const ORDERS_QUERY = `
+  query archiveOrders($first: Int!, $after: String, $query: String) {
+    orders(first: $first, after: $after, query: $query, sortKey: PROCESSED_AT) {
+      edges {
+        node {
+          id
+          name
+          createdAt
+          processedAt
+          displayFinancialStatus
+          displayFulfillmentStatus
+          currentTotalPriceSet { shopMoney { amount currencyCode } }
+          currentSubtotalPriceSet { shopMoney { amount currencyCode } }
+          currentTotalTaxSet { shopMoney { amount currencyCode } }
+          totalShippingPriceSet { shopMoney { amount currencyCode } }
+          currentTotalDiscountsSet { shopMoney { amount currencyCode } }
+          totalRefundedSet { shopMoney { amount currencyCode } }
+          customer { id email }
+          sourceIdentifier
+          sourceName
+          tags
+          note
+          lineItems(first: 100) {
+            edges {
+              node {
+                sku
+                title
+                quantity
+                product { id }
+                variant { id }
+                originalUnitPriceSet { shopMoney { amount currencyCode } }
+              }
+            }
+          }
+        }
+      }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+`;
+
+function dollarsToCents(amount: string | null | undefined): number {
+  if (!amount) return 0;
+  const f = Number.parseFloat(amount);
+  if (!Number.isFinite(f)) return 0;
+  return Math.round(f * 100);
+}
+
+interface ArchiveLineItem {
+  sku: string | null;
+  title: string | null;
+  productId: string | null;
+  variantId: string | null;
+  quantity: number;
+  unitPriceCents: number;
+}
+
+function flattenLineItems(node: ShopifyAdminOrderNode): ArchiveLineItem[] {
+  return node.lineItems.edges.map((e) => ({
+    sku: e.node.sku,
+    title: e.node.title,
+    productId: e.node.product?.id ?? null,
+    variantId: e.node.variant?.id ?? null,
+    quantity: e.node.quantity,
+    unitPriceCents: dollarsToCents(e.node.originalUnitPriceSet?.shopMoney.amount),
+  }));
+}
+
+async function upsertOrder(node: ShopifyAdminOrderNode): Promise<void> {
+  const processedAtIso = node.processedAt ?? node.createdAt;
+  const currency = node.currentTotalPriceSet.shopMoney.currencyCode || 'USD';
+  const data = {
+    shopifyOrderId: node.id,
+    shopifyOrderName: node.name,
+    processedAt: new Date(processedAtIso),
+    shopifyCreatedAt: new Date(node.createdAt),
+    totalPriceCents: dollarsToCents(node.currentTotalPriceSet.shopMoney.amount),
+    subtotalPriceCents: dollarsToCents(node.currentSubtotalPriceSet.shopMoney.amount),
+    totalTaxCents: dollarsToCents(node.currentTotalTaxSet?.shopMoney.amount),
+    totalShippingCents: dollarsToCents(node.totalShippingPriceSet?.shopMoney.amount),
+    totalDiscountsCents: dollarsToCents(node.currentTotalDiscountsSet?.shopMoney.amount),
+    totalRefundsCents: dollarsToCents(node.totalRefundedSet?.shopMoney.amount),
+    currency,
+    financialStatus: node.displayFinancialStatus,
+    fulfillmentStatus: node.displayFulfillmentStatus,
+    customerEmail: node.customer?.email ?? null,
+    shopifyCustomerId: node.customer?.id ?? null,
+    // landingPage + referringSite live on the older REST Order resource only;
+    // Phase 5C falls back to tags / source_name / group order name to classify
+    // segments when these are null.
+    landingPage: null,
+    referringSite: null,
+    sourceIdentifier: node.sourceIdentifier,
+    sourceName: node.sourceName,
+    lineItems: flattenLineItems(node) as unknown as object,
+    tags: node.tags,
+    note: node.note,
+    syncedAt: new Date(),
+  };
+
+  await prisma.shopifyOrderArchive.upsert({
+    where: { shopifyOrderId: node.id },
+    create: data,
+    update: data,
+  });
+}
+
+export interface ArchiveSyncReport {
+  pagesFetched: number;
+  ordersUpserted: number;
+  lastProcessedAt: string | null;
+  durationMs: number;
+  errors: string[];
+}
+
+interface RunPaginatedOptions {
+  /** Optional Shopify search query (e.g. "updated_at:>=2026-06-01"). */
+  query?: string;
+  /** Hard cap on pages — defensive guard for runaway loops. */
+  maxPages?: number;
+}
+
+async function runPaginatedSync(
+  options: RunPaginatedOptions
+): Promise<ArchiveSyncReport> {
+  const startedAt = Date.now();
+  const report: ArchiveSyncReport = {
+    pagesFetched: 0,
+    ordersUpserted: 0,
+    lastProcessedAt: null,
+    durationMs: 0,
+    errors: [],
+  };
+
+  const maxPages = options.maxPages ?? 10_000;
+  let cursor: string | null = null;
+  let hasNextPage = true;
+
+  while (hasNextPage && report.pagesFetched < maxPages) {
+    let data: OrdersPageResponse;
+    try {
+      data = await adminGraphQL<OrdersPageResponse>(ORDERS_QUERY, {
+        first: PAGE_SIZE,
+        after: cursor,
+        query: options.query ?? null,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      report.errors.push(`page ${report.pagesFetched + 1}: ${msg}`);
+      break;
+    }
+
+    report.pagesFetched += 1;
+    const nodes = data.orders.edges.map((e) => e.node);
+    for (const node of nodes) {
+      try {
+        await upsertOrder(node);
+        report.ordersUpserted += 1;
+        const processedAt = node.processedAt ?? node.createdAt;
+        if (processedAt && (!report.lastProcessedAt || processedAt > report.lastProcessedAt)) {
+          report.lastProcessedAt = processedAt;
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        report.errors.push(`order ${node.id}: ${msg}`);
+      }
+    }
+
+    hasNextPage = data.orders.pageInfo.hasNextPage;
+    cursor = data.orders.pageInfo.endCursor;
+
+    if (hasNextPage) {
+      await new Promise((resolve) => setTimeout(resolve, INTER_PAGE_SLEEP_MS));
+    }
+  }
+
+  report.durationMs = Date.now() - startedAt;
+  return report;
+}
+
+/**
+ * Pull every Shopify order from inception. Idempotent — re-running just
+ * refreshes financial totals + refund totals on existing rows.
+ *
+ * `maxPages` is a defensive cap for partial backfills + smoke tests; omit it
+ * for a real full backfill.
+ */
+export async function syncAllOrders(
+  options: { maxPages?: number } = {}
+): Promise<ArchiveSyncReport> {
+  const report = await runPaginatedSync({ maxPages: options.maxPages });
+  await updateSyncState({
+    fullBackfill: true,
+    cursorUpdatedAt: report.lastProcessedAt,
+    ordersUpserted: report.ordersUpserted,
+    error: report.errors[0] ?? null,
+  });
+  return report;
+}
+
+/**
+ * Pull orders updated since a given timestamp. Used by the daily safety-net
+ * cron to backfill anything created or refunded after the last sync.
+ */
+export async function syncOrdersSince(since: Date): Promise<ArchiveSyncReport> {
+  const iso = since.toISOString();
+  const report = await runPaginatedSync({
+    query: `updated_at:>=${iso}`,
+  });
+  await updateSyncState({
+    fullBackfill: false,
+    cursorUpdatedAt: report.lastProcessedAt,
+    ordersUpserted: report.ordersUpserted,
+    error: report.errors[0] ?? null,
+  });
+  return report;
+}
+
+interface UpdateStateInput {
+  fullBackfill: boolean;
+  cursorUpdatedAt: string | null;
+  ordersUpserted: number;
+  error: string | null;
+}
+
+async function updateSyncState(input: UpdateStateInput): Promise<void> {
+  const now = new Date();
+  const existing = await prisma.shopifyArchiveSyncState.findUnique({
+    where: { id: 'singleton' },
+  });
+  const totalOrdersArchived = (existing?.totalOrdersArchived ?? 0) + input.ordersUpserted;
+  const data = {
+    lastFullBackfillAt: input.fullBackfill ? now : existing?.lastFullBackfillAt ?? null,
+    lastIncrementalAt: input.fullBackfill ? existing?.lastIncrementalAt ?? null : now,
+    lastCursorUpdatedAt: input.cursorUpdatedAt ? new Date(input.cursorUpdatedAt) : existing?.lastCursorUpdatedAt ?? null,
+    lastError: input.error,
+    totalOrdersArchived,
+  };
+  await prisma.shopifyArchiveSyncState.upsert({
+    where: { id: 'singleton' },
+    create: { id: 'singleton', ...data },
+    update: data,
+  });
+}
+
+export async function getSyncState() {
+  return prisma.shopifyArchiveSyncState.findUnique({ where: { id: 'singleton' } });
+}

--- a/vercel.json
+++ b/vercel.json
@@ -61,6 +61,10 @@
       "schedule": "15 7 * * *"
     },
     {
+      "path": "/api/cron/finance-shopify-archive-sync",
+      "schedule": "0 7 * * *"
+    },
+    {
       "path": "/api/cron/finance-snapshot",
       "schedule": "45 7 * * *"
     },


### PR DESCRIPTION
## Summary

Lays the groundwork for the multi-year monthly trajectory briefing the operator asked for. The `Order` table only has about 5 months of history (oldest row: 2026-01-16), but the monthly rollup builder in the next phase needs much further back. This PR adds a thin per-order Shopify archive + a one-shot backfill + a daily safety-net cron.

This is **PR A of 5** in the Phase 5 follow-up sequence:

- **PR A (this one)** — Shopify all-time order archive
- PR B — QuickBooks all-time financial backfill
- PR C — `FinanceMonthlyRollup` model + builder + segment classifier
- PR D — Monthly close email with LLM narrative
- PR E — Weekly briefing addition: affiliate payouts due

## Schema diff

Two new tables (raw SQL migration in `prisma/migrations/manual/2026-06-12-finance-phase-5a-shopify-archive.sql`):

- `shopify_order_archive` — financial snapshot of every Shopify order
  - Totals, refunds, taxes, shipping, discounts (all in cents)
  - Denormalised `line_items` JSONB so the monthly rollup builder can compute top-SKUs without a per-order join
  - `tags`, `source_identifier`, `source_name` for segment classification
  - Unique on `shopify_order_id` → safe to re-run backfill
- `shopify_archive_sync_state` — singleton tracker for last full backfill + last incremental cursor + total archived count + last error

## Code

- `src/lib/finance/shopify-archive-service.ts` — Admin GraphQL pull with cursor pagination, 500 ms inter-page sleep, idempotent upsert keyed by Shopify order GID. Two entry points: `syncAllOrders()` for backfill, `syncOrdersSince()` for the daily cron.
- `scripts/finance/backfill-shopify-archive.ts` — operator runs once after the migration. Supports `--max-pages=N` for testing.
- `src/app/api/cron/finance-shopify-archive-sync/route.ts` — daily safety net at 07:00 UTC, 36 h overlap window (so refunds + status changes near the boundary still get picked up). Behind `Bearer ${CRON_SECRET}`.
- `vercel.json` — registers the new cron at `0 7 * * *`, just before the existing 07:45 finance-snapshot.

## What this does NOT replace

The `Order` table is still the system of record for fulfillment, picking, refund flows, and accounting. The archive is **read-only trajectory data** for the Finance Director — Shopify-side numbers only.

## Operator action items after merge

1. Run the migration against prod:
   ```bash
   psql "$DATABASE_URL" -f prisma/migrations/manual/2026-06-12-finance-phase-5a-shopify-archive.sql
   ```
2. `npx prisma generate`
3. Run the one-shot backfill (can take a while depending on how much Shopify history we have):
   ```bash
   set -a && source .env.local && set +a
   npx tsx scripts/finance/backfill-shopify-archive.ts
   ```
4. Verify the daily cron `/api/cron/finance-shopify-archive-sync` is registered in Vercel project settings after the next deploy.

## Pre-merge checklist

- [x] `npx prisma generate` — clean
- [x] `npx tsc --noEmit` — clean for new files (pre-existing `group-v2-payments.test.ts` typing error is unrelated)
- [x] `npx next lint` on new files — clean
- [x] `npm run test:run` — no new failures (existing group-v2-payments failures are pre-existing per saved memory)
- [x] **Did not run `next build`** (forbidden in CLAUDE.md)

## Test plan

- [ ] Migration runs against prod and is idempotent (re-run is a no-op).
- [ ] Backfill upserts orders correctly — spot-check 5–10 orders against the Shopify Admin UI for total, refunds, line items, tags.
- [ ] Daily cron returns `{success:true}` when invoked with the `CRON_SECRET` bearer.
- [ ] After 24 h, `shopify_archive_sync_state.last_incremental_at` advances daily and `last_error` stays null.
- [ ] Existing finance crons (`finance-stripe-sync`, `finance-snapshot`, etc.) keep working.

## Dependency notes

- Depends on Phase 5 (#125 — the recovery PR currently in flight) landing first if you want the agent to reference this data, but Phase 5A itself does not import anything from Phase 5. Order of merge is flexible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)