### PR TITLE
feat(landing): add Bubbly & Champagne to bachelorette package builder

### DIFF
--- a/src/app/austin-bachelorette-party-delivery/page.tsx
+++ b/src/app/austin-bachelorette-party-delivery/page.tsx
@@ -22,7 +22,7 @@ export const metadata: Metadata = {
 
 export default async function Page() {
   const [catalog, lastMinuteCatalog, packages, upsellProducts] = await Promise.all([
-    getCuratedCatalog(),
+    getCuratedCatalog({ includeBubbly: true }),
     getLastMinuteCatalog(),
     getOccasionPackages('bachelorette'),
     getUpsellProducts(),

--- a/src/lib/landing/getCuratedCatalog.ts
+++ b/src/lib/landing/getCuratedCatalog.ts
@@ -23,7 +23,8 @@ type ProductTypeKey =
   | 'Gin'
   | 'Rum'
   | 'Cocktail Kit'
-  | 'Mixer';
+  | 'Mixer'
+  | 'Sparkling Wine';
 
 type Bucket = {
   type: ProductTypeKey;
@@ -52,6 +53,19 @@ const STEP_TWO: Bucket[] = [
 const STEP_THREE: Bucket[] = [
   { type: 'Mixer', take: 10, idPrefix: 'm', emoji: '🥤', accent: 'bg-emerald-500' },
 ];
+
+// Bubbly/champagne — opt-in per occasion (e.g. bachelorette). Pulls the live
+// "Sparkling Wine" productType, which covers champagne, prosecco AND rosé,
+// so it fills the bachelorette Step One ("Bubbly, rosé & seltzers") tab.
+const BUBBLY: Bucket = {
+  type: 'Sparkling Wine',
+  take: 10,
+  idPrefix: 'sp',
+  emoji: '🥂',
+  accent: 'bg-amber-300',
+};
+
+export type CuratedCatalogOptions = { includeBubbly?: boolean };
 
 async function fetchBucket(
   bucket: Bucket,
@@ -97,11 +111,15 @@ async function fetchBucket(
   };
 }
 
-async function buildCatalogUncached() {
+async function buildCatalogUncached(opts: CuratedCatalogOptions = {}) {
+  // Bubbly/champagne rides in Step One (the bachelorette "Bubbly, rosé &
+  // seltzers" step) only when the occasion asks for it.
+  const stepOneBuckets: Bucket[] = opts.includeBubbly ? [...STEP_ONE, BUBBLY] : STEP_ONE;
+
   let stepOne, stepTwo, stepThree;
   try {
     [stepOne, stepTwo, stepThree] = await Promise.all([
-      Promise.all(STEP_ONE.map(fetchBucket)),
+      Promise.all(stepOneBuckets.map(fetchBucket)),
       Promise.all(STEP_TWO.map(fetchBucket)),
       Promise.all(STEP_THREE.map(fetchBucket)),
     ]);
@@ -110,14 +128,19 @@ async function buildCatalogUncached() {
     // empty catalog rather than 500ing the whole landing page.
     console.error('[getCuratedCatalog] DB fetch failed:', err);
     const empty = { top: [], extras: [] };
-    stepOne = STEP_ONE.map(() => empty);
+    stepOne = stepOneBuckets.map(() => empty);
     stepTwo = STEP_TWO.map(() => empty);
     stepThree = STEP_THREE.map(() => empty);
   }
 
-  const stepOneCategories: BuilderCategory[] = STEP_ONE.map((b, i) => ({
+  const stepOneCategories: BuilderCategory[] = stepOneBuckets.map((b, i) => ({
     key: b.type.toLowerCase().replace(/\s+/g, '-'),
-    label: b.type === 'Seltzer' ? 'Seltzers' : b.type,
+    label:
+      b.type === 'Seltzer'
+        ? 'Seltzers'
+        : b.type === 'Sparkling Wine'
+          ? 'Bubbly & Champagne'
+          : b.type,
     products: stepOne[i].top,
     extras: stepOne[i].extras,
   }));


### PR DESCRIPTION
## What
Adds a **Bubbly & Champagne** category to the bachelorette landing-page Package Builder.

## Why
A customer building a custom "sunset yacht pack" reported champagne wasn't selectable. The builder's curated catalog (`getCuratedCatalog`) only surfaced beer / seltzer / liquor / kits / mixers — no wine or sparkling — even though the bachelorette Step One tab is labeled **"Bubbly, rosé & seltzers."** (The *standard* Sunset Yacht Pack package already includes champagne; this fixes the *custom builder* path.)

## How
- `getCuratedCatalog`: opt-in `Sparkling Wine` bucket (covers champagne, prosecco **and** rosé) + `includeBubbly` option.
- Bachelorette page passes `{ includeBubbly: true }`. **Other landing pages unaffected.**
- Builder items resolve to live products by `handle`, so they check out exactly like beer/seltzer.

## Verified
- 10/10 top sparkling products resolve to active variants (checkout-safe).
- `tsc --noEmit` + eslint clean.
- Scoped to bachelorette only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)