### PR TITLE
fix(compliance): SMS consent language for A2P 10DLC (privacy, terms, checkout)

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -29,7 +29,7 @@ export default function PrivacyPage() {
           <h1 className="font-heading text-5xl text-gray-900 mb-4 tracking-[0.1em]">
             Privacy Policy
           </h1>
-          <p className="text-gray-600">Last updated: January 2024</p>
+          <p className="text-gray-600">Last updated: June 2026</p>
         </div>
       </section>
 
@@ -84,6 +84,22 @@ export default function PrivacyPage() {
                 <li>Comply with legal obligations</li>
                 <li>Protect against fraud and unauthorized activity</li>
               </ul>
+            </div>
+
+            <div>
+              <h2 className="font-heading text-2xl text-gray-900 mb-4 tracking-[0.1em]">Text Messaging (SMS)</h2>
+              <p className="text-gray-600 leading-relaxed mb-4">
+                When you provide your mobile number &mdash; for example, during checkout after completing age verification &mdash; you consent to receive text messages from Party On Delivery related to your orders and customer service, including order confirmations, delivery status and scheduling updates, review requests, and replies to your questions. Consent to receive these texts is not a condition of any purchase.
+              </p>
+              <ul className="text-gray-600 space-y-2 list-disc pl-6 mb-4">
+                <li>Message frequency varies based on your order activity.</li>
+                <li>Message and data rates may apply.</li>
+                <li>Reply STOP to any message to unsubscribe, or HELP for help.</li>
+                <li>For assistance, contact us at info@partyondelivery.com or (737) 371-9700.</li>
+              </ul>
+              <p className="text-gray-600 leading-relaxed mb-4">
+                No mobile information will be shared with third parties or affiliates for marketing or promotional purposes. Text messaging originator opt-in data and consent will not be shared with any third parties.
+              </p>
             </div>
 
             <div>

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -29,7 +29,7 @@ export default function TermsPage() {
           <h1 className="font-heading text-5xl text-gray-900 mb-4 tracking-[0.1em]">
             Terms of Service
           </h1>
-          <p className="text-gray-600">Last updated: January 2024</p>
+          <p className="text-gray-600">Last updated: June 2026</p>
         </div>
       </section>
 
@@ -98,14 +98,30 @@ export default function TermsPage() {
             </div>
 
             <div>
-              <h2 className="font-heading text-2xl text-gray-900 mb-4 tracking-[0.1em]">9. Changes to Terms</h2>
+              <h2 className="font-heading text-2xl text-gray-900 mb-4 tracking-[0.1em]">9. Text Messaging (SMS)</h2>
+              <p className="text-gray-600 leading-relaxed mb-4">
+                When you provide your mobile number, you consent to receive text messages from Party On Delivery related to your orders and customer service, including order confirmations, delivery status and scheduling updates, review requests, and replies to your questions. Consent is not a condition of purchase.
+              </p>
+              <ul className="text-gray-600 space-y-2 list-disc pl-6 mb-4">
+                <li>Message frequency varies based on your order activity.</li>
+                <li>Message and data rates may apply.</li>
+                <li>Reply STOP at any time to unsubscribe; reply HELP for assistance.</li>
+                <li>Carriers are not liable for delayed or undelivered messages.</li>
+              </ul>
+              <p className="text-gray-600 leading-relaxed mb-4">
+                We do not share mobile information with third parties or affiliates for marketing or promotional purposes. See our <Link href="/privacy" className="text-brand-yellow hover:text-yellow-600">Privacy Policy</Link> for details on how we handle your information.
+              </p>
+            </div>
+
+            <div>
+              <h2 className="font-heading text-2xl text-gray-900 mb-4 tracking-[0.1em]">10. Changes to Terms</h2>
               <p className="text-gray-600 leading-relaxed mb-4">
                 We reserve the right to modify these terms at any time. Changes will be effective immediately upon posting to our website. Your continued use of our services constitutes acceptance of any changes.
               </p>
             </div>
 
             <div>
-              <h2 className="font-heading text-2xl text-gray-900 mb-4 tracking-[0.1em]">10. Contact Information</h2>
+              <h2 className="font-heading text-2xl text-gray-900 mb-4 tracking-[0.1em]">11. Contact Information</h2>
               <p className="text-gray-600 leading-relaxed mb-4">
                 If you have questions about these Terms of Service, please contact us at:
               </p>

--- a/src/lib/stripe/checkout.ts
+++ b/src/lib/stripe/checkout.ts
@@ -171,6 +171,13 @@ export async function createCheckoutSession(
       enabled: true,
     },
     billing_address_collection: 'required',
+    // SMS consent disclosure shown at the phone-number field (A2P 10DLC opt-in).
+    custom_text: {
+      submit: {
+        message:
+          'By providing your phone number, you agree to receive order and delivery text messages from Party On Delivery. Message and data rates may apply. Reply STOP to opt out. See our Privacy Policy at partyondelivery.com/privacy.',
+      },
+    },
   };
 
   // Add customer info if available


### PR DESCRIPTION
## What

Adds SMS consent language across three surfaces so our Twilio **A2P 10DLC** campaign passes carrier vetting:

- **Privacy Policy** (`src/app/privacy/page.tsx`) — new "Text Messaging (SMS)" section: message types, frequency, msg & data rates, STOP/HELP, and the required "no mobile information shared with third parties for marketing" clause. "Last updated" bumped to June 2026.
- **Terms of Service** (`src/app/terms/page.tsx`) — new "Text Messaging (SMS)" program-terms section (frequency, rates, STOP/HELP, carrier-liability disclaimer, no third-party sharing); subsequent sections renumbered.
- **Stripe checkout** (`src/lib/stripe/checkout.ts`) — `custom_text.submit.message` surfaces the SMS consent disclosure at the phone-number field on Stripe's hosted checkout (where the phone is collected via `phone_number_collection`).

## Why

We're moving SMS off GoHighLevel onto our own Twilio number (port in progress). A2P 10DLC registration for alcohol is **age-gated → manual carrier review**, and reviewers visit the live `/privacy` and `/terms` URLs looking for SMS consent terms. Without this language, the campaign is rejected (verification fee + another multi-week wait).

## Deploy note

Must reach production (`partyondelivery.com/privacy` and `/terms`) **before** the campaign's manual review looks — merging to `main` deploys via Vercel.

## Verification

- `tsc --noEmit` clean (privacy + checkout).
- Terms change is static JSX; `Link` already imported.
- Post-merge: confirm both live URLs show the SMS section and "June 2026".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
