### PR TITLE
feat(finance): Phase 5C — monthly trajectory rollup + segment classifier

### DIFF
--- a/docs/FINANCE-DIRECTOR-AGENT-BUILDOUT.md
+++ b/docs/FINANCE-DIRECTOR-AGENT-BUILDOUT.md
@@ -393,6 +393,27 @@ $2.7k/10 txns. Clean 2023-2025 split: ~$297k true OpEx · ~$251k COGS · ~$81k
 non-operating. Phase 5C's rollup MUST exclude COGS + non_operating from OpEx
 (pl-calculation.ts line 229 currently sums ALL qb_expenses — fix in 5C).
 
+### Phase 5C — Monthly trajectory rollup
+
+- New `FinanceMonthlyRollup` table (one row per year+month). Built by
+  `src/lib/finance/monthly-rollup.ts` — UNIONs Shopify archive (≤2025-12) +
+  Order table (2026+), deduped on the rare overlap, layers QB OpEx where
+  available. Stores revenue, top SKUs, segment mix, top customers/affiliates,
+  expense categories (with top vendor), and a `dataHealth` block.
+- Segment classifier `order-segment.ts` reuses the existing analytics
+  `classifySegment` taxonomy (bach/wedding/corporate/boat/kegs/general); coarse
+  historically (Shopify era has no landing page / empty tags).
+- `dataHealth.netIncomeReliable` is the honesty gate: net income is only
+  trustworthy when there are no completeness flags. In practice it's **false
+  for every month so far** — 2023-2025 revenue is Shopify-understated vs real
+  expenses (artificial losses); 2026 has real revenue but QB is dormant (COGS=0,
+  artificial profit). The Phase 5D briefing must render net income as "pending"
+  + the flags, never the raw number.
+- Full backfill: `scripts/finance/backfill-monthly-rollups.ts` (run after the
+  migration). Nightly refresh: `/api/cron/finance-monthly-rollup` (08:10 UTC,
+  trailing 2 months; `?months=N` after a re-categorization).
+- Bookkeeper handoff for the 2026 gap: `docs/QUICKBOOKS-2026-CATCHUP-FOR-BOOKKEEPER.md`.
+
 ### Phase 6 — Auto-categorize graduation (post-trust)
 
 Only after the operator has reviewed Phase 5 briefings for 4+ weeks and feels confident, graduate the Director's auto-categorize behavior from "one-by-one with reversal button" to "batch auto-categorize with weekly audit summary." This is a config flag, not new code.

