### PR TITLE
ci: run vitest + eslint on PRs to main/dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+# Runs the Vitest suite and ESLint on every PR into main/dev and on pushes to
+# main. Until this existed, nothing in CI ran the tests — only Vercel's build,
+# which doesn't fail on test failures. That let a red suite land on main
+# unnoticed (e.g. the financeRecommendation mock drift in #140). This is the
+# gate that catches that class of regression at PR time.
+
+on:
+  pull_request:
+    branches: [main, dev]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# A newer commit on the same branch supersedes an in-flight run.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test & Lint
+    runs-on: ubuntu-latest
+    env:
+      # Placeholder so `prisma generate` can resolve the datasource env() at
+      # generate time. The suite is fully mocked and never opens a real
+      # connection, so no live database or secrets are needed.
+      POSTGRES_URL: postgresql://test:test@localhost:5432/test
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma Client
+        run: npx prisma generate
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Run tests
+        run: npm run test:run


### PR DESCRIPTION
## What

Adds `.github/workflows/ci.yml` — a GitHub Actions job that runs `npm run test:run` (Vitest) and `npm run lint` (ESLint) on:
- every PR into `main` or `dev`
- every push to `main`
- manual `workflow_dispatch`

## Why

**There was no CI running the test suite.** The only PR checks were Vercel's build + preview comments, and a Vercel build doesn't fail on test failures. So a red suite could — and did — land on `main` behind all-green checks:

- The 3 `recommendations/[id]` handler tests fixed in #140 had been red on `main` since the Phase 5 finance work (#125) added a `financeRecommendation` lookup without updating the test mock. Nothing surfaced it until it was run locally.

This workflow is the gate that catches that class of regression at PR time.

## Scope / decisions

- **Tests + lint only.** Both are green on current `main` (280/280 tests; lint exits 0 with only `no-img-element` warnings).
- **`tsc --noEmit` intentionally excluded for now.** It's currently red on `main` — 6 errors, all in `src/lib/finance/qb-pull-service.ts` (`realmId` not present on the generated Prisma types; looks like schema drift). Gating on it today would block every PR. Recommend a follow-up that fixes those finance type errors, then adds a `typecheck` job. (Left untouched here — separate concern, finance code.)
- **No DB or secrets needed.** The suite is fully mocked (`src/__tests__/setup.ts` only stubs `next/navigation` + `fetch`; no `.env` loading). `POSTGRES_URL` is set to a throwaway placeholder solely so `prisma generate` can resolve the datasource `env()`.
- Mirrors the existing `generate-daily-blog.yml` setup (checkout@v4, setup-node@20 + npm cache, `npm ci`, explicit `prisma generate`).
- `concurrency` with `cancel-in-progress` so a newer push supersedes an in-flight run; `permissions: contents: read` (least privilege).

## Validation

This PR targets `main`, so the workflow runs against itself — the **Test & Lint** check on this PR is the proof it's green. Locally: `npm run test:run` → 280 passed; `npm run lint` → exit 0.

## Suggested follow-up

Once merged, add **Test & Lint** as a required status check in branch protection for `main` so a red suite blocks merges. (Requires repo admin — your call.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)