### PR TITLE
fix(finance): flag zero-COGS revenue months as unreliable net income

### DIFF
--- a/src/lib/finance/monthly-rollup.ts
+++ b/src/lib/finance/monthly-rollup.ts
@@ -415,7 +415,10 @@ function buildDataHealth(h: HealthInput): Record<string, unknown> {
   } else if (h.revenueCents > 0 && expensesTotalCents < h.revenueCents * 0.1) {
     flags.push('QB expenses trivial vs revenue — books likely incomplete this month');
   }
-  if ((h.cogsCents ?? 0) === 0 && h.orderItemCostCents === 0 && h.revenueCents > 0) {
+  // For a liquor-delivery business every revenue month has alcohol cost, so a
+  // zero COGS month means it wasn't recorded (the sparse OrderItem cost data
+  // is too thin to count as real COGS). Always flag it.
+  if ((h.cogsCents ?? 0) === 0 && h.revenueCents > 0) {
     flags.push('no COGS recorded — gross profit unreliable');
   }
   if (h.revenueFromShopifyCents > h.revenueCents * 0.5) {


### PR DESCRIPTION
## Summary

One-line correctness fix to the Phase 5C ([#146](https://github.com/allan-cmyk/PartyOn2/pull/146)) data-health gate. Net income read "reliable" for **1 of 36** revenue months — a 2026 month where QB COGS summed to \$0 (dormant books) was treated as "COGS known = \$0" instead of "COGS missing."

For a liquor-delivery business, every revenue month has alcohol cost, so a zero-COGS month always means it wasn't recorded. The sparse `OrderItem` cost data (~4% coverage) is too thin to count as real COGS, so I dropped that escape hatch from the flag.

## Result

After re-running the backfill against prod: **0/36 months read `netIncomeReliable`** — exactly right given the books aren't complete for any period yet. The Phase 5D briefing will never surface a fake profit number.

## Verification

- `npx tsc --noEmit` clean for the file
- Re-ran `scripts/finance/backfill-monthly-rollups.ts` — 65/65 months persisted, reliability now 0/36 (was 1/36)

🤖 Generated with [Claude Code](https://claude.com/claude-code)