### PR TITLE
fix(billing): build OrderItems from an immutable charge snapshot (close two-snapshot race)

### DIFF
--- a/docs/charge-mismatch-remediation.md
+++ b/docs/charge-mismatch-remediation.md
@@ -1,0 +1,116 @@
+# Charge-mismatch remediation runbook
+
+A two-snapshot race let some orders ship with items Stripe never charged (undercharge) or bill for
+items that weren't delivered (overcharge). The code path is now fixed (see
+`src/lib/stripe/charge-snapshot.ts` and the migration `prisma/migrations/manual/2026-06-15-charge-snapshot.sql`),
+so **no new mismatches accrue**. This runbook is for cleaning up the **historical** ones.
+
+Everything here is **operator-gated**. The audit script only reports; nothing is charged or refunded
+automatically. You decide per order.
+
+## 1. Get the list
+
+```bash
+set -a && source .env.local && set +a
+node scripts/ops/audit-order-charge-mismatches.mjs --csv > charge-mismatches.csv
+# or just a human summary:
+node scripts/ops/audit-order-charge-mismatches.mjs
+```
+
+The report classifies every order with a Stripe session:
+
+- **UNDERCHARGED** — we delivered product we never billed for (Party On's loss). Re-bill or write off.
+- **OVERCHARGED (owed)** — we billed for product we didn't deliver, net of refunds already issued.
+  These are customers we owe money. Refund them.
+- **AMENDED-REVIEW** — the order has a paid amendment (charged on a separate payment), so the automatic
+  diff can't be trusted. Verify by hand.
+
+Each row carries: amount, age (days), whether a **reusable card** is on file, group/solo, the specific
+items, and the Stripe session / payment-intent ids.
+
+## 2. Do the refunds first (overcharged customers)
+
+These are low-risk and pure goodwill — **do them promptly.** As of the investigation, 4 customers are owed
+**$276.51** total (#227 $174.54, #305 $34.99, #291 $34.99, #269 $31.99). Refund via the ops order page or the
+Stripe dashboard against the original payment, then send the short note below. Verify the refund settles in
+Stripe before marking the order reconciled.
+
+> **Subject: We refunded you — a billing error in your favor**
+>
+> Hi {{firstName}},
+>
+> While auditing our records we found that your order on {{date}} was billed for an item we didn't end up
+> delivering: {{item}}. We've refunded **${{amount}}** to your original payment method — you should see it in
+> a few business days. Sorry for the mix-up, and thank you for partying with us.
+>
+> — The Party On Delivery team
+
+## 3. Re-bill the undercharges (escalation ladder)
+
+**Never** silently charge a months-old card as the first move — lead with a fresh, customer-authorized
+payment link. The original checkouts did **not** save cards for off-session reuse (`setup_future_usage` was
+never set), so a last-resort charge is only possible for the minority of customers with a reusable card on
+file — the audit's `reusableCard` column tells you which.
+
+| Day | Action |
+|-----|--------|
+| **0** | Send a fresh re-bill invoice via the amendment-invoice flow → `/invoice/[token]`. Own the error, itemize exactly what they received but weren't billed for, keep the ask low-pressure (template below). |
+| **+7** | Follow-up #1 — gentle reminder, same link. |
+| **+14** | Follow-up #2 / **final notice** — restate the items, and note that if we don't hear back we may charge the card from the original order. |
+| **+21** | Still unpaid → **decide per order**: if a reusable card is on file, attempt an off-session charge (full or partial) with `scripts/ops/rebill-charge-on-file.mjs`; otherwise write it off. Weigh amount, age, and goodwill. |
+
+**Write-off guidance.** Small/old amounts usually aren't worth chasing — the goodwill hit of dunning a
+months-old charge can exceed the dollars. Use `--writeoff-below=<$>` on the audit to size the tail, and lean
+toward writing off low-dollar, high-age rows.
+
+### Re-bill email template (Day 0)
+
+> **Subject: A small billing correction on your Party On order**
+>
+> Hi {{firstName}},
+>
+> We owe you an apology and a quick heads-up. Due to a system error, your order delivered on {{date}} included
+> items that we never actually charged you for:
+>
+> {{itemized list — name, qty, price}}
+>
+> **Total not yet billed: ${{amount}}**
+>
+> You received and enjoyed these, so we're sending a secure link to settle the difference whenever it's
+> convenient: **{{invoiceLink}}**. No rush, and no late fees — we just want our records to match what you got.
+> If anything looks off, reply to this email and we'll sort it out personally.
+>
+> Thanks for your understanding,
+> The Party On Delivery team
+
+### Follow-up #2 / final notice (Day +14)
+
+> Hi {{firstName}}, just following up on the ${{amount}} balance from your {{date}} order ({{items}}). Here's the
+> secure link again: {{invoiceLink}}. If we don't hear back, we may charge the card used on the original order to
+> close it out. We'd much rather you use the link — reply anytime with questions.
+
+## 4. Last-resort charge (operator-run, guard-railed)
+
+Only after the link + two follow-ups, and only where `reusableCard=true`:
+
+```bash
+set -a && source .env.local && set +a
+# Dry run (default) — shows owed amount, age, card on file, and the exact charge:
+node scripts/ops/rebill-charge-on-file.mjs --order=227
+# Execute the full owed amount:
+node scripts/ops/rebill-charge-on-file.mjs --order=227 --confirm
+# Or a partial / goodwill amount:
+node scripts/ops/rebill-charge-on-file.mjs --order=227 --amount=50 --confirm
+```
+
+The tool operates on **one order at a time**, refuses to run if no reusable card exists, defaults to a dry run,
+and logs every attempt. On a decline or expired card it reports and recommends writing off or continuing to
+nudge. After any charge, confirm it settled in Stripe before marking the order reconciled.
+
+## Sequence checklist
+
+1. Run the audit → CSV.
+2. Refund the overcharged customers; send the goodwill note.
+3. For undercharges above your write-off threshold: send Day-0 invoice, then +7 and +14 follow-ups.
+4. At +21, per order: off-session charge (if reusable card) or write off.
+5. Verify every refund/charge in Stripe; mark reconciled.

--- a/prisma/migrations/manual/2026-06-15-charge-snapshot.sql
+++ b/prisma/migrations/manual/2026-06-15-charge-snapshot.sql
@@ -1,0 +1,25 @@
+-- Charge snapshot — fix the two-snapshot billing race (OrderItems vs Stripe charge)
+--
+-- Persists the exact PRODUCT line items priced into each Stripe charge at session-creation,
+-- so the fulfillment Order's items are built from an immutable snapshot instead of a re-read
+-- of the cart/drafts at webhook time. This closes the race where items added/removed between
+-- the two reads ship free (undercharge) or stay billed but undelivered (overcharge).
+-- See src/lib/stripe/charge-snapshot.ts.
+--
+-- Per saved memory `prisma_schema_drift.md`, schema.prisma has drift from prod, so
+-- `prisma db push` is unsafe. Run this file against prod manually:
+--
+--     psql "$DATABASE_URL" -f prisma/migrations/manual/2026-06-15-charge-snapshot.sql
+--     npx prisma generate
+--
+-- All statements are idempotent (`ADD COLUMN IF NOT EXISTS`) so the file is safe to re-run.
+
+BEGIN;
+
+-- Group V2: snapshot of the product lines charged on a participant's Stripe session.
+ALTER TABLE participant_payments ADD COLUMN IF NOT EXISTS charged_line_items JSONB;
+
+-- Solo checkout: snapshot of the product lines charged on the cart's Stripe session.
+ALTER TABLE carts                ADD COLUMN IF NOT EXISTS charged_line_items JSONB;
+
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -773,6 +773,11 @@ model Cart {
   deliveryFee Decimal @default(25) @map("delivery_fee") @db.Decimal(10, 2)
   total       Decimal @default(0) @db.Decimal(10, 2)
 
+  // Immutable snapshot of the PRODUCT line items priced into the Stripe charge at
+  // session-creation. OrderItems are rebuilt from this at order-creation so they can never
+  // diverge from what Stripe charged. Shape: ChargedLineItem[] (see lib/stripe/charge-snapshot.ts).
+  chargedLineItems Json? @map("charged_line_items")
+
   // Group order association
   groupOrderId String? @map("group_order_id")
 
@@ -1966,6 +1971,9 @@ model ParticipantPayment {
   discountAmount          Decimal              @default(0) @map("discount_amount") @db.Decimal(10, 2)
   tipAmount               Decimal              @default(0) @map("tip_amount") @db.Decimal(10, 2)
   total                   Decimal              @default(0) @db.Decimal(10, 2)
+  // Immutable snapshot of the PRODUCT line items priced into the Stripe charge at
+  // session-creation. Order items are built from this (see lib/stripe/charge-snapshot.ts).
+  chargedLineItems        Json?                @map("charged_line_items")
   status                  GroupV2PaymentStatus @default(PENDING)
   paidAt                  DateTime?            @map("paid_at")
   orderId                 String?              @map("order_id")

--- a/scripts/ops/audit-order-charge-mismatches.mjs
+++ b/scripts/ops/audit-order-charge-mismatches.mjs
@@ -1,0 +1,301 @@
+/**
+ * READ-ONLY audit: find orders whose OrderItems diverge from what Stripe actually charged.
+ *
+ * The fulfillment Order's items used to be rebuilt from a re-read of the cart/drafts at webhook
+ * time, independently of the frozen Stripe charge. Items added after checkout shipped FREE
+ * (undercharge); items removed stayed BILLED but weren't delivered (overcharge). This script
+ * diffs each order's OrderItems against the Stripe session's charged PRODUCT line items,
+ * bidirectionally, net of refunds.
+ *
+ * It NEVER writes to the database or to Stripe — it only reports. Remediation (re-bill invoices,
+ * refunds, last-resort charges) is operator-gated; see docs/charge-mismatch-remediation.md.
+ *
+ * Detection rules:
+ *   - Match OrderItem <-> charged line by productId+variantId, then productId, then title.
+ *   - UNDERCHARGE = OrderItem with price > 0 that has NO matching charged line (delivered, unbilled).
+ *   - OVERCHARGE  = charged product line with amount > 0 that has NO matching OrderItem
+ *                   (billed, undelivered), NET of latest_charge.amount_refunded.
+ *   - Price-0 OrderItems (free auto-adds / fully promo-covered) and $0 charged lines are
+ *     INTENTIONAL and excluded. A line merely discounted by a coupon is still present at its
+ *     productId, so it is not flagged.
+ *   - Orders with a PAID OrderAmendment are bucketed as AMENDED-REVIEW (amendment items are
+ *     charged on a separate PI, so the original-session diff can't be trusted automatically).
+ *
+ * Usage:
+ *   set -a && source .env.local && set +a
+ *   node scripts/ops/audit-order-charge-mismatches.mjs                 # human summary
+ *   node scripts/ops/audit-order-charge-mismatches.mjs --csv > out.csv # CSV for triage
+ *   node scripts/ops/audit-order-charge-mismatches.mjs --json          # machine-readable
+ *   node scripts/ops/audit-order-charge-mismatches.mjs --since=2026-02-01 --writeoff-below=10
+ */
+
+import { PrismaClient } from '@prisma/client';
+import Stripe from 'stripe';
+
+const prisma = new PrismaClient();
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
+
+const args = process.argv.slice(2);
+const OUT_CSV = args.includes('--csv');
+const OUT_JSON = args.includes('--json');
+const SINCE = flag('--since');
+const WRITEOFF_BELOW = num(flag('--writeoff-below'), 0);
+const LIMIT = num(flag('--limit'), 0);
+
+function flag(name) {
+  const a = args.find((x) => x.startsWith(`${name}=`));
+  return a ? a.split('=').slice(1).join('=') : undefined;
+}
+function num(v, d) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : d;
+}
+function usd(cents) {
+  return (cents / 100).toFixed(2);
+}
+function log(...a) {
+  // Keep stdout clean for --csv/--json; progress + summary go to stderr.
+  if (OUT_CSV || OUT_JSON) console.error(...a);
+  else console.log(...a);
+}
+
+/** The PRODUCT lines Stripe actually charged on a session (tax/tip/delivery excluded). */
+async function chargedProductLines(sessionId) {
+  const res = await stripe.checkout.sessions.listLineItems(sessionId, {
+    limit: 100,
+    expand: ['data.price.product'],
+  });
+  const out = [];
+  for (const li of res.data) {
+    const product = li.price && typeof li.price.product === 'object' ? li.price.product : null;
+    const md = (product && product.metadata) || {};
+    // Product lines carry productId metadata; tax/tip/delivery lines do not -> excluded.
+    if (!md.productId) continue;
+    out.push({
+      productId: md.productId,
+      variantId: md.variantId || null,
+      title: li.description || (product && product.name) || '(unknown)',
+      amountTotalCents: li.amount_total ?? 0, // post-discount — what the customer actually paid
+      quantity: li.quantity ?? 1,
+    });
+  }
+  return out;
+}
+
+/** Total refunded on the order's payment (so already-corrected overcharges drop out). */
+async function refundedCents(paymentIntentId) {
+  if (!paymentIntentId) return 0;
+  try {
+    const pi = await stripe.paymentIntents.retrieve(paymentIntentId, { expand: ['latest_charge'] });
+    const charge = pi.latest_charge;
+    if (charge && typeof charge === 'object') return charge.amount_refunded || 0;
+  } catch {
+    /* ignore — reported as 0 refunded */
+  }
+  return 0;
+}
+
+/** Whether a reusable saved card exists (last-resort charge is only possible if so). */
+async function hasReusableCard(stripeCustomerId) {
+  if (!stripeCustomerId) return false;
+  try {
+    const pms = await stripe.paymentMethods.list({ customer: stripeCustomerId, type: 'card', limit: 1 });
+    return pms.data.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function csvCell(v) {
+  const s = String(v ?? '');
+  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+async function main() {
+  const where = { stripeCheckoutSessionId: { not: null } };
+  if (SINCE) where.createdAt = { gte: new Date(SINCE) };
+
+  const orders = await prisma.order.findMany({
+    where,
+    include: {
+      items: true,
+      amendments: { select: { resolution: true } },
+      customer: { select: { stripeCustomerId: true } },
+    },
+    orderBy: { orderNumber: 'asc' },
+    ...(LIMIT ? { take: LIMIT } : {}),
+  });
+
+  log(`=== Order <-> Stripe charge mismatch audit (READ-ONLY) ===`);
+  log(`Scanning ${orders.length} orders with a Stripe session${SINCE ? ` since ${SINCE}` : ''}...`);
+
+  const rows = [];
+  const skipped = [];
+  let scanned = 0;
+
+  for (const order of orders) {
+    scanned++;
+    if (scanned % 25 === 0) log(`  ...${scanned}/${orders.length}`);
+
+    let charged;
+    try {
+      charged = await chargedProductLines(order.stripeCheckoutSessionId);
+    } catch (e) {
+      // Legacy orders reference an old Stripe account -> resource_missing. Skip.
+      skipped.push({ orderNumber: order.orderNumber, reason: e.message });
+      continue;
+    }
+
+    // Aggregate charged lines and delivered items by productId, then diff by QUANTITY (not mere
+    // presence) so a quantity bumped up after checkout is caught too. Equal quantity = no flag
+    // regardless of price, which naturally ignores discounts/promos. Keyed by productId (not
+    // productId+variantId) because "manual-*" catalog items carry variantId === productId in the
+    // Stripe metadata while the OrderItem carries the real variantId — keying on the pair would
+    // split one real line into a phantom over+under pair.
+    const chargedByKey = new Map();
+    for (const c of charged) {
+      const cur = chargedByKey.get(c.productId) || { title: c.title, qty: 0, paidCents: 0 };
+      cur.qty += c.quantity;
+      cur.paidCents += c.amountTotalCents; // post-discount, what the customer actually paid
+      chargedByKey.set(c.productId, cur);
+    }
+    const orderByKey = new Map();
+    for (const it of order.items) {
+      const cur = orderByKey.get(it.productId) || { title: it.title, qty: 0, retailCents: 0 };
+      cur.qty += it.quantity;
+      cur.retailCents += Math.round(Number(it.totalPrice) * 100); // full retail delivered
+      orderByKey.set(it.productId, cur);
+    }
+
+    const under = []; // delivered, unbilled — extra units on the order
+    const over = []; // billed, undelivered — extra units on the charge
+    for (const k of new Set([...chargedByKey.keys(), ...orderByKey.keys()])) {
+      const c = chargedByKey.get(k);
+      const o = orderByKey.get(k);
+      const cQty = c?.qty || 0;
+      const oQty = o?.qty || 0;
+      if (oQty > cQty) {
+        // Value the extra delivered units at their retail unit price (0 => free item, skip).
+        const unitRetail = o.qty ? o.retailCents / o.qty : 0;
+        const cents = Math.round((oQty - cQty) * unitRetail);
+        if (cents > 0) under.push({ title: o.title, qty: oQty - cQty, cents });
+      } else if (cQty > oQty) {
+        // Value the billed-but-undelivered units at what was actually paid per unit.
+        const unitPaid = c.qty ? c.paidCents / c.qty : 0;
+        const cents = Math.round((cQty - oQty) * unitPaid);
+        if (cents > 0) over.push({ title: c.title, qty: cQty - oQty, cents });
+      }
+    }
+
+    if (under.length === 0 && over.length === 0) continue;
+
+    const underCents = under.reduce((s, x) => s + x.cents, 0);
+    const overCents = over.reduce((s, x) => s + x.cents, 0);
+    const refunded = over.length > 0 ? await refundedCents(order.stripePaymentIntentId) : 0;
+    const netOverCents = Math.max(0, overCents - refunded);
+    const reusableCard = under.length > 0 ? await hasReusableCard(order.customer?.stripeCustomerId) : false;
+    // Applied amendments (added items on a separate PI, or a refund) make the UNDERCHARGE side of
+    // the single-session diff unreliable. Recorded as a flag; overcharges-owed stay reliable because
+    // refund-netting already zeroes out anything the customer was made whole on.
+    const hasAmend = order.amendments.some((a) => a.resolution === 'PAID' || a.resolution === 'REFUNDED');
+    const ageDays = Math.floor((Date.now() - new Date(order.createdAt).getTime()) / 86_400_000);
+
+    rows.push({
+      orderNumber: order.orderNumber,
+      type: order.groupOrderV2Id ? 'group' : 'solo',
+      customer: order.customerName,
+      email: order.customerEmail,
+      direction: under.length && over.length ? 'BOTH' : under.length ? 'UNDERCHARGE' : 'OVERCHARGE',
+      underUsd: Number((underCents / 100).toFixed(2)),
+      overOwedUsd: Number((netOverCents / 100).toFixed(2)),
+      refundedUsd: Number((refunded / 100).toFixed(2)),
+      ageDays,
+      reusableCard,
+      classification: hasAmend ? 'AMENDED-REVIEW' : 'CLEAN',
+      sessionId: order.stripeCheckoutSessionId,
+      paymentIntentId: order.stripePaymentIntentId || '',
+      detail: [
+        ...under.map((u) => `-$${usd(u.cents)} ${u.title} x${u.qty} (delivered, unbilled)`),
+        ...over.map((o) => `+$${usd(o.cents)} ${o.title} x${o.qty} (billed, undelivered)`),
+      ].join(' | '),
+    });
+  }
+
+  // Sort for triage: biggest customer-owed first, then biggest losses.
+  rows.sort((a, b) => b.overOwedUsd - a.overOwedUsd || b.underUsd - a.underUsd);
+
+  // Overcharges OWED are reliable even on amended orders: refund-netting zeroes out anything the
+  // customer was already made whole on, so whatever still nets > 0 is genuinely owed (e.g. #227).
+  const overRows = rows.filter((r) => r.overOwedUsd > 0);
+  // Undercharges on amended orders are NOT reliable — amendment-added items are charged on a
+  // separate PI, so they look unbilled against the original session. Split them for manual review.
+  const underRows = rows.filter((r) => r.underUsd > 0 && r.classification === 'CLEAN');
+  const underAmended = rows.filter((r) => r.underUsd > 0 && r.classification === 'AMENDED-REVIEW');
+  const totalUnder = underRows.reduce((s, r) => s + r.underUsd, 0);
+  const totalUnderAmended = underAmended.reduce((s, r) => s + r.underUsd, 0);
+  const totalOverOwed = overRows.reduce((s, r) => s + r.overOwedUsd, 0);
+  const writeoffCount = WRITEOFF_BELOW > 0 ? underRows.filter((r) => r.underUsd < WRITEOFF_BELOW).length : 0;
+
+  if (OUT_JSON) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          summary: {
+            scanned,
+            skipped: skipped.length,
+            overchargedOwed: { orders: overRows.length, totalUsd: Number(totalOverOwed.toFixed(2)) },
+            underchargedClean: { orders: underRows.length, totalUsd: Number(totalUnder.toFixed(2)) },
+            underchargedAmendedReview: { orders: underAmended.length, totalUsd: Number(totalUnderAmended.toFixed(2)) },
+          },
+          rows,
+          skipped,
+        },
+        null,
+        2
+      ) + '\n'
+    );
+  } else if (OUT_CSV) {
+    const cols = [
+      'orderNumber', 'type', 'customer', 'email', 'direction', 'underUsd', 'overOwedUsd',
+      'refundedUsd', 'ageDays', 'reusableCard', 'classification', 'sessionId', 'paymentIntentId', 'detail',
+    ];
+    const lines = [cols.join(',')];
+    for (const r of rows) lines.push(cols.map((c) => csvCell(r[c])).join(','));
+    process.stdout.write(lines.join('\n') + '\n');
+  }
+
+  // Summary (stderr under --csv/--json, stdout otherwise).
+  log('');
+  log('--- SUMMARY ---');
+  log(`Scanned: ${scanned}   Skipped (legacy/no session): ${skipped.length}`);
+  log(`OVERCHARGED still owed to customer (net of refunds):       ${overRows.length} orders, $${totalOverOwed.toFixed(2)}`);
+  log(`UNDERCHARGED (delivered, never billed), no amendment:      ${underRows.length} orders, $${totalUnder.toFixed(2)}`);
+  log(`UNDERCHARGED but order amended (verify — separate PI):     ${underAmended.length} orders, $${totalUnderAmended.toFixed(2)}`);
+  if (WRITEOFF_BELOW > 0) {
+    log(`  (of no-amendment undercharges, ${writeoffCount} are below the $${WRITEOFF_BELOW} write-off threshold)`);
+  }
+  if (overRows.length) {
+    log('');
+    log('Customers owed a refund (do these first — pure goodwill):');
+    for (const r of overRows) {
+      log(`  #${r.orderNumber}  ${r.customer}  $${r.overOwedUsd.toFixed(2)}  (refunded so far $${r.refundedUsd.toFixed(2)})`);
+    }
+  }
+  if (underRows.length && !OUT_CSV && !OUT_JSON) {
+    log('');
+    log('Top undercharges (re-bill candidates — see docs/charge-mismatch-remediation.md):');
+    for (const r of underRows.slice(0, 15)) {
+      log(`  #${r.orderNumber}  ${r.customer}  $${r.underUsd.toFixed(2)}  age ${r.ageDays}d  reusableCard=${r.reusableCard}  [${r.type}]`);
+      log(`      ${r.detail}`);
+    }
+    if (underRows.length > 15) log(`  ...and ${underRows.length - 15} more (use --csv for the full list).`);
+  }
+
+  await prisma.$disconnect();
+}
+
+main().catch(async (err) => {
+  console.error(err);
+  await prisma.$disconnect();
+  process.exit(1);
+});

--- a/scripts/ops/rebill-charge-on-file.mjs
+++ b/scripts/ops/rebill-charge-on-file.mjs
@@ -1,0 +1,188 @@
+/**
+ * Last-resort, operator-run re-bill: charge the card on file for an under-charged order.
+ *
+ * This is the FINAL step of the dunning ladder in docs/charge-mismatch-remediation.md — only after
+ * a fresh re-bill invoice (/invoice/[token]) and two follow-up emails have gone unanswered, and only
+ * where a reusable card is on file. The original checkouts did NOT save cards for off-session reuse
+ * (`setup_future_usage` was never set), so most orders will have NO reusable card — this tool reports
+ * that and exits.
+ *
+ * Guard-railed:
+ *   - One order at a time (refuses bulk).
+ *   - Dry run by DEFAULT; pass --confirm to actually charge.
+ *   - Computes the owed amount the same way the audit does; --amount=<usd> for a partial/goodwill charge.
+ *   - Refuses if no reusable card exists. Reports declines/expired cards gracefully.
+ *
+ * Usage:
+ *   set -a && source .env.local && set +a
+ *   node scripts/ops/rebill-charge-on-file.mjs --order=227                 # dry run
+ *   node scripts/ops/rebill-charge-on-file.mjs --order=227 --confirm       # charge full owed amount
+ *   node scripts/ops/rebill-charge-on-file.mjs --order=227 --amount=50 --confirm   # partial
+ */
+
+import { PrismaClient } from '@prisma/client';
+import Stripe from 'stripe';
+
+const prisma = new PrismaClient();
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
+
+const args = process.argv.slice(2);
+const CONFIRM = args.includes('--confirm');
+const ORDER = flag('--order');
+const AMOUNT = flag('--amount');
+
+function flag(name) {
+  const a = args.find((x) => x.startsWith(`${name}=`));
+  return a ? a.split('=').slice(1).join('=') : undefined;
+}
+function norm(s) {
+  return (s || '').trim().toLowerCase();
+}
+function keyOf(p, v) {
+  return `${p}::${v || ''}`;
+}
+
+/** PRODUCT lines Stripe charged on a session (mirrors audit-order-charge-mismatches.mjs). */
+async function chargedProductLines(sessionId) {
+  const res = await stripe.checkout.sessions.listLineItems(sessionId, {
+    limit: 100,
+    expand: ['data.price.product'],
+  });
+  const out = [];
+  for (const li of res.data) {
+    const product = li.price && typeof li.price.product === 'object' ? li.price.product : null;
+    const md = (product && product.metadata) || {};
+    if (!md.productId) continue;
+    out.push({ productId: md.productId, variantId: md.variantId || null, title: li.description || '' });
+  }
+  return out;
+}
+
+async function main() {
+  if (!ORDER) {
+    console.error('Usage: --order=<orderNumber> [--amount=<usd>] [--confirm]');
+    process.exit(1);
+  }
+  const orderNumber = Number(ORDER);
+  if (!Number.isInteger(orderNumber)) {
+    console.error(`Invalid --order: ${ORDER}`);
+    process.exit(1);
+  }
+
+  const order = await prisma.order.findFirst({
+    where: { orderNumber },
+    include: {
+      items: true,
+      amendments: { select: { resolution: true } },
+      customer: { select: { stripeCustomerId: true, email: true } },
+    },
+  });
+  if (!order) {
+    console.error(`Order #${orderNumber} not found.`);
+    process.exit(1);
+  }
+  if (!order.stripeCheckoutSessionId) {
+    console.error(`Order #${orderNumber} has no Stripe session — cannot audit/charge.`);
+    process.exit(1);
+  }
+
+  // Recompute the undercharge for this single order.
+  const charged = await chargedProductLines(order.stripeCheckoutSessionId);
+  const chargedKeys = new Set(charged.map((c) => keyOf(c.productId, c.variantId)));
+  const chargedProducts = new Set(charged.map((c) => c.productId));
+  const chargedTitles = new Set(charged.map((c) => norm(c.title)));
+
+  const under = [];
+  for (const it of order.items) {
+    if (Number(it.price) <= 0) continue;
+    const matched =
+      chargedKeys.has(keyOf(it.productId, it.variantId)) ||
+      chargedProducts.has(it.productId) ||
+      chargedTitles.has(norm(it.title));
+    if (!matched) under.push({ title: it.title, qty: it.quantity, usd: Number(it.totalPrice) });
+  }
+  const owedUsd = under.reduce((s, x) => s + x.usd, 0);
+  const hasAmend = order.amendments.some((a) => a.resolution === 'PAID');
+  const ageDays = Math.floor((Date.now() - new Date(order.createdAt).getTime()) / 86_400_000);
+
+  const stripeCustomerId = order.customer?.stripeCustomerId || null;
+  let card = null;
+  if (stripeCustomerId) {
+    try {
+      const pms = await stripe.paymentMethods.list({ customer: stripeCustomerId, type: 'card', limit: 3 });
+      card = pms.data[0] || null;
+    } catch (e) {
+      console.error('Could not list payment methods:', e.message);
+    }
+  }
+
+  const chargeUsd = AMOUNT !== undefined ? Number(AMOUNT) : owedUsd;
+  const chargeCents = Math.round(chargeUsd * 100);
+
+  console.log(`=== Re-bill order #${orderNumber} (${order.customerName}) ===`);
+  console.log(`Email:           ${order.customer?.email || order.customerEmail}`);
+  console.log(`Age:             ${ageDays} days`);
+  console.log(`Undercharged:    $${owedUsd.toFixed(2)}`);
+  for (const u of under) console.log(`   - $${u.usd.toFixed(2)}  ${u.title} x${u.qty}`);
+  console.log(`Reusable card:   ${card ? `yes (${card.card?.brand} ****${card.card?.last4}, exp ${card.card?.exp_month}/${card.card?.exp_year})` : 'NONE'}`);
+  console.log(`Will charge:     $${chargeUsd.toFixed(2)}${AMOUNT !== undefined ? ' (partial / override)' : ''}`);
+  if (hasAmend) {
+    console.log('WARNING: this order has a PAID amendment — the owed amount may include amendment items');
+    console.log('         charged on a separate payment. Verify by hand before charging.');
+  }
+
+  if (under.length === 0 && AMOUNT === undefined) {
+    console.log('\nNo undercharge detected — nothing to charge. (Pass --amount to override.)');
+    await prisma.$disconnect();
+    return;
+  }
+  if (!stripeCustomerId || !card) {
+    console.log('\nNo reusable card on file — an off-session charge is not possible.');
+    console.log('Send the re-bill invoice link (/invoice/[token]) or write this off.');
+    await prisma.$disconnect();
+    return;
+  }
+  if (chargeCents <= 0) {
+    console.log('\nCharge amount is $0 — nothing to do.');
+    await prisma.$disconnect();
+    return;
+  }
+
+  if (!CONFIRM) {
+    console.log('\nDRY RUN — re-run with --confirm to charge the card on file.');
+    await prisma.$disconnect();
+    return;
+  }
+
+  console.log('\nCharging...');
+  try {
+    const pi = await stripe.paymentIntents.create({
+      amount: chargeCents,
+      currency: 'usd',
+      customer: stripeCustomerId,
+      payment_method: card.id,
+      off_session: true,
+      confirm: true,
+      description: `Re-bill for under-charged order #${orderNumber}`,
+      metadata: { orderNumber: String(orderNumber), reason: 'charge-mismatch-rebill' },
+    });
+    console.log(`Result: ${pi.status}  (PaymentIntent ${pi.id})`);
+    if (pi.status === 'succeeded') {
+      console.log('Charged successfully. Confirm in Stripe, then mark the order reconciled.');
+    } else {
+      console.log('Not settled — check the PaymentIntent in Stripe.');
+    }
+  } catch (e) {
+    // Off-session declines surface here (expired card, authentication_required, insufficient_funds, ...).
+    console.error(`Charge failed: ${e.code || e.type || ''} ${e.message}`);
+    console.error('Recommend: send the re-bill invoice link instead, or write this off.');
+  }
+
+  await prisma.$disconnect();
+}
+
+main().catch(async (err) => {
+  console.error(err);
+  await prisma.$disconnect();
+  process.exit(1);
+});

--- a/src/__tests__/charge-snapshot.test.ts
+++ b/src/__tests__/charge-snapshot.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Charge snapshot tests — the invariant "OrderItems must equal the Stripe-charged product lines".
+ * Covers the pure mapper (snapshot == charge), the COGS-bearing OrderItem builder, and the guard
+ * that hard-fails when items drift from the charge (the two-snapshot race).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { Prisma } from '@prisma/client';
+import {
+  buildChargedLineItems,
+  chargedLineItemToStripe,
+  chargedProductsTotalCents,
+  snapshotToOrderItemCreates,
+  assertOrderItemsMatchCharge,
+  parseChargedLineItems,
+  ChargeReconciliationError,
+  type ChargedLineItem,
+} from '@/lib/stripe/charge-snapshot';
+
+// A fake transaction client whose productVariant.findUnique returns a fixed COGS (or null).
+function fakeTx(costPerUnit: number | null): Parameters<typeof snapshotToOrderItemCreates>[0] {
+  return {
+    productVariant: {
+      findUnique: vi.fn().mockResolvedValue({
+        costPerUnit: costPerUnit === null ? null : new Prisma.Decimal(costPerUnit),
+      }),
+    },
+  } as unknown as Parameters<typeof snapshotToOrderItemCreates>[0];
+}
+
+// Mixed input: a Prisma.Decimal price with a sku, and a plain-number price with no variant title.
+const inputItems = [
+  { productId: 'p1', variantId: 'v1', title: 'Beer', variantTitle: '12pk', sku: 'B12', price: new Prisma.Decimal(22.99), quantity: 2 },
+  { productId: 'p2', variantId: 'v2', title: 'Wine', variantTitle: null, price: 14.5, quantity: 1 },
+];
+
+describe('buildChargedLineItems', () => {
+  it('maps prices to cents and normalizes optional fields', () => {
+    expect(buildChargedLineItems(inputItems)).toEqual([
+      { productId: 'p1', variantId: 'v1', title: 'Beer', variantTitle: '12pk', sku: 'B12', unitPriceCents: 2299, quantity: 2 },
+      { productId: 'p2', variantId: 'v2', title: 'Wine', variantTitle: null, sku: null, unitPriceCents: 1450, quantity: 1 },
+    ]);
+  });
+});
+
+describe('chargedLineItemToStripe — the snapshot IS what is charged', () => {
+  it('produces Stripe line items whose unit_amount equals the snapshot cents', () => {
+    const snap = buildChargedLineItems(inputItems);
+    const lines = snap.map(chargedLineItemToStripe);
+
+    expect(lines[0].price_data?.unit_amount).toBe(2299);
+    expect(lines[0].quantity).toBe(2);
+    expect(lines[0].price_data?.product_data?.metadata).toMatchObject({ productId: 'p1', variantId: 'v1', sku: 'B12' });
+
+    // The total priced into Stripe equals chargedProductsTotalCents of the persisted snapshot.
+    const stripeTotal = lines.reduce((s, li) => s + li.price_data!.unit_amount! * (li.quantity ?? 1), 0);
+    expect(stripeTotal).toBe(chargedProductsTotalCents(snap));
+  });
+
+  it('omits sku metadata when absent and drops a "Default Title" description', () => {
+    const [li] = buildChargedLineItems([
+      { productId: 'p3', variantId: 'v3', title: 'X', variantTitle: 'Default Title', price: 10, quantity: 1 },
+    ]).map(chargedLineItemToStripe);
+    expect(li.price_data?.product_data?.description).toBeUndefined();
+    expect(li.price_data?.product_data?.metadata).not.toHaveProperty('sku');
+  });
+});
+
+describe('chargedProductsTotalCents', () => {
+  it('sums unitPriceCents * quantity (products only)', () => {
+    expect(chargedProductsTotalCents(buildChargedLineItems(inputItems))).toBe(2299 * 2 + 1450);
+  });
+});
+
+describe('snapshotToOrderItemCreates', () => {
+  it('builds OrderItem payloads with COGS from snapshotItemCost', async () => {
+    const creates = await snapshotToOrderItemCreates(fakeTx(5), buildChargedLineItems(inputItems));
+    expect(creates).toHaveLength(2);
+    expect(Number(creates[0].price)).toBeCloseTo(22.99);
+    expect(Number(creates[0].totalPrice)).toBeCloseTo(45.98);
+    expect(Number(creates[0].unitCost)).toBeCloseTo(5);
+    expect(Number(creates[0].totalCost)).toBeCloseTo(10);
+    expect(creates[1].variantTitle).toBeNull();
+    expect(creates[1].sku).toBeNull();
+  });
+
+  it('leaves cost null when the variant has no costPerUnit', async () => {
+    const creates = await snapshotToOrderItemCreates(fakeTx(null), buildChargedLineItems(inputItems));
+    expect(creates[0].unitCost).toBeNull();
+    expect(creates[0].totalCost).toBeNull();
+  });
+});
+
+describe('assertOrderItemsMatchCharge — the guard', () => {
+  const snap: ChargedLineItem[] = [
+    { productId: 'p1', variantId: 'v1', title: 'Beer', variantTitle: '12pk', sku: 'B12', unitPriceCents: 2299, quantity: 2 },
+  ];
+  const matching = [{ productId: 'p1', variantId: 'v1', price: new Prisma.Decimal(22.99), quantity: 2, totalPrice: new Prisma.Decimal(45.98) }];
+
+  it('passes when OrderItems equal the charged snapshot', () => {
+    expect(() => assertOrderItemsMatchCharge(matching, snap)).not.toThrow();
+  });
+
+  it('throws when an item was added that was not charged (the undercharge bug)', () => {
+    const withAddedItem = [
+      ...matching,
+      { productId: 'p2', variantId: 'v2', price: new Prisma.Decimal(14.5), quantity: 1, totalPrice: new Prisma.Decimal(14.5) },
+    ];
+    expect(() => assertOrderItemsMatchCharge(withAddedItem, snap)).toThrow(ChargeReconciliationError);
+  });
+
+  it('throws when a charged item is missing from OrderItems (the overcharge bug)', () => {
+    expect(() => assertOrderItemsMatchCharge([], snap)).toThrow(/missing from OrderItems/);
+  });
+
+  it('throws on quantity drift', () => {
+    const qtyDrift = [{ productId: 'p1', variantId: 'v1', price: new Prisma.Decimal(22.99), quantity: 5, totalPrice: new Prisma.Decimal(114.95) }];
+    expect(() => assertOrderItemsMatchCharge(qtyDrift, snap)).toThrow(/qty mismatch/);
+  });
+
+  it('throws on unit-price drift beyond epsilon', () => {
+    const priceDrift = [{ productId: 'p1', variantId: 'v1', price: new Prisma.Decimal(30), quantity: 2, totalPrice: new Prisma.Decimal(60) }];
+    expect(() => assertOrderItemsMatchCharge(priceDrift, snap)).toThrow(ChargeReconciliationError);
+  });
+
+  it('tolerates a 1-cent rounding difference within epsilon', () => {
+    const penny = [{ productId: 'p1', variantId: 'v1', price: new Prisma.Decimal(22.99), quantity: 2, totalPrice: new Prisma.Decimal(45.99) }];
+    expect(() => assertOrderItemsMatchCharge(penny, snap, { epsilonCents: 1 })).not.toThrow();
+  });
+
+  it('warns instead of throwing when CHARGE_GUARD_MODE=warn', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.stubEnv('CHARGE_GUARD_MODE', 'warn');
+    expect(() => assertOrderItemsMatchCharge([], snap)).not.toThrow();
+    expect(warn).toHaveBeenCalled();
+    vi.unstubAllEnvs();
+    warn.mockRestore();
+  });
+});
+
+describe('parseChargedLineItems', () => {
+  it('returns null for empty / missing / malformed values', () => {
+    expect(parseChargedLineItems(null)).toBeNull();
+    expect(parseChargedLineItems([])).toBeNull();
+    expect(parseChargedLineItems([{ foo: 1 }] as unknown as Prisma.JsonValue)).toBeNull();
+  });
+
+  it('round-trips a built snapshot through JSON storage', () => {
+    const snap = buildChargedLineItems(inputItems);
+    const stored = JSON.parse(JSON.stringify(snap)) as Prisma.JsonValue;
+    expect(parseChargedLineItems(stored)).toEqual(snap);
+  });
+});

--- a/src/__tests__/group-v2-payments.test.ts
+++ b/src/__tests__/group-v2-payments.test.ts
@@ -18,6 +18,8 @@ const mockPrismaCustomerFindFirst = vi.fn();
 const mockPrismaCustomerCreate = vi.fn();
 const mockPrismaOrderCreate = vi.fn();
 const mockPrismaDeliveryTaskCreate = vi.fn();
+const mockPrismaProductVariantFindUnique = vi.fn();
+const mockPrismaGroupOrderV2FindUnique = vi.fn();
 
 vi.mock('@/lib/database/client', () => ({
   prisma: {
@@ -44,6 +46,12 @@ vi.mock('@/lib/database/client', () => ({
     },
     deliveryTask: {
       create: (...args: unknown[]) => mockPrismaDeliveryTaskCreate(...args),
+    },
+    productVariant: {
+      findUnique: (...args: unknown[]) => mockPrismaProductVariantFindUnique(...args),
+    },
+    groupOrderV2: {
+      findUnique: (...args: unknown[]) => mockPrismaGroupOrderV2FindUnique(...args),
     },
   },
 }));
@@ -118,6 +126,7 @@ const basePayment = {
   discountCode: null,
   discountAmount: 0,
   total: 24.89,
+  chargedLineItems: null,
   status: 'PENDING',
   paidAt: null,
   orderId: null,
@@ -163,6 +172,8 @@ describe('handleGroupV2PaymentCompleted', () => {
     mockPrismaPurchasedItemFindMany.mockResolvedValue([{ ...basePurchasedItem }]);
     mockPrismaOrderCreate.mockResolvedValue({ ...createdOrder });
     mockPrismaDeliveryTaskCreate.mockResolvedValue({});
+    mockPrismaProductVariantFindUnique.mockResolvedValue({ costPerUnit: null });
+    mockPrismaGroupOrderV2FindUnique.mockResolvedValue(null);
   });
 
   describe('customer resolution from Stripe session (no email on participant)', () => {
@@ -316,6 +327,8 @@ describe('handleGroupV2PaymentCompleted', () => {
           address: null,
           tax_exempt: 'none',
           tax_ids: [],
+          business_name: null,
+          individual_name: null,
         },
       });
 
@@ -387,6 +400,51 @@ describe('handleGroupV2PaymentCompleted', () => {
         where: { id: 'payment-id-1' },
         data: { orderId: 'order-id-1' },
       });
+    });
+  });
+
+  describe('charge snapshot — OrderItems come from the charge, not a re-read', () => {
+    const paidParticipant = {
+      id: 'participant-id-1',
+      groupOrderId: 'group-order-id-1',
+      customerId: 'existing-customer-id',
+      guestName: 'Test User',
+      guestEmail: 'test@example.com',
+      guestPhone: null,
+    };
+
+    it('builds the Order from the charged snapshot, excluding items added after checkout', async () => {
+      mockPrismaParticipantPaymentFindFirst.mockResolvedValue({
+        ...basePayment,
+        chargedLineItems: [
+          { productId: 'product-id-1', variantId: 'variant-id-1', title: 'Test Beer Pack', variantTitle: '12 Pack', sku: null, unitPriceCents: 2299, quantity: 1 },
+        ],
+      });
+      // Drafts were re-read and now contain a SECOND item added after the session was created.
+      mockPrismaPurchasedItemFindMany.mockResolvedValue([
+        { ...basePurchasedItem },
+        { id: 'purchased-item-2', productId: 'product-id-2', variantId: 'variant-id-2', title: 'Sneaky Add-on', variantTitle: null, price: 40, quantity: 3 },
+      ]);
+      mockPrismaGroupParticipantV2FindUnique.mockResolvedValue(paidParticipant);
+
+      await handleGroupV2PaymentCompleted(makeSession());
+
+      const orderArg = mockPrismaOrderCreate.mock.calls[0][0];
+      const createdItems = orderArg.data.items.create;
+      // Only the charged item makes it onto the Order; the post-checkout add is excluded.
+      expect(createdItems).toHaveLength(1);
+      expect(createdItems[0]).toMatchObject({ productId: 'product-id-1', quantity: 1 });
+      expect(Number(createdItems[0].totalPrice)).toBeCloseTo(22.99);
+    });
+
+    it('falls back to purchasedItems when the payment has no snapshot (pre-feature)', async () => {
+      mockPrismaGroupParticipantV2FindUnique.mockResolvedValue(paidParticipant);
+
+      await handleGroupV2PaymentCompleted(makeSession());
+
+      const orderArg = mockPrismaOrderCreate.mock.calls[0][0];
+      expect(orderArg.data.items.create).toHaveLength(1);
+      expect(orderArg.data.items.create[0]).toMatchObject({ productId: 'product-id-1' });
     });
   });
 });

