### PR TITLE
feat(affiliates): Centex FareHarbor->webhook auto-dashboard integration

### DIFF
--- a/docs/integrations/centex-fareharbor.md
+++ b/docs/integrations/centex-fareharbor.md
@@ -1,0 +1,144 @@
+# Centex Boat Rentals — FareHarbor → Auto-Dashboard Integration
+
+Goal: every booking Centex takes (web **or** phone) is pushed to Party On Delivery,
+which auto-creates a co-branded "Drink Delivery" dashboard for that customer and
+kicks off the free-delivery offer. This is the same mechanism Premier Party
+Cruises runs (Xola → Zapier → our webhook); Centex just uses **FareHarbor**.
+
+- **Booking platform:** FareHarbor (shortname `centexboatrentals`, booking flow `903202`)
+- **Affiliate code:** `CENTEXBOATRENTALS`
+- **Delivery point (current):** 17141 Rocky Ridge Rd, Austin, TX 78734 (Lake Travis — in our footprint)
+- **Outreach model:** Hybrid — Centex embeds the dashboard link in their confirmations/pre-trip comms; we follow up by **email**; **SMS only to customers who opted in** at booking.
+
+## Data flow
+
+```
+Centex takes a booking in FareHarbor (online or staff-entered phone booking)
+        │  FareHarbor "New Booking" event
+        ▼
+Zapier  ── FareHarbor trigger → "Webhooks by Zapier" POST action
+        │  header: apikey: <Centex webhookApiKey>
+        ▼
+POST https://partyondelivery.com/api/webhooks/create-dashboard
+        ├─ creates a GroupOrderV2 dashboard (boat tab + stock-the-house tab)
+        ├─ logs to AffiliateWebhookLog (SUCCESS / FAILED, cross-ref booking_id)
+        ├─ (optional) callback → posts dashboard URL back to Centex's system
+        └─ notifyDashboardCreated → GHL dashboard.created workflow → email / opt-in SMS
+```
+
+## What we need FROM Centex
+
+1. **A FareHarbor API key** — generated in their FareHarbor Dashboard
+   (Settings → API / Integrations, or via FareHarbor support). Needed to connect
+   the FareHarbor app in Zapier. Confirm their plan tier permits Zapier/API.
+2. **A booking opt-in question** (for SMS): a checkbox on the FareHarbor booking
+   form like *"Get a free drink-delivery offer from Party On Delivery (texts OK)."*
+   FareHarbor supports custom booking questions. Without it, we email only.
+3. Confirm the **delivery dock / launch point** and typical **launch times** per boat.
+
+## Our endpoint contract
+
+`POST /api/webhooks/create-dashboard`
+
+| Header | Value |
+|---|---|
+| `Content-Type` | `application/json` |
+| `apikey` | Centex `webhookApiKey` (from the provisioning script below) |
+
+JSON body (field names our schema expects):
+
+| Field | Required | Type | Notes |
+|---|---|---|---|
+| `customer_name` | ✓ | string | Booking contact name |
+| `customer_email` | ✓ | string (email) | Must be a valid email or the request is rejected |
+| `customer_phone` | ✓ | string | Booking contact phone |
+| `items_name` | ✓ | string | Boat / experience booked (e.g. "Party Barge") |
+| `guest_count` | ✓ | number or numeric string | Party size |
+| `cruise_date` **or** `arrival` | ✓ | string | `YYYY-MM-DD`, or a full ISO datetime in `arrival` (we slice the date) |
+| `cruise_start_time` | – | string `HH:MM` (24h) | Sets the delivery window: 2h–1h before launch. Defaults to 12–2 PM if omitted |
+| `booking_id` | – | string | FareHarbor booking UUID/PK — cross-reference + dedupe |
+| `sms_consent` | – | boolean / `"yes"` / `"true"` | From the opt-in question. Defaults to **false** (email-only) |
+
+## Zapier setup
+
+1. **Trigger:** FareHarbor → *New Booking*. Connect using Centex's FareHarbor API key.
+2. **Action:** *Webhooks by Zapier* → **POST**.
+   - URL: `https://partyondelivery.com/api/webhooks/create-dashboard`
+   - Payload type: JSON
+   - Headers: `apikey` = Centex `webhookApiKey`
+   - Data (map FareHarbor trigger fields → our fields):
+
+     | Our field | FareHarbor trigger field |
+     |---|---|
+     | `customer_name` | Contact Name |
+     | `customer_email` | Contact Email |
+     | `customer_phone` | Contact Phone |
+     | `items_name` | Item Name |
+     | `guest_count` | Customer Count |
+     | `arrival` | Availability Start At (full datetime — we slice the date) |
+     | `cruise_start_time` | Availability Start At → formatted `HH:mm` (24h) via a Zapier Formatter step |
+     | `booking_id` | Booking UUID / PK |
+     | `sms_consent` | Opt-in question answer |
+
+> **Native alternative (phase 2):** FareHarbor also supports first-party webhooks
+> (HMAC-SHA256, `x-fareharbor-signature`). That removes the per-task Zapier cost
+> but requires us to parse FareHarbor's nested booking payload and verify the
+> signature. Start on Zapier (fastest to ship); revisit native webhooks if volume
+> makes Zapier task costs meaningful.
+
+## Consent / compliance (Hybrid)
+
+We ingest customer PII and pitch **alcohol**, so SMS is TCPA + A2P 10DLC territory —
+no cold texting boat renters.
+
+- The webhook forwards `partner_code` and `sms_consent` to the GHL `dashboard.created` event.
+- **GHL workflow must branch:** email everyone; send SMS **only when `sms_consent` is true**.
+- Centex owns the first touch to their own customers (link in confirmation / pre-trip),
+  which is the cleanest basis for any follow-up we do.
+
+## Provisioning (our side)
+
+```bash
+# from the repo root, with env loaded (Node 20+):
+node --env-file=.env.local scripts/ops/provision-centex-webhook.mjs
+```
+
+Generates (or reuses) the Centex `webhookApiKey`, forces status `ACTIVE`, and
+prints the exact `apikey` header value for the Zap. Idempotent.
+
+## Test / demo
+
+> ⚠️ Hitting **production** creates a real dashboard and fires the GHL
+> `dashboard.created` workflow. For tests use **your own** name/email/phone so any
+> outreach lands on you, not a stranger.
+
+```bash
+curl -i -X POST https://partyondelivery.com/api/webhooks/create-dashboard \
+  -H 'Content-Type: application/json' \
+  -H 'apikey: <CENTEX_WEBHOOK_KEY>' \
+  -d '{
+    "customer_name": "Allan Demo",
+    "customer_email": "allan@partyondelivery.com",
+    "customer_phone": "+17373719700",
+    "items_name": "Party Barge",
+    "guest_count": 12,
+    "arrival": "2026-06-28T11:00:00",
+    "cruise_start_time": "11:00",
+    "booking_id": "FH-DEMO-001",
+    "sms_consent": true
+  }'
+```
+
+A success response returns the `dashboard_url` (`/dashboard/<share_code>`) you can
+open to show the auto-generated co-branded dashboard.
+
+## Go-live checklist
+
+- [ ] Centex generates a FareHarbor API key
+- [ ] Run `provision-centex-webhook.mjs` (prod) → capture `webhookApiKey`
+- [ ] Deploy the code changes (affiliate-aware webhook + Centex preset)
+- [ ] Build the Zap (trigger + POST action + field mapping)
+- [ ] Update the GHL `dashboard.created` workflow to gate SMS on `sms_consent`
+- [ ] (Optional) Centex adds the opt-in question to their FareHarbor booking form
+- [ ] End-to-end test with a real test booking (your own contact info)
+- [ ] (Optional) Build the bespoke co-branded Centex landing page

