### PR TITLE
feat(finance): Phase 5B — QuickBooks all-time expense backfill

### DIFF
--- a/docs/CONNECT-PRODUCTION-QUICKBOOKS.md
+++ b/docs/CONNECT-PRODUCTION-QUICKBOOKS.md
@@ -1,0 +1,93 @@
+# Connecting production QuickBooks (Finance Director)
+
+Right now the Finance Director's QuickBooks link points at the **Intuit sandbox**
+— a fake sample company. To pull Party On Delivery's real books (and run the
+Phase 5B expense backfill), you need to point it at **production** and reconnect.
+
+This is a one-time setup. Once it's done, the Director reads your real OpEx and
+net-profit numbers, and the all-time backfill becomes meaningful.
+
+You'll touch three places: the Intuit developer portal, Vercel env vars, and the
+admin connect page. ~20 minutes.
+
+---
+
+## Step 1 — Get production keys from Intuit
+
+1. Go to <https://developer.intuit.com> and sign in.
+2. **My Apps** → open the existing Party On Delivery app (the one created during
+   Phase 0 setup).
+3. Left nav → **Keys & credentials**. There are two tabs: **Development** (what
+   we're using now — sandbox) and **Production**.
+4. Click the **Production** tab. If it asks you to finish the app profile first,
+   fill in the required fields:
+   - App name, host domain (`partyondelivery.com`)
+   - Privacy policy URL and EULA/terms URL (any live page on the site is fine —
+     e.g. `https://partyondelivery.com/privacy` and `/terms`)
+   - Select the **com.intuit.quickbooks.accounting** scope
+   - Agree to the production terms
+   Accessing your *own* single company doesn't require Intuit's full marketplace
+   review — completing the profile is enough to activate production keys.
+5. Copy the **Production Client ID** and **Production Client Secret**. You'll
+   paste these into Vercel in Step 3. (Treat the secret like a password.)
+
+## Step 2 — Set the production redirect URI in Intuit
+
+Still in the Intuit app, under **Keys & credentials → Production**:
+
+1. Find **Redirect URIs**.
+2. Add exactly (no trailing slash, must match character-for-character):
+   ```
+   https://partyondelivery.com/api/admin/finance/qb/callback
+   ```
+3. Save.
+
+## Step 3 — Set Vercel environment variables (Production)
+
+In the Vercel dashboard → Party On Delivery project → **Settings → Environment
+Variables**. Add/update these four for the **Production** environment:
+
+| Variable | Value |
+|----------|-------|
+| `INTUIT_ENV` | `production` |
+| `INTUIT_CLIENT_ID` | *(Production Client ID from Step 1)* |
+| `INTUIT_CLIENT_SECRET` | *(Production Client Secret from Step 1)* |
+| `INTUIT_REDIRECT_URI` | `https://partyondelivery.com/api/admin/finance/qb/callback` |
+
+If `INTUIT_CLIENT_ID` / `INTUIT_CLIENT_SECRET` already exist with sandbox values,
+**overwrite** them with the production values.
+
+## Step 4 — Redeploy
+
+Vercel only picks up new env vars on the next deploy. Either:
+- Push any commit, or
+- Vercel dashboard → **Deployments** → latest → **⋯ → Redeploy**.
+
+## Step 5 — Reconnect to your real QuickBooks
+
+1. Go to <https://partyondelivery.com/admin/finance/connect-quickbooks>.
+2. It will still show the sandbox connection. Click **Reconnect QuickBooks**.
+3. You'll land on the Intuit consent screen — **sign in with the real Party On
+   Delivery QuickBooks login** (not the sandbox/developer account) and authorize.
+4. You'll bounce back to the connect page.
+
+## Step 6 — Verify it's production + real
+
+On the connect page, confirm:
+- **Environment** now says `production` (not `sandbox`)
+- **Company** shows *Party On Delivery* (not "Sandbox Company_US_1" or a sample name)
+- No "Last error"
+
+That's it. Tell Claude it's connected and the Phase 5B backfill can run — it'll
+pull every Purchase, Bill, Journal Entry (and optionally Sales Receipt / Invoice
+/ Deposit) from your real books, then keep current nightly.
+
+---
+
+## Notes
+
+- The sandbox expense rows currently in `qb_expenses` (47 fake ones) should be
+  cleared before/after the production backfill so they don't pollute OpEx. The
+  Phase 5B backfill script will include a `--purge-sandbox` step keyed on the
+  sandbox realm ID.
+- Plaid (bank feed) is a separate connection and isn't affected by this.

--- a/docs/CONNECT-PRODUCTION-QUICKBOOKS.md
+++ b/docs/CONNECT-PRODUCTION-QUICKBOOKS.md
@@ -86,8 +86,13 @@ pull every Purchase, Bill, Journal Entry (and optionally Sales Receipt / Invoice
 
 ## Notes
 
-- The sandbox expense rows currently in `qb_expenses` (47 fake ones) should be
-  cleared before/after the production backfill so they don't pollute OpEx. The
-  Phase 5B backfill script will include a `--purge-sandbox` step keyed on the
-  sandbox realm ID.
+- The sandbox expense rows currently in `qb_expenses` (47 fake ones) are cleared
+  automatically on the Phase 5B cutover run via the
+  `GET /api/cron/finance-qb-pull?all=true&purgeSandbox=true` endpoint — it deletes
+  every cached row not stamped with the connected production realm, then pulls all
+  real history. (Requires the Phase 5B `realm_id` migration first.)
+- **After the cutover, re-map the QB journal accounts** at
+  `/admin/finance/journals/settings`. The sandbox→prod switch invalidates the old
+  account mappings (they pointed at sandbox account IDs), so the autonomous sales-
+  journal posting needs the production accounts re-selected before you trust it.
 - Plaid (bank feed) is a separate connection and isn't affected by this.

--- a/docs/FINANCE-DIRECTOR-AGENT-BUILDOUT.md
+++ b/docs/FINANCE-DIRECTOR-AGENT-BUILDOUT.md
@@ -349,6 +349,28 @@ period comes from the `Order` table (Stripe-populated) instead. Segment
 classification falls back to `source_name` + group order name (Shopify `tags`
 are empty on this store too).
 
+### Phase 5B — QuickBooks all-time expense backfill
+
+- **Blocker resolved (2026-06-17):** QB was connected to the Intuit **sandbox**
+  (realm 9341457195868909, 47 fake sample expenses). Operator connected
+  **production** — realm 9130357382202626, company **Premier Concierge Worldwide**
+  (the legal entity holding PartyOn's books). Runbook:
+  `docs/CONNECT-PRODUCTION-QUICKBOOKS.md`.
+- New `realm_id` column on `qb_expenses` + `qb_accounts` so sandbox vs prod rows
+  are separable. `purgeOtherRealmData(keepRealmId)` clears everything not from the
+  connected realm (NULL rows = pre-column sandbox).
+- The existing `/api/cron/finance-qb-pull` cron gains params: `?all=true`
+  (all-time floor 2010-01-01), `?since=YYYY-MM-DD` (explicit floor for year-by-year
+  chunking), `?purgeSandbox=true` (cutover cleanup). Cutover run:
+  `GET /api/cron/finance-qb-pull?all=true&purgeSandbox=true` with the CRON_SECRET bearer.
+- **Scope:** Purchase + Bill (the proven OpEx path). JournalEntry / SalesReceipt /
+  Invoice / Deposit deferred — JournalEntry expense lines are a fast-follow once we
+  confirm the Purchase+Bill totals match the operator's sense of real OpEx.
+- **⚠️ Operator action after cutover:** the sandbox→prod switch invalidates the
+  Phase 2B journal-account mappings (they point at sandbox account IDs). Re-map at
+  `/admin/finance/journals/settings` against the new production accounts before
+  trusting the autonomous sales-journal posting.
+
 ### Phase 6 — Auto-categorize graduation (post-trust)
 
 Only after the operator has reviewed Phase 5 briefings for 4+ weeks and feels confident, graduate the Director's auto-categorize behavior from "one-by-one with reversal button" to "batch auto-categorize with weekly audit summary." This is a config flag, not new code.

--- a/prisma/migrations/manual/2026-06-17-finance-phase-5b-qb-realm.sql
+++ b/prisma/migrations/manual/2026-06-17-finance-phase-5b-qb-realm.sql
@@ -1,0 +1,24 @@
+-- Finance Director — Phase 5B: stamp QB realm on cached expense/account rows
+--
+-- Adds a realm_id column to qb_expenses + qb_accounts so we can tell which
+-- QuickBooks company a cached row came from. This lets the all-time backfill
+-- purge the old SANDBOX rows (realm 9341457195868909, written before this
+-- column existed → NULL) without touching real production data
+-- (realm 9130357382202626 = Premier Concierge Worldwide).
+--
+-- Additive + idempotent. Existing rows get realm_id = NULL; the backfill's
+-- purge step treats NULL as "not the current production realm" and clears them.
+--
+-- Run against prod manually (Neon SQL editor or psql):
+--     psql "$DATABASE_URL" -f prisma/migrations/manual/2026-06-17-finance-phase-5b-qb-realm.sql
+--     npx prisma generate
+
+BEGIN;
+
+ALTER TABLE qb_expenses ADD COLUMN IF NOT EXISTS realm_id TEXT;
+ALTER TABLE qb_accounts ADD COLUMN IF NOT EXISTS realm_id TEXT;
+
+CREATE INDEX IF NOT EXISTS qb_expenses_realm_id_idx ON qb_expenses (realm_id);
+CREATE INDEX IF NOT EXISTS qb_accounts_realm_id_idx ON qb_accounts (realm_id);
+
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2740,6 +2740,10 @@ model QbAccount {
   accountSubType  String?  @map("account_sub_type")
   currency        String   @default("USD")
   active          Boolean  @default(true)
+  /// QB realm (company) this account came from. Lets the Phase 5B backfill
+  /// purge stale sandbox rows without touching production data. NULL on rows
+  /// written before Phase 5B.
+  realmId         String?  @map("realm_id")
   lastSyncedAt    DateTime @default(now()) @map("last_synced_at")
   createdAt       DateTime @default(now()) @map("created_at")
   updatedAt       DateTime @updatedAt @map("updated_at")
@@ -2747,6 +2751,7 @@ model QbAccount {
   expenses        QbExpense[]
 
   @@index([accountType])
+  @@index([realmId])
   @@map("qb_accounts")
 }
 
@@ -2767,6 +2772,10 @@ model QbExpense {
   /// "Software", "Fuel", "Rent"). Derived from qb-account-map.ts.
   categorySlug      String?  @map("category_slug")
   memo              String?  @db.Text
+  /// QB realm (company) this expense came from. Lets the Phase 5B backfill
+  /// purge stale sandbox rows without touching production data. NULL on rows
+  /// written before Phase 5B.
+  realmId           String?  @map("realm_id")
   rawPayload        Json     @map("raw_payload")
   createdAt         DateTime @default(now()) @map("created_at")
   updatedAt         DateTime @updatedAt @map("updated_at")
@@ -2776,6 +2785,7 @@ model QbExpense {
   @@index([txnDate])
   @@index([categorySlug, txnDate])
   @@index([qbAccountId])
+  @@index([realmId])
   @@map("qb_expenses")
 }
 

--- a/src/app/api/cron/finance-qb-pull/route.ts
+++ b/src/app/api/cron/finance-qb-pull/route.ts
@@ -8,29 +8,57 @@
  * Schedule: Mondays at 07:50 UTC (after the daily snapshot at 07:45).
  * Bearer auth: `Authorization: Bearer ${CRON_SECRET}`.
  *
- * Optional query param `?days=N` overrides the trailing window (default 30,
- * max 365). Useful for one-shot backfills.
+ * Query params (all optional):
+ *   ?days=N            trailing window in days (default 30, max 365)
+ *   ?since=YYYY-MM-DD  explicit floor date (overrides days). Lets a big
+ *                      all-time backfill be chunked year-by-year if it's slow.
+ *   ?all=true          Phase 5B all-time floor (2010-01-01) — overrides days/since
+ *   ?purgeSandbox=true before pulling, delete cached rows from any OTHER QB
+ *                      realm (clears the old Intuit sandbox data on the first
+ *                      production run). Use ONCE on the sandbox→prod cutover.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import {
   pullQbExpenses,
+  purgeOtherRealmData,
   syncQbAccounts,
 } from '@/lib/finance/qb-pull-service';
-import { getStoredTokens } from '@/lib/finance/qb-client';
+import { getStoredTokens, getValidAccessToken } from '@/lib/finance/qb-client';
 
 export const maxDuration = 300; // 5 min — QB pagination can take a while
+
+/** Phase 5B all-time floor — far enough back to cover the whole company. */
+const ALL_TIME_FLOOR_ISO = '2010-01-01';
 
 interface SyncReport {
   startedAt: string;
   finishedAt: string;
   durationMs: number;
   qbConnected: boolean;
+  realmId: string | null;
+  sinceIso: string;
+  purgedExpenses: number;
+  purgedAccounts: number;
   accountsUpserted: number;
   purchasesUpserted: number;
   billsUpserted: number;
-  windowDays: number;
   errors: string[];
+}
+
+/** Resolve the floor date from query params. Precedence: all > since > days. */
+function resolveSinceIso(request: NextRequest): string {
+  const params = request.nextUrl.searchParams;
+  if (params.get('all') === 'true') return ALL_TIME_FLOOR_ISO;
+
+  const sinceParam = params.get('since');
+  if (sinceParam && /^\d{4}-\d{2}-\d{2}$/.test(sinceParam)) return sinceParam;
+
+  const daysParam = params.get('days');
+  let days = daysParam ? Number.parseInt(daysParam, 10) : 30;
+  if (!Number.isFinite(days) || days < 1) days = 30;
+  if (days > 365) days = 365;
+  return new Date(Date.now() - days * 86_400_000).toISOString().slice(0, 10);
 }
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
@@ -45,10 +73,13 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     finishedAt: '',
     durationMs: 0,
     qbConnected: false,
+    realmId: null,
+    sinceIso: '',
+    purgedExpenses: 0,
+    purgedAccounts: 0,
     accountsUpserted: 0,
     purchasesUpserted: 0,
     billsUpserted: 0,
-    windowDays: 30,
     errors: [],
   };
 
@@ -61,15 +92,21 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ success: false, data: report });
   }
   report.qbConnected = true;
+  report.sinceIso = resolveSinceIso(request);
 
-  const daysParam = request.nextUrl.searchParams.get('days');
-  let days = daysParam ? Number.parseInt(daysParam, 10) : 30;
-  if (!Number.isFinite(days) || days < 1) days = 30;
-  if (days > 365) days = 365;
-  report.windowDays = days;
-
-  const since = new Date(Date.now() - days * 86_400_000);
-  const sinceIso = since.toISOString().slice(0, 10);
+  // Purge stale (sandbox / other-realm) rows BEFORE the pull so we never
+  // serve a mix. Keyed on the currently connected realm.
+  if (request.nextUrl.searchParams.get('purgeSandbox') === 'true') {
+    try {
+      const { realmId } = await getValidAccessToken();
+      report.realmId = realmId;
+      const purged = await purgeOtherRealmData(realmId);
+      report.purgedExpenses = purged.expensesDeleted;
+      report.purgedAccounts = purged.accountsDeleted;
+    } catch (err) {
+      report.errors.push(`purge: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
 
   try {
     const { upserted, perTypeErrors } = await syncQbAccounts();
@@ -82,7 +119,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   }
 
   try {
-    const { purchases, bills } = await pullQbExpenses(sinceIso);
+    const { purchases, bills } = await pullQbExpenses(report.sinceIso);
     report.purchasesUpserted = purchases;
     report.billsUpserted = bills;
   } catch (err) {

--- a/src/lib/finance/qb-pull-service.ts
+++ b/src/lib/finance/qb-pull-service.ts
@@ -15,7 +15,7 @@
  */
 
 import { prisma } from '@/lib/database/client';
-import { qboQuery } from './qb-client';
+import { qboQuery, getValidAccessToken } from './qb-client';
 import {
   categorizeQbAccount,
   type CategorySlug,
@@ -82,6 +82,7 @@ export async function syncQbAccounts(): Promise<{
 }> {
   let upserted = 0;
   const perTypeErrors: string[] = [];
+  const { realmId } = await getValidAccessToken();
 
   // Pull EVERY account regardless of type. Phase 2A (OpEx) only consumes
   // expense-type rows, but Phase 2B's journal mapping needs Income, Asset,
@@ -97,7 +98,7 @@ export async function syncQbAccounts(): Promise<{
       const accounts = (resp?.Account ?? []) as QbAccountApi[];
       if (accounts.length === 0) break;
       for (const a of accounts) {
-        await upsertQbAccountRow(a);
+        await upsertQbAccountRow(a, realmId);
         upserted++;
       }
       if (accounts.length < PAGE_SIZE) break;
@@ -112,7 +113,7 @@ export async function syncQbAccounts(): Promise<{
   return { upserted, perTypeErrors };
 }
 
-async function upsertQbAccountRow(a: QbAccountApi): Promise<void> {
+async function upsertQbAccountRow(a: QbAccountApi, realmId: string): Promise<void> {
   await prisma.qbAccount.upsert({
     where: { qbAccountId: a.Id },
     create: {
@@ -123,6 +124,7 @@ async function upsertQbAccountRow(a: QbAccountApi): Promise<void> {
       accountSubType: a.AccountSubType ?? null,
       currency: a.CurrencyRef?.value ?? 'USD',
       active: a.Active ?? true,
+      realmId,
       lastSyncedAt: new Date(),
     },
     update: {
@@ -131,9 +133,29 @@ async function upsertQbAccountRow(a: QbAccountApi): Promise<void> {
       accountType: a.AccountType ?? null,
       accountSubType: a.AccountSubType ?? null,
       active: a.Active ?? true,
+      realmId,
       lastSyncedAt: new Date(),
     },
   });
+}
+
+/**
+ * Delete cached QB accounts + expenses that did NOT come from `keepRealmId`.
+ * Used by the Phase 5B all-time backfill to clear the old Intuit sandbox rows
+ * (realm 9341457195868909, written before the realm_id column existed → NULL)
+ * before pulling real production data. NULL realm rows are treated as "not the
+ * current realm" and removed.
+ */
+export async function purgeOtherRealmData(
+  keepRealmId: string
+): Promise<{ expensesDeleted: number; accountsDeleted: number }> {
+  const expensesDeleted = await prisma.$executeRaw`
+    DELETE FROM qb_expenses WHERE realm_id IS DISTINCT FROM ${keepRealmId}
+  `;
+  const accountsDeleted = await prisma.$executeRaw`
+    DELETE FROM qb_accounts WHERE realm_id IS DISTINCT FROM ${keepRealmId}
+  `;
+  return { expensesDeleted, accountsDeleted };
 }
 
 // ---------------------------------------------------------------------------
@@ -201,6 +223,7 @@ export async function pullQbExpenses(
 ): Promise<PullExpensesResult> {
   let purchases = 0;
   let bills = 0;
+  const { realmId } = await getValidAccessToken();
 
   // Purchase
   let position = 1;
@@ -227,6 +250,7 @@ export async function pullQbExpenses(
           qbAccountId: cachedAccountId,
           categorySlug: category,
           memo: p.PrivateNote ?? null,
+          realmId,
           rawPayload: p as unknown as object,
         },
         update: {
@@ -236,6 +260,7 @@ export async function pullQbExpenses(
           qbAccountId: cachedAccountId,
           categorySlug: category,
           memo: p.PrivateNote ?? null,
+          realmId,
           rawPayload: p as unknown as object,
         },
       });
@@ -269,6 +294,7 @@ export async function pullQbExpenses(
           qbAccountId: cachedAccountId,
           categorySlug: category,
           memo: b.PrivateNote ?? null,
+          realmId,
           rawPayload: b as unknown as object,
         },
         update: {
@@ -278,6 +304,7 @@ export async function pullQbExpenses(
           qbAccountId: cachedAccountId,
           categorySlug: category,
           memo: b.PrivateNote ?? null,
+          realmId,
           rawPayload: b as unknown as object,
         },
       });


### PR DESCRIPTION
## Summary

PR B of the Finance Director trajectory work. Now that QuickBooks is connected to **production** (operator switched it off the Intuit sandbox this session — real company *Premier Concierge Worldwide*, realm `9130357382202626`), this enables pulling **all-time** real expenses to feed OpEx / net-profit into the monthly trajectory.

Includes the production-QB connection runbook (`docs/CONNECT-PRODUCTION-QUICKBOOKS.md`) the operator followed to do the cutover.

## Schema diff

Raw SQL migration `prisma/migrations/manual/2026-06-17-finance-phase-5b-qb-realm.sql`:
- `ALTER TABLE qb_expenses ADD COLUMN IF NOT EXISTS realm_id TEXT;`
- `ALTER TABLE qb_accounts ADD COLUMN IF NOT EXISTS realm_id TEXT;`
- indexes on `realm_id`

The realm column lets us purge the 47 old **sandbox** rows precisely (by realm) instead of blindly truncating.

## Code

- `qb-pull-service.ts` — stamps `realmId` (from the connected token) on every account + expense upsert; adds `purgeOtherRealmData(keepRealmId)` which deletes cached rows from any realm other than the one currently connected (NULL = pre-column sandbox rows).
- `/api/cron/finance-qb-pull` — three new query params:
  - `?all=true` → all-time floor (2010-01-01), overrides the old 365-day cap
  - `?since=YYYY-MM-DD` → explicit floor, so a slow all-time pull can be chunked year-by-year
  - `?purgeSandbox=true` → run the realm purge before pulling (cutover cleanup)

**Cutover run:** `GET /api/cron/finance-qb-pull?all=true&purgeSandbox=true` with the `CRON_SECRET` bearer.

## Scope (deliberately tight — can't test QB locally)

- **In:** Purchase + Bill all-time (reuses the proven Phase 2A pull path).
- **Deferred fast-follow:** JournalEntry / SalesReceipt / Invoice / Deposit. JournalEntry expense lines need careful handling (must exclude our own Phase 2B revenue sales-journals). I'll add them once we confirm Purchase+Bill totals match the operator's sense of real OpEx — the empirical approach that caught the Shopify scope issue.

## Operator action items (ORDER MATTERS)

1. **Run the migration in Neon FIRST**, before merging — the deployed code writes `realm_id`, so the column must exist or the weekly pull errors:
   ```sql
   ALTER TABLE qb_expenses ADD COLUMN IF NOT EXISTS realm_id TEXT;
   ALTER TABLE qb_accounts ADD COLUMN IF NOT EXISTS realm_id TEXT;
   CREATE INDEX IF NOT EXISTS qb_expenses_realm_id_idx ON qb_expenses (realm_id);
   CREATE INDEX IF NOT EXISTS qb_accounts_realm_id_idx ON qb_accounts (realm_id);
   ```
2. Merge → Vercel deploys.
3. Claude triggers the cutover backfill (`?all=true&purgeSandbox=true`).
4. **Re-map QB journal accounts** at `/admin/finance/journals/settings` — the sandbox→prod switch invalidated the Phase 2B account-ID mappings.

## Pre-merge checklist

- [x] `npx prisma generate` — clean
- [x] `npx tsc --noEmit` — clean for changed files (pre-existing `group-v2-payments` typing error unrelated)
- [x] `npx next lint` on changed files — clean
- [x] `npm run test:run` — no NEW failures. Pre-existing: 6 `group-v2-payments` + 3 `recommendations/route-handlers` (confirmed failing on clean `main` with my changes stashed — the recommendations ones likely rode in with the Phase 5 recovery #125 and want a separate look).
- [x] **Did not run `next build`** (forbidden in CLAUDE.md)

## Test plan

- [ ] Migration applies idempotently in Neon.
- [ ] Cutover run returns `{success:true}`, `purgedExpenses: 47`, `purgedAccounts: 89`, and `purchasesUpserted + billsUpserted` reflecting real history.
- [ ] `/admin/finance` OpEx-by-category now shows real vendors (RNDC, Specs, fuel, ads…), not sandbox sample data.
- [ ] Daily/weekly `finance-qb-pull` keeps current with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)