### PR TITLE
fix(group-v2): use participant name over payer's Stripe name on fulfillment order

### DIFF
--- a/src/lib/stripe/group-v2-payments.ts
+++ b/src/lib/stripe/group-v2-payments.ts
@@ -453,9 +453,12 @@ export async function handleGroupV2PaymentCompleted(
   // Resolve or create Customer for guest participants
   // Fall back to Stripe checkout session email/name when participant record is missing them
   const customerEmail = participant.guestEmail || session.customer_details?.email || '';
-  const customerName = session.customer_details?.name
-    || participant.guestName
-    || 'Guest';
+  // Prefer the participant's own name (matches the email line above), UNLESS it's the
+  // 'Party Host' placeholder — the host default when they skipped entering a name — in
+  // which case fall back to the Stripe checkout name.
+  const customerName = (participant.guestName && participant.guestName !== 'Party Host')
+    ? participant.guestName
+    : (session.customer_details?.name || participant.guestName || 'Guest');
   const customerPhone = participant.guestPhone || session.customer_details?.phone || '';
 
   let customerId = participant.customerId;


### PR DESCRIPTION
## Problem

In `handleGroupV2PaymentCompleted`, the customer name was resolved Stripe-first:

```ts
const customerName = session.customer_details?.name || participant.guestName || 'Guest';
```

This contradicts the email line right above it (which is participant-first) and the adjacent comment. The effect: when a group participant pays through a checkout where the **payer's** name lands in `session.customer_details.name`, the *payer's* name was written onto the participant's fulfillment order — overwriting the real name they entered when joining.

This is pre-existing on `main`. Two tests in `group-v2-payments.test.ts` already encode the intended behavior; they were masked on `main` by an unrelated throw that the charge-snapshot fix (#130) removed, exposing the bug.

## Fix

Prefer `participant.guestName` unless it's the `'Party Host'` placeholder (the host default when no name was entered), in which case fall back to the Stripe checkout name:

```ts
const customerName = (participant.guestName && participant.guestName !== 'Party Host')
  ? participant.guestName
  : (session.customer_details?.name || participant.guestName || 'Guest');
```

Verified `'Party Host'` is the **only** placeholder:
- Joining participants are Zod-validated to a non-empty name (`validation.ts` → `min(1, 'Name is required')`).
- Only the host inherits the default (`service.ts` → `guestName: input.hostName`, where `hostName` falls back to `'Party Host'`).

## Verification

- `npx vitest run src/__tests__/group-v2-payments.test.ts` → **10/10 pass** (the two previously-masked tests flip to green; the third, which expects the Stripe name to win on the `'Party Host'` placeholder, still passes).
- `npx tsc --noEmit` → clean.

Scoped to the single `customerName` line — nothing else in the function changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)