### PR TITLE
fix(security): require ops auth on unprotected /api/admin routes

### DIFF
--- a/src/app/api/admin/affiliates/lookup/route.ts
+++ b/src/app/api/admin/affiliates/lookup/route.ts
@@ -5,8 +5,12 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getAffiliateByCode } from '@/lib/affiliates/affiliate-service';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
 
 export async function GET(request: NextRequest) {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
   try {
     const code = request.nextUrl.searchParams.get('code');
     if (!code) {

--- a/src/app/api/admin/affiliates/stop-impersonating/route.ts
+++ b/src/app/api/admin/affiliates/stop-impersonating/route.ts
@@ -6,8 +6,17 @@
 import { NextResponse } from 'next/server';
 import { clearAffiliateSessionCookie } from '@/lib/affiliates/affiliate-session';
 import { cookies } from 'next/headers';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
 
 export async function POST(): Promise<NextResponse> {
+  // Only a logged-in operator can stop impersonating. The ops_session cookie
+  // is set at login and persists through impersonation (the impersonate route
+  // only ADDS affiliate_session + admin_impersonating), so requireOpsAuth
+  // still passes for the un-impersonate round trip — and never locks the
+  // operator out of the exit hatch.
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
   await clearAffiliateSessionCookie();
 
   const cookieStore = await cookies();

--- a/src/app/api/admin/analytics/route.ts
+++ b/src/app/api/admin/analytics/route.ts
@@ -11,6 +11,7 @@ import { getBehaviorMetrics } from '@/lib/analytics/ga4-behavior';
 import { generateRecommendations } from '@/lib/analytics/recommendations';
 import { isGoogleConfigured } from '@/lib/analytics/google-auth';
 import { prisma } from '@/lib/prisma';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
 import {
   ExtendedDashboardData,
   AnalyticsConfig,
@@ -26,6 +27,9 @@ export const dynamic = 'force-dynamic';
  * Fetches dashboard data for the specified period
  */
 export async function GET(request: NextRequest) {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
   const searchParams = request.nextUrl.searchParams;
   const period = searchParams.get('period') || '30d';
 

--- a/src/app/api/admin/experiments/[id]/route.ts
+++ b/src/app/api/admin/experiments/[id]/route.ts
@@ -8,6 +8,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
 
 // Validation schema for updating an experiment
 const UpdateExperimentSchema = z.object({
@@ -32,6 +33,9 @@ export async function GET(
   request: NextRequest,
   { params }: RouteParams
 ): Promise<NextResponse> {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
   try {
     const { id } = await params;
 
@@ -122,6 +126,9 @@ export async function PATCH(
   request: NextRequest,
   { params }: RouteParams
 ): Promise<NextResponse> {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
   try {
     const { id } = await params;
     const body = await request.json();
@@ -182,6 +189,9 @@ export async function DELETE(
   request: NextRequest,
   { params }: RouteParams
 ): Promise<NextResponse> {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
   try {
     const { id } = await params;
 

--- a/src/app/api/admin/experiments/funnel/route.ts
+++ b/src/app/api/admin/experiments/funnel/route.ts
@@ -25,6 +25,7 @@
  */
 import { NextResponse, type NextRequest } from 'next/server';
 import { prisma } from '@/lib/database/client';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
 import { Prisma } from '@prisma/client';
 import {
   EXPERIMENTS,
@@ -47,6 +48,9 @@ type VariantStats = {
 };
 
 export async function GET(req: NextRequest) {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
   const url = new URL(req.url);
   const page = url.searchParams.get('page');
   const expFilter = url.searchParams.get('experiment');

--- a/src/app/api/admin/experiments/route.ts
+++ b/src/app/api/admin/experiments/route.ts
@@ -7,6 +7,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
 
 // Validation schema for creating an experiment
 const CreateExperimentSchema = z.object({
@@ -29,6 +30,9 @@ const CreateExperimentSchema = z.object({
  * List all experiments with their variants
  */
 export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
   try {
     const { searchParams } = new URL(request.url);
     const status = searchParams.get('status');
@@ -119,6 +123,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
  * Create a new experiment with variants
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
   try {
     const body = await request.json();
     const validatedData = CreateExperimentSchema.parse(body);

--- a/src/app/api/admin/orders/route.ts
+++ b/src/app/api/admin/orders/route.ts
@@ -4,6 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
 
 export const dynamic = 'force-dynamic';
 
@@ -66,6 +67,9 @@ export interface OrderForDisplay {
  * Fetches recent orders from Shopify
  */
 export async function GET(request: NextRequest) {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
   if (!SHOPIFY_DOMAIN || !SHOPIFY_ADMIN_TOKEN) {
     return NextResponse.json(
       { success: false, error: 'Shopify not configured' },

--- a/src/app/api/admin/seo/latest-snapshot/route.ts
+++ b/src/app/api/admin/seo/latest-snapshot/route.ts
@@ -14,11 +14,15 @@
  */
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/database/client';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
 export async function GET() {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
   try {
     // Latest run: derived from MAX(capturedAt) and its runRef.
     const newest = await prisma.seoSnapshot.findFirst({

--- a/src/app/api/admin/seo/trigger-scrape/route.ts
+++ b/src/app/api/admin/seo/trigger-scrape/route.ts
@@ -4,8 +4,9 @@
  * Fires the SEMrush scrape GitHub Actions workflow on demand. Powered
  * by GitHub's `workflow_dispatch` API.
  *
- * Auth: this is mounted under /api/admin which is gated by the existing
- * ops-auth middleware. No extra auth check needed.
+ * Auth: requireOpsAuth() — /api/admin is NOT covered by middleware (only
+ * /api/v1/admin is), so each handler must guard itself. Returns 401 without
+ * a valid ops session.
  *
  * Env needed (set on Vercel + locally):
  *   GH_DISPATCH_TOKEN  — fine-grained PAT with Actions:Write on the repo
@@ -17,6 +18,7 @@
  *   { ok: false, error: 'gh_<status>', detail: '...' }  → GitHub rejected
  */
 import { NextResponse, type NextRequest } from 'next/server';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -25,6 +27,9 @@ const WORKFLOW_FILE = 'seo-scrape.yml';
 const DEFAULT_REPO = 'allan-cmyk/PartyOn2';
 
 export async function POST(req: NextRequest) {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
   const token = process.env.GH_DISPATCH_TOKEN;
   if (!token) {
     return NextResponse.json(


### PR DESCRIPTION
## What

`/api/admin/**` is **not** covered by middleware — only `/api/v1/admin/**` is (closed by #127). So every `/api/admin` handler must guard itself, and **9 route files (12 handlers) were callable unauthenticated** — including create/update/**delete** of A/B experiments, a Shopify orders feed carrying customer PII (names, emails, phones, addresses), the full analytics dashboard, and an endpoint that dispatches GitHub Actions workflows.

This adds the standard ops-session guard to each handler:

```ts
const auth = await requireOpsAuth();
if (auth instanceof NextResponse) return auth;
```

## Handlers guarded (all `requireOpsAuth`)

| Route | Handlers |
|---|---|
| `analytics` | GET |
| `experiments` | GET, POST |
| `experiments/[id]` | GET, PATCH, DELETE |
| `experiments/funnel` | GET |
| `orders` | GET |
| `affiliates/lookup` | GET |
| `seo/latest-snapshot` | GET |
| `seo/trigger-scrape` | POST |
| `affiliates/stop-impersonating` | POST |

`affiliates/stop-impersonating` uses `requireOpsAuth` (not `requireAdminRole`): the `ops_session` cookie persists through impersonation (the impersonate route only *adds* `affiliate_session` + `admin_impersonating`), so this guards the exit hatch without ever locking the operator out of it.

Also corrected the misleading comment in `seo/trigger-scrape` that claimed `/api/admin` was middleware-gated — it never was.

## Intentionally left as-is (called out, not changed)

- `admin/sync` — already authed by `ADMIN_API_KEY` bearer (programmatic caller)
- `admin/inventory/receiving/reocr` — already authed by `CRON_SECRET` bearer (cron-style one-shot)
- `admin/verify` — the login endpoint itself; sets the ops-session cookie, must stay public

## Verification

- `npx tsc --noEmit` — no new errors in any changed file (the only repo errors are pre-existing, in `qb-pull-service.ts`)
- `npx eslint` — clean (exit 0) on all 9 files
- Re-scanned every `/api/admin` route handler: all now carry an auth marker except `verify` (intentional)

## Supersedes #128

#128 did the same fix but is **11 commits stale**. Simulating its merge into current `main` is conflict-free, but the result **deletes the `financeRecommendation` test mock** that current `main` still needs (`recommendations/[id]/execute/route.ts` still calls `prisma.financeRecommendation.findUnique`), which would break the recommendations test suite. #128's only CI check is the Vercel build (no test run), so this was never caught. This PR is cut from current `main` and touches only the 9 route files — no test churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
