### PR TITLE
fix(build): unblock #130 — drop unused var failing Vercel ESLint

### DIFF
--- a/src/lib/stripe/charge-snapshot.ts
+++ b/src/lib/stripe/charge-snapshot.ts
@@ -229,7 +229,7 @@ export function assertOrderItemsMatchCharge(
       diffs.push(`unit-price mismatch "${li.title}": order ${oiUnitCents}¢ vs charged ${li.unitPriceCents}¢`);
     }
   }
-  for (const [k, oi] of itemsByKey) {
+  for (const k of itemsByKey.keys()) {
     if (!snapByKey.has(k)) {
       diffs.push(`OrderItem (${k}) was not in the Stripe charge`);
     }


### PR DESCRIPTION
## Why
The production deploy of #130 (`dpl_AdEvsvEet…`) and its PR preview both failed to build with:

```
./src/lib/stripe/charge-snapshot.ts
232:18  Error: 'oi' is assigned a value but never used.  @typescript-eslint/no-unused-vars
```

`next build` runs ESLint and treats `no-unused-vars` as a **fatal error**. The final loop in `assertOrderItemsMatchCharge` destructured `[k, oi]` but only uses `k`. (`tsc --noEmit` doesn't flag unused destructured elements, and it was buried among `<img>` warnings in the local `next lint` output — so it slipped through.)

## Fix
Iterate `itemsByKey.keys()` instead of destructuring the entries. One line.

**Verified:** `npm run build` now exits 0 (504/504 static pages generated).

## ⚠️ Still required before this serves traffic
Production is currently safe because the #130 build errored and never promoted (prod is still on #129). But once this lands and deploys, the new code writes `charged_line_items` on every checkout — so the additive migration **must be applied to the DB first**, or checkout will 500:

```
prisma/migrations/manual/2026-06-15-charge-snapshot.sql
```

The columns are **not yet in prod** (confirmed). Apply the migration, then merge+deploy this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)