### PR TITLE
fix(security): require ops auth on unprotected /api/admin routes

### DIFF
--- a/src/app/api/admin/affiliates/lookup/route.ts
+++ b/src/app/api/admin/affiliates/lookup/route.ts
@@ -5,8 +5,12 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getAffiliateByCode } from '@/lib/affiliates/affiliate-service';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
 
 export async function GET(request: NextRequest) {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
   try {
     const code = request.nextUrl.searchParams.get('code');
     if (!code) {

--- a/src/app/api/admin/affiliates/stop-impersonating/route.ts
+++ b/src/app/api/admin/affiliates/stop-impersonating/route.ts
@@ -5,9 +5,17 @@
 
 import { NextResponse } from 'next/server';
 import { clearAffiliateSessionCookie } from '@/lib/affiliates/affiliate-session';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
 import { cookies } from 'next/headers';
 
 export async function POST(): Promise<NextResponse> {
+  // Only a logged-in operator can stop impersonating. The ops_session cookie
+  // is set when the admin starts impersonating and persists through it (the
+  // impersonate route only ADDS affiliate_session + admin_impersonating), so
+  // this check passes for the un-impersonate round trip.
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
   await clearAffiliateSessionCookie();
 
   const cookieStore = await cookies();

--- a/src/app/api/admin/analytics/route.ts
+++ b/src/app/api/admin/analytics/route.ts
@@ -10,6 +10,7 @@ import { getSEOMetrics, getTopKeywords } from '@/lib/analytics/search-console';
 import { getBehaviorMetrics } from '@/lib/analytics/ga4-behavior';
 import { generateRecommendations } from '@/lib/analytics/recommendations';
 import { isGoogleConfigured } from '@/lib/analytics/google-auth';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
 import { prisma } from '@/lib/prisma';
 import {
   ExtendedDashboardData,
@@ -26,6 +27,9 @@ export const dynamic = 'force-dynamic';
  * Fetches dashboard data for the specified period
  */
 export async function GET(request: NextRequest) {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
   const searchParams = request.nextUrl.searchParams;
   const period = searchParams.get('period') || '30d';
 

--- a/src/app/api/admin/experiments/[id]/route.ts
+++ b/src/app/api/admin/experiments/[id]/route.ts
@@ -7,6 +7,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
 import { z } from 'zod';
 
 // Validation schema for updating an experiment
@@ -32,6 +33,9 @@ export async function GET(
   request: NextRequest,
   { params }: RouteParams
 ): Promise<NextResponse> {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
   try {
     const { id } = await params;
 
@@ -122,6 +126,9 @@ export async function PATCH(
   request: NextRequest,
   { params }: RouteParams
 ): Promise<NextResponse> {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
   try {
     const { id } = await params;
     const body = await request.json();
@@ -182,6 +189,9 @@ export async function DELETE(
   request: NextRequest,
   { params }: RouteParams
 ): Promise<NextResponse> {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
   try {
     const { id } = await params;
 

--- a/src/app/api/admin/experiments/funnel/route.ts
+++ b/src/app/api/admin/experiments/funnel/route.ts
@@ -26,6 +26,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { prisma } from '@/lib/database/client';
 import { Prisma } from '@prisma/client';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
 import {
   EXPERIMENTS,
   type ExperimentDef,
@@ -47,6 +48,9 @@ type VariantStats = {
 };
 
 export async function GET(req: NextRequest) {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
   const url = new URL(req.url);
   const page = url.searchParams.get('page');
   const expFilter = url.searchParams.get('experiment');

--- a/src/app/api/admin/experiments/route.ts
+++ b/src/app/api/admin/experiments/route.ts
@@ -6,6 +6,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
 import { z } from 'zod';
 
 // Validation schema for creating an experiment
@@ -29,6 +30,9 @@ const CreateExperimentSchema = z.object({
  * List all experiments with their variants
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
   try {
     const { searchParams } = new URL(request.url);
     const status = searchParams.get('status');
@@ -119,6 +123,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
  * Create a new experiment with variants
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
   try {
     const body = await request.json();
     const validatedData = CreateExperimentSchema.parse(body);

--- a/src/app/api/admin/orders/route.ts
+++ b/src/app/api/admin/orders/route.ts
@@ -4,6 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
 
 export const dynamic = 'force-dynamic';
 
@@ -66,6 +67,9 @@ export interface OrderForDisplay {
  * Fetches recent orders from Shopify
  */
 export async function GET(request: NextRequest) {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
   if (!SHOPIFY_DOMAIN || !SHOPIFY_ADMIN_TOKEN) {
     return NextResponse.json(
       { success: false, error: 'Shopify not configured' },

--- a/src/app/api/admin/seo/latest-snapshot/route.ts
+++ b/src/app/api/admin/seo/latest-snapshot/route.ts
@@ -14,11 +14,15 @@
  */
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/database/client';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
 export async function GET() {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
   try {
     // Latest run: derived from MAX(capturedAt) and its runRef.
     const newest = await prisma.seoSnapshot.findFirst({

--- a/src/app/api/admin/seo/trigger-scrape/route.ts
+++ b/src/app/api/admin/seo/trigger-scrape/route.ts
@@ -4,8 +4,9 @@
  * Fires the SEMrush scrape GitHub Actions workflow on demand. Powered
  * by GitHub's `workflow_dispatch` API.
  *
- * Auth: this is mounted under /api/admin which is gated by the existing
- * ops-auth middleware. No extra auth check needed.
+ * Auth: requireOpsAuth() per handler. NOTE: /api/admin/** is NOT covered by
+ * the middleware ops-auth gate (only /api/v1/admin/** is), so the check must
+ * live in the handler itself.
  *
  * Env needed (set on Vercel + locally):
  *   GH_DISPATCH_TOKEN  — fine-grained PAT with Actions:Write on the repo
@@ -17,6 +18,7 @@
  *   { ok: false, error: 'gh_<status>', detail: '...' }  → GitHub rejected
  */
 import { NextResponse, type NextRequest } from 'next/server';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -25,6 +27,9 @@ const WORKFLOW_FILE = 'seo-scrape.yml';
 const DEFAULT_REPO = 'allan-cmyk/PartyOn2';
 
 export async function POST(req: NextRequest) {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
   const token = process.env.GH_DISPATCH_TOKEN;
   if (!token) {
     return NextResponse.json(


### PR DESCRIPTION
## What

`/api/admin/**` is **not** covered by the middleware ops-auth gate in `src/middleware.ts` — only `/api/v1/admin/**` is. That left 9 admin API routes publicly reachable. This adds a per-handler `requireOpsAuth()` guard (the same pattern used in `/api/ops/orders/[id]/picks`) to each missing handler:

| Route | Handlers |
|---|---|
| `analytics` | GET |
| `experiments` | GET, POST |
| `experiments/[id]` | GET, PATCH, DELETE |
| `experiments/funnel` | GET |
| `orders` | GET |
| `seo/trigger-scrape` | POST |
| `seo/latest-snapshot` | GET |
| `affiliates/lookup` | GET |
| `affiliates/stop-impersonating` | POST |

It also corrects a misleading comment in `seo/trigger-scrape` that claimed the middleware already gated `/api/admin`.

## Why it's safe

- **All callers carry an ops session.** Every caller is an `/admin/*` or `/ops/*` page. `stop-impersonating` is called from the affiliate dashboard, but impersonation only *adds* the affiliate + `admin_impersonating` cookies — it keeps the `ops_session` cookie — so the guard passes through the un-impersonate round trip.
- **No automation breaks.** No Vercel cron or GitHub workflow calls these endpoints (crons all hit `/api/cron/*`).
- **A/B exposure tracking is unaffected.** Public impression/click recording lives in `/api/experiments/track` (not under `/api/admin`) and stays public — the admin experiments routes only read/manage experiment definitions and funnel aggregates.

## Deliberately not changed

- `inventory/receiving/reocr` already authenticates via `Bearer CRON_SECRET` (same pattern as `admin/sync`); adding cookie auth would break its documented curl/cron workflow.
- `admin/verify` is the login endpoint and stays open.

## Verification

- `npx tsc --noEmit` — clean (the one error is a pre-existing, unrelated Stripe type issue in `group-v2-payments.test.ts`).
- Live curl against the dev server: **401** on all 9 routes without an ops cookie; **200 / 404** (i.e. past the auth gate) with an `admin` ops session obtained via `POST /api/admin/verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