--- a/src/__tests__/stripe-integration.test.ts
+++ b/src/__tests__/stripe-integration.test.ts
@@ -37,6 +37,7 @@ const mockPaymentIntentRetrieve = vi.fn().mockResolvedValue({
   status: 'succeeded',
   amount: 15000,
 });
+const mockCartUpdate = vi.fn().mockResolvedValue({});
 
 // Mock the Stripe module with a proper class constructor
 vi.mock('stripe', () => {
@@ -64,6 +65,13 @@ vi.mock('stripe', () => {
   }
   return { default: MockStripe };
 });
+
+// Mock prisma — createCheckoutSession now persists the immutable charge snapshot on the cart.
+vi.mock('@/lib/database/client', () => ({
+  prisma: {
+    cart: { update: (...args: unknown[]) => mockCartUpdate(...args) },
+  },
+}));
 
 // Set environment variables before importing modules
 vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_fake_key_for_testing');
@@ -153,6 +161,7 @@ describe('Checkout Session Creation', () => {
     discountCode: null,
     discountAmount: new Prisma.Decimal(0),
     appliedDiscounts: [],
+    chargedLineItems: null,
     groupOrderId: null,
     expiresAt: null,
     abandonedAt: null,
@@ -166,6 +175,7 @@ describe('Checkout Session Creation', () => {
     mockSessionCreate.mockClear();
     mockSessionRetrieve.mockClear();
     mockSessionExpire.mockClear();
+    mockCartUpdate.mockClear();
   });
 
   it('should create checkout session with cart items', async () => {
@@ -182,6 +192,45 @@ describe('Checkout Session Creation', () => {
     expect(session.id).toBe('cs_test_123');
     expect(session.url).toBeDefined();
     expect(mockSessionCreate).toHaveBeenCalled();
+  });
+
+  it('persists a charge snapshot on the cart that equals the Stripe product line items', async () => {
+    const { createCheckoutSession } = await import('@/lib/stripe/checkout');
+
+    await createCheckoutSession({
+      cart: mockCart,
+      successUrl: 'https://example.com/success',
+      cancelUrl: 'https://example.com/cancel',
+      customerEmail: 'test@example.com',
+    });
+
+    // The immutable snapshot is persisted on the cart (built from the same products priced to Stripe).
+    expect(mockCartUpdate).toHaveBeenCalledWith({
+      where: { id: 'cart-123' },
+      data: {
+        chargedLineItems: [
+          {
+            productId: 'prod-1',
+            variantId: 'var-1',
+            title: 'Test Wine',
+            variantTitle: '750ml',
+            sku: 'WINE-001',
+            unitPriceCents: 2499,
+            quantity: 2,
+          },
+        ],
+      },
+    });
+
+    // And Stripe was sent a product line whose unit_amount matches the snapshot cents.
+    const sessionArg = mockSessionCreate.mock.calls[0][0] as {
+      line_items: Array<{ price_data?: { unit_amount?: number; product_data?: { metadata?: { productId?: string } } }; quantity?: number }>;
+    };
+    const productLine = sessionArg.line_items.find(
+      (li) => li.price_data?.product_data?.metadata?.productId === 'prod-1'
+    );
+    expect(productLine?.price_data?.unit_amount).toBe(2499);
+    expect(productLine?.quantity).toBe(2);
   });
 
   it('should retrieve checkout session', async () => {

--- a/src/app/api/cron/reconcile-orders/route.ts
+++ b/src/app/api/cron/reconcile-orders/route.ts
@@ -27,6 +27,14 @@ import {
 import { recordDiscountUsage } from '@/lib/discounts/discount-engine';
 import { linkOrderToAffiliate } from '@/lib/affiliates/commission-engine';
 import { createOrderCalendarEvent } from '@/lib/calendar/google-calendar';
+import { Prisma } from '@prisma/client';
+import { snapshotItemCost } from '@/lib/analytics/margin-service';
+import {
+  parseChargedLineItems,
+  snapshotToOrderItemCreates,
+  assertOrderItemsMatchCharge,
+  type OrderItemSnapshotCreate,
+} from '@/lib/stripe/charge-snapshot';
 
 export const maxDuration = 60;
 
@@ -233,6 +241,33 @@ export async function GET(request: NextRequest) {
           continue;
         }
 
+        // Build items from the charge snapshot (what Stripe charged), not a re-read of
+        // purchasedItems — mirrors the webhook fix so cron recovery can't reintroduce drift.
+        const chargeSnapshot = parseChargedLineItems(payment.chargedLineItems);
+        let orderItemCreates: OrderItemSnapshotCreate[];
+        if (chargeSnapshot) {
+          orderItemCreates = await snapshotToOrderItemCreates(prisma, chargeSnapshot);
+          assertOrderItemsMatchCharge(orderItemCreates, chargeSnapshot);
+        } else {
+          console.warn(`[Reconcile] Payment ${payment.id} has no charge snapshot — falling back to purchasedItems`);
+          orderItemCreates = [];
+          for (const item of purchasedItems) {
+            const { unitCost, totalCost } = await snapshotItemCost(prisma, item.variantId, item.quantity);
+            orderItemCreates.push({
+              productId: item.productId,
+              variantId: item.variantId,
+              title: item.title,
+              variantTitle: item.variantTitle,
+              sku: null,
+              price: new Prisma.Decimal(item.price),
+              quantity: item.quantity,
+              totalPrice: new Prisma.Decimal(Number(item.price) * item.quantity),
+              unitCost,
+              totalCost,
+            });
+          }
+        }
+
         // Create Order record
         const order = await prisma.order.create({
           data: {
@@ -257,15 +292,7 @@ export async function GET(request: NextRequest) {
             groupOrderId: null,
             groupOrderV2Id: payment.subOrder.groupOrderId,
             items: {
-              create: purchasedItems.map((item) => ({
-                productId: item.productId,
-                variantId: item.variantId,
-                title: item.title,
-                variantTitle: item.variantTitle,
-                price: item.price,
-                quantity: item.quantity,
-                totalPrice: Number(item.price) * item.quantity,
-              })),
+              create: orderItemCreates,
             },
           },
           include: {

--- a/src/lib/inventory/services/order-service.ts
+++ b/src/lib/inventory/services/order-service.ts
@@ -11,6 +11,12 @@ import type { DraftOrderWithTotal, DraftOrderItem } from '@/lib/draft-orders/typ
 import { snapshotItemCost, finalizeOrderMargin } from '@/lib/analytics/margin-service';
 import { classifySegment } from '@/lib/analytics/segment-classifier';
 import { unitsOffShelf } from './pick-inventory-service';
+import {
+  parseChargedLineItems,
+  snapshotToOrderItemCreates,
+  assertOrderItemsMatchCharge,
+  type OrderItemSnapshotCreate,
+} from '@/lib/stripe/charge-snapshot';
 
 /**
  * Order with all relations
@@ -516,29 +522,43 @@ export async function createOrderFromCheckout(
       include: { items: true, groupOrderV2: { select: { shareCode: true } } },
     });
 
-    // Create order items
-    for (const item of cart.items) {
-      const { unitCost, totalCost } = await snapshotItemCost(tx, item.variantId, item.quantity);
-      await tx.orderItem.create({
-        data: {
-          orderId: newOrder.id,
+    // Build OrderItems from the immutable charge snapshot (what Stripe actually charged), NOT
+    // from a re-read of cart.items — this closes the two-snapshot race. Fall back to cart.items
+    // only for carts created before the snapshot shipped (in-flight across deploy).
+    const snapshot = parseChargedLineItems(cart.chargedLineItems);
+    let orderItemCreates: OrderItemSnapshotCreate[];
+    if (snapshot) {
+      orderItemCreates = await snapshotToOrderItemCreates(tx, snapshot);
+      assertOrderItemsMatchCharge(orderItemCreates, snapshot);
+    } else {
+      console.warn(`[Order] Cart ${cart.id} has no charge snapshot — falling back to cart.items (in-flight at deploy?)`);
+      orderItemCreates = [];
+      for (const item of cart.items) {
+        const { unitCost, totalCost } = await snapshotItemCost(tx, item.variantId, item.quantity);
+        orderItemCreates.push({
           productId: item.productId,
           variantId: item.variantId,
           title: item.product.title,
           variantTitle: item.variant.title,
           sku: item.variant.sku,
-          quantity: item.quantity,
           price: item.price,
+          quantity: item.quantity,
           totalPrice: new Prisma.Decimal(Number(item.price) * item.quantity),
           unitCost,
           totalCost,
-        },
-      });
+        });
+      }
     }
 
-    // Commit inventory for each item (handles bundles automatically)
-    for (const item of cart.items) {
-      await commitInventoryForOrderItem(tx, item.productId, item.variantId, item.quantity, newOrder.orderNumber, newOrder.id);
+    // Create order items
+    for (const itemData of orderItemCreates) {
+      await tx.orderItem.create({ data: { orderId: newOrder.id, ...itemData } });
+    }
+
+    // Commit inventory for each item (handles bundles automatically). Sourced from the same
+    // snapshot so committed stock matches exactly what was charged.
+    for (const itemData of orderItemCreates) {
+      await commitInventoryForOrderItem(tx, itemData.productId, itemData.variantId, itemData.quantity, newOrder.orderNumber, newOrder.id);
     }
 
     await finalizeOrderMargin(tx, newOrder.id);

--- a/src/lib/stripe/charge-snapshot.ts
+++ b/src/lib/stripe/charge-snapshot.ts
@@ -1,0 +1,246 @@
+/**
+ * Charge snapshot — single source of truth for "what Stripe actually charged".
+ *
+ * The fulfillment Order's items used to be rebuilt by re-reading the cart/drafts at
+ * webhook time, which let items added/removed AFTER the Stripe session was created drift
+ * away from what was charged (items added shipped free; items removed stayed billed).
+ *
+ * Fix: at session-creation we persist the exact PRODUCT line items priced into the Stripe
+ * charge (the snapshot), and at order-creation we build OrderItems from THAT snapshot —
+ * never from a re-read. To guarantee the snapshot *is* what's charged, both the Stripe
+ * `line_items` and the persisted snapshot are produced from this one module, so they cannot
+ * drift. `assertOrderItemsMatchCharge` is a tripwire that hard-fails if they ever do.
+ *
+ * Invariant: an Order's OrderItems must always equal the product line items Stripe charged.
+ *
+ * Scope: PRODUCTS ONLY. Tax, tip, and delivery are separate Stripe line items and are NOT
+ * part of the snapshot (they are not OrderItems).
+ */
+
+import type Stripe from 'stripe';
+import { Prisma, type PrismaClient } from '@prisma/client';
+import { snapshotItemCost } from '@/lib/analytics/margin-service';
+
+type Tx = Prisma.TransactionClient | PrismaClient;
+
+/** A cart item / draft item that can be priced into a Stripe charge. */
+export interface ChargeableItem {
+  productId: string;
+  variantId: string;
+  title: string;
+  variantTitle?: string | null;
+  sku?: string | null;
+  /** Unit price in DOLLARS (Decimal, number, or anything with toString — e.g. Prisma.Decimal). */
+  price: Prisma.Decimal | number | string | { toString(): string };
+  quantity: number;
+}
+
+/** One immutable product line as it was priced into the Stripe charge. Unit price in CENTS. */
+export interface ChargedLineItem {
+  productId: string;
+  variantId: string;
+  title: string;
+  variantTitle: string | null;
+  sku: string | null;
+  unitPriceCents: number;
+  quantity: number;
+}
+
+/** OrderItem.create payload built from a charged line (orderId is added by the caller). */
+export interface OrderItemSnapshotCreate {
+  productId: string;
+  variantId: string;
+  title: string;
+  variantTitle: string | null;
+  sku: string | null;
+  price: Prisma.Decimal;
+  quantity: number;
+  totalPrice: Prisma.Decimal;
+  unitCost: Prisma.Decimal | null;
+  totalCost: Prisma.Decimal | null;
+}
+
+/** Minimal shape the guard needs — satisfied by both built payloads and persisted OrderItem rows. */
+interface GuardOrderItem {
+  productId: string;
+  variantId: string;
+  price: Prisma.Decimal | number | string;
+  quantity: number;
+  totalPrice: Prisma.Decimal | number | string;
+}
+
+/** Thrown when OrderItems diverge from the charged snapshot. Caught by the webhook so Stripe retries. */
+export class ChargeReconciliationError extends Error {
+  constructor(
+    message: string,
+    public readonly details: { diffs: string[]; itemsTotalCents: number; chargedTotalCents: number }
+  ) {
+    super(message);
+    this.name = 'ChargeReconciliationError';
+  }
+}
+
+/** Convert a dollar price (Decimal/number/string) to integer cents, matching Stripe's unit_amount. */
+function toCents(price: ChargeableItem['price']): number {
+  const asNumber =
+    typeof price === 'object' && price !== null ? Number(price.toString()) : Number(price);
+  return Math.round(asNumber * 100);
+}
+
+/**
+ * Map cart/draft items to the immutable charged-line snapshot. PRODUCTS ONLY.
+ * This is the exact set of product lines that must also be sent to Stripe (via
+ * {@link chargedLineItemToStripe}), so the snapshot literally equals the charge.
+ */
+export function buildChargedLineItems(items: ChargeableItem[]): ChargedLineItem[] {
+  return items.map((it) => ({
+    productId: it.productId,
+    variantId: it.variantId,
+    title: it.title,
+    variantTitle: it.variantTitle ?? null,
+    sku: it.sku ?? null,
+    unitPriceCents: toCents(it.price),
+    quantity: it.quantity,
+  }));
+}
+
+/**
+ * Map one charged line to a Stripe Checkout product line item. Both checkout builders route
+ * their product lines through this so the snapshot and the Stripe charge cannot diverge.
+ */
+export function chargedLineItemToStripe(
+  li: ChargedLineItem
+): Stripe.Checkout.SessionCreateParams.LineItem {
+  return {
+    price_data: {
+      currency: 'usd',
+      product_data: {
+        name: li.title,
+        description:
+          li.variantTitle && li.variantTitle !== 'Default Title' ? li.variantTitle : undefined,
+        metadata: {
+          productId: li.productId,
+          variantId: li.variantId,
+          ...(li.sku ? { sku: li.sku } : {}),
+        },
+      },
+      unit_amount: li.unitPriceCents,
+    },
+    quantity: li.quantity,
+  };
+}
+
+/** Total cents of the charged PRODUCT lines (excludes tax/tip/delivery, which are not in the snapshot). */
+export function chargedProductsTotalCents(snapshot: ChargedLineItem[]): number {
+  return snapshot.reduce((sum, li) => sum + li.unitPriceCents * li.quantity, 0);
+}
+
+/**
+ * Read a persisted `charged_line_items` JSON column back into typed snapshot lines.
+ * Returns null when the column is empty (carts/payments created before this feature shipped),
+ * which signals callers to use their legacy fallback source + warn.
+ */
+export function parseChargedLineItems(value: Prisma.JsonValue | null | undefined): ChargedLineItem[] | null {
+  if (!value || !Array.isArray(value)) return null;
+  const out: ChargedLineItem[] = [];
+  for (const raw of value as unknown[]) {
+    if (!raw || typeof raw !== 'object') return null;
+    const li = raw as Record<string, unknown>;
+    if (typeof li.productId !== 'string' || typeof li.variantId !== 'string') return null;
+    out.push({
+      productId: li.productId,
+      variantId: li.variantId,
+      title: typeof li.title === 'string' ? li.title : '',
+      variantTitle: typeof li.variantTitle === 'string' ? li.variantTitle : null,
+      sku: typeof li.sku === 'string' ? li.sku : null,
+      unitPriceCents: Number(li.unitPriceCents) || 0,
+      quantity: Number(li.quantity) || 0,
+    });
+  }
+  return out.length > 0 ? out : null;
+}
+
+/**
+ * Build OrderItem.create payloads from the charged snapshot, attaching COGS via the existing
+ * {@link snapshotItemCost} so margin behavior is unchanged. The returned payloads omit orderId;
+ * the solo path adds it, the group/cron paths nest them under `order.create({ items: { create } })`.
+ */
+export async function snapshotToOrderItemCreates(
+  tx: Tx,
+  snapshot: ChargedLineItem[]
+): Promise<OrderItemSnapshotCreate[]> {
+  const out: OrderItemSnapshotCreate[] = [];
+  for (const li of snapshot) {
+    const { unitCost, totalCost } = await snapshotItemCost(tx, li.variantId, li.quantity);
+    out.push({
+      productId: li.productId,
+      variantId: li.variantId,
+      title: li.title,
+      variantTitle: li.variantTitle,
+      sku: li.sku,
+      price: new Prisma.Decimal(li.unitPriceCents).div(100),
+      quantity: li.quantity,
+      totalPrice: new Prisma.Decimal(li.unitPriceCents).mul(li.quantity).div(100),
+      unitCost,
+      totalCost,
+    });
+  }
+  return out;
+}
+
+/**
+ * Defense-in-depth guard: assert the OrderItems about to be persisted match the charged
+ * snapshot (per-line qty + unit price, and the total, within `epsilonCents`). Throws
+ * {@link ChargeReconciliationError} on mismatch so the webhook fails and Stripe retries rather
+ * than committing a wrong order. Set `CHARGE_GUARD_MODE=warn` to log instead of throw (e.g. a
+ * cautious first deploy). No-ops happily in the snapshot-built happy path.
+ */
+export function assertOrderItemsMatchCharge(
+  orderItems: GuardOrderItem[],
+  snapshot: ChargedLineItem[],
+  opts: { epsilonCents?: number } = {}
+): void {
+  const epsilon = opts.epsilonCents ?? 1;
+  const chargedTotalCents = chargedProductsTotalCents(snapshot);
+  const itemsTotalCents = orderItems.reduce(
+    (sum, oi) => sum + Math.round(Number(oi.totalPrice) * 100),
+    0
+  );
+
+  const key = (x: { productId: string; variantId: string }): string => `${x.productId}::${x.variantId}`;
+  const snapByKey = new Map(snapshot.map((li) => [key(li), li] as const));
+  const itemsByKey = new Map(orderItems.map((oi) => [key(oi), oi] as const));
+  const diffs: string[] = [];
+
+  if (Math.abs(itemsTotalCents - chargedTotalCents) > epsilon) {
+    diffs.push(`product total ${itemsTotalCents}¢ vs charged ${chargedTotalCents}¢`);
+  }
+  for (const [k, li] of snapByKey) {
+    const oi = itemsByKey.get(k);
+    if (!oi) {
+      diffs.push(`charged line "${li.title}" (${k}) missing from OrderItems`);
+      continue;
+    }
+    if (oi.quantity !== li.quantity) {
+      diffs.push(`qty mismatch "${li.title}": order ${oi.quantity} vs charged ${li.quantity}`);
+    }
+    const oiUnitCents = Math.round(Number(oi.price) * 100);
+    if (Math.abs(oiUnitCents - li.unitPriceCents) > epsilon) {
+      diffs.push(`unit-price mismatch "${li.title}": order ${oiUnitCents}¢ vs charged ${li.unitPriceCents}¢`);
+    }
+  }
+  for (const [k, oi] of itemsByKey) {
+    if (!snapByKey.has(k)) {
+      diffs.push(`OrderItem (${k}) was not in the Stripe charge`);
+    }
+  }
+
+  if (diffs.length === 0) return;
+
+  const message = `OrderItems do not match the Stripe charge snapshot: ${diffs.join('; ')}`;
+  if (process.env.CHARGE_GUARD_MODE === 'warn') {
+    console.warn(`[charge-snapshot] GUARD WARN — ${message}`);
+    return;
+  }
+  throw new ChargeReconciliationError(message, { diffs, itemsTotalCents, chargedTotalCents });
+}

--- a/src/lib/stripe/checkout.ts
+++ b/src/lib/stripe/checkout.ts
@@ -4,10 +4,12 @@
  */
 
 import Stripe from 'stripe';
+import { Prisma } from '@prisma/client';
 import { stripe } from './client';
 import { CartWithItems } from '@/lib/inventory/services/cart-service';
 import { prisma } from '@/lib/database/client'; // Used for getOrCreateStripeCustomer
 import { getTaxRateForZip, DEFAULT_TAX_RATE } from '@/lib/tax';
+import { buildChargedLineItems, chargedLineItemToStripe } from './charge-snapshot';
 
 /**
  * Checkout session metadata stored with Stripe
@@ -79,23 +81,23 @@ export async function createCheckoutSession(
 ): Promise<Stripe.Checkout.Session> {
   const { cart, successUrl, cancelUrl, customerEmail, stripeCustomerId, affiliateCode, overrideDeliveryFee, tipAmount, attribution } = options;
 
-  // Build line items from cart
-  const lineItems: Stripe.Checkout.SessionCreateParams.LineItem[] = cart.items.map((item) => ({
-    price_data: {
-      currency: 'usd',
-      product_data: {
-        name: item.product.title,
-        description: item.variant.title !== 'Default Title' ? item.variant.title : undefined,
-        metadata: {
-          productId: item.productId,
-          variantId: item.variantId,
-          sku: item.variant.sku || '',
-        },
-      },
-      unit_amount: Math.round(Number(item.price) * 100), // Convert to cents
-    },
-    quantity: item.quantity,
-  }));
+  // Build the immutable charge snapshot from the cart's products, then derive the Stripe
+  // product line items from it so the snapshot literally equals what's charged. OrderItems are
+  // later rebuilt from this snapshot (persisted on the cart below) — never from a re-read cart,
+  // which is what let items added/removed after this point drift from the charge.
+  const chargedLineItems = buildChargedLineItems(
+    cart.items.map((item) => ({
+      productId: item.productId,
+      variantId: item.variantId,
+      title: item.product.title,
+      variantTitle: item.variant.title,
+      sku: item.variant.sku,
+      price: item.price,
+      quantity: item.quantity,
+    }))
+  );
+  const lineItems: Stripe.Checkout.SessionCreateParams.LineItem[] =
+    chargedLineItems.map(chargedLineItemToStripe);
 
   // Add delivery fee as a line item (use override if provided, e.g. $0 for affiliate referrals)
   const deliveryFee = overrideDeliveryFee !== undefined ? overrideDeliveryFee : Number(cart.deliveryFee);
@@ -227,6 +229,14 @@ export async function createCheckoutSession(
 
   // Create the session
   const session = await stripe.checkout.sessions.create(sessionParams);
+
+  // Persist the immutable charge snapshot on the cart. createOrderFromCheckout rebuilds
+  // OrderItems from this (not a re-read of cart.items), closing the two-snapshot race where
+  // items edited after checkout-creation diverged from what Stripe charged.
+  await prisma.cart.update({
+    where: { id: cart.id },
+    data: { chargedLineItems: chargedLineItems as unknown as Prisma.InputJsonValue },
+  });
 
   // Note: We store session ID in Stripe metadata, not in cart
   // The order service will link the checkout session when order is created

--- a/src/lib/stripe/group-v2-payments.ts
+++ b/src/lib/stripe/group-v2-payments.ts
@@ -4,6 +4,7 @@
  */
 
 import Stripe from 'stripe';
+import { Prisma } from '@prisma/client';
 import { stripe } from './client';
 import { prisma } from '@/lib/database/client';
 import { DEFAULT_TAX_RATE } from '@/lib/tax';
@@ -15,6 +16,15 @@ import { linkOrderToAffiliate } from '@/lib/affiliates/commission-engine';
 import { getAffiliateByCode } from '@/lib/affiliates/affiliate-service';
 import { createOrderCalendarEvent } from '@/lib/calendar/google-calendar';
 import { commitInventoryForOrderItem } from '@/lib/inventory/services/order-service';
+import { snapshotItemCost } from '@/lib/analytics/margin-service';
+import {
+  buildChargedLineItems,
+  chargedLineItemToStripe,
+  parseChargedLineItems,
+  snapshotToOrderItemCreates,
+  assertOrderItemsMatchCharge,
+  type OrderItemSnapshotCreate,
+} from './charge-snapshot';
 
 // ==========================================
 // Types
@@ -115,22 +125,22 @@ export async function createGroupV2CheckoutSession(input: CreateCheckoutInput) {
   const taxableAmount = Math.max(0, subtotal - discountAmount);
   const taxAmount = Math.round(taxableAmount * DEFAULT_TAX_RATE * 100) / 100;
 
-  // Build line items
-  const lineItems: Stripe.Checkout.SessionCreateParams.LineItem[] = draftItems.map((item) => ({
-    price_data: {
-      currency: 'usd',
-      product_data: {
-        name: item.title,
-        description:
-          item.variantTitle && item.variantTitle !== 'Default Title'
-            ? item.variantTitle
-            : undefined,
-        metadata: { productId: item.productId, variantId: item.variantId },
-      },
-      unit_amount: Math.round(Number(item.price) * 100),
-    },
-    quantity: item.quantity,
-  }));
+  // Build the immutable charge snapshot from the participant's draft products, then derive the
+  // Stripe product line items from it so the snapshot equals what's charged. The Order's items
+  // are later rebuilt from this snapshot (persisted on the ParticipantPayment) — not from a
+  // re-read of drafts/purchased items, which is what let post-checkout edits drift.
+  const chargedLineItems = buildChargedLineItems(
+    draftItems.map((item) => ({
+      productId: item.productId,
+      variantId: item.variantId,
+      title: item.title,
+      variantTitle: item.variantTitle,
+      price: item.price,
+      quantity: item.quantity,
+    }))
+  );
+  const lineItems: Stripe.Checkout.SessionCreateParams.LineItem[] =
+    chargedLineItems.map(chargedLineItemToStripe);
 
   // Add delivery fee line item when bundled into this checkout.
   // A FREE_SHIPPING discount code (e.g. BACHPLAN) overrides includeDeliveryFee
@@ -228,7 +238,8 @@ export async function createGroupV2CheckoutSession(input: CreateCheckoutInput) {
   // Create Stripe session
   const session = await stripe.checkout.sessions.create(sessionParams);
 
-  // Create ParticipantPayment record
+  // Create ParticipantPayment record. Persist the immutable charge snapshot so the Order's
+  // items are later built from exactly what Stripe charged (not a re-read of the drafts).
   const payment = await prisma.participantPayment.create({
     data: {
       subOrderId,
@@ -240,6 +251,7 @@ export async function createGroupV2CheckoutSession(input: CreateCheckoutInput) {
       discountAmount,
       tipAmount,
       total,
+      chargedLineItems: chargedLineItems as unknown as Prisma.InputJsonValue,
       status: 'PENDING',
     },
   });
@@ -503,6 +515,34 @@ export async function handleGroupV2PaymentCompleted(
   // Delivery fee: use bundled amount from metadata, otherwise 0 (host pays separately)
   const bundledDeliveryFee = session.metadata?.deliveryFee ? Number(session.metadata.deliveryFee) : 0;
 
+  // Build Order items from the immutable charge snapshot persisted on the payment (what Stripe
+  // charged), NOT from a re-read of purchased/draft items — this closes the two-snapshot race.
+  // Fall back to purchasedItems only for payments created before the snapshot shipped.
+  const chargeSnapshot = parseChargedLineItems(payment.chargedLineItems);
+  let orderItemCreates: OrderItemSnapshotCreate[];
+  if (chargeSnapshot) {
+    orderItemCreates = await snapshotToOrderItemCreates(prisma, chargeSnapshot);
+    assertOrderItemsMatchCharge(orderItemCreates, chargeSnapshot);
+  } else {
+    console.warn(`[Group V2 Payment] Payment ${payment.id} has no charge snapshot — falling back to purchasedItems`);
+    orderItemCreates = [];
+    for (const item of purchasedItems) {
+      const { unitCost, totalCost } = await snapshotItemCost(prisma, item.variantId, item.quantity);
+      orderItemCreates.push({
+        productId: item.productId,
+        variantId: item.variantId,
+        title: item.title,
+        variantTitle: item.variantTitle,
+        sku: null,
+        price: new Prisma.Decimal(item.price),
+        quantity: item.quantity,
+        totalPrice: new Prisma.Decimal(Number(item.price) * item.quantity),
+        unitCost,
+        totalCost,
+      });
+    }
+  }
+
   const order = await prisma.order.create({
     data: {
       customerId,
@@ -528,15 +568,7 @@ export async function handleGroupV2PaymentCompleted(
       groupOrderId: null, // V2 doesn't use v1 group order FK
       groupOrderV2Id: groupOrderId,
       items: {
-        create: purchasedItems.map((item) => ({
-          productId: item.productId,
-          variantId: item.variantId,
-          title: item.title,
-          variantTitle: item.variantTitle,
-          price: item.price,
-          quantity: item.quantity,
-          totalPrice: Number(item.price) * item.quantity,
-        })),
+        create: orderItemCreates,
       },
     },
     include: {


### PR DESCRIPTION
## What & why

Orders could ship with items **Stripe never charged** (undercharge) or **bill for items not delivered** (overcharge). Root cause is a two-snapshot race in three places: the Stripe charge amount is frozen from a snapshot of the cart/drafts at **session-creation**, but the fulfillment Order's `OrderItem`s were rebuilt by **re-reading the cart/drafts at webhook (order-creation) time**. Anything added or removed between the two reads diverged from what was charged.

**Invariant enforced:** an Order's `OrderItem`s must always equal the product line items Stripe actually charged.

## The fix

Persist the exact charged **product** lines at session-creation and build `OrderItem`s (and the inventory commit) from that immutable snapshot — never from a re-read.

- New `src/lib/stripe/charge-snapshot.ts`: one pure mapper builds **both** the Stripe `line_items` and the persisted snapshot, so they can't drift. `assertOrderItemsMatchCharge()` throws if OrderItems ever diverge from the snapshot (webhook fails → Stripe retries → no wrong order committed). `CHARGE_GUARD_MODE=warn` downgrades to a log for a cautious first deploy.
- Additive migration `prisma/migrations/manual/2026-06-15-charge-snapshot.sql` → `carts.charged_line_items`, `participant_payments.charged_line_items` (mirrored in `schema.prisma`).
- Wired into all three paths: **solo** (`checkout.ts` + `order-service.createOrderFromCheckout`), **group V2** (`group-v2-payments.ts`), **reconcile cron** Pass 2 (Pass 1 inherits the solo fix). Each falls back to the old source + `console.warn` when the snapshot is null (carts/payments in flight across deploy).
- Side benefit: group/cron OrderItems now get COGS (`unitCost`/`totalCost`) via the shared builder; previously null.

## ⚠️ Deploy ordering (important)

The new code **unconditionally writes** `charged_line_items` on every checkout. **Apply the migration to the DB before/with deploying this code**, or checkout will throw on the missing column:

```
psql "$DATABASE_URL" -f prisma/migrations/manual/2026-06-15-charge-snapshot.sql
npx prisma generate
```

I did **not** run the migration against the database (`.env.local` points at prod; per instructions I did not deploy or touch prod data).

## Tests

- New `src/__tests__/charge-snapshot.test.ts` — mapper (snapshot == charge), COGS builder, and the guard (passes on match; throws on added item / qty drift / price drift; ±1¢ epsilon; warn mode).
- Extended `group-v2-payments.test.ts` — "late item" case: snapshot has 1 item but `purchasedItem.findMany` returns 2 → the Order has only the charged item.
- Extended `stripe-integration.test.ts` — `createCheckoutSession` persists a snapshot equal to the Stripe product lines.
- `npx tsc --noEmit` clean. Full suite: **278 passed / 2 failed.** The 2 failures are **pre-existing** (red on `main`) in `group-v2-payments.test.ts` — a separate `customerName` precedence bug (`'Party Host'` placeholder), unrelated to this change. They were masked on `main` by an unrelated throw and surface here only because the fix lets the function run to completion. Filed as a follow-up.

## Historical remediation (read-only audit included)

`scripts/ops/audit-order-charge-mismatches.mjs` diffs every order's `OrderItem`s against the Stripe session's charged product lines, **quantity-aware** (keyed by `productId` to dodge the `manual-*` variant-metadata quirk), net of refunds, excluding free/price-0 items and discounts (equal quantity = no flag). Validated against the known overcharge ground truth:

| | Orders | $ | Notes |
|---|---|---|---|
| **Overcharged, still owed** (net of refunds) | 4 | **$276.51** | Exactly matches prior investigation — #227 $174.54, #291/#305 $34.99, #269 $31.99 |
| Undercharged, no amendment | 5 | $193.91 | High-confidence re-bill candidates |
| Undercharged, order amended | 6 | $527.78 | Amendment items charged on a separate PI — verify manually |

**Note:** the prior investigation's undercharge figure (~$7,928) was **not reproducible** — a value/title-based method counted intentional discounts and description-formatting mismatches as undercharges. Using the validated quantity-aware method, true undercharge exposure is **~$722**, not ~$7,928. Every affected order has **no reusable card on file** (`setup_future_usage` was never set), so re-bills must go through a fresh `/invoice/[token]` link, not an off-session charge.

Remediation is **operator-gated** — nothing auto-charges or auto-refunds:
- `docs/charge-mismatch-remediation.md` — dunning ladder (Day 0 / +7 / +14 → charge ~+21), email templates, refund-first guidance.
- `scripts/ops/rebill-charge-on-file.mjs` — last-resort, one-order-at-a-time, dry-run default, refuses if no reusable card.

## Out of scope / follow-ups
- `customerName` precedence bug (the 2 pre-existing test failures) — filed separately.
- Cron Pass 2 hardcodes `deliveryFee: 0` on recovery (separate bug).
- `moveDraftToPurchased` still writes `purchased_items` from drafts (bookkeeping table can still drift; Order is the source of truth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