--- a/scripts/ops/provision-centex-webhook.mjs
+++ b/scripts/ops/provision-centex-webhook.mjs
@@ -1,0 +1,48 @@
+// Provision the FareHarbor -> Zapier webhook credential for Centex Boat Rentals.
+//
+// Idempotent: generates a webhookApiKey only if one is not already set, and
+// ensures the affiliate is ACTIVE so POST /api/webhooks/create-dashboard will
+// accept its requests. Safe to re-run.
+//
+// Run from the worktree with the env file loaded (Node 20+):
+//   node --env-file=../../../.env.local scripts/ops/provision-centex-webhook.mjs
+// or from the repo root:
+//   node --env-file=.env.local scripts/ops/provision-centex-webhook.mjs
+//
+// Prints the key + the exact Zapier header value to paste into the Zap.
+
+import { PrismaClient } from '@prisma/client';
+import { randomBytes } from 'node:crypto';
+
+const p = new PrismaClient();
+const CODE = 'CENTEXBOATRENTALS';
+
+const aff = await p.affiliate.findUnique({ where: { code: CODE } });
+if (!aff) {
+  console.error(`✗ No affiliate with code ${CODE}. Aborting (nothing changed).`);
+  await p.$disconnect();
+  process.exit(1);
+}
+
+let key = aff.webhookApiKey;
+const generated = !key;
+if (!key) {
+  key = `whk_centex_${randomBytes(24).toString('hex')}`;
+}
+
+await p.affiliate.update({
+  where: { code: CODE },
+  data: { webhookApiKey: key, status: 'ACTIVE' },
+});
+
+console.log('✓ Centex webhook credential provisioned\n');
+console.log('  affiliateId   :', aff.id);
+console.log('  code          :', CODE);
+console.log('  status        : ACTIVE', aff.status === 'ACTIVE' ? '(unchanged)' : `(was ${aff.status})`);
+console.log('  webhookApiKey :', key, generated ? '(NEW)' : '(existing — reused)');
+console.log('\n--- Paste into the Zapier "Webhooks by Zapier" POST action ---');
+console.log('  URL    : https://partyondelivery.com/api/webhooks/create-dashboard');
+console.log('  Header : apikey =', key);
+console.log('---------------------------------------------------------------');
+
+await p.$disconnect();

