### PR TITLE
Fix Dad's Gone Wild RSVP capture + add ops guest-list view

### DIFF
--- a/src/app/api/events/rsvp/__tests__/route.test.ts
+++ b/src/app/api/events/rsvp/__tests__/route.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for POST /api/events/rsvp — the one-off event invite RSVP endpoint
+ * (e.g. the /dads-gone-wild Father's Day boat party).
+ *
+ * The load-bearing guarantee: a guest is only ever told "you're confirmed"
+ * when we actually persisted a row (response carries an `id`). A honeypot trip
+ * must drop silently WITHOUT an `id`, and a bad payload must 400 — neither may
+ * write to the DB.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const prismaMock = vi.hoisted(() => ({
+  eventRsvp: { create: vi.fn() },
+}));
+
+vi.mock('@/lib/database/client', () => ({ prisma: prismaMock }));
+
+import { POST } from '../route';
+
+let ipCounter = 0;
+
+/** Build a POST request with a fresh per-test IP so the in-memory rate limiter never bleeds across cases. */
+function makeRequest(body: unknown): NextRequest {
+  ipCounter += 1;
+  return new NextRequest('http://localhost/api/events/rsvp', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-forwarded-for': `10.0.0.${ipCounter}`,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = {
+  event: 'dads-gone-wild',
+  name: 'Matt Rundle',
+  adults: 2,
+  kids: 1,
+  dish: 'Queso',
+};
+
+beforeEach(() => {
+  prismaMock.eventRsvp.create.mockReset();
+});
+
+describe('POST /api/events/rsvp', () => {
+  it('persists a valid RSVP and returns ok + id', async () => {
+    prismaMock.eventRsvp.create.mockResolvedValue({ id: 'rsvp_123' });
+
+    const res = await POST(makeRequest(validBody));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toEqual({ ok: true, id: 'rsvp_123' });
+    expect(prismaMock.eventRsvp.create).toHaveBeenCalledTimes(1);
+    expect(prismaMock.eventRsvp.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          event: 'dads-gone-wild',
+          name: 'Matt Rundle',
+          adults: 2,
+          kids: 1,
+          dish: 'Queso',
+          totalHeads: 3,
+        }),
+      }),
+    );
+  });
+
+  it('drops a honeypot submission WITHOUT an id and never writes to the DB', async () => {
+    const res = await POST(makeRequest({ ...validBody, hp_event_notes: 'http://spam.example' }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    // ok:true keeps bots in the dark, but no `id` means the client won't show a
+    // "confirmed" card — exactly what protects a real guest from a false confirm.
+    expect(json.id).toBeUndefined();
+    expect(prismaMock.eventRsvp.create).not.toHaveBeenCalled();
+  });
+
+  it('ignores an empty honeypot and still saves', async () => {
+    prismaMock.eventRsvp.create.mockResolvedValue({ id: 'rsvp_456' });
+
+    const res = await POST(makeRequest({ ...validBody, hp_event_notes: '' }));
+    const json = await res.json();
+
+    expect(json).toEqual({ ok: true, id: 'rsvp_456' });
+    expect(prismaMock.eventRsvp.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a missing name with 400 and does not write', async () => {
+    const res = await POST(makeRequest({ ...validBody, name: '' }));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.ok).toBe(false);
+    expect(prismaMock.eventRsvp.create).not.toHaveBeenCalled();
+  });
+
+  it('coerces stringified counts and computes totalHeads', async () => {
+    prismaMock.eventRsvp.create.mockResolvedValue({ id: 'rsvp_789' });
+
+    await POST(makeRequest({ ...validBody, adults: '3', kids: '2' }));
+
+    expect(prismaMock.eventRsvp.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ adults: 3, kids: 2, totalHeads: 5 }),
+      }),
+    );
+  });
+});

--- a/src/app/api/events/rsvp/route.ts
+++ b/src/app/api/events/rsvp/route.ts
@@ -50,13 +50,22 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       return NextResponse.json({ ok: false, error: 'Invalid request.' }, { status: 400 });
     }
 
