### PR TITLE
feat(admin): Game Plan strategy living-document tracker at /admin/strategy

### DIFF
--- a/prisma/migrations/manual/2026-06-17-strategy-initiatives.sql
+++ b/prisma/migrations/manual/2026-06-17-strategy-initiatives.sql
@@ -1,0 +1,136 @@
+-- Game Plan — strategy_initiatives table + seed
+--
+-- Backs the internal "Game Plan" living-document page at /admin/strategy where Allan + Brian
+-- track the company's bottom-line strategy and its execution. Human-authored strategic
+-- initiatives (owners, priority, sub-tasks, progress log) — distinct from the machine-detected
+-- /admin/recommendations queue.
+--
+-- Per saved memory `prisma_schema_drift.md`: schema.prisma is intentionally drifted from prod,
+-- so `prisma db push` is unsafe. This file is applied automatically on prod deploys by
+-- scripts/db/apply-manual-migrations.mjs (recorded once in the _manual_migrations ledger).
+-- Apply locally with:  npm run db:migrate:manual   (after sourcing .env.local)
+-- After applying, regenerate the prisma client:  npx prisma generate
+--
+-- All statements are idempotent (IF NOT EXISTS / ON CONFLICT DO NOTHING) so the file is safe
+-- to re-run. The seed uses stable slug ids, so a row a user later deletes is NOT resurrected.
+
+BEGIN;
+
+-- =========================================================================
+-- strategy_initiatives — one row per strategic initiative
+-- =========================================================================
+CREATE TABLE IF NOT EXISTS strategy_initiatives (
+  id            TEXT PRIMARY KEY,
+  pillar        TEXT NOT NULL,                                   -- finance | operations | acquisition | partnerships
+  title         TEXT NOT NULL,
+  description   TEXT,
+  status        TEXT NOT NULL DEFAULT 'not_started',            -- not_started | in_progress | blocked | done
+  priority      TEXT NOT NULL DEFAULT 'later',                  -- now | next | later
+  owner         TEXT,                                           -- freeform: Allan | Brian | Vic | Gus | ...
+  next_action   TEXT,
+  target_date   DATE,
+  linked_domain TEXT,                                           -- finance | operations | marketing | seo
+  sort_order    INTEGER NOT NULL DEFAULT 0,
+  subtasks      JSONB NOT NULL DEFAULT '[]'::jsonb,             -- [{ id, label, done, createdAt }]
+  updates       JSONB NOT NULL DEFAULT '[]'::jsonb,             -- [{ id, author, body, createdAt }] append-only
+  archived_at   TIMESTAMP(3),
+  created_at    TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at    TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS strategy_initiatives_pillar_idx
+  ON strategy_initiatives (pillar);
+CREATE INDEX IF NOT EXISTS strategy_initiatives_status_idx
+  ON strategy_initiatives (status);
+CREATE INDEX IF NOT EXISTS strategy_initiatives_pillar_priority_sort_idx
+  ON strategy_initiatives (pillar, priority, sort_order);
+
+-- =========================================================================
+-- Seed — the 10 kickoff initiatives, prioritized Now / Next / Later.
+-- Editable in-app after seeding; ON CONFLICT keeps re-runs/edits safe.
+-- =========================================================================
+INSERT INTO strategy_initiatives
+  (id, pillar, title, description, status, priority, owner, next_action, linked_domain, sort_order, subtasks)
+VALUES
+  -- ---- Finances ----------------------------------------------------------
+  ('seed-finance-integrations', 'finance',
+   'Finish financial integrations → accurate snapshots',
+   'Foundation for everything else: until the daily snapshot is accurate we cannot measure whether any initiative is actually moving the bottom line. Already in flight via the Finance Director phases (QuickBooks production connect, Plaid bank feed, Stripe reconciliation).',
+   'not_started', 'now', 'Allan',
+   'Confirm the QuickBooks production connection, then verify the daily P&L snapshot reconciles.',
+   'finance', 0,
+   '[{"id":"st-fi-1","label":"Connect production QuickBooks","done":false,"createdAt":"2026-06-17T00:00:00.000Z"},{"id":"st-fi-2","label":"Verify daily P&L snapshot accuracy","done":false,"createdAt":"2026-06-17T00:00:00.000Z"},{"id":"st-fi-3","label":"Reconcile bank transactions via Plaid","done":false,"createdAt":"2026-06-17T00:00:00.000Z"}]'::jsonb),
+
+  -- ---- Operations & Delegation ------------------------------------------
+  ('seed-vic-ops', 'operations',
+   'Vic owns ordering, inventory & fulfillment',
+   'Highest time-leverage move — handing the daily ordering / inventory / fulfillment grind to Vic frees both owners to run the growth plays below.',
+   'not_started', 'now', 'Brian',
+   'Document the daily workflow and give Vic access to the ops + inventory tools.',
+   'operations', 0,
+   '[{"id":"st-vic-1","label":"Document the daily ordering + fulfillment workflow","done":false,"createdAt":"2026-06-17T00:00:00.000Z"},{"id":"st-vic-2","label":"Grant Vic ops + inventory access","done":false,"createdAt":"2026-06-17T00:00:00.000Z"},{"id":"st-vic-3","label":"Shadow for one week","done":false,"createdAt":"2026-06-17T00:00:00.000Z"},{"id":"st-vic-4","label":"Full hand-off","done":false,"createdAt":"2026-06-17T00:00:00.000Z"}]'::jsonb),
+
+  ('seed-centex-workflow', 'operations',
+   'Finalize automated workflow with Centex',
+   'Supplier / ordering automation that supports Vic owning ordering. (Confirm exactly what Centex covers — assumed supplier automation.)',
+   'not_started', 'next', 'Brian',
+   'Confirm what Centex covers, then define the automated hand-off.',
+   'operations', 1, '[]'::jsonb),
+
+  ('seed-driver-shifts', 'operations',
+   'Gus / another driver on semi-recurring shifts',
+   'Delivery capacity for the volume that ads + the short-term-rental channel will drive.',
+   'not_started', 'next', 'Brian',
+   'Lock Gus into a recurring weekly slot, or recruit a backup driver.',
+   NULL, 2, '[]'::jsonb),
+
+  -- ---- Paid Acquisition --------------------------------------------------
+  ('seed-landing-pages', 'acquisition',
+   'Fix segmented landing pages (bachelorette, wedding, corporate)',
+   'Blocks Google Ads — do not pay for traffic to broken or mismatched pages. The bachelor page is already overhauled; replicate that quality across the bachelorette, wedding, and corporate pages.',
+   'not_started', 'now', 'Allan',
+   'Audit each segment page against the finished bachelor page.',
+   'marketing', 0,
+   '[{"id":"st-lp-1","label":"Bachelorette page","done":false,"createdAt":"2026-06-17T00:00:00.000Z"},{"id":"st-lp-2","label":"Wedding page","done":false,"createdAt":"2026-06-17T00:00:00.000Z"},{"id":"st-lp-3","label":"Corporate page","done":false,"createdAt":"2026-06-17T00:00:00.000Z"}]'::jsonb),
+
+  ('seed-google-ads', 'acquisition',
+   'Google Ads per segment (bachelor / bachelorette / wedding / corporate)',
+   'Depends on the landing pages being fixed first. The bachelor campaign is already serving — replicate per segment. Respect the delivery footprint: do NOT geo-target Round Rock, Pflugerville, Leander, Dripping Springs, Buda, or Kyle.',
+   'not_started', 'next', 'Allan',
+   'Replicate the live bachelor campaign for the next segment once its page is fixed.',
+   'marketing', 1,
+   '[{"id":"st-ga-1","label":"Bachelorette campaign","done":false,"createdAt":"2026-06-17T00:00:00.000Z"},{"id":"st-ga-2","label":"Wedding campaign","done":false,"createdAt":"2026-06-17T00:00:00.000Z"},{"id":"st-ga-3","label":"Corporate campaign","done":false,"createdAt":"2026-06-17T00:00:00.000Z"}]'::jsonb),
+
+  -- ---- Rental Partnerships ----------------------------------------------
+  ('seed-five-star', 'partnerships',
+   'Re-engage Lucas → Five-Star Rentals workflow',
+   'Relationship re-engagement that unlocks the whole short-term-rental (STR) channel — the onboarding email campaign and the fridge magnets both hang off this.',
+   'not_started', 'now', 'Allan',
+   'Reach back out to Lucas and his friend to restart the conversation.',
+   NULL, 0,
+   '[{"id":"st-fs-1","label":"Reach out to Lucas","done":false,"createdAt":"2026-06-17T00:00:00.000Z"},{"id":"st-fs-2","label":"Agree the referral / ordering workflow","done":false,"createdAt":"2026-06-17T00:00:00.000Z"},{"id":"st-fs-3","label":"Pilot with a few properties","done":false,"createdAt":"2026-06-17T00:00:00.000Z"}]'::jsonb),
+
+  ('seed-str-email', 'partnerships',
+   'STR customer onboarding email campaign',
+   'Part of the Five-Star integration — an onboarding email sequence for short-term-rental guests and hosts. Build once that workflow is agreed.',
+   'not_started', 'next', 'Allan',
+   'Draft the onboarding sequence once the Five-Star workflow is agreed.',
+   'marketing', 1, '[]'::jsonb),
+
+  ('seed-neal-rentals', 'partnerships',
+   'Workflow with Neal & his rentals',
+   'Second STR partner — roll out the same partner workflow after Five-Star proves the playbook.',
+   'not_started', 'next', 'Brian',
+   'Set up the partner workflow with Neal.',
+   NULL, 2, '[]'::jsonb),
+
+  ('seed-fridge-magnets', 'partnerships',
+   'Fridge magnets at Airbnbs around town',
+   'Cheap, delegable channel-builder. Do this once a partner workflow exists so the magnets point somewhere (QR to the right landing page / offer).',
+   'not_started', 'later', 'Brian',
+   'Design + order a first batch of magnets with a QR code.',
+   NULL, 3,
+   '[{"id":"st-fm-1","label":"Design magnet + QR","done":false,"createdAt":"2026-06-17T00:00:00.000Z"},{"id":"st-fm-2","label":"Order first batch","done":false,"createdAt":"2026-06-17T00:00:00.000Z"},{"id":"st-fm-3","label":"Distribute to partner properties","done":false,"createdAt":"2026-06-17T00:00:00.000Z"}]'::jsonb)
+ON CONFLICT (id) DO NOTHING;
+
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2636,6 +2636,36 @@ model FinanceSnapshot {
   @@map("finance_snapshots")
 }
 
+/// Game Plan — human-authored strategic initiatives for the /admin/strategy
+/// living-document page (Allan + Brian). Distinct from the machine-detected
+/// recommendation queues above: these are owned, prioritized, hand-tracked
+/// initiatives with a sub-task checklist and an append-only progress log.
+/// Seeded with the 10 kickoff items via
+/// prisma/migrations/manual/2026-06-17-strategy-initiatives.sql.
+model StrategyInitiative {
+  id           String    @id @default(cuid())
+  pillar       String    // finance | operations | acquisition | partnerships
+  title        String
+  description  String?   @db.Text
+  status       String    @default("not_started") // not_started | in_progress | blocked | done
+  priority     String    @default("later")       // now | next | later
+  owner        String?
+  nextAction   String?   @map("next_action") @db.Text
+  targetDate   DateTime? @map("target_date") @db.Date
+  linkedDomain String?   @map("linked_domain")   // finance | operations | marketing | seo
+  sortOrder    Int       @default(0) @map("sort_order")
+  subtasks     Json      @default("[]") // [{ id, label, done, createdAt }]
+  updates      Json      @default("[]") // [{ id, author, body, createdAt }] append-only progress log
+  archivedAt   DateTime? @map("archived_at")
+  createdAt    DateTime  @default(now()) @map("created_at")
+  updatedAt    DateTime  @updatedAt @map("updated_at")
+
+  @@index([pillar])
+  @@index([status])
+  @@index([pillar, priority, sortOrder])
+  @@map("strategy_initiatives")
+}
+
 /// Single-row holder for the active QuickBooks Online OAuth state. Refresh
 /// token rotates on each refresh; the row is updated in place. Operator-created
 /// via the /admin/finance/connect-quickbooks OAuth flow — never seeded by migration.

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -167,6 +167,7 @@ export default function AdminLayout({ children }: AdminLayoutProps): ReactElemen
 
   // Navigation items (admin-only strategic/management features)
   const navItems = [
+    { href: '/admin/strategy', label: 'Game Plan' },
     { href: '/admin/dashboard', label: 'Analytics' },
     { href: '/admin/customers', label: 'Customers' },
     { href: '/admin/emails', label: 'Emails' },

--- a/src/app/admin/strategy/_components/initiative-card.tsx
+++ b/src/app/admin/strategy/_components/initiative-card.tsx
@@ -1,0 +1,345 @@
+/**
+ * One Game Plan initiative card: status/priority at a glance, inline status +
+ * priority controls, and an expandable body with the sub-task checklist, the
+ * append-only progress log, and any linked director recommendations.
+ */
+
+'use client';
+
+import { useState, ReactElement } from 'react';
+import {
+  ChevronDownIcon,
+  ChevronUpIcon,
+  TrashIcon,
+  PencilSquareIcon,
+  PlusIcon,
+  UserCircleIcon,
+  CalendarDaysIcon,
+  ArrowTopRightOnSquareIcon,
+} from '@heroicons/react/24/outline';
+import { StatusBadge, PriorityBadge } from './strategy-status-badge';
+import {
+  STATUSES,
+  PRIORITIES,
+  STATUS_LABEL,
+  PRIORITY_LABEL,
+  LINKED_DOMAIN_LABEL,
+  type StrategyInitiativeDTO,
+  type LinkedRecsSummary,
+  type Subtask,
+  type InitiativeStatus,
+  type Priority,
+  type UpdateInitiativeInput,
+  type LinkedDomain,
+} from '@/lib/strategy/types';
+
+interface Props {
+  initiative: StrategyInitiativeDTO;
+  recs: LinkedRecsSummary;
+  currentUser: string | null;
+  saving: boolean;
+  onPatch: (id: string, input: UpdateInitiativeInput) => Promise<boolean>;
+  onRemove: (id: string) => Promise<boolean>;
+  onAddNote: (id: string, author: string, body: string) => Promise<boolean>;
+  onEdit: (initiative: StrategyInitiativeDTO) => void;
+}
+
+function relativeTime(iso: string): string {
+  const minutes = Math.round((Date.now() - new Date(iso).getTime()) / 60000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+const COMPACT_CONTROL = 'text-sm border border-gray-200 rounded-md px-2 py-1 bg-white focus:border-brand-blue focus:outline-none';
+const SELECT = `${COMPACT_CONTROL} text-gray-800`;
+
+/** Sub-task checklist with add + toggle + remove, persisted via a full-array patch. */
+function SubtasksSection({
+  initiative,
+  disabled,
+  onPatch,
+}: {
+  initiative: StrategyInitiativeDTO;
+  disabled: boolean;
+  onPatch: Props['onPatch'];
+}): ReactElement {
+  const [label, setLabel] = useState('');
+  const subtasks = initiative.subtasks;
+
+  const persist = (next: Subtask[]): void => {
+    void onPatch(initiative.id, { subtasks: next });
+  };
+  const toggle = (id: string): void =>
+    persist(subtasks.map((s) => (s.id === id ? { ...s, done: !s.done } : s)));
+  const remove = (id: string): void => persist(subtasks.filter((s) => s.id !== id));
+  const add = (): void => {
+    const text = label.trim();
+    if (!text) return;
+    persist([
+      ...subtasks,
+      { id: crypto.randomUUID(), label: text, done: false, createdAt: new Date().toISOString() },
+    ]);
+    setLabel('');
+  };
+
+  return (
+    <div>
+      <h4 className="text-sm font-bold tracking-[0.08em] text-gray-700 uppercase mb-2">Sub-tasks</h4>
+      <ul className="space-y-1.5">
+        {subtasks.map((s) => (
+          <li key={s.id} className="flex items-center gap-2 group">
+            <input
+              type="checkbox"
+              checked={s.done}
+              disabled={disabled}
+              onChange={() => toggle(s.id)}
+              className="h-4 w-4 rounded border-gray-300 text-brand-blue focus:ring-brand-blue"
+            />
+            <span className={`text-sm flex-1 ${s.done ? 'line-through text-gray-400' : 'text-gray-800'}`}>
+              {s.label}
+            </span>
+            <button
+              onClick={() => remove(s.id)}
+              disabled={disabled}
+              className="opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-600 transition"
+              aria-label="Remove sub-task"
+            >
+              <TrashIcon className="h-4 w-4" />
+            </button>
+          </li>
+        ))}
+        {subtasks.length === 0 && <li className="text-sm text-gray-500">No sub-tasks yet.</li>}
+      </ul>
+      <div className="flex gap-2 mt-2">
+        <input
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), add())}
+          placeholder="Add a step…"
+          disabled={disabled}
+          className={`${COMPACT_CONTROL} flex-1`}
+        />
+        <button onClick={add} disabled={disabled || !label.trim()} className="btn-ghost px-2" aria-label="Add sub-task">
+          <PlusIcon className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/** Append-only progress log, newest first, with an add-note form. */
+function ProgressLog({
+  initiative,
+  currentUser,
+  disabled,
+  onAddNote,
+}: {
+  initiative: StrategyInitiativeDTO;
+  currentUser: string | null;
+  disabled: boolean;
+  onAddNote: Props['onAddNote'];
+}): ReactElement {
+  const [note, setNote] = useState('');
+  const entries = [...initiative.updates].reverse();
+
+  const submit = async (): Promise<void> => {
+    const body = note.trim();
+    if (!body || !currentUser) return;
+    const ok = await onAddNote(initiative.id, currentUser, body);
+    if (ok) setNote('');
+  };
+
+  return (
+    <div>
+      <h4 className="text-sm font-bold tracking-[0.08em] text-gray-700 uppercase mb-2">Progress log</h4>
+      <div className="space-y-2 mb-2">
+        {entries.map((u) => (
+          <div key={u.id} className="text-sm bg-gray-50 border border-gray-100 rounded-lg px-3 py-2">
+            <div className="flex items-center justify-between text-xs text-gray-500 mb-0.5">
+              <span className="font-semibold text-gray-700">{u.author}</span>
+              <span>{relativeTime(u.createdAt)}</span>
+            </div>
+            <p className="text-gray-800 whitespace-pre-wrap">{u.body}</p>
+          </div>
+        ))}
+        {entries.length === 0 && <p className="text-sm text-gray-500">No updates yet.</p>}
+      </div>
+      <div className="flex gap-2">
+        <textarea
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder={currentUser ? `Add an update as ${currentUser}…` : 'Pick who you are first'}
+          disabled={disabled || !currentUser}
+          rows={2}
+          className={`${COMPACT_CONTROL} flex-1`}
+        />
+        <button onClick={submit} disabled={disabled || !note.trim() || !currentUser} className="btn-primary self-end">
+          Post
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/** Read-only roll-up of related director recs, linking to the triage queue. */
+function LinkedRecsSection({
+  linkedDomain,
+  recs,
+}: {
+  linkedDomain: LinkedDomain;
+  recs: LinkedRecsSummary;
+}): ReactElement {
+  const count = recs.counts[linkedDomain];
+  const titles = recs.titles[linkedDomain];
+  return (
+    <div>
+      <h4 className="text-sm font-bold tracking-[0.08em] text-gray-700 uppercase mb-2">
+        Linked {LINKED_DOMAIN_LABEL[linkedDomain]} recs
+      </h4>
+      {count === 0 ? (
+        <p className="text-sm text-gray-500">No open recommendations right now.</p>
+      ) : (
+        <ul className="space-y-1 mb-2">
+          {titles.map((t, i) => (
+            <li key={i} className="text-sm text-gray-700 truncate">• {t}</li>
+          ))}
+        </ul>
+      )}
+      <a
+        href={`/admin/recommendations?domain=${linkedDomain}`}
+        className="inline-flex items-center gap-1 text-sm font-semibold text-brand-blue hover:underline"
+      >
+        {count > 0 ? `View all ${count} in triage` : 'Open triage queue'}
+        <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+      </a>
+    </div>
+  );
+}
+
+export default function InitiativeCard({
+  initiative,
+  recs,
+  currentUser,
+  saving,
+  onPatch,
+  onRemove,
+  onAddNote,
+  onEdit,
+}: Props): ReactElement {
+  const [expanded, setExpanded] = useState(false);
+  const doneCount = initiative.subtasks.filter((s) => s.done).length;
+  const isDone = initiative.status === 'done';
+
+  const handleRemove = (): void => {
+    if (confirm(`Archive “${initiative.title}”? It will be hidden from the board.`)) {
+      void onRemove(initiative.id);
+    }
+  };
+
+  return (
+    <div className={`card !p-4 ${isDone ? 'opacity-70' : ''}`}>
+      {/* Header */}
+      <div className="flex items-start justify-between gap-3">
+        <h3 className={`text-base font-semibold line-clamp-2 ${isDone ? 'line-through text-gray-400' : 'text-gray-900'}`}>
+          {initiative.title}
+        </h3>
+        <div className="flex items-center gap-1.5 shrink-0">
+          <StatusBadge status={initiative.status} />
+          <PriorityBadge priority={initiative.priority} />
+        </div>
+      </div>
+
+      {/* Meta */}
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-2 text-sm text-gray-600">
+        <span className="inline-flex items-center gap-1">
+          <UserCircleIcon className="h-4 w-4 text-gray-400" />
+          {initiative.owner || 'Unassigned'}
+        </span>
+        {initiative.targetDate && (
+          <span className="inline-flex items-center gap-1">
+            <CalendarDaysIcon className="h-4 w-4 text-gray-400" />
+            {initiative.targetDate}
+          </span>
+        )}
+        {initiative.linkedDomain && recs.counts[initiative.linkedDomain] > 0 && (
+          <span className="inline-flex items-center gap-1 text-brand-blue font-medium">
+            {recs.counts[initiative.linkedDomain]} {LINKED_DOMAIN_LABEL[initiative.linkedDomain]} recs
+          </span>
+        )}
+      </div>
+
+      {initiative.nextAction && (
+        <p className="text-sm text-gray-800 mt-2">
+          <span className="font-semibold text-gray-500">Next:</span> {initiative.nextAction}
+        </p>
+      )}
+
+      {/* Controls */}
+      <div className="flex flex-wrap items-center gap-2 mt-3">
+        <select
+          value={initiative.status}
+          disabled={saving}
+          onChange={(e) => void onPatch(initiative.id, { status: e.target.value as InitiativeStatus })}
+          className={SELECT}
+          aria-label="Status"
+        >
+          {STATUSES.map((s) => (
+            <option key={s} value={s}>{STATUS_LABEL[s]}</option>
+          ))}
+        </select>
+        <select
+          value={initiative.priority}
+          disabled={saving}
+          onChange={(e) => void onPatch(initiative.id, { priority: e.target.value as Priority })}
+          className={SELECT}
+          aria-label="Priority"
+        >
+          {PRIORITIES.map((p) => (
+            <option key={p} value={p}>{PRIORITY_LABEL[p]}</option>
+          ))}
+        </select>
+        <div className="ml-auto flex items-center gap-3 text-sm text-gray-500">
+          {initiative.subtasks.length > 0 && <span>{doneCount}/{initiative.subtasks.length} steps</span>}
+          {initiative.updates.length > 0 && <span>{initiative.updates.length} notes</span>}
+          <button
+            onClick={() => setExpanded((v) => !v)}
+            className="inline-flex items-center gap-1 font-semibold text-gray-700 hover:text-brand-blue"
+          >
+            {expanded ? 'Less' : 'More'}
+            {expanded ? <ChevronUpIcon className="h-4 w-4" /> : <ChevronDownIcon className="h-4 w-4" />}
+          </button>
+        </div>
+      </div>
+
+      {/* Expanded body */}
+      {expanded && (
+        <div className="mt-4 pt-4 border-t border-gray-100 space-y-5">
+          {initiative.description && (
+            <p className="text-sm text-gray-700 whitespace-pre-wrap">{initiative.description}</p>
+          )}
+          <SubtasksSection initiative={initiative} disabled={saving} onPatch={onPatch} />
+          <ProgressLog
+            initiative={initiative}
+            currentUser={currentUser}
+            disabled={saving}
+            onAddNote={onAddNote}
+          />
+          {initiative.linkedDomain && <LinkedRecsSection linkedDomain={initiative.linkedDomain} recs={recs} />}
+          <div className="flex justify-end gap-3 pt-1">
+            <button onClick={() => onEdit(initiative)} className="btn-ghost inline-flex items-center gap-1">
+              <PencilSquareIcon className="h-4 w-4" /> Edit
+            </button>
+            <button onClick={handleRemove} className="btn-ghost inline-flex items-center gap-1 text-red-600 hover:text-red-700">
+              <TrashIcon className="h-4 w-4" /> Archive
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/strategy/_components/name-picker.tsx
+++ b/src/app/admin/strategy/_components/name-picker.tsx
@@ -1,0 +1,97 @@
+/**
+ * Lightweight identity for the Game Plan page. Both owners log in with the same
+ * shared admin password, so the session can't tell Allan from Brian. Instead we
+ * remember "who's working" in localStorage and stamp it on progress notes /
+ * default owner. No change to the auth system (see plan: Identity).
+ */
+
+'use client';
+
+import { useState, useEffect, ReactElement } from 'react';
+
+const STORAGE_KEY = 'strategy_user';
+export const PEOPLE = ['Allan', 'Brian'] as const;
+
+/** Read/write the active viewer name from localStorage. */
+export function useStrategyUser(): {
+  user: string | null;
+  ready: boolean;
+  setUser: (name: string) => void;
+} {
+  const [user, setUserState] = useState<string | null>(null);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    try {
+      setUserState(localStorage.getItem(STORAGE_KEY));
+    } catch {
+      // localStorage unavailable — treat as unset
+    }
+    setReady(true);
+  }, []);
+
+  const setUser = (name: string): void => {
+    try {
+      localStorage.setItem(STORAGE_KEY, name);
+    } catch {
+      // ignore persistence failure
+    }
+    setUserState(name);
+  };
+
+  return { user, ready, setUser };
+}
+
+/** Full-width prompt shown until the viewer says who they are. */
+export function NamePrompt({ onPick }: { onPick: (name: string) => void }): ReactElement {
+  return (
+    <div className="min-h-[60vh] flex items-center justify-center p-6">
+      <div className="card max-w-md w-full text-center">
+        <h2 className="text-2xl font-heading tracking-[0.1em] text-gray-900">
+          Who&apos;s working on this?
+        </h2>
+        <p className="text-sm text-gray-600 mt-2">
+          We stamp your name on progress notes and use it as the default owner. You can switch
+          any time.
+        </p>
+        <div className="flex gap-3 justify-center mt-6">
+          {PEOPLE.map((name) => (
+            <button key={name} onClick={() => onPick(name)} className="btn-primary px-8">
+              {name}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Compact header control to switch the active viewer. */
+export function NameSwitcher({
+  user,
+  onPick,
+}: {
+  user: string | null;
+  onPick: (name: string) => void;
+}): ReactElement {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-sm text-gray-500">Working as</span>
+      <div className="flex rounded-lg border border-gray-200 overflow-hidden">
+        {PEOPLE.map((name) => (
+          <button
+            key={name}
+            onClick={() => onPick(name)}
+            className={`px-3 py-1.5 text-sm font-semibold transition-colors ${
+              user === name
+                ? 'bg-brand-blue text-white'
+                : 'bg-white text-gray-700 hover:bg-gray-50'
+            }`}
+          >
+            {name}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/strategy/_components/new-initiative-modal.tsx
+++ b/src/app/admin/strategy/_components/new-initiative-modal.tsx
@@ -1,0 +1,204 @@
+/**
+ * Create / edit modal for a Game Plan initiative. Used for both flows: pass
+ * `initial` to edit, omit it to create. Builds a CreateInitiativeInput payload
+ * the parent sends to POST (create) or PATCH (edit).
+ */
+
+'use client';
+
+import { useState, useEffect, ReactElement } from 'react';
+import Modal from '@/components/ui/Modal';
+import {
+  PILLARS,
+  STATUSES,
+  PRIORITIES,
+  LINKED_DOMAINS,
+  PILLAR_META,
+  STATUS_LABEL,
+  PRIORITY_LABEL,
+  LINKED_DOMAIN_LABEL,
+  type CreateInitiativeInput,
+  type StrategyInitiativeDTO,
+  type Pillar,
+  type InitiativeStatus,
+  type Priority,
+  type LinkedDomain,
+} from '@/lib/strategy/types';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (values: CreateInitiativeInput) => Promise<boolean>;
+  saving: boolean;
+  /** Present when editing. */
+  initial?: StrategyInitiativeDTO | null;
+  /** Prefill owner on create (the active viewer). */
+  defaultOwner?: string | null;
+}
+
+const LABEL = 'block text-base font-medium text-gray-700 mb-1';
+const CONTROL =
+  'w-full px-4 py-3 text-base border-2 border-gray-200 rounded-lg transition-colors hover:border-gray-300 focus:border-brand-blue focus:outline-none';
+
+export default function NewInitiativeModal({
+  isOpen,
+  onClose,
+  onSubmit,
+  saving,
+  initial,
+  defaultOwner,
+}: Props): ReactElement {
+  const [pillar, setPillar] = useState<Pillar>('operations');
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [owner, setOwner] = useState('');
+  const [status, setStatus] = useState<InitiativeStatus>('not_started');
+  const [priority, setPriority] = useState<Priority>('next');
+  const [linkedDomain, setLinkedDomain] = useState<LinkedDomain | ''>('');
+  const [nextAction, setNextAction] = useState('');
+  const [targetDate, setTargetDate] = useState('');
+
+  // Reset fields whenever the modal opens (with or without an initial).
+  useEffect(() => {
+    if (!isOpen) return;
+    setPillar(initial?.pillar ?? 'operations');
+    setTitle(initial?.title ?? '');
+    setDescription(initial?.description ?? '');
+    setOwner(initial?.owner ?? defaultOwner ?? '');
+    setStatus(initial?.status ?? 'not_started');
+    setPriority(initial?.priority ?? 'next');
+    setLinkedDomain(initial?.linkedDomain ?? '');
+    setNextAction(initial?.nextAction ?? '');
+    setTargetDate(initial?.targetDate ?? '');
+  }, [isOpen, initial, defaultOwner]);
+
+  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault();
+    if (!title.trim()) return;
+    const ok = await onSubmit({
+      pillar,
+      title: title.trim(),
+      description: description.trim() || null,
+      status,
+      priority,
+      owner: owner.trim() || null,
+      nextAction: nextAction.trim() || null,
+      targetDate: targetDate || null,
+      linkedDomain: linkedDomain || null,
+    });
+    if (ok) onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={initial ? 'Edit initiative' : 'New initiative'} maxWidth="2xl">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className={LABEL}>Title</label>
+          <input
+            className={CONTROL}
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="What needs to happen?"
+            autoFocus
+            required
+          />
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className={LABEL}>Pillar</label>
+            <select className={CONTROL} value={pillar} onChange={(e) => setPillar(e.target.value as Pillar)}>
+              {PILLARS.map((p) => (
+                <option key={p} value={p}>
+                  {PILLAR_META[p].label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className={LABEL}>Owner</label>
+            <input
+              className={CONTROL}
+              value={owner}
+              onChange={(e) => setOwner(e.target.value)}
+              placeholder="Allan, Brian, Vic…"
+            />
+          </div>
+          <div>
+            <label className={LABEL}>Priority</label>
+            <select className={CONTROL} value={priority} onChange={(e) => setPriority(e.target.value as Priority)}>
+              {PRIORITIES.map((p) => (
+                <option key={p} value={p}>
+                  {PRIORITY_LABEL[p]}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className={LABEL}>Status</label>
+            <select className={CONTROL} value={status} onChange={(e) => setStatus(e.target.value as InitiativeStatus)}>
+              {STATUSES.map((s) => (
+                <option key={s} value={s}>
+                  {STATUS_LABEL[s]}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className={LABEL}>Target date</label>
+            <input
+              type="date"
+              className={CONTROL}
+              value={targetDate}
+              onChange={(e) => setTargetDate(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className={LABEL}>Linked recs</label>
+            <select
+              className={CONTROL}
+              value={linkedDomain}
+              onChange={(e) => setLinkedDomain(e.target.value as LinkedDomain | '')}
+            >
+              <option value="">None</option>
+              {LINKED_DOMAINS.map((d) => (
+                <option key={d} value={d}>
+                  {LINKED_DOMAIN_LABEL[d]}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div>
+          <label className={LABEL}>Next step</label>
+          <input
+            className={CONTROL}
+            value={nextAction}
+            onChange={(e) => setNextAction(e.target.value)}
+            placeholder="The single next action"
+          />
+        </div>
+
+        <div>
+          <label className={LABEL}>Why / details</label>
+          <textarea
+            className={`${CONTROL} min-h-[90px]`}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Context, rationale, dependencies…"
+          />
+        </div>
+
+        <div className="flex justify-end gap-3 pt-2">
+          <button type="button" onClick={onClose} className="btn-ghost">
+            Cancel
+          </button>
+          <button type="submit" className="btn-primary" disabled={saving || !title.trim()}>
+            {saving ? 'Saving…' : initial ? 'Save changes' : 'Create initiative'}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/src/app/admin/strategy/_components/strategy-status-badge.tsx
+++ b/src/app/admin/strategy/_components/strategy-status-badge.tsx
@@ -1,0 +1,46 @@
+/**
+ * Status + priority pills for Game Plan initiative cards. Colors follow the
+ * codebase convention (light tint + matching border/text), all on white → dark
+ * text per the contrast rules. Badges are the one place text-xs is allowed.
+ */
+
+import { ReactElement } from 'react';
+import {
+  STATUS_LABEL,
+  PRIORITY_LABEL,
+  type InitiativeStatus,
+  type Priority,
+} from '@/lib/strategy/types';
+
+const STATUS_STYLES: Record<InitiativeStatus, string> = {
+  not_started: 'bg-gray-100 text-gray-700 border-gray-200',
+  in_progress: 'bg-blue-50 text-blue-700 border-blue-200',
+  blocked: 'bg-red-50 text-red-700 border-red-200',
+  done: 'bg-green-50 text-green-700 border-green-200',
+};
+
+export function StatusBadge({ status }: { status: InitiativeStatus }): ReactElement {
+  return (
+    <span
+      className={`text-xs px-2 py-0.5 rounded-full border font-semibold uppercase tracking-wider ${STATUS_STYLES[status]}`}
+    >
+      {STATUS_LABEL[status]}
+    </span>
+  );
+}
+
+const PRIORITY_STYLES: Record<Priority, string> = {
+  now: 'bg-brand-blue/10 text-brand-blue border-brand-blue/30',
+  next: 'bg-amber-50 text-amber-800 border-amber-200',
+  later: 'bg-gray-50 text-gray-500 border-gray-200',
+};
+
+export function PriorityBadge({ priority }: { priority: Priority }): ReactElement {
+  return (
+    <span
+      className={`text-xs px-2 py-0.5 rounded-full border font-semibold uppercase tracking-wider ${PRIORITY_STYLES[priority]}`}
+    >
+      {PRIORITY_LABEL[priority]}
+    </span>
+  );
+}

--- a/src/app/admin/strategy/_components/use-strategy-mutations.ts
+++ b/src/app/admin/strategy/_components/use-strategy-mutations.ts
@@ -1,0 +1,95 @@
+/**
+ * Client mutation hook for Game Plan initiatives — create / patch / archive /
+ * add-note, each calling the /api/admin/strategy endpoints and refreshing the
+ * list on success. Mirrors the recommendations queue's use-queue-mutations.
+ */
+
+'use client';
+
+import { useCallback, useState } from 'react';
+import type { CreateInitiativeInput, UpdateInitiativeInput } from '@/lib/strategy/types';
+
+export interface StrategyMutations {
+  /** id of the initiative currently saving (for disabling its controls). */
+  savingId: string | null;
+  creating: boolean;
+  create: (input: CreateInitiativeInput) => Promise<boolean>;
+  patch: (id: string, input: UpdateInitiativeInput) => Promise<boolean>;
+  remove: (id: string) => Promise<boolean>;
+  addNote: (id: string, author: string, body: string) => Promise<boolean>;
+}
+
+export function useStrategyMutations(onChanged: () => Promise<void>): StrategyMutations {
+  const [savingId, setSavingId] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  const create = useCallback(
+    async (input: CreateInitiativeInput): Promise<boolean> => {
+      setCreating(true);
+      try {
+        const res = await fetch('/api/admin/strategy', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(input),
+        });
+        if (res.ok) await onChanged();
+        return res.ok;
+      } finally {
+        setCreating(false);
+      }
+    },
+    [onChanged]
+  );
+
+  const patch = useCallback(
+    async (id: string, input: UpdateInitiativeInput): Promise<boolean> => {
+      setSavingId(id);
+      try {
+        const res = await fetch(`/api/admin/strategy/${id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(input),
+        });
+        if (res.ok) await onChanged();
+        return res.ok;
+      } finally {
+        setSavingId(null);
+      }
+    },
+    [onChanged]
+  );
+
+  const remove = useCallback(
+    async (id: string): Promise<boolean> => {
+      setSavingId(id);
+      try {
+        const res = await fetch(`/api/admin/strategy/${id}`, { method: 'DELETE' });
+        if (res.ok) await onChanged();
+        return res.ok;
+      } finally {
+        setSavingId(null);
+      }
+    },
+    [onChanged]
+  );
+
+  const addNote = useCallback(
+    async (id: string, author: string, body: string): Promise<boolean> => {
+      setSavingId(id);
+      try {
+        const res = await fetch(`/api/admin/strategy/${id}/updates`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ author, body }),
+        });
+        if (res.ok) await onChanged();
+        return res.ok;
+      } finally {
+        setSavingId(null);
+      }
+    },
+    [onChanged]
+  );
+
+  return { savingId, creating, create, patch, remove, addNote };
+}

--- a/src/app/admin/strategy/page.tsx
+++ b/src/app/admin/strategy/page.tsx
@@ -1,0 +1,184 @@
+/**
+ * Game Plan — the back-end living-document + to-do tracker for Allan & Brian.
+ * Initiatives grouped under strategic pillars, each with status, owner,
+ * priority, a sub-task checklist, an append-only progress log, and linked
+ * director recommendations. Admin-gated by the /admin layout.
+ */
+
+'use client';
+
+import { useState, useEffect, useCallback, useMemo, ReactElement } from 'react';
+import { PlusIcon } from '@heroicons/react/24/outline';
+import { useStrategyUser, NamePrompt, NameSwitcher } from './_components/name-picker';
+import { useStrategyMutations } from './_components/use-strategy-mutations';
+import InitiativeCard from './_components/initiative-card';
+import NewInitiativeModal from './_components/new-initiative-modal';
+import {
+  PILLARS,
+  PILLAR_META,
+  type StrategyInitiativeDTO,
+  type LinkedRecsSummary,
+  type CreateInitiativeInput,
+} from '@/lib/strategy/types';
+
+const EMPTY_RECS: LinkedRecsSummary = {
+  counts: { finance: 0, operations: 0, marketing: 0, seo: 0 },
+  titles: { finance: [], operations: [], marketing: [], seo: [] },
+};
+
+export default function StrategyPage(): ReactElement {
+  const { user, ready, setUser } = useStrategyUser();
+  const [initiatives, setInitiatives] = useState<StrategyInitiativeDTO[]>([]);
+  const [recs, setRecs] = useState<LinkedRecsSummary>(EMPTY_RECS);
+  const [loading, setLoading] = useState(true);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editing, setEditing] = useState<StrategyInitiativeDTO | null>(null);
+
+  const fetchData = useCallback(async (): Promise<void> => {
+    try {
+      const res = await fetch('/api/admin/strategy');
+      if (res.ok) {
+        const data = await res.json();
+        setInitiatives(data.initiatives ?? []);
+        setRecs(data.recs ?? EMPTY_RECS);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchData();
+  }, [fetchData]);
+
+  const mutations = useStrategyMutations(fetchData);
+
+  const stats = useMemo(() => {
+    const total = initiatives.length;
+    const done = initiatives.filter((i) => i.status === 'done').length;
+    const inProgress = initiatives.filter((i) => i.status === 'in_progress').length;
+    const blocked = initiatives.filter((i) => i.status === 'blocked').length;
+    const pct = total === 0 ? 0 : Math.round((done / total) * 100);
+    return { total, done, inProgress, blocked, pct };
+  }, [initiatives]);
+
+  const openCreate = (): void => {
+    setEditing(null);
+    setModalOpen(true);
+  };
+  const openEdit = (initiative: StrategyInitiativeDTO): void => {
+    setEditing(initiative);
+    setModalOpen(true);
+  };
+  const handleSubmit = async (values: CreateInitiativeInput): Promise<boolean> =>
+    editing ? mutations.patch(editing.id, values) : mutations.create(values);
+
+  if (!ready || loading) {
+    return (
+      <div className="p-4 md:p-8 bg-gray-50 min-h-screen">
+        <div className="max-w-6xl mx-auto animate-pulse">
+          <div className="h-9 w-48 bg-gray-200 rounded mb-6" />
+          <div className="h-16 bg-gray-200 rounded-xl mb-8" />
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="h-32 bg-gray-200 rounded-xl" />
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return <NamePrompt onPick={setUser} />;
+  }
+
+  return (
+    <div className="p-4 md:p-8 bg-gray-50 min-h-screen">
+      <div className="max-w-6xl mx-auto">
+      {/* Header */}
+      <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-4 mb-6">
+        <div>
+          <h1 className="text-3xl md:text-4xl font-heading tracking-[0.1em] text-gray-900">Game Plan</h1>
+          <p className="text-sm text-gray-600 mt-1">
+            Our living plan to grow the bottom line — and where each piece stands.
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <NameSwitcher user={user} onPick={setUser} />
+          <button onClick={openCreate} className="btn-primary inline-flex items-center gap-1.5">
+            <PlusIcon className="h-5 w-5" /> New
+          </button>
+        </div>
+      </div>
+
+      {/* Summary */}
+      <div className="card !p-4 mb-8">
+        <div className="flex flex-wrap items-center gap-x-8 gap-y-2">
+          <div>
+            <div className="text-2xl font-bold text-gray-900">{stats.pct}%</div>
+            <div className="text-sm text-gray-500">complete</div>
+          </div>
+          <div className="flex gap-6 text-sm">
+            <div><span className="font-bold text-gray-900">{stats.done}</span> <span className="text-gray-500">done</span></div>
+            <div><span className="font-bold text-blue-700">{stats.inProgress}</span> <span className="text-gray-500">in progress</span></div>
+            <div><span className="font-bold text-red-600">{stats.blocked}</span> <span className="text-gray-500">blocked</span></div>
+            <div><span className="font-bold text-gray-900">{stats.total}</span> <span className="text-gray-500">total</span></div>
+          </div>
+          <div className="flex-1 min-w-[160px]">
+            <div className="h-2 rounded-full bg-gray-100 overflow-hidden">
+              <div className="h-full bg-green-500 transition-all" style={{ width: `${stats.pct}%` }} />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Pillars */}
+      <div className="space-y-10">
+        {PILLARS.map((pillar) => {
+          const items = initiatives.filter((i) => i.pillar === pillar);
+          return (
+            <section key={pillar}>
+              <div className="flex items-baseline gap-3 mb-3">
+                <h2 className="text-2xl font-heading tracking-[0.1em] text-gray-900">
+                  {PILLAR_META[pillar].label}
+                </h2>
+                <span className="text-sm text-gray-400">{items.length}</span>
+              </div>
+              <p className="text-sm text-gray-500 -mt-2 mb-4">{PILLAR_META[pillar].blurb}</p>
+              {items.length === 0 ? (
+                <p className="text-sm text-gray-500 italic">Nothing here yet.</p>
+              ) : (
+                <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                  {items.map((initiative) => (
+                    <InitiativeCard
+                      key={initiative.id}
+                      initiative={initiative}
+                      recs={recs}
+                      currentUser={user}
+                      saving={mutations.savingId === initiative.id}
+                      onPatch={mutations.patch}
+                      onRemove={mutations.remove}
+                      onAddNote={mutations.addNote}
+                      onEdit={openEdit}
+                    />
+                  ))}
+                </div>
+              )}
+            </section>
+          );
+        })}
+      </div>
+      </div>
+
+      <NewInitiativeModal
+        isOpen={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onSubmit={handleSubmit}
+        saving={mutations.creating || (editing ? mutations.savingId === editing.id : false)}
+        initial={editing}
+        defaultOwner={user}
+      />
+    </div>
+  );
+}

--- a/src/app/api/admin/strategy/[id]/route.ts
+++ b/src/app/api/admin/strategy/[id]/route.ts
@@ -1,0 +1,63 @@
+/**
+ * Game Plan strategy API — update + archive a single initiative.
+ *   PATCH  /api/admin/strategy/[id]  — patch fields (incl. the subtasks array)
+ *   DELETE /api/admin/strategy/[id]  — soft-delete (archive)
+ *
+ * Self-guarded — /api/admin/** is not middleware-protected.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
+import { updateInitiative, archiveInitiative } from '@/lib/strategy/strategy-service';
+import { updateInitiativeSchema } from '@/lib/strategy/types';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: RouteParams
+): Promise<NextResponse> {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const data = updateInitiativeSchema.parse(body);
+    const updated = await updateInitiative(id, data);
+    if (!updated) {
+      return NextResponse.json({ error: 'Initiative not found' }, { status: 404 });
+    }
+    return NextResponse.json(updated);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: error.issues },
+        { status: 400 }
+      );
+    }
+    console.error('[strategy] PATCH failed:', error);
+    return NextResponse.json({ error: 'Failed to update initiative' }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: RouteParams
+): Promise<NextResponse> {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+  try {
+    const { id } = await params;
+    const ok = await archiveInitiative(id);
+    if (!ok) {
+      return NextResponse.json({ error: 'Initiative not found' }, { status: 404 });
+    }
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('[strategy] DELETE failed:', error);
+    return NextResponse.json({ error: 'Failed to delete initiative' }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/strategy/[id]/updates/route.ts
+++ b/src/app/api/admin/strategy/[id]/updates/route.ts
@@ -1,0 +1,43 @@
+/**
+ * Game Plan strategy API — append a progress note (the "living" log).
+ *   POST /api/admin/strategy/[id]/updates  — body { author, body }
+ *
+ * Append-only: the server stamps the note id + timestamp. Self-guarded.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
+import { addUpdate } from '@/lib/strategy/strategy-service';
+import { addUpdateSchema } from '@/lib/strategy/types';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: RouteParams
+): Promise<NextResponse> {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const data = addUpdateSchema.parse(body);
+    const updated = await addUpdate(id, data);
+    if (!updated) {
+      return NextResponse.json({ error: 'Initiative not found' }, { status: 404 });
+    }
+    return NextResponse.json(updated, { status: 201 });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: error.issues },
+        { status: 400 }
+      );
+    }
+    console.error('[strategy] add-update failed:', error);
+    return NextResponse.json({ error: 'Failed to add update' }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/strategy/route.ts
+++ b/src/app/api/admin/strategy/route.ts
@@ -1,0 +1,85 @@
+/**
+ * Game Plan strategy API — list + create.
+ *   GET  /api/admin/strategy  — all active initiatives + linked director-rec summary
+ *   POST /api/admin/strategy  — create an initiative
+ *
+ * /api/admin/** is NOT middleware-guarded, so each handler guards itself with
+ * requireOpsAuth() (see saved memory `api_admin_not_middleware_guarded`).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
+import { listInitiatives, createInitiative } from '@/lib/strategy/strategy-service';
+import { createInitiativeSchema, type LinkedRecsSummary } from '@/lib/strategy/types';
+import { listUnifiedRecommendations } from '@/lib/recommendations/unified-list';
+
+const EMPTY_RECS: LinkedRecsSummary = {
+  counts: { finance: 0, operations: 0, marketing: 0, seo: 0 },
+  titles: { finance: [], operations: [], marketing: [], seo: [] },
+};
+
+/**
+ * Read-only roll-up of open/approved director recommendations, grouped to the
+ * domains an initiative can link to. Best-effort: if the rec subsystem errors,
+ * the Game Plan page still loads with empty counts.
+ */
+async function loadLinkedRecs(): Promise<LinkedRecsSummary> {
+  try {
+    const res = await listUnifiedRecommendations({ status: ['open', 'approved'], limit: 250 });
+    const pick = (domain: 'finance' | 'ops' | 'marketing' | 'seo'): string[] =>
+      res.data
+        .filter((r) => r.domain === domain)
+        .slice(0, 3)
+        .map((r) => r.title);
+    return {
+      counts: {
+        finance: res.counts.finance,
+        operations: res.counts.operations,
+        marketing: res.counts.marketing,
+        seo: res.counts.seo,
+      },
+      titles: {
+        finance: pick('finance'),
+        operations: pick('ops'), // card domain for operations recs is 'ops'
+        marketing: pick('marketing'),
+        seo: pick('seo'),
+      },
+    };
+  } catch (error) {
+    console.error('[strategy] failed to load linked recs:', error);
+    return EMPTY_RECS;
+  }
+}
+
+export async function GET(): Promise<NextResponse> {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+  try {
+    const [initiatives, recs] = await Promise.all([listInitiatives(), loadLinkedRecs()]);
+    return NextResponse.json({ initiatives, recs });
+  } catch (error) {
+    console.error('[strategy] GET failed:', error);
+    return NextResponse.json({ error: 'Failed to load initiatives' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+  try {
+    const body = await request.json();
+    const data = createInitiativeSchema.parse(body);
+    const created = await createInitiative(data);
+    return NextResponse.json(created, { status: 201 });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: error.issues },
+        { status: 400 }
+      );
+    }
+    console.error('[strategy] POST failed:', error);
+    return NextResponse.json({ error: 'Failed to create initiative' }, { status: 500 });
+  }
+}

--- a/src/lib/strategy/strategy-service.ts
+++ b/src/lib/strategy/strategy-service.ts
@@ -1,0 +1,235 @@
+/**
+ * Service layer for Game Plan strategic initiatives (/admin/strategy).
+ * Owns all Prisma access for the `strategy_initiatives` table and maps rows to
+ * the client-facing {@link StrategyInitiativeDTO}. Server-only — never import
+ * from a client component.
+ */
+
+import { randomUUID } from 'crypto';
+import type { StrategyInitiative } from '@prisma/client';
+import type { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/database/client';
+import {
+  PILLARS,
+  STATUSES,
+  PRIORITIES,
+  LINKED_DOMAINS,
+  subtaskSchema,
+  type StrategyInitiativeDTO,
+  type Subtask,
+  type InitiativeUpdate,
+  type Pillar,
+  type InitiativeStatus,
+  type Priority,
+  type LinkedDomain,
+  type CreateInitiativeInput,
+  type UpdateInitiativeInput,
+  type AddUpdateInput,
+} from './types';
+
+const PILLAR_RANK: Record<Pillar, number> = {
+  finance: 0,
+  operations: 1,
+  acquisition: 2,
+  partnerships: 3,
+};
+
+const PRIORITY_RANK: Record<Priority, number> = { now: 0, next: 1, later: 2 };
+
+const STATUS_RANK: Record<InitiativeStatus, number> = {
+  blocked: 0,
+  in_progress: 1,
+  not_started: 2,
+  done: 3,
+};
+
+function asPillar(v: string): Pillar {
+  return (PILLARS as readonly string[]).includes(v) ? (v as Pillar) : 'operations';
+}
+function asStatus(v: string): InitiativeStatus {
+  return (STATUSES as readonly string[]).includes(v) ? (v as InitiativeStatus) : 'not_started';
+}
+function asPriority(v: string): Priority {
+  return (PRIORITIES as readonly string[]).includes(v) ? (v as Priority) : 'later';
+}
+function asLinkedDomain(v: string | null): LinkedDomain | null {
+  if (!v) return null;
+  return (LINKED_DOMAINS as readonly string[]).includes(v) ? (v as LinkedDomain) : null;
+}
+
+/** Defensively parse the JSON subtasks column into a typed array. */
+function parseSubtasks(value: Prisma.JsonValue): Subtask[] {
+  if (!Array.isArray(value)) return [];
+  const out: Subtask[] = [];
+  for (const raw of value) {
+    const parsed = subtaskSchema.safeParse(raw);
+    if (parsed.success) out.push(parsed.data);
+  }
+  return out;
+}
+
+/** Defensively parse the JSON updates column, newest last (stored append order). */
+function parseUpdates(value: Prisma.JsonValue): InitiativeUpdate[] {
+  if (!Array.isArray(value)) return [];
+  const out: InitiativeUpdate[] = [];
+  for (const raw of value) {
+    if (
+      raw &&
+      typeof raw === 'object' &&
+      'id' in raw &&
+      'author' in raw &&
+      'body' in raw &&
+      'createdAt' in raw
+    ) {
+      const r = raw as Record<string, unknown>;
+      out.push({
+        id: String(r.id),
+        author: String(r.author),
+        body: String(r.body),
+        createdAt: String(r.createdAt),
+      });
+    }
+  }
+  return out;
+}
+
+function toDate(yyyymmdd: string | null | undefined): Date | null {
+  if (!yyyymmdd) return null;
+  return new Date(`${yyyymmdd}T00:00:00.000Z`);
+}
+
+function toDTO(row: StrategyInitiative): StrategyInitiativeDTO {
+  return {
+    id: row.id,
+    pillar: asPillar(row.pillar),
+    title: row.title,
+    description: row.description,
+    status: asStatus(row.status),
+    priority: asPriority(row.priority),
+    owner: row.owner,
+    nextAction: row.nextAction,
+    targetDate: row.targetDate ? row.targetDate.toISOString().slice(0, 10) : null,
+    linkedDomain: asLinkedDomain(row.linkedDomain),
+    sortOrder: row.sortOrder,
+    subtasks: parseSubtasks(row.subtasks),
+    updates: parseUpdates(row.updates),
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+/**
+ * Sort for display: pillar order → priority (now/next/later) → manual sortOrder
+ * → in-pillar status emphasis. Done in JS because the ranks are custom, not
+ * lexical.
+ */
+function sortForDisplay(a: StrategyInitiativeDTO, b: StrategyInitiativeDTO): number {
+  if (a.pillar !== b.pillar) return PILLAR_RANK[a.pillar] - PILLAR_RANK[b.pillar];
+  if (a.priority !== b.priority) return PRIORITY_RANK[a.priority] - PRIORITY_RANK[b.priority];
+  if (a.sortOrder !== b.sortOrder) return a.sortOrder - b.sortOrder;
+  return STATUS_RANK[a.status] - STATUS_RANK[b.status];
+}
+
+/** All active (non-archived) initiatives, sorted for the board. */
+export async function listInitiatives(): Promise<StrategyInitiativeDTO[]> {
+  const rows = await prisma.strategyInitiative.findMany({
+    where: { archivedAt: null },
+  });
+  return rows.map(toDTO).sort(sortForDisplay);
+}
+
+/** Create a new initiative. */
+export async function createInitiative(
+  input: CreateInitiativeInput
+): Promise<StrategyInitiativeDTO> {
+  const row = await prisma.strategyInitiative.create({
+    data: {
+      pillar: input.pillar,
+      title: input.title,
+      description: input.description ?? null,
+      status: input.status ?? 'not_started',
+      priority: input.priority ?? 'later',
+      owner: input.owner ?? null,
+      nextAction: input.nextAction ?? null,
+      targetDate: toDate(input.targetDate),
+      linkedDomain: input.linkedDomain ?? null,
+      sortOrder: input.sortOrder ?? 0,
+    },
+  });
+  return toDTO(row);
+}
+
+/**
+ * Patch an existing initiative. Only provided keys are written. Returns null if
+ * the id does not exist (or is already archived).
+ */
+export async function updateInitiative(
+  id: string,
+  input: UpdateInitiativeInput
+): Promise<StrategyInitiativeDTO | null> {
+  const existing = await prisma.strategyInitiative.findFirst({
+    where: { id, archivedAt: null },
+    select: { id: true },
+  });
+  if (!existing) return null;
+
+  const data: Prisma.StrategyInitiativeUpdateInput = {};
+  if (input.pillar !== undefined) data.pillar = input.pillar;
+  if (input.title !== undefined) data.title = input.title;
+  if (input.description !== undefined) data.description = input.description ?? null;
+  if (input.status !== undefined) data.status = input.status;
+  if (input.priority !== undefined) data.priority = input.priority;
+  if (input.owner !== undefined) data.owner = input.owner ?? null;
+  if (input.nextAction !== undefined) data.nextAction = input.nextAction ?? null;
+  if (input.targetDate !== undefined) data.targetDate = toDate(input.targetDate);
+  if (input.linkedDomain !== undefined) data.linkedDomain = input.linkedDomain ?? null;
+  if (input.sortOrder !== undefined) data.sortOrder = input.sortOrder;
+  if (input.subtasks !== undefined) data.subtasks = input.subtasks;
+
+  const row = await prisma.strategyInitiative.update({ where: { id }, data });
+  return toDTO(row);
+}
+
+/** Soft-delete (archive) an initiative. Returns false if not found. */
+export async function archiveInitiative(id: string): Promise<boolean> {
+  const existing = await prisma.strategyInitiative.findFirst({
+    where: { id, archivedAt: null },
+    select: { id: true },
+  });
+  if (!existing) return false;
+  await prisma.strategyInitiative.update({
+    where: { id },
+    data: { archivedAt: new Date() },
+  });
+  return true;
+}
+
+/**
+ * Append a progress note to the (append-only) update log. The server stamps the
+ * id and timestamp; the author is client-supplied (not verifiable in a shared
+ * admin session — acceptable for a 2-person internal tool). Returns null if the
+ * id does not exist.
+ */
+export async function addUpdate(
+  id: string,
+  input: AddUpdateInput
+): Promise<StrategyInitiativeDTO | null> {
+  const existing = await prisma.strategyInitiative.findFirst({
+    where: { id, archivedAt: null },
+    select: { updates: true },
+  });
+  if (!existing) return null;
+
+  const current = parseUpdates(existing.updates);
+  const entry: InitiativeUpdate = {
+    id: randomUUID(),
+    author: input.author,
+    body: input.body,
+    createdAt: new Date().toISOString(),
+  };
+  const row = await prisma.strategyInitiative.update({
+    where: { id },
+    data: { updates: [...current, entry] },
+  });
+  return toDTO(row);
+}

--- a/src/lib/strategy/types.ts
+++ b/src/lib/strategy/types.ts
@@ -1,0 +1,158 @@
+/**
+ * Types, constants, and Zod schemas for the Game Plan strategy tracker
+ * (/admin/strategy). Shared by the API routes, the service layer, and the
+ * client page — this file must stay free of server-only imports (no Prisma)
+ * so it can be bundled into the client.
+ */
+
+import { z } from 'zod';
+
+/** Strategic pillars, in display order. */
+export const PILLARS = ['finance', 'operations', 'acquisition', 'partnerships'] as const;
+export type Pillar = (typeof PILLARS)[number];
+
+/** Execution status of an initiative. */
+export const STATUSES = ['not_started', 'in_progress', 'blocked', 'done'] as const;
+export type InitiativeStatus = (typeof STATUSES)[number];
+
+/** Priority / sequencing tier. */
+export const PRIORITIES = ['now', 'next', 'later'] as const;
+export type Priority = (typeof PRIORITIES)[number];
+
+/** Director-recommendation domains an initiative can surface inline. */
+export const LINKED_DOMAINS = ['finance', 'operations', 'marketing', 'seo'] as const;
+export type LinkedDomain = (typeof LINKED_DOMAINS)[number];
+
+/** Display metadata per pillar (label + one-line blurb for the section header). */
+export const PILLAR_META: Record<Pillar, { label: string; blurb: string }> = {
+  finance: {
+    label: 'Finances',
+    blurb: 'Accurate numbers so we can measure the bottom line.',
+  },
+  operations: {
+    label: 'Operations & Delegation',
+    blurb: 'Hand off the daily grind to free up owner time.',
+  },
+  acquisition: {
+    label: 'Paid Acquisition',
+    blurb: 'Segment landing pages + Google Ads by customer type.',
+  },
+  partnerships: {
+    label: 'Rental Partnerships',
+    blurb: 'The short-term-rental channel: Five-Star, Neal, magnets.',
+  },
+};
+
+export const STATUS_LABEL: Record<InitiativeStatus, string> = {
+  not_started: 'Not started',
+  in_progress: 'In progress',
+  blocked: 'Blocked',
+  done: 'Done',
+};
+
+export const PRIORITY_LABEL: Record<Priority, string> = {
+  now: 'Now',
+  next: 'Next',
+  later: 'Later',
+};
+
+export const LINKED_DOMAIN_LABEL: Record<LinkedDomain, string> = {
+  finance: 'Finance',
+  operations: 'Operations',
+  marketing: 'Marketing',
+  seo: 'SEO',
+};
+
+/**
+ * A small step inside an initiative. Declared as a `type` (not `interface`) so
+ * it carries an implicit index signature and is assignable to Prisma's
+ * InputJsonValue when written to the JSON column.
+ */
+export type Subtask = {
+  id: string;
+  label: string;
+  done: boolean;
+  createdAt: string;
+};
+
+/** An append-only progress note on an initiative. (`type` for the same reason.) */
+export type InitiativeUpdate = {
+  id: string;
+  author: string;
+  body: string;
+  createdAt: string;
+};
+
+/** The shape returned by the API and rendered by the UI. */
+export interface StrategyInitiativeDTO {
+  id: string;
+  pillar: Pillar;
+  title: string;
+  description: string | null;
+  status: InitiativeStatus;
+  priority: Priority;
+  owner: string | null;
+  nextAction: string | null;
+  targetDate: string | null; // yyyy-mm-dd
+  linkedDomain: LinkedDomain | null;
+  sortOrder: number;
+  subtasks: Subtask[];
+  updates: InitiativeUpdate[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Per-domain open-recommendation counts + a few sample titles, for the cards. */
+export interface LinkedRecsSummary {
+  counts: Record<LinkedDomain, number>;
+  titles: Record<LinkedDomain, string[]>;
+}
+
+export interface StrategyListResponse {
+  initiatives: StrategyInitiativeDTO[];
+  recs: LinkedRecsSummary;
+}
+
+// --- Zod schemas (request validation) ------------------------------------
+
+export const subtaskSchema = z.object({
+  id: z.string().min(1),
+  label: z.string().min(1).max(200),
+  done: z.boolean(),
+  createdAt: z.string().min(1),
+});
+
+export const createInitiativeSchema = z.object({
+  pillar: z.enum(PILLARS),
+  title: z.string().min(1, 'Title is required').max(200),
+  description: z.string().max(2000).nullish(),
+  status: z.enum(STATUSES).optional(),
+  priority: z.enum(PRIORITIES).optional(),
+  owner: z.string().max(60).nullish(),
+  nextAction: z.string().max(500).nullish(),
+  targetDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Use yyyy-mm-dd').nullish(),
+  linkedDomain: z.enum(LINKED_DOMAINS).nullish(),
+  sortOrder: z.number().int().optional(),
+});
+export type CreateInitiativeInput = z.infer<typeof createInitiativeSchema>;
+
+export const updateInitiativeSchema = z.object({
+  pillar: z.enum(PILLARS).optional(),
+  title: z.string().min(1).max(200).optional(),
+  description: z.string().max(2000).nullish(),
+  status: z.enum(STATUSES).optional(),
+  priority: z.enum(PRIORITIES).optional(),
+  owner: z.string().max(60).nullish(),
+  nextAction: z.string().max(500).nullish(),
+  targetDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Use yyyy-mm-dd').nullish(),
+  linkedDomain: z.enum(LINKED_DOMAINS).nullish(),
+  sortOrder: z.number().int().optional(),
+  subtasks: z.array(subtaskSchema).optional(),
+});
+export type UpdateInitiativeInput = z.infer<typeof updateInitiativeSchema>;
+
+export const addUpdateSchema = z.object({
+  author: z.string().min(1, 'Author is required').max(60),
+  body: z.string().min(1, 'Note cannot be empty').max(2000),
+});
+export type AddUpdateInput = z.infer<typeof addUpdateSchema>;


### PR DESCRIPTION
## What this adds

An internal back-end page at **`/admin/strategy`** ("Game Plan" in the admin nav) where Allan and Brian track the company's bottom-line strategy and its execution — a living document, not a static list.

Initiatives are grouped under four pillars — **Finances · Operations & Delegation · Paid Acquisition · Rental Partnerships**. Each card shows status, owner, Now/Next/Later priority, target date, a sub-task checklist, an append-only progress log, and linked director recommendations. Fully editable: add/edit/archive, change status & priority inline, check off sub-tasks, post updates.

## Seeded prioritization

Ships pre-loaded with the 10 kickoff initiatives in a recommended order (dependency + leverage), all editable in-app:

- **Now**: Finish financial integrations (Allan) · Vic owns ops (Brian) · Fix segment landing pages (Allan) · Re-engage Lucas/Five-Star (Allan)
- **Next**: Google Ads per segment · Centex workflow · Gus/driver shifts · STR onboarding email · Neal's rentals
- **Later**: Fridge magnets

Key dependencies baked into the copy: landing pages before Google Ads; Five-Star before its email campaign + magnets; the Ads card carries the delivery-footprint geo-exclusions.

## How it's built

- **Data**: new `strategy_initiatives` table (sub-tasks + progress log as JSONB) via an additive, idempotent manual migration. Seeded with `INSERT … ON CONFLICT DO NOTHING` so a user-deleted row isn't resurrected.
- **API**: `/api/admin/strategy` (+ `[id]`, `[id]/updates`). Every handler self-guards with `requireOpsAuth()` since `/api/admin` is **not** middleware-protected.
- **Identity**: a localStorage name picker (Allan/Brian) stamps progress notes & default owner — no change to the shared admin login.
- **Linked recs**: read-only reuse of `listUnifiedRecommendations` from the existing director-recommendation queue.
- **Design**: reuses the shared `Modal`, status/priority pills, and sanctioned button classes; centered `max-w-6xl` shell to match `/admin/recommendations`.

## Database note

The migration is **already applied to production** and recorded in the `_manual_migrations` ledger, so the deploy's build step will skip it (no double-run, no double-seed). It's additive and invisible to the live site until this merges.

## Verification

- `tsc --noEmit` and ESLint clean
- Schema verified against prod; all 10 seed rows confirmed in the right pillars/owners
- Dev server: API returns 401 unauthenticated and 200 with all 10 initiatives + live rec roll-up when authed; page route 200
- Front-end design audit passed (sibling-consistent; form-label/contrast/wrapper fixes applied)

## Follow-ups (out of scope)

- Several other `/api/admin/**` routes (e.g. `experiments` create/**delete**) have **no auth guard** — worth a separate audit + fix.
- Minor pre-existing label drift: the admin login and shared `Input` primitive use `text-sm` labels vs. the documented `text-base`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