--- a/src/app/api/webhooks/create-dashboard/route.ts
+++ b/src/app/api/webhooks/create-dashboard/route.ts
@@ -8,15 +8,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { createMultiTabDashboardOrder } from '@/lib/group-orders-v2/service';
-import { PREMIER_MARINA_ADDRESS } from '@/lib/affiliates/presets';
 import {
   affiliateWebhookSchema,
   normalizeCruiseType,
-  buildCruiseTabName,
-  buildDashboardTitle,
   formatDeliveryWindow,
   sendDashboardCallback,
-  LODGING_TAB_NAME,
+  getWebhookDashboardConfig,
 } from '@/lib/webhooks/affiliate-dashboard';
 import type { DashboardCallbackPayload } from '@/lib/webhooks/affiliate-dashboard';
 import { notifyDashboardCreated } from '@/lib/webhooks/ghl';
@@ -58,11 +55,15 @@ export async function POST(request: NextRequest) {
   const payload = parsed.data;
 
   // ── Build dashboard input ────────────────────
+  // Resolve per-partner config (marina address, tab naming) by affiliate code.
+  // Falls back to the Premier config for any unregistered affiliate.
+  const config = getWebhookDashboardConfig(affiliate.code);
   const cruiseType = normalizeCruiseType(payload.items_name);
-  const cruiseTabName = buildCruiseTabName(cruiseType, payload.customer_name);
-  const dashboardTitle = buildDashboardTitle(payload.customer_name);
+  const cruiseTabName = config.buildPrimaryTabName(payload.items_name, payload.customer_name);
+  const dashboardTitle = config.buildDashboardTitle(payload.customer_name);
   const deliveryTime = formatDeliveryWindow(payload.cruise_start_time);
-  const marinaAddress = `${PREMIER_MARINA_ADDRESS.address1}, ${PREMIER_MARINA_ADDRESS.city}, ${PREMIER_MARINA_ADDRESS.province} ${PREMIER_MARINA_ADDRESS.zip}`;
+  const m = config.marinaAddress;
+  const marinaAddress = `${m.address1}, ${m.city}, ${m.province} ${m.zip}`;
 
   try {
     const result = await createMultiTabDashboardOrder({
@@ -82,7 +83,7 @@ export async function POST(request: NextRequest) {
           deliveryContextType: 'BOAT',
         },
         {
-          name: LODGING_TAB_NAME,
+          name: config.lodgingTabName,
           deliveryContextType: 'HOUSE',
         },
       ],
@@ -146,6 +147,8 @@ export async function POST(request: NextRequest) {
         cruise_date: payload.cruise_date,
         cruise_type: cruiseType,
         booking_id: payload.booking_id || '',
+        partner_code: affiliate.code,
+        sms_consent: payload.sms_consent,
       });
     } catch (ghlErr) {
       console.error('[Affiliate Webhook] GHL dashboard notify failed:', ghlErr);

--- a/src/lib/affiliates/presets.ts
+++ b/src/lib/affiliates/presets.ts
@@ -49,6 +49,14 @@ export const INN_CAHOOTS_ADDRESS: AffiliateAddress = {
   country: 'US',
 };
 
+export const CENTEX_MARINA_ADDRESS: AffiliateAddress = {
+  address1: '17141 Rocky Ridge Rd',
+  city: 'Austin',
+  province: 'TX',
+  zip: '78734',
+  country: 'US',
+};
+
 const PREMIER_PRESETS: AffiliatePresetConfig = {
   partyTypes: [
     {
@@ -116,6 +124,11 @@ const AFFILIATE_ORDER_DEFAULTS: Record<string, AffiliateOrderDefaults> = {
     tabName: 'Inn Cahoots Delivery',
     deliveryContextType: 'HOTEL',
     skipPartyType: true,
+  },
+  CENTEXBOATRENTALS: {
+    address: CENTEX_MARINA_ADDRESS,
+    tabName: 'Lake Travis Boat Delivery',
+    deliveryContextType: 'BOAT',
   },
 };
 

--- a/src/lib/webhooks/affiliate-dashboard.ts
+++ b/src/lib/webhooks/affiliate-dashboard.ts
@@ -6,6 +6,11 @@
  */
 
 import { z } from 'zod';
+import {
+  PREMIER_MARINA_ADDRESS,
+  CENTEX_MARINA_ADDRESS,
+  type AffiliateAddress,
+} from '@/lib/affiliates/presets';
 
 // ──────────────────────────────────────────────
 // Zod schema for inbound webhook payload
@@ -28,6 +33,9 @@ const rawWebhookSchema = z.object({
   ]).pipe(z.number().int().positive('guest_count must be a positive integer')),
   // Xola booking ID for cross-referencing
   booking_id: z.string().optional(),
+  // Marketing/SMS consent captured at booking time (e.g. a FareHarbor opt-in
+  // question). Accepts boolean or common truthy strings; defaults to false.
+  sms_consent: z.union([z.boolean(), z.string()]).optional(),
 });
 
 export const affiliateWebhookSchema = rawWebhookSchema.transform((data) => {
@@ -41,6 +49,11 @@ export const affiliateWebhookSchema = rawWebhookSchema.transform((data) => {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(dateOnly)) {
     throw new Error('cruise_date/arrival must start with YYYY-MM-DD');
   }
+  const smsConsent =
+    data.sms_consent === true ||
+    ['true', 'yes', '1', 'on', 'checked'].includes(
+      String(data.sms_consent ?? '').toLowerCase()
+    );
   return {
     customer_name: data.customer_name,
     customer_phone: data.customer_phone,
@@ -50,6 +63,7 @@ export const affiliateWebhookSchema = rawWebhookSchema.transform((data) => {
     items_name: data.items_name,
     guest_count: data.guest_count,
     booking_id: data.booking_id || null,
+    sms_consent: smsConsent,
   };
 });
 
@@ -113,6 +127,55 @@ function formatTime12h(totalMinutes: number): string {
   const period = hours >= 12 ? 'PM' : 'AM';
   const display = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours;
   return minutes === 0 ? `${display}:00 ${period}` : `${display}:${String(minutes).padStart(2, '0')} ${period}`;
+}
+
+// ──────────────────────────────────────────────
+// Per-affiliate webhook dashboard config
+// ──────────────────────────────────────────────
+
+export interface WebhookDashboardConfig {
+  /** Marina / dock address the drinks are delivered to for the on-water tab */
+  marinaAddress: AffiliateAddress;
+  /** Build the on-water tab name from the booked item + customer name */
+  buildPrimaryTabName: (itemsName: string, customerName: string) => string;
+  /** Build the dashboard (group order) title */
+  buildDashboardTitle: (customerName: string) => string;
+  /** Name of the secondary lodging / stock-the-house tab */
+  lodgingTabName: string;
+}
+
+const PREMIER_WEBHOOK_CONFIG: WebhookDashboardConfig = {
+  marinaAddress: PREMIER_MARINA_ADDRESS,
+  buildPrimaryTabName: (itemsName, customerName) =>
+    buildCruiseTabName(normalizeCruiseType(itemsName), customerName),
+  buildDashboardTitle,
+  lodgingTabName: LODGING_TAB_NAME,
+};
+
+const CENTEX_WEBHOOK_CONFIG: WebhookDashboardConfig = {
+  marinaAddress: CENTEX_MARINA_ADDRESS,
+  buildPrimaryTabName: (_itemsName, customerName) =>
+    `${customerName}'s Lake Travis Boat Drink Delivery!`,
+  buildDashboardTitle,
+  lodgingTabName: LODGING_TAB_NAME,
+};
+
+/** Registry keyed by normalized affiliate code (uppercase, no dashes). */
+const WEBHOOK_CONFIG_BY_CODE: Record<string, WebhookDashboardConfig> = {
+  PREMIER: PREMIER_WEBHOOK_CONFIG,
+  CENTEXBOATRENTALS: CENTEX_WEBHOOK_CONFIG,
+};
+
+/**
+ * Resolve the dashboard config for an affiliate webhook by affiliate code.
+ * Falls back to the Premier config (the original hardcoded behavior) for any
+ * code that is not explicitly registered, so existing partners are unaffected.
+ */
+export function getWebhookDashboardConfig(
+  affiliateCode: string | null | undefined
+): WebhookDashboardConfig {
+  const key = (affiliateCode || '').toUpperCase().replace(/-/g, '');
+  return WEBHOOK_CONFIG_BY_CODE[key] || PREMIER_WEBHOOK_CONFIG;
 }
 
 // ──────────────────────────────────────────────

--- a/src/lib/webhooks/ghl.ts
+++ b/src/lib/webhooks/ghl.ts
@@ -232,6 +232,14 @@ export interface GhlDashboardPayload {
   cruise_date: string;
   cruise_type: string;
   booking_id: string;
+  /** Affiliate/partner code that sourced this booking (e.g. PREMIER, CENTEXBOATRENTALS) */
+  partner_code?: string;
+  /**
+   * Whether the customer opted in to SMS at booking time. The GHL
+   * dashboard.created workflow should gate texting on this flag and fall back
+   * to email-only outreach when it is false (Hybrid partners like Centex).
+   */
+  sms_consent?: boolean;
 }
 
 /**


### PR DESCRIPTION
## What

Pre-builds the **Centex Boat Rentals** booking integration. Centex books on **FareHarbor**, which has a native Zapier integration — so every booking can flow into our existing `/api/webhooks/create-dashboard` endpoint and auto-create a co-branded "Drink Delivery" dashboard. Same model Premier Party Cruises runs today via Xola → Zapier → webhook.

## Changes

- **Affiliate-aware webhook** — `create-dashboard` route now resolves marina address + tab naming **per affiliate code** (`getWebhookDashboardConfig`) instead of hardcoding Premier. Unregistered codes fall back to the Premier config, so **no behavior change for existing partners**.
- **Centex config** — Lake Travis marina address (17141 Rocky Ridge Rd) + boat-based tab/title.
- **Hybrid outreach plumbing** — `partner_code` + `sms_consent` now flow to the GHL `dashboard.created` event so SMS can be gated on booking-time opt-in (email everyone / text only opt-ins).
- **Provisioning script** — `scripts/ops/provision-centex-webhook.mjs`, idempotent, mints the Centex `webhookApiKey`.
- **Docs** — `docs/integrations/centex-fareharbor.md`: Zapier field mapping, curl test, consent notes, go-live checklist.

## Validation

- `tsc --noEmit`: clean
- ESLint (changed files): clean
- Backward-compatible: Premier path unchanged (default config).

## ⚠️ Draft — do not merge until go-live

Merging triggers a prod deploy. Per plan, hold until right before the Centex meeting. Still outstanding for full go-live:

- [ ] Run `provision-centex-webhook.mjs` (prod) to mint the key
- [ ] Build the Zap (needs Centex's FareHarbor API key)
- [ ] Add the `sms_consent` branch to the GHL `dashboard.created` workflow
- [ ] (Optional) Centex adds the booking opt-in question

🤖 Generated with [Claude Code](https://claude.com/claude-code)