--- a/docs/QUICKBOOKS-2026-CATCHUP-FOR-BOOKKEEPER.md
+++ b/docs/QUICKBOOKS-2026-CATCHUP-FOR-BOOKKEEPER.md
@@ -1,0 +1,79 @@
+# Party On Delivery — QuickBooks catch-up needed for 2026
+
+Prepared 2026-06-18. This is a plain-language summary of gaps we found in the
+QuickBooks books for **Party On Delivery**, for the bookkeeper / accountant to
+review and address. Nothing here is urgent-as-in-emergency, but the 2026 books
+are currently not usable for a profit picture or a clean tax basis until these
+are closed.
+
+**Company in question:** "Premier Concierge Worldwide" (the QuickBooks Online
+company that holds Party On Delivery's books). Please confirm this is the correct
+company — if PartyOn's 2026 activity is supposed to be in a *different* QuickBooks
+company, that changes everything below.
+
+---
+
+## What looks good
+
+2023, 2024, and 2025 are in solid shape. Expenses were entered and categorized
+throughout — roughly **$629,000** of recorded spend across those years, including
+cost of goods (alcohol inventory), rent, payroll, utilities, advertising, and so
+on. No concerns there.
+
+---
+
+## The three gaps for 2026
+
+### 1. Expenses appear to stop at the end of 2025
+
+From January 2026 onward, the only expense entries in this company are small
+automated **Shopify selling-fee** charges (about **$1,700 total** for the whole
+year so far). There are **no** entries for the things the business clearly spends
+money on in 2026 — alcohol/inventory purchases, rent, payroll, fuel, insurance,
+etc. There are also **no Bills and no Journal Entries** dated in 2026.
+
+**What we need:** please confirm whether 2026 expenses were entered anywhere, and
+if not, catch up the expense entry for **January 2026 → today** — distributor/
+alcohol purchases (cost of goods), rent, payroll, utilities, insurance, ads, etc.
+The cleanest ongoing fix is to connect the **operating bank account inside
+QuickBooks** (QuickBooks' built-in bank feed) so transactions import automatically
+for you to categorize, instead of manual entry.
+
+### 2. Sales income isn't recorded in QuickBooks
+
+Party On Delivery moved to taking payments directly through **Stripe** in early
+2026. Those sales — roughly **$107,000 collected January through mid-June 2026** —
+are **not showing up as income in QuickBooks**. There is no Stripe→QuickBooks
+connection recording them.
+
+**What we need:** a way to record Stripe sales as income in QuickBooks — either a
+Stripe/QuickBooks sync app, a periodic sales-receipt/deposit entry, or a recurring
+journal from the Stripe payout reports. (Our internal system can post daily sales
+summaries automatically, but we've paused that until the account setup below is
+confirmed, to avoid double-counting with anything you enter.)
+
+### 3. Please confirm the income/clearing account setup
+
+If we do turn our automated daily sales posting back on, it needs to point at the
+right accounts in this company's chart of accounts:
+- a **Sales / Revenue** income account
+- a **Stripe clearing** (bank/asset) account
+- a **Stripe fees** expense account
+- a **Sales tax payable** liability account
+
+Please confirm those four accounts exist and are set up the way you'd want sales,
+fees, and sales tax recorded.
+
+---
+
+## Quick way to confirm the 2026 gap
+
+In QuickBooks Online for this company: **Reports → Profit and Loss →** set the date
+range to **Jan 1, 2026 – today → Run**. If income shows roughly $0 and expenses
+show only the small Shopify fees, that matches what we're seeing and the catch-up
+above is needed. If it shows real income and expenses, then the data is there and
+we have a sync issue on our end to fix instead — just let us know.
+
+---
+
+*Questions on any of this can go back to Allan.*

--- a/prisma/migrations/manual/2026-06-18-finance-phase-5c-monthly-rollup.sql
+++ b/prisma/migrations/manual/2026-06-18-finance-phase-5c-monthly-rollup.sql
@@ -1,0 +1,51 @@
+-- Finance Director — Phase 5C: monthly trajectory rollup
+--
+-- One pre-computed row per (year, month) so the monthly close email + the
+-- /admin/finance trajectory view render instantly without re-aggregating the
+-- whole history. Built by src/lib/finance/monthly-rollup.ts, which UNIONs the
+-- two revenue eras (ShopifyOrderArchive ≤2025-12 + Order ≥2026-01) and layers
+-- in QB OpEx (2023-2025) where available.
+--
+-- Scalars are in cents (match Stripe / qb_expenses). Breakdowns are JSONB so
+-- the shape can evolve without a migration. Nullable profit columns stay NULL
+-- when the underlying data is incomplete (e.g. no QB expenses for the month) —
+-- the briefing renders "pending" rather than a fake number.
+--
+-- Additive + idempotent. Run against prod manually:
+--   psql "$DATABASE_URL" -f prisma/migrations/manual/2026-06-18-finance-phase-5c-monthly-rollup.sql
+--   npx prisma generate
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS finance_monthly_rollup (
+  id                     TEXT PRIMARY KEY,
+  year                   INTEGER NOT NULL,
+  month                  INTEGER NOT NULL, -- 1-12
+  -- Revenue (union of both eras, deduped)
+  revenue_cents          BIGINT NOT NULL DEFAULT 0,
+  order_count            INTEGER NOT NULL DEFAULT 0,
+  -- Cost / profit (NULL when data incomplete)
+  cogs_cents             BIGINT,
+  gross_profit_cents     BIGINT,
+  opex_cents             BIGINT,
+  net_income_cents       BIGINT,
+  -- Which revenue sources contributed this month
+  revenue_from_shopify_cents  BIGINT NOT NULL DEFAULT 0,
+  revenue_from_orders_cents   BIGINT NOT NULL DEFAULT 0,
+  -- Breakdowns (JSONB)
+  top_skus               JSONB NOT NULL DEFAULT '[]'::jsonb,
+  segment_breakdown      JSONB NOT NULL DEFAULT '{}'::jsonb,
+  top_customers          JSONB NOT NULL DEFAULT '[]'::jsonb,
+  top_affiliates         JSONB NOT NULL DEFAULT '[]'::jsonb,
+  expense_categories     JSONB NOT NULL DEFAULT '[]'::jsonb,
+  -- Per-month data-health flags (what's missing / not trustworthy)
+  data_health            JSONB NOT NULL DEFAULT '{}'::jsonb,
+  computed_at            TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  created_at             TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at             TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS finance_monthly_rollup_year_month_key
+  ON finance_monthly_rollup (year, month);
+
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2869,6 +2869,36 @@ model ShopifyArchiveSyncState {
   @@map("shopify_archive_sync_state")
 }
 
+/// Pre-computed monthly trajectory rollup (Phase 5C). One row per (year,
+/// month). UNIONs the two revenue eras (ShopifyOrderArchive ≤2025-12 + Order
+/// ≥2026-01, deduped) and layers QB OpEx where available. Profit columns stay
+/// null when data is incomplete. Built by src/lib/finance/monthly-rollup.ts.
+model FinanceMonthlyRollup {
+  id                       String   @id @default(cuid())
+  year                     Int
+  month                    Int // 1-12
+  revenueCents             BigInt   @default(0) @map("revenue_cents")
+  orderCount               Int      @default(0) @map("order_count")
+  cogsCents                BigInt?  @map("cogs_cents")
+  grossProfitCents         BigInt?  @map("gross_profit_cents")
+  opexCents                BigInt?  @map("opex_cents")
+  netIncomeCents           BigInt?  @map("net_income_cents")
+  revenueFromShopifyCents  BigInt   @default(0) @map("revenue_from_shopify_cents")
+  revenueFromOrdersCents   BigInt   @default(0) @map("revenue_from_orders_cents")
+  topSkus                  Json     @default("[]") @map("top_skus")
+  segmentBreakdown         Json     @default("{}") @map("segment_breakdown")
+  topCustomers             Json     @default("[]") @map("top_customers")
+  topAffiliates            Json     @default("[]") @map("top_affiliates")
+  expenseCategories        Json     @default("[]") @map("expense_categories")
+  dataHealth               Json     @default("{}") @map("data_health")
+  computedAt               DateTime @default(now()) @map("computed_at")
+  createdAt                DateTime @default(now()) @map("created_at")
+  updatedAt                DateTime @updatedAt @map("updated_at")
+
+  @@unique([year, month])
+  @@map("finance_monthly_rollup")
+}
+
 /// Per-day sales journal entries posted from PartyOn → QuickBooks (Phase 2B).
 /// Drafted by the daily cron, REQUIRE operator approval before posting
 /// (autonomy decision #4 — only qb-categorize bypasses operator click).

--- a/scripts/finance/backfill-monthly-rollups.ts
+++ b/scripts/finance/backfill-monthly-rollups.ts
@@ -1,0 +1,52 @@
+/**
+ * One-shot backfill of finance_monthly_rollup for the full history
+ * (Finance Director Phase 5C).
+ *
+ * Computes + persists one row per month from the earliest order on record
+ * through the current month. Idempotent — re-running recomputes in place.
+ *
+ * Usage:
+ *   set -a && source .env.local && set +a
+ *   npx tsx scripts/finance/backfill-monthly-rollups.ts
+ */
+
+import {
+  computeMonthlyRollup,
+  persistMonthlyRollup,
+  enumerateMonths,
+  earliestDataMonth,
+} from '../../src/lib/finance/monthly-rollup';
+import { prisma } from '../../src/lib/database/client';
+
+async function main(): Promise<void> {
+  const start = await earliestDataMonth();
+  const now = new Date();
+  const end = { year: now.getUTCFullYear(), month: now.getUTCMonth() + 1 };
+  const months = enumerateMonths(start, end);
+  console.log(
+    `[backfill-monthly-rollups] ${months.length} months from ` +
+      `${start.year}-${String(start.month).padStart(2, '0')} to ` +
+      `${end.year}-${String(end.month).padStart(2, '0')}`
+  );
+
+  let ok = 0;
+  for (const { year, month } of months) {
+    try {
+      const result = await computeMonthlyRollup(year, month);
+      await persistMonthlyRollup(result);
+      ok += 1;
+      const rev = (result.revenueCents / 100).toLocaleString('en-US', { maximumFractionDigits: 0 });
+      console.log(`  ${year}-${String(month).padStart(2, '0')}: $${rev} (${result.orderCount} orders)`);
+    } catch (err) {
+      console.error(`  ${year}-${String(month).padStart(2, '0')} FAILED:`, err instanceof Error ? err.message : err);
+    }
+  }
+  console.log(`[backfill-monthly-rollups] done — ${ok}/${months.length} months persisted`);
+}
+
+main()
+  .catch((err) => {
+    console.error('[backfill-monthly-rollups] FATAL:', err);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/app/api/cron/finance-monthly-rollup/route.ts
+++ b/src/app/api/cron/finance-monthly-rollup/route.ts
@@ -1,0 +1,80 @@
+/**
+ * GET /api/cron/finance-monthly-rollup
+ *
+ * Phase 5C — nightly recompute of the current + prior month's trajectory
+ * rollup so the monthly close email + admin trajectory view stay fresh as new
+ * orders / QB expenses land. The full-history backfill is the one-shot script
+ * (scripts/finance/backfill-monthly-rollups.ts); this cron only touches the
+ * trailing two months.
+ *
+ * Schedule: nightly at 08:10 UTC (after the daily snapshot 07:45 + QB/Plaid).
+ * Bearer auth: `Authorization: Bearer ${CRON_SECRET}`.
+ *
+ * Optional `?months=N` recomputes the trailing N months (default 2, max 24) —
+ * handy after a QB re-categorization.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  computeMonthlyRollup,
+  persistMonthlyRollup,
+  enumerateMonths,
+} from '@/lib/finance/monthly-rollup';
+
+export const maxDuration = 300;
+
+interface Report {
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  monthsRecomputed: number;
+  months: string[];
+  errors: string[];
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = request.headers.get('authorization');
+  if (auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const startedAt = new Date();
+  const monthsParam = request.nextUrl.searchParams.get('months');
+  let trailing = monthsParam ? Number.parseInt(monthsParam, 10) : 2;
+  if (!Number.isFinite(trailing) || trailing < 1) trailing = 2;
+  if (trailing > 24) trailing = 24;
+
+  // Trailing N months ending this month.
+  const now = startedAt;
+  const endYm = { year: now.getUTCFullYear(), month: now.getUTCMonth() + 1 };
+  const startDate = new Date(Date.UTC(endYm.year, endYm.month - 1 - (trailing - 1), 1));
+  const startYm = { year: startDate.getUTCFullYear(), month: startDate.getUTCMonth() + 1 };
+  const months = enumerateMonths(startYm, endYm);
+
+  const report: Report = {
+    startedAt: startedAt.toISOString(),
+    finishedAt: '',
+    durationMs: 0,
+    monthsRecomputed: 0,
+    months: [],
+    errors: [],
+  };
+
+  for (const { year, month } of months) {
+    const label = `${year}-${String(month).padStart(2, '0')}`;
+    try {
+      const result = await computeMonthlyRollup(year, month);
+      await persistMonthlyRollup(result);
+      report.monthsRecomputed += 1;
+      report.months.push(label);
+    } catch (err) {
+      report.errors.push(`${label}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  const finishedAt = new Date();
+  report.finishedAt = finishedAt.toISOString();
+  report.durationMs = finishedAt.getTime() - startedAt.getTime();
+  console.log('[finance-monthly-rollup] report:', JSON.stringify(report));
+  return NextResponse.json({ success: report.errors.length === 0, data: report });
+}

--- a/src/lib/finance/monthly-rollup.ts
+++ b/src/lib/finance/monthly-rollup.ts
@@ -1,0 +1,435 @@
+/**
+ * Monthly trajectory rollup builder (Phase 5C).
+ *
+ * Computes one month's finance picture by UNIONing the two revenue eras
+ * (ShopifyOrderArchive ≤2025-12 + Order ≥2026-01, deduped on the rare overlap)
+ * and layering QB OpEx where available. Profit fields stay null when the data
+ * is incomplete; `dataHealth` records WHY so the briefing renders honestly
+ * instead of inventing a number.
+ *
+ * Pure compute + read-only — persistence is the caller's job
+ * (scripts/finance/backfill-monthly-rollups.ts + the cron).
+ */
+
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/database/client';
+import { segmentForOrder, segmentForArchive, type Segment } from './order-segment';
+import {
+  isOperatingExpense,
+  CATEGORY_LABELS,
+  type CategorySlug,
+} from './qb-account-map';
+
+const SEGMENTS: readonly Segment[] = ['bach', 'wedding', 'corporate', 'boat', 'kegs', 'general'];
+const TOP_N = 10;
+
+export interface SkuRow { sku: string | null; title: string; revenueCents: number; qty: number }
+export interface CustomerRow { name: string; email: string; revenueCents: number; orderCount: number }
+export interface AffiliateRow { code: string; name: string; revenueCents: number; commissionCents: number }
+export interface ExpenseCatRow {
+  category: CategorySlug;
+  label: string;
+  cents: number;
+  topVendor: string | null;
+  topVendorCents: number;
+}
+export interface SegmentStat { revenueCents: number; orderCount: number }
+
+export interface MonthlyRollupResult {
+  year: number;
+  month: number;
+  revenueCents: number;
+  orderCount: number;
+  revenueFromShopifyCents: number;
+  revenueFromOrdersCents: number;
+  cogsCents: number | null;
+  grossProfitCents: number | null;
+  opexCents: number | null;
+  netIncomeCents: number | null;
+  topSkus: SkuRow[];
+  segmentBreakdown: Record<Segment, SegmentStat>;
+  topCustomers: CustomerRow[];
+  topAffiliates: AffiliateRow[];
+  expenseCategories: ExpenseCatRow[];
+  dataHealth: Record<string, unknown>;
+}
+
+function monthWindow(year: number, month: number): { start: Date; end: Date } {
+  return {
+    start: new Date(Date.UTC(year, month - 1, 1)),
+    end: new Date(Date.UTC(year, month, 1)),
+  };
+}
+
+export interface YearMonth { year: number; month: number }
+
+/** Inclusive list of {year,month} from start to end. */
+export function enumerateMonths(start: YearMonth, end: YearMonth): YearMonth[] {
+  const out: YearMonth[] = [];
+  let y = start.year;
+  let m = start.month;
+  while (y < end.year || (y === end.year && m <= end.month)) {
+    out.push({ year: y, month: m });
+    m += 1;
+    if (m > 12) { m = 1; y += 1; }
+  }
+  return out;
+}
+
+/** Earliest month that has revenue in either era, for full-history backfill. */
+export async function earliestDataMonth(): Promise<YearMonth> {
+  const [arch, order] = await Promise.all([
+    prisma.shopifyOrderArchive.findFirst({ orderBy: { processedAt: 'asc' }, select: { processedAt: true } }),
+    prisma.order.findFirst({ orderBy: { createdAt: 'asc' }, select: { createdAt: true } }),
+  ]);
+  const dates = [arch?.processedAt, order?.createdAt].filter((d): d is Date => !!d);
+  if (dates.length === 0) {
+    const now = new Date();
+    return { year: now.getUTCFullYear(), month: now.getUTCMonth() + 1 };
+  }
+  const min = new Date(Math.min(...dates.map((d) => d.getTime())));
+  return { year: min.getUTCFullYear(), month: min.getUTCMonth() + 1 };
+}
+
+function toBigIntOrNull(n: number | null): bigint | null {
+  return n === null ? null : BigInt(Math.round(n));
+}
+
+/** Upsert a computed rollup into finance_monthly_rollup (keyed on year+month). */
+export async function persistMonthlyRollup(r: MonthlyRollupResult): Promise<void> {
+  const data = {
+    revenueCents: BigInt(r.revenueCents),
+    orderCount: r.orderCount,
+    cogsCents: toBigIntOrNull(r.cogsCents),
+    grossProfitCents: toBigIntOrNull(r.grossProfitCents),
+    opexCents: toBigIntOrNull(r.opexCents),
+    netIncomeCents: toBigIntOrNull(r.netIncomeCents),
+    revenueFromShopifyCents: BigInt(r.revenueFromShopifyCents),
+    revenueFromOrdersCents: BigInt(r.revenueFromOrdersCents),
+    topSkus: r.topSkus as unknown as Prisma.InputJsonValue,
+    segmentBreakdown: r.segmentBreakdown as unknown as Prisma.InputJsonValue,
+    topCustomers: r.topCustomers as unknown as Prisma.InputJsonValue,
+    topAffiliates: r.topAffiliates as unknown as Prisma.InputJsonValue,
+    expenseCategories: r.expenseCategories as unknown as Prisma.InputJsonValue,
+    dataHealth: r.dataHealth as Prisma.InputJsonValue,
+    computedAt: new Date(),
+  };
+  await prisma.financeMonthlyRollup.upsert({
+    where: { year_month: { year: r.year, month: r.month } },
+    create: { year: r.year, month: r.month, ...data },
+    update: data,
+  });
+}
+
+function decToCents(d: Prisma.Decimal | null | undefined): number {
+  if (d === null || d === undefined) return 0;
+  return Math.round(Number(d) * 100);
+}
+
+function emptySegments(): Record<Segment, SegmentStat> {
+  const out = {} as Record<Segment, SegmentStat>;
+  for (const s of SEGMENTS) out[s] = { revenueCents: 0, orderCount: 0 };
+  return out;
+}
+
+export async function computeMonthlyRollup(
+  year: number,
+  month: number
+): Promise<MonthlyRollupResult> {
+  const { start, end } = monthWindow(year, month);
+
+  const [orders, archive, commissions, qbExpenses] = await Promise.all([
+    prisma.order.findMany({
+      where: { financialStatus: 'PAID', createdAt: { gte: start, lt: end } },
+      select: {
+        total: true,
+        customerName: true,
+        customerEmail: true,
+        landingPage: true,
+        utmCampaign: true,
+        segment: true,
+        shopifyOrderId: true,
+        groupOrderV2: { select: { name: true } },
+        items: { select: { sku: true, title: true, totalPrice: true, totalCost: true, quantity: true } },
+      },
+    }),
+    prisma.shopifyOrderArchive.findMany({
+      where: { financialStatus: 'PAID', processedAt: { gte: start, lt: end } },
+      select: {
+        shopifyOrderId: true,
+        totalPriceCents: true,
+        sourceName: true,
+        note: true,
+        tags: true,
+        lineItems: true,
+      },
+    }),
+    prisma.affiliateCommission.findMany({
+      where: { createdAt: { gte: start, lt: end } },
+      select: {
+        commissionAmountCents: true,
+        affiliate: { select: { code: true, businessName: true } },
+        order: { select: { total: true } },
+      },
+    }),
+    prisma.qbExpense.findMany({
+      where: { txnDate: { gte: start, lt: end } },
+      select: { amountCents: true, categorySlug: true, vendorName: true },
+    }),
+  ]);
+
+  // Dedup: skip archive rows that are also represented in the Order table.
+  const orderShopifyIds = new Set(
+    orders.map((o) => o.shopifyOrderId).filter((x): x is string => !!x)
+  );
+  const archiveDeduped = archive.filter(
+    (a) => !a.shopifyOrderId || !orderShopifyIds.has(a.shopifyOrderId)
+  );
+
+  const revenueFromOrdersCents = orders.reduce((s, o) => s + decToCents(o.total), 0);
+  const revenueFromShopifyCents = archiveDeduped.reduce((s, a) => s + a.totalPriceCents, 0);
+  const revenueCents = revenueFromOrdersCents + revenueFromShopifyCents;
+  const orderCount = orders.length + archiveDeduped.length;
+
+  const topSkus = buildTopSkus(orders, archiveDeduped);
+  const segmentBreakdown = buildSegments(orders, archiveDeduped);
+  const topCustomers = buildTopCustomers(orders);
+  const topAffiliates = buildTopAffiliates(commissions);
+  const { expenseCategories, cogsCents, opexCents } = buildExpenses(qbExpenses);
+
+  // Per-order COGS from OrderItem cost (sparse, ~4% coverage) — only used as a
+  // fallback signal; QB inventory cogs is the primary cost source.
+  const orderItemCostCents = orders.reduce(
+    (s, o) => s + o.items.reduce((is, it) => is + decToCents(it.totalCost), 0),
+    0
+  );
+
+  const effectiveCogs = cogsCents ?? (orderItemCostCents > 0 ? orderItemCostCents : null);
+  const grossProfitCents = effectiveCogs !== null ? revenueCents - effectiveCogs : null;
+  const netIncomeCents =
+    grossProfitCents !== null && opexCents !== null ? grossProfitCents - opexCents : null;
+
+  const dataHealth = buildDataHealth({
+    year,
+    month,
+    revenueCents,
+    revenueFromShopifyCents,
+    qbExpenseCount: qbExpenses.length,
+    cogsCents,
+    opexCents,
+    orderItemCostCents,
+    orderCount: orders.length,
+    archiveCount: archiveDeduped.length,
+  });
+
+  return {
+    year,
+    month,
+    revenueCents,
+    orderCount,
+    revenueFromShopifyCents,
+    revenueFromOrdersCents,
+    cogsCents: effectiveCogs,
+    grossProfitCents,
+    opexCents,
+    netIncomeCents,
+    topSkus,
+    segmentBreakdown,
+    topCustomers,
+    topAffiliates,
+    expenseCategories,
+    dataHealth,
+  };
+}
+
+interface OrderItemRow {
+  sku: string | null;
+  title: string;
+  totalPrice: Prisma.Decimal;
+  totalCost: Prisma.Decimal | null;
+  quantity: number;
+}
+interface OrderRow {
+  total: Prisma.Decimal;
+  customerName: string | null;
+  customerEmail: string | null;
+  landingPage: string | null;
+  utmCampaign: string | null;
+  segment: string | null;
+  shopifyOrderId: string | null;
+  groupOrderV2: { name: string | null } | null;
+  items: OrderItemRow[];
+}
+
+interface ArchiveLineItem { sku: string | null; title: string | null; quantity: number; unitPriceCents: number }
+
+function buildTopSkus(
+  orders: OrderRow[],
+  archive: { lineItems: Prisma.JsonValue }[]
+): SkuRow[] {
+  const map = new Map<string, SkuRow>();
+  const add = (sku: string | null, title: string, revenueCents: number, qty: number) => {
+    const key = sku || title;
+    const cur = map.get(key) ?? { sku, title, revenueCents: 0, qty: 0 };
+    cur.revenueCents += revenueCents;
+    cur.qty += qty;
+    map.set(key, cur);
+  };
+  for (const o of orders) {
+    for (const it of o.items) add(it.sku, it.title, decToCents(it.totalPrice), it.quantity);
+  }
+  for (const a of archive) {
+    const items = Array.isArray(a.lineItems) ? (a.lineItems as unknown as ArchiveLineItem[]) : [];
+    for (const it of items) {
+      add(it.sku, it.title ?? '(unknown)', it.unitPriceCents * it.quantity, it.quantity);
+    }
+  }
+  return [...map.values()].sort((a, b) => b.revenueCents - a.revenueCents).slice(0, TOP_N);
+}
+
+function buildSegments(
+  orders: OrderRow[],
+  archive: { sourceName: string | null; note: string | null; tags: string[]; totalPriceCents: number }[]
+): Record<Segment, SegmentStat> {
+  const out = emptySegments();
+  for (const o of orders) {
+    const seg = segmentForOrder({
+      landingPage: o.landingPage,
+      utmCampaign: o.utmCampaign,
+      storedSegment: o.segment,
+      groupName: o.groupOrderV2?.name ?? null,
+    });
+    out[seg].revenueCents += decToCents(o.total);
+    out[seg].orderCount += 1;
+  }
+  for (const a of archive) {
+    const seg = segmentForArchive({ sourceName: a.sourceName, note: a.note, tags: a.tags });
+    out[seg].revenueCents += a.totalPriceCents;
+    out[seg].orderCount += 1;
+  }
+  return out;
+}
+
+function buildTopCustomers(orders: OrderRow[]): CustomerRow[] {
+  const map = new Map<string, CustomerRow>();
+  for (const o of orders) {
+    const email = (o.customerEmail || '').toLowerCase();
+    if (!email) continue;
+    const cur = map.get(email) ?? {
+      name: o.customerName || email,
+      email,
+      revenueCents: 0,
+      orderCount: 0,
+    };
+    cur.revenueCents += decToCents(o.total);
+    cur.orderCount += 1;
+    map.set(email, cur);
+  }
+  return [...map.values()].sort((a, b) => b.revenueCents - a.revenueCents).slice(0, TOP_N);
+}
+
+function buildTopAffiliates(
+  commissions: {
+    commissionAmountCents: number;
+    affiliate: { code: string; businessName: string } | null;
+    order: { total: Prisma.Decimal } | null;
+  }[]
+): AffiliateRow[] {
+  const map = new Map<string, AffiliateRow>();
+  for (const c of commissions) {
+    if (!c.affiliate) continue;
+    const cur = map.get(c.affiliate.code) ?? {
+      code: c.affiliate.code,
+      name: c.affiliate.businessName,
+      revenueCents: 0,
+      commissionCents: 0,
+    };
+    cur.revenueCents += decToCents(c.order?.total);
+    cur.commissionCents += c.commissionAmountCents;
+    map.set(c.affiliate.code, cur);
+  }
+  return [...map.values()].sort((a, b) => b.revenueCents - a.revenueCents).slice(0, TOP_N);
+}
+
+function buildExpenses(
+  qbExpenses: { amountCents: number; categorySlug: string | null; vendorName: string | null }[]
+): { expenseCategories: ExpenseCatRow[]; cogsCents: number | null; opexCents: number | null } {
+  if (qbExpenses.length === 0) {
+    return { expenseCategories: [], cogsCents: null, opexCents: null };
+  }
+  const byCat = new Map<CategorySlug, { cents: number; vendors: Map<string, number> }>();
+  for (const e of qbExpenses) {
+    const cat = (e.categorySlug ?? 'other') as CategorySlug;
+    const bucket = byCat.get(cat) ?? { cents: 0, vendors: new Map() };
+    bucket.cents += e.amountCents;
+    const vendor = e.vendorName || '(no vendor)';
+    bucket.vendors.set(vendor, (bucket.vendors.get(vendor) ?? 0) + e.amountCents);
+    byCat.set(cat, bucket);
+  }
+  const expenseCategories: ExpenseCatRow[] = [...byCat.entries()]
+    .map(([category, b]) => {
+      const top = [...b.vendors.entries()].sort((a, c) => c[1] - a[1])[0];
+      return {
+        category,
+        label: CATEGORY_LABELS[category] ?? category,
+        cents: b.cents,
+        topVendor: top ? top[0] : null,
+        topVendorCents: top ? top[1] : 0,
+      };
+    })
+    .sort((a, b) => b.cents - a.cents);
+
+  let cogsCents = 0;
+  let opexCents = 0;
+  for (const row of expenseCategories) {
+    if (row.category === 'cogs') cogsCents += row.cents;
+    else if (isOperatingExpense(row.category)) opexCents += row.cents;
+  }
+  return { expenseCategories, cogsCents, opexCents };
+}
+
+interface HealthInput {
+  year: number;
+  month: number;
+  revenueCents: number;
+  revenueFromShopifyCents: number;
+  qbExpenseCount: number;
+  cogsCents: number | null;
+  opexCents: number | null;
+  orderItemCostCents: number;
+  orderCount: number;
+  archiveCount: number;
+}
+
+/**
+ * Flags every reason a month's profit number can't be trusted, and sets
+ * `netIncomeReliable` accordingly. The Phase 5D briefing renders net income
+ * only when reliable; otherwise it shows "pending" + these flags.
+ */
+function buildDataHealth(h: HealthInput): Record<string, unknown> {
+  const flags: string[] = [];
+  const expensesTotalCents = (h.cogsCents ?? 0) + (h.opexCents ?? 0);
+
+  if (h.qbExpenseCount === 0) {
+    flags.push('no QB expenses recorded this month — OpEx + net income unavailable');
+  } else if (h.revenueCents > 0 && expensesTotalCents < h.revenueCents * 0.1) {
+    flags.push('QB expenses trivial vs revenue — books likely incomplete this month');
+  }
+  if ((h.cogsCents ?? 0) === 0 && h.orderItemCostCents === 0 && h.revenueCents > 0) {
+    flags.push('no COGS recorded — gross profit unreliable');
+  }
+  if (h.revenueFromShopifyCents > h.revenueCents * 0.5) {
+    flags.push('Shopify-era revenue is net-of-refund and understated vs real expenses');
+  }
+
+  const netIncomeReliable =
+    flags.length === 0 && h.cogsCents !== null && h.opexCents !== null;
+
+  return {
+    hasOrders: h.orderCount > 0,
+    hasArchive: h.archiveCount > 0,
+    hasQbExpenses: h.qbExpenseCount > 0,
+    netIncomeReliable,
+    flags,
+  };
+}

--- a/src/lib/finance/order-segment.ts
+++ b/src/lib/finance/order-segment.ts
@@ -1,0 +1,69 @@
+/**
+ * Segment classification for the monthly rollup (Phase 5C).
+ *
+ * Thin wrappers over the existing analytics classifier so the trajectory uses
+ * the SAME taxonomy as every other segment-aware metric (bach / wedding /
+ * corporate / boat / kegs / general). Two entry points because the two revenue
+ * eras carry different signals:
+ *   - Order table (2026+): landing page + UTM campaign (best signal), with a
+ *     group-order-name fallback for boat/wedding/bach events.
+ *   - ShopifyOrderArchive (≤2025): no landing page (PII-gated) and empty tags
+ *     on this store, so signal is weak — source_name + note keywords, else
+ *     'general'. Historical segment data is therefore coarse by nature.
+ */
+
+import { classifySegment, type Segment } from '@/lib/analytics/segment-classifier';
+
+export type { Segment };
+
+/** Keyword → segment for the few free-text signals we can read. */
+function keywordSegment(text: string | null | undefined): Segment | null {
+  const t = (text ?? '').toLowerCase();
+  if (!t) return null;
+  if (/bachelor|bachelorette|\bbach\b/.test(t)) return 'bach';
+  if (/wedding/.test(t)) return 'wedding';
+  if (/corporate/.test(t)) return 'corporate';
+  if (/\bboat\b|cruise|yacht|marina|lake\s*travis|pontoon/.test(t)) return 'boat';
+  if (/\bkeg\b/.test(t)) return 'kegs';
+  return null;
+}
+
+export interface OrderSegmentInput {
+  landingPage: string | null;
+  utmCampaign: string | null;
+  /** Pre-stored Order.segment, if already classified (skip recompute when set). */
+  storedSegment?: string | null;
+  /** GroupOrderV2.name (boat manifest / event name), if the order is in a group. */
+  groupName?: string | null;
+}
+
+/** Classify an Order-table row. */
+export function segmentForOrder(input: OrderSegmentInput): Segment {
+  // Trust a pre-stored non-general segment.
+  if (input.storedSegment && input.storedSegment !== 'general') {
+    if (isSegment(input.storedSegment)) return input.storedSegment;
+  }
+  const primary = classifySegment(input.landingPage, input.utmCampaign);
+  if (primary !== 'general') return primary;
+  // Group-order name is a strong event signal when the page/UTM are generic.
+  return keywordSegment(input.groupName) ?? 'general';
+}
+
+export interface ArchiveSegmentInput {
+  sourceName: string | null;
+  note: string | null;
+  tags: string[];
+}
+
+/** Classify a ShopifyOrderArchive row (weak signal — usually 'general'). */
+export function segmentForArchive(input: ArchiveSegmentInput): Segment {
+  for (const tag of input.tags) {
+    const s = keywordSegment(tag);
+    if (s) return s;
+  }
+  return keywordSegment(input.note) ?? keywordSegment(input.sourceName) ?? 'general';
+}
+
+function isSegment(s: string): s is Segment {
+  return ['bach', 'wedding', 'corporate', 'boat', 'kegs', 'general'].includes(s);
+}

--- a/vercel.json
+++ b/vercel.json
@@ -81,6 +81,10 @@
       "schedule": "5 8 * * *"
     },
     {
+      "path": "/api/cron/finance-monthly-rollup",
+      "schedule": "10 8 * * *"
+    },
+    {
       "path": "/api/cron/finance-weekly-briefing",
       "schedule": "0 14 * * 1"
     }


### PR DESCRIPTION
## Summary

The foundation for the monthly close email. Pre-computes one row per month (`FinanceMonthlyRollup`) so the briefing + admin trajectory view render instantly instead of re-aggregating the whole history each time.

UNIONs the two revenue eras established earlier — **Shopify archive (≤2025-12) + Order table (2026+)**, deduped on the rare overlap — and layers in QB OpEx where available.

## What's in it

- **`FinanceMonthlyRollup` table** (raw SQL migration `prisma/migrations/manual/2026-06-18-finance-phase-5c-monthly-rollup.sql`): revenue, order count, cogs/grossProfit/opex/netIncome (nullable when incomplete), revenue-by-source, top SKUs, segment mix, top customers, top affiliates, expense categories (with top vendor per category), and a `dataHealth` block.
- **`monthly-rollup.ts`** — `computeMonthlyRollup(year, month)` + persist + enumerate / earliest-month helpers. Excludes `cogs` + `non_operating` from OpEx via `isOperatingExpense()` (from PR #142).
- **`order-segment.ts`** — reuses the existing analytics `classifySegment` taxonomy (bach/wedding/corporate/boat/kegs/general). Order rows use landing page + UTM + group-order name; archive rows use tags/note/source (coarse historically — Shopify era has no landing page).
- **`scripts/finance/backfill-monthly-rollups.ts`** — full-history one-shot.
- **`/api/cron/finance-monthly-rollup`** (08:10 UTC) — nightly trailing-2-month refresh; `?months=N` after a re-categorization.
- **`docs/QUICKBOOKS-2026-CATCHUP-FOR-BOOKKEEPER.md`** — forwardable fix-list for the 2026 bookkeeping gap the investigation surfaced.

## The honesty gate

`dataHealth.netIncomeReliable` is **false for every month so far**, on purpose:
- 2023–2025: revenue is Shopify-understated (net-of-refund) vs real QB expenses → artificial *losses*
- 2026: real revenue (Order table) but QB is dormant (COGS=0, OpEx≈0) → artificial *profit*

Phase 5D renders net income as "pending" + the flags, never the raw number.

## Validated against real data

`computeMonthlyRollup` run against 2024-06 / 2025-04 / 2026-04 — revenue unions correctly, segments/SKUs/customers/affiliates/expense-categories all populate, and the data-health flags fire exactly where expected (the artificial loss/profit months).

## Pre-merge checklist

- [x] `npx tsc --noEmit` — clean for new files
- [x] `npx next lint` — clean
- [x] `npm run test:run` — **280/280 pass** (the old group-v2 / recommendations failures are fixed on main now)
- [x] **Did not run `next build`**

## Operator action items

1. Run the migration (or let it auto-apply on deploy):
   ```sql
   -- finance_monthly_rollup table (see migration file)
   ```
2. After deploy, Claude runs `npx tsx scripts/finance/backfill-monthly-rollups.ts` to populate all months, then shows the full trajectory.

## What's next

- **PR D** — the monthly close email renders this rollup (LLM narrative + 12-month table + segments + top SKUs/customers/affiliates + expense categories + the data-health panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)