### PR TITLE
fix: hide PartyChat bubble on the /dads-gone-wild invite

### DIFF
--- a/src/components/chat/PartyChatMount.tsx
+++ b/src/components/chat/PartyChatMount.tsx
@@ -15,6 +15,7 @@
  *   - /checkout/*, /invoice/* (don't distract during checkout)
  *   - /api/*               (no UI)
  *   - /affiliate/*, /partners/* (separate funnels with their own forms)
+ *   - /dads-gone-wild         (private friends-only invite — no marketing widgets)
  */
 import { usePathname } from 'next/navigation';
 import PartyChat from './PartyChat';
@@ -30,6 +31,7 @@ const HIDE_PATTERNS: RegExp[] = [
   /^\/api\//,
   /^\/affiliate(\/|$)/,
   /^\/partners(\/|$)/,
+  /^\/dads-gone-wild(\/|$)/,
 ];
 
 export default function PartyChatMount() {


### PR DESCRIPTION
The 🥂 PartyChat launcher is globally mounted (`PixelMount` → `PartyChatMount`) and shows on every non-hidden route. Add `/dads-gone-wild` to `PartyChatMount`'s `HIDE_PATTERNS` so the private, friends-only invite carries no marketing widgets — consistent with its age-gate exemption and the delivery-window gate now being order-flow-only.

One-line behavior change; verified on prod after deploy (bubble absent on the invite, still present elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)