-    // Honeypot — a hidden field bots tend to fill. Pretend success so we
-    // don't tip them off, but persist nothing.
-    if (body.website_url) {
+    // Honeypot — a hidden, deliberately non-autofill-named field bots tend to
+    // fill. We log every trip (so a real person caught here is visible instead
+    // of vanishing) and return a success WITHOUT an `id`. The client only
+    // celebrates on an `id`, so a honeypot drop never shows a false "confirmed"
+    // card — and a real bot doesn't care either way.
+    const honeypot = body.hp_event_notes;
+    if (typeof honeypot === 'string' && honeypot.trim().length > 0) {
+      console.warn('[Event RSVP] honeypot tripped — dropped', {
+        event: typeof body.event === 'string' ? body.event : null,
+        ip,
+      });
       return NextResponse.json({ ok: true });
     }
 
     if (rateLimited(ip)) {
+      console.warn('[Event RSVP] rate limited', { ip });
       return NextResponse.json(
         { ok: false, error: 'Too many submissions. Please try again in a minute.' },
         { status: 429 },
@@ -65,6 +74,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     const parsed = RsvpSchema.safeParse(body);
     if (!parsed.success) {
+      console.warn('[Event RSVP] validation failed', {
+        ip,
+        event: typeof body.event === 'string' ? body.event : null,
+        issues: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`),
+      });
       return NextResponse.json(
         { ok: false, error: 'Please check your entries and try again.' },
         { status: 400 },
@@ -83,6 +97,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         totalHeads: adults + kids,
       },
       select: { id: true },
+    });
+
+    console.log('[Event RSVP] saved', {
+      id: rsvp.id,
+      event,
+      name,
+      totalHeads: adults + kids,
     });
 
     return NextResponse.json({ ok: true, id: rsvp.id });

--- a/src/app/api/ops/event-rsvps/route.ts
+++ b/src/app/api/ops/event-rsvps/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
+import { prisma } from '@/lib/database/client';
+
+/**
+ * GET /api/ops/event-rsvps — the guest list for one-off event invites
+ * (e.g. /dads-gone-wild). Ops-only. Returns RSVPs grouped by event slug, each
+ * group carrying rolled-up head counts so the ops page can show totals without
+ * re-summing on the client.
+ */
+export async function GET(): Promise<NextResponse> {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  try {
+    const rsvps = await prisma.eventRsvp.findMany({
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        event: true,
+        name: true,
+        adults: true,
+        kids: true,
+        dish: true,
+        totalHeads: true,
+        createdAt: true,
+      },
+    });
+
+    // Group by event slug, newest-first within each group (the query order is
+    // preserved as we push).
+    const groups = new Map<
+      string,
+      {
+        event: string;
+        parties: number;
+        totalAdults: number;
+        totalKids: number;
+        totalHeads: number;
+        rsvps: typeof rsvps;
+      }
+    >();
+
+    for (const r of rsvps) {
+      const g = groups.get(r.event) ?? {
+        event: r.event,
+        parties: 0,
+        totalAdults: 0,
+        totalKids: 0,
+        totalHeads: 0,
+        rsvps: [],
+      };
+      g.parties += 1;
+      g.totalAdults += r.adults;
+      g.totalKids += r.kids;
+      g.totalHeads += r.totalHeads;
+      g.rsvps.push(r);
+      groups.set(r.event, g);
+    }
+
+    return NextResponse.json({ events: Array.from(groups.values()) });
+  } catch (error) {
+    console.error('[Ops Event RSVPs] error:', error);
+    return NextResponse.json({ error: 'Failed to load RSVPs.' }, { status: 500 });
+  }
+}

--- a/src/app/dads-gone-wild/RsvpForm.tsx
+++ b/src/app/dads-gone-wild/RsvpForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, type ReactElement } from 'react';
+import { useState, type FormEvent, type ReactElement } from 'react';
 
 const MIN_ADULTS = 1;
 const MAX_ADULTS = 20;
@@ -51,9 +51,13 @@ function Stepper({ label, value, onDec, onInc }: StepperProps): ReactElement {
 
 /**
  * Inline RSVP form for the boat-party invite. Validates name (required),
- * clamps the steppers, shows a live "total heads" count, and on a successful
- * POST to /api/events/rsvp flips to a confirmation state. "Edit my answer"
- * returns to the form with all entered values preserved.
+ * clamps the steppers, shows a live "total heads" count, and only flips to the
+ * confirmation state when the server confirms a *persisted* row (a response
+ * with an `id`) — so we never show "you're confirmed" for an RSVP we didn't
+ * actually save. "Edit my answer" returns to the form with all entered values
+ * preserved.
+ *
+ * Rendered as a real <form> so the mobile keyboard's "Go"/Return key submits.
  */
 export default function RsvpForm({ event, hostName }: RsvpFormProps): ReactElement {
   const [name, setName] = useState('');
@@ -69,7 +73,9 @@ export default function RsvpForm({ event, hostName }: RsvpFormProps): ReactEleme
   const totalHeads = adults + kids;
   const nameError = triedSubmit && !name.trim();
 
-  async function handleSubmit(): Promise<void> {
+  async function handleSubmit(e: FormEvent<HTMLFormElement>): Promise<void> {
+    e.preventDefault();
+    if (submitting) return;
     if (!name.trim()) {
       setTriedSubmit(true);
       return;
@@ -86,12 +92,17 @@ export default function RsvpForm({ event, hostName }: RsvpFormProps): ReactEleme
           adults,
           kids,
           dish: dish.trim(),
-          website_url: honeypot,
+          hp_event_notes: honeypot,
         }),
       });
-      const data = (await res.json().catch(() => null)) as { ok?: boolean; error?: string } | null;
-      if (!res.ok || !data?.ok) {
-        setServerError(data?.error || 'Something went sideways. Try again.');
+      const data = (await res.json().catch(() => null)) as
+        | { ok?: boolean; id?: string; error?: string }
+        | null;
+      // A real, saved RSVP always comes back with an `id`. Anything else — a
+      // network error, a validation reject, or a honeypot drop — must NOT show
+      // the confirmation card, or we'd promise a seat we never recorded.
+      if (!res.ok || !data?.ok || !data.id) {
+        setServerError(data?.error || "That didn't save — give it one more tap.");
         return;
       }
       setSubmitted(true);
@@ -130,11 +141,16 @@ export default function RsvpForm({ event, hostName }: RsvpFormProps): ReactEleme
   }
 
   return (
-    <div className="flex flex-col gap-5">
-      {/* Honeypot — hidden from humans; bots that fill it are silently dropped. */}
+    <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-5">
+      {/*
+        Honeypot — hidden from humans; bots that fill it are silently dropped.
+        The name is deliberately NOT autofill-mapped (avoid url/website/email/
+        name/phone/etc.) so iOS Safari and password managers don't fill it for
+        a real guest and get them silently dropped on the server.
+      */}
       <input
         type="text"
-        name="website_url"
+        name="hp_event_notes"
         tabIndex={-1}
         autoComplete="off"
         aria-hidden="true"
@@ -192,13 +208,12 @@ export default function RsvpForm({ event, hostName }: RsvpFormProps): ReactEleme
       {serverError && <p className="text-sm text-brand-yellow">{serverError}</p>}
 
       <button
-        type="button"
-        onClick={handleSubmit}
+        type="submit"
         disabled={submitting}
         className="rounded-lg bg-brand-yellow p-[18px] font-sans text-base font-bold uppercase tracking-[0.08em] text-gray-900 transition-colors hover:bg-yellow-400 disabled:opacity-60"
       >
         {submitting ? 'Locking It In…' : 'Lock It In'}
       </button>
-    </div>
+    </form>
   );
 }

--- a/src/app/ops/layout.tsx
+++ b/src/app/ops/layout.tsx
@@ -154,6 +154,7 @@ export default function OpsLayout({ children }: OpsLayoutProps): ReactElement {
     { href: '/ops/orders', label: 'Orders' },
     { href: '/ops/orders?view=carts', label: 'Unpaid Carts' },
     { href: '/ops/boat-schedule', label: 'Boats' },
+    { href: '/ops/rsvps', label: 'RSVPs' },
     { href: '/ops/orders?view=weekly', label: 'Weekly' },
     { href: '/ops/collections', label: 'Collections' },
     { href: '/ops/agent', label: 'Agent' },

--- a/src/app/ops/rsvps/page.tsx
+++ b/src/app/ops/rsvps/page.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import { useState, useEffect, useCallback, type ReactElement } from 'react';
+
+interface Rsvp {
+  id: string;
+  event: string;
+  name: string;
+  adults: number;
+  kids: number;
+  dish: string | null;
+  totalHeads: number;
+  createdAt: string;
+}
+
+interface EventGroup {
+  event: string;
+  parties: number;
+  totalAdults: number;
+  totalKids: number;
+  totalHeads: number;
+  rsvps: Rsvp[];
+}
+
+/** "dads-gone-wild" -> "Dads Gone Wild" for a friendlier section heading. */
+function humanizeSlug(slug: string): string {
+  return slug
+    .split('-')
+    .map((w) => (w ? w[0].toUpperCase() + w.slice(1) : w))
+    .join(' ');
+}
+
+function formatWhen(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function StatTile({ label, value }: { label: string; value: number }): ReactElement {
+  return (
+    <div className="rounded-xl border border-gray-100 bg-white px-5 py-4 shadow-sm">
+      <div className="text-3xl font-bold text-gray-900">{value}</div>
+      <div className="mt-0.5 text-xs font-bold uppercase tracking-wider text-gray-500">{label}</div>
+    </div>
+  );
+}
+
+/**
+ * Ops guest-list view for one-off event invites (Father's Day boat party, etc.).
+ * Read-only: lists every RSVP grouped by event with rolled-up head counts.
+ * Auto-gated by the /ops layout password.
+ */
+export default function EventRsvpsPage(): ReactElement {
+  const [events, setEvents] = useState<EventGroup[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const fetchRsvps = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const res = await fetch('/api/ops/event-rsvps');
+      const json = await res.json();
+      if (!res.ok) {
+        setError(json.error || 'Failed to load RSVPs.');
+        return;
+      }
+      setEvents(json.events ?? []);
+    } catch {
+      setError('Network error — try refreshing.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchRsvps();
+  }, [fetchRsvps]);
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-4 md:p-8">
+      {/* Header */}
+      <div className="mb-8 flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
+        <div className="flex items-center gap-3">
+          <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-blue-500 to-blue-600 shadow-lg">
+            <svg className="h-6 w-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M17 20h5v-2a4 4 0 00-3-3.87M9 20H4v-2a4 4 0 013-3.87m6-1.13a4 4 0 10-4-4 4 4 0 004 4zm6-3a3 3 0 10-3-3"
+              />
+            </svg>
+          </div>
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900">Event RSVPs</h1>
+            <p className="mt-0.5 text-gray-500">Guest lists for one-off invite pages</p>
+          </div>
+        </div>
+        <button
+          onClick={fetchRsvps}
+          disabled={loading}
+          className="flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2.5 font-medium text-gray-700 shadow-sm transition-all duration-200 hover:border-gray-300 hover:bg-gray-50 disabled:opacity-50"
+        >
+          <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+            />
+          </svg>
+          {loading ? 'Refreshing…' : 'Refresh'}
+        </button>
+      </div>
+
+      {error && (
+        <div className="mb-6 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="space-y-4">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-16 animate-pulse rounded-xl bg-white shadow-sm" />
+          ))}
+        </div>
+      ) : events.length === 0 ? (
+        <div className="rounded-xl border border-gray-100 bg-white p-16 text-center shadow-sm">
+          <p className="text-xl font-semibold text-gray-700">No RSVPs yet</p>
+          <p className="mt-2 text-gray-500">
+            As guests submit an invite page, they&apos;ll show up here.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-10">
+          {events.map((group) => (
+            <section key={group.event}>
+              <div className="mb-3 flex items-baseline justify-between gap-3">
+                <h2 className="text-xl font-bold text-gray-900">{humanizeSlug(group.event)}</h2>
+                <a
+                  href={`/${group.event}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm font-medium text-blue-600 hover:underline"
+                >
+                  View page ↗
+                </a>
+              </div>
+
+              <div className="mb-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+                <StatTile label="Parties" value={group.parties} />
+                <StatTile label="Adults" value={group.totalAdults} />
+                <StatTile label="Kids" value={group.totalKids} />
+                <StatTile label="Total Heads" value={group.totalHeads} />
+              </div>
+
+              <div className="overflow-hidden rounded-xl border border-gray-100 bg-white shadow-sm">
+                <div className="overflow-x-auto">
+                  <table className="w-full">
+                    <thead className="border-b border-gray-200 bg-gradient-to-r from-gray-50 to-gray-100/50">
+                      <tr>
+                        <th className="px-6 py-3 text-left text-xs font-bold uppercase tracking-wider text-gray-600">
+                          Name
+                        </th>
+                        <th className="px-4 py-3 text-center text-xs font-bold uppercase tracking-wider text-gray-600">
+                          Adults
+                        </th>
+                        <th className="px-4 py-3 text-center text-xs font-bold uppercase tracking-wider text-gray-600">
+                          Kids
+                        </th>
+                        <th className="px-4 py-3 text-center text-xs font-bold uppercase tracking-wider text-gray-600">
+                          Heads
+                        </th>
+                        <th className="px-6 py-3 text-left text-xs font-bold uppercase tracking-wider text-gray-600">
+                          Bringing
+                        </th>
+                        <th className="px-6 py-3 text-left text-xs font-bold uppercase tracking-wider text-gray-600">
+                          RSVP&apos;d
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-100">
+                      {group.rsvps.map((r) => (
+                        <tr key={r.id} className="hover:bg-gray-50">
+                          <td className="px-6 py-3 font-medium text-gray-900">{r.name}</td>
+                          <td className="px-4 py-3 text-center text-gray-700">{r.adults}</td>
+                          <td className="px-4 py-3 text-center text-gray-700">{r.kids}</td>
+                          <td className="px-4 py-3 text-center font-semibold text-gray-900">
+                            {r.totalHeads}
+                          </td>
+                          <td className="px-6 py-3 text-gray-700">
+                            {r.dish || <span className="text-gray-400">—</span>}
+                          </td>
+                          <td className="whitespace-nowrap px-6 py-3 text-gray-500">
+                            {formatWhen(r.createdAt)}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Why

A guest reported tapping **Lock It In** on `/dads-gone-wild` and nothing happening — and his RSVP never showed up. Investigation: the `event_rsvps` table and API work (2 RSVPs were captured), but there were silent paths where a submission is lost while the page looks fine. No server logs existed to catch it.

## What changed

**RSVP reliability (`fix` commit)**
- **Honeypot rename.** The hidden spam-trap field was named `website_url` — iOS Safari / password managers autofill hidden URL-named fields, and a filled honeypot makes the server silently drop the RSVP. Renamed to a non-autofill-mapped name (`hp_event_notes`).
- **Real `<form>`.** The form wasn't a `<form>`, so the mobile keyboard "Go"/Return key did nothing. Now wrapped in `<form onSubmit>` with a `type="submit"` button.
- **Truthful confirmation.** The "You're On The Boat" card showed on any `ok:true` response, including the honeypot drop. It now requires a persisted row `id`, so we never confirm a seat we didn't save.
- **Observability.** Backend now logs saves, honeypot trips, validation rejects, and rate limits (previously it logged nothing but 500s — which is why the lost RSVP left no trace).
- Adds route tests: save / honeypot-drop / validation / count coercion.

**Ops guest-list view (`feat` commit)**
- New **`/ops/rsvps`** page (linked in the ops nav) — read-only, grouped by event with rolled-up adults/kids/total-heads and a per-guest table. Backed by ops-authed `GET /api/ops/event-rsvps`.

## Testing
- `vitest run` — 285 passed (5 new).
- `tsc --noEmit` clean on changed files; `next lint` clean.

## Note
The currently-affected guest (Matt Rundle) is **not** in the DB — this stops future drops but can't recover his lost submit. He'll need to re-RSVP once this is live (or insert manually with his head count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)