### PR TITLE
fix(forms): harden lead-capture honeypots against autofill drops

### DIFF
--- a/src/app/api/partners/inquiry/__tests__/route.test.ts
+++ b/src/app/api/partners/inquiry/__tests__/route.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for POST /api/partners/inquiry — the shared partner lead-capture
+ * endpoint behind the corporate, mobile-bartender, vacation-rental,
+ * hotels-resort, austin-partners and wedding-DJ forms.
+ *
+ * The load-bearing guarantee mirrors the event RSVP route: a lead is only ever
+ * told "we got it" (and only fires a Meta Lead event) when a row was actually
+ * persisted — the response carries an `inquiryId`. A honeypot trip must drop
+ * silently WITHOUT an `inquiryId` and write nothing; a failed DB save must also
+ * return without an `inquiryId` (which is why every form now gates its success
+ * state on it).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { HONEYPOT_FIELD } from '@/lib/forms/honeypot';
+
+const dbMock = vi.hoisted(() => ({ savePartnerInquiry: vi.fn() }));
+vi.mock('@/lib/group-orders/database-vercel', () => ({ db: dbMock }));
+
+const emailMock = vi.hoisted(() => ({
+  sendPartnerInquiryNotification: vi.fn(),
+  sendPartnerOnePagerEmail: vi.fn(),
+}));
+vi.mock('@/lib/email/email-service', () => emailMock);
+
+vi.mock('@/lib/email/resend-audiences', () => ({ addContactToAudience: vi.fn() }));
+
+const prismaMock = vi.hoisted(() => ({
+  partnerInquiry: { findFirst: vi.fn(), update: vi.fn() },
+}));
+vi.mock('@/lib/database/client', () => ({
+  kv: {},
+  isKVConfigured: () => false,
+  prisma: prismaMock,
+}));
+
+import { POST } from '../route';
+
+let ipCounter = 0;
+
+/** Build a POST request with a fresh per-test IP so the in-memory rate limiter never bleeds across cases. */
+function makeRequest(body: unknown): NextRequest {
+  ipCounter += 1;
+  return new NextRequest('http://localhost/api/partners/inquiry', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-forwarded-for': `10.1.0.${ipCounter}`,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = {
+  contactName: 'Jane Smith',
+  email: 'jane@example.com',
+  businessName: 'Smith Events',
+  phone: '512-555-1234',
+  partnerType: 'Corporate Events',
+  source: 'corporate-landing-page',
+};
+
+beforeEach(() => {
+  dbMock.savePartnerInquiry.mockReset();
+  emailMock.sendPartnerInquiryNotification.mockReset();
+  emailMock.sendPartnerOnePagerEmail.mockReset();
+  prismaMock.partnerInquiry.findFirst.mockReset();
+  prismaMock.partnerInquiry.update.mockReset();
+});
+
+describe('POST /api/partners/inquiry', () => {
+  it('persists a valid inquiry and returns success + inquiryId', async () => {
+    dbMock.savePartnerInquiry.mockResolvedValue({ id: 'inq_123' });
+
+    const res = await POST(makeRequest(validBody));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.inquiryId).toBe('inq_123');
+    expect(dbMock.savePartnerInquiry).toHaveBeenCalledTimes(1);
+    expect(dbMock.savePartnerInquiry).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'jane@example.com', contactName: 'Jane Smith' }),
+    );
+  });
+
+  it('drops a honeypot submission WITHOUT an inquiryId and never writes', async () => {
+    const res = await POST(makeRequest({ ...validBody, [HONEYPOT_FIELD]: 'http://spam.example' }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    // success:true keeps bots in the dark, but no inquiryId means the form
+    // won't show a "thank you" — what protects a real autofilled visitor.
+    expect(json.success).toBe(true);
+    expect(json.inquiryId).toBeUndefined();
+    expect(dbMock.savePartnerInquiry).not.toHaveBeenCalled();
+  });
+
+  it('still drops the legacy honeypot names (zero rollout gap)', async () => {
+    const resUrl = await POST(makeRequest({ ...validBody, website_url: 'x' }));
+    expect((await resUrl.json()).inquiryId).toBeUndefined();
+
+    const resFax = await POST(makeRequest({ ...validBody, fax_number: '555' }));
+    expect((await resFax.json()).inquiryId).toBeUndefined();
+
+    expect(dbMock.savePartnerInquiry).not.toHaveBeenCalled();
+  });
+
+  it('ignores an empty honeypot and still saves', async () => {
+    dbMock.savePartnerInquiry.mockResolvedValue({ id: 'inq_456' });
+
+    const res = await POST(makeRequest({ ...validBody, [HONEYPOT_FIELD]: '' }));
+    const json = await res.json();
+
+    expect(json.inquiryId).toBe('inq_456');
+    expect(dbMock.savePartnerInquiry).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a missing email with 400 and does not write', async () => {
+    const res = await POST(makeRequest({ ...validBody, email: '' }));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.success).toBe(false);
+    expect(dbMock.savePartnerInquiry).not.toHaveBeenCalled();
+  });
+
+  it('returns success WITHOUT an inquiryId when the DB save fails (why forms gate on it)', async () => {
+    dbMock.savePartnerInquiry.mockResolvedValue(null);
+
+    const res = await POST(makeRequest(validBody));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.inquiryId).toBeUndefined();
+  });
+});

--- a/src/app/api/partners/inquiry/route.ts
+++ b/src/app/api/partners/inquiry/route.ts
@@ -4,6 +4,7 @@ import { sendPartnerInquiryNotification, sendPartnerOnePagerEmail } from '@/lib/
 import type { PartnerInquiryData } from '@/lib/email/email-service'
 import { addContactToAudience } from '@/lib/email/resend-audiences'
 import { kv, isKVConfigured, prisma } from '@/lib/database/client'
+import { isHoneypotTripped } from '@/lib/forms/honeypot'
 
 // Sources that trigger an automated outbound email with the partner one-pager
 // PDF + Calendly CTA (in addition to the existing ops notification).
@@ -154,10 +155,15 @@ export async function POST(request: NextRequest) {
       hasData: !!body && Object.keys(body).length > 0
     })
 
-    // Honeypot check — hidden field that should always be empty
-    if (body.website_url || body.fax_number) {
-      console.warn('[Partner Inquiry] REJECTED: Honeypot triggered', { ip, userAgent })
-      // Return success to not tip off bots
+    // Honeypot check — a hidden, deliberately non-autofill-named field bots
+    // tend to fill (see src/lib/forms/honeypot.ts for why the name matters).
+    // We log every trip with the ip + which trap fired, so a real person caught
+    // here is visible in logs instead of vanishing. We return success WITHOUT
+    // an `inquiryId` — the client only celebrates on an `inquiryId`, so a drop
+    // never shows a false "thank you", and a bot can't tell it was caught.
+    const honeypot = isHoneypotTripped(body)
+    if (honeypot.tripped) {
+      console.warn('[Partner Inquiry] honeypot tripped — dropped', { field: honeypot.field, ip, userAgent })
       return NextResponse.json({
         success: true,
         message: 'Thank you for your interest! Our partnership team will contact you within 24 hours.',

--- a/src/app/austin-partners/page.tsx
+++ b/src/app/austin-partners/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useRef } from 'react';
+import { blankHoneypotFields } from '@/lib/forms/honeypot';
 import Image from 'next/image';
 import Link from 'next/link';
 import Navigation from "@/components/Navigation";
@@ -63,13 +64,15 @@ export default function PartnersPage() {
           source: 'partners-main-page',
           submittedAt: new Date().toISOString(),
           _formLoadedAt: formLoadedAt.current,
-          website_url: '',
-          fax_number: '',
+          // Honeypot: always-empty trap, unified non-autofill name (see @/lib/forms/honeypot).
+          ...blankHoneypotFields(),
         }),
       });
 
       const data = await response.json();
-      if (!response.ok || !data.success) {
+      // Require a persisted inquiryId — a honeypot/too-fast/gibberish drop (or a
+      // failed save) returns success:true without one.
+      if (!response.ok || !data.success || !data.inquiryId) {
         throw new Error(data.error || 'Failed to submit form');
       }
 

--- a/src/app/corporate/holiday-party/page.tsx
+++ b/src/app/corporate/holiday-party/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useRef } from 'react';
+import { blankHoneypotFields } from '@/lib/forms/honeypot';
 import Image from 'next/image';
 import Link from 'next/link';
 import CorporateEventCalculatorLanding from '@/components/CorporateEventCalculatorLanding';
@@ -91,8 +92,8 @@ export default function CorporateHolidayPartyPage() {
         utm_campaign: sessionStorage.getItem('utm_campaign') || '',
         utm_content: sessionStorage.getItem('utm_content') || '',
         _formLoadedAt: formLoadedAt.current,
-        website_url: '',
-        fax_number: '',
+        // Honeypot: always-empty trap, unified non-autofill name (see @/lib/forms/honeypot).
+        ...blankHoneypotFields(),
       };
 
       const response = await fetch('/api/partners/inquiry', {
@@ -102,7 +103,10 @@ export default function CorporateHolidayPartyPage() {
       });
 
       const data = await response.json();
-      if (!response.ok || !data.success) {
+      // Require a persisted inquiryId — a honeypot/too-fast/gibberish drop (or a
+      // failed save) returns success:true without one, so this keeps the
+      // confirmation (and the Meta Lead event below) honest.
+      if (!response.ok || !data.success || !data.inquiryId) {
         throw new Error(data.error || 'Failed to submit form');
       }
 

--- a/src/app/corporate/page.tsx
+++ b/src/app/corporate/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useRef } from 'react';
+import { blankHoneypotFields } from '@/lib/forms/honeypot';
 import Image from 'next/image';
 import Link from 'next/link';
 import Navigation from "@/components/Navigation";
@@ -89,8 +90,8 @@ export default function CorporateLandingPage() {
         utm_medium: sessionStorage.getItem('utm_medium') || '',
         utm_campaign: sessionStorage.getItem('utm_campaign') || '',
         _formLoadedAt: formLoadedAt.current,
-        website_url: '',
-        fax_number: '',
+        // Honeypot: always-empty trap, unified non-autofill name (see @/lib/forms/honeypot).
+        ...blankHoneypotFields(),
       };
 
       const response = await fetch('/api/partners/inquiry', {
@@ -100,7 +101,10 @@ export default function CorporateLandingPage() {
       });
 
       const data = await response.json();
-      if (!response.ok || !data.success) {
+      // Require a persisted inquiryId — a honeypot/too-fast/gibberish drop (or a
+      // failed save) returns success:true without one, so this keeps the
+      // confirmation (and the Meta Lead event below) honest.
+      if (!response.ok || !data.success || !data.inquiryId) {
         throw new Error(data.error || 'Failed to submit form');
       }
 

--- a/src/app/partners/hotels-resorts/page.tsx
+++ b/src/app/partners/hotels-resorts/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useState, useEffect, useRef } from 'react'
+import { blankHoneypotFields } from '@/lib/forms/honeypot'
 import Image from 'next/image'
 import Navigation from "@/components/Navigation"
 import Footer from '@/components/Footer'
@@ -58,13 +59,15 @@ export default function HotelsResortsPartnerPage() {
           source: 'hotels-resorts-page',
           submittedAt: new Date().toISOString(),
           _formLoadedAt: formLoadedAt.current,
-          website_url: '',
-          fax_number: '',
+          // Honeypot: always-empty trap, unified non-autofill name (see @/lib/forms/honeypot).
+          ...blankHoneypotFields(),
         }),
       })
 
       const data = await response.json();
-      if (!response.ok || !data.success) {
+      // Require a persisted inquiryId — a honeypot/too-fast/gibberish drop (or a
+      // failed save) returns success:true without one.
+      if (!response.ok || !data.success || !data.inquiryId) {
         throw new Error(data.error || 'Failed to submit form');
       }
 

--- a/src/app/partners/mobile-bartenders/page.tsx
+++ b/src/app/partners/mobile-bartenders/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useRef } from 'react';
+import { blankHoneypotFields } from '@/lib/forms/honeypot';
 import Image from 'next/image';
 import Link from 'next/link';
 import Navigation from "@/components/Navigation";
@@ -130,14 +131,16 @@ Source: ${formData.source}`,
           // System fields
           submittedAt: new Date().toISOString(),
           _formLoadedAt: formLoadedAt.current,
-          website_url: '',
-          fax_number: '',
+          // Honeypot: always-empty trap, unified non-autofill name (see @/lib/forms/honeypot).
+          ...blankHoneypotFields(),
         }),
       });
 
       const result = await response.json();
 
-      if (!response.ok || !result.success) {
+      // Require a persisted inquiryId — a honeypot/too-fast/gibberish drop (or a
+      // failed save) returns success:true without one.
+      if (!response.ok || !result.success || !result.inquiryId) {
         throw new Error(result.error || 'Failed to submit form');
       }
 

--- a/src/app/partners/vacation-rentals/page.tsx
+++ b/src/app/partners/vacation-rentals/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useRef, useState } from 'react';
+import { blankHoneypotFields } from '@/lib/forms/honeypot';
 import Image from 'next/image';
 import Navigation from '@/components/Navigation';
 import Footer from '@/components/Footer';
@@ -270,12 +271,14 @@ UTM Campaign: ${formData.utm_campaign || 'none'}`,
           source: 'vacation-rental-partners-page',
           submittedAt: new Date().toISOString(),
           _formLoadedAt: formLoadedAt.current,
-          website_url: '',
-          fax_number: '',
+          // Honeypot: always-empty trap, unified non-autofill name (see @/lib/forms/honeypot).
+          ...blankHoneypotFields(),
         }),
       });
       const result = await response.json();
-      if (!response.ok || !result.success) {
+      // Require a persisted inquiryId — a honeypot/too-fast/gibberish drop (or a
+      // failed save) returns success:true without one.
+      if (!response.ok || !result.success || !result.inquiryId) {
         throw new Error(result.error || 'Submission failed');
       }
       setSubmitStatus('success');

--- a/src/components/partners/AustinWeddingDjInquiryForm.tsx
+++ b/src/components/partners/AustinWeddingDjInquiryForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useRef, type FormEvent, type ReactElement } from 'react';
+import { HONEYPOT_FIELD } from '@/lib/forms/honeypot';
 
 /**
  * Inquiry form for the Austin Wedding DJ partner landing page (WS3).
@@ -38,8 +39,9 @@ export default function AustinWeddingDjInquiryForm({ refCode }: Props): ReactEle
       partnerType: 'wedding-dj',
       source: 'wedding-dj-landing',
       refCode,
-      // honeypot — must stay empty
-      website_url: String(formData.get('website_url') || ''),
+      // honeypot — must stay empty; name carries no browser-autofill mapping
+      // so a real visitor is never trapped (see @/lib/forms/honeypot).
+      [HONEYPOT_FIELD]: String(formData.get(HONEYPOT_FIELD) || ''),
       _formLoadedAt: formLoadedAtRef.current,
       submittedAt: new Date().toISOString(),
     };
@@ -51,7 +53,11 @@ export default function AustinWeddingDjInquiryForm({ refCode }: Props): ReactEle
         body: JSON.stringify(payload),
       });
       const json = await res.json();
-      if (!res.ok || !json.success) {
+      // Only celebrate on a genuinely-persisted row. A honeypot/too-fast/
+      // gibberish drop (or a failed DB write) returns success:true WITHOUT an
+      // inquiryId, so requiring one means we never promise a follow-up we
+      // didn't actually record.
+      if (!res.ok || !json.success || !json.inquiryId) {
         throw new Error(json.error || 'Submission failed');
       }
       setStatus('success');
@@ -80,10 +86,12 @@ export default function AustinWeddingDjInquiryForm({ refCode }: Props): ReactEle
 
   return (
     <form onSubmit={handleSubmit} className="card space-y-4">
-      {/* honeypot */}
+      {/* honeypot — hidden from humans; bots that fill it are dropped. The
+          name is deliberately NOT autofill-mapped so iOS Safari / password
+          managers don't fill it for a real guest (see @/lib/forms/honeypot). */}
       <input
         type="text"
-        name="website_url"
+        name={HONEYPOT_FIELD}
         tabIndex={-1}
         autoComplete="off"
         aria-hidden="true"

--- a/src/components/partners/VacationRentalLeadCapture.tsx
+++ b/src/components/partners/VacationRentalLeadCapture.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useRef, useState } from 'react';
+import { HONEYPOT_FIELD } from '@/lib/forms/honeypot';
 
 interface VacationRentalLeadCaptureProps {
   /**
@@ -26,6 +27,7 @@ export default function VacationRentalLeadCapture({
   const [companyName, setCompanyName] = useState('');
   const [propertyCount, setPropertyCount] = useState('');
   const [signupQrId, setSignupQrId] = useState('');
+  const [honeypot, setHoneypot] = useState('');
   const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle');
   const [errorMessage, setErrorMessage] = useState('');
   const formLoadedAt = useRef(Date.now());
@@ -72,13 +74,14 @@ export default function VacationRentalLeadCapture({
           signupQrId: signupQrId || undefined,
           submittedAt: new Date().toISOString(),
           _formLoadedAt: formLoadedAt.current,
-          website_url: '',
-          fax_number: '',
+          [HONEYPOT_FIELD]: honeypot,
         }),
       });
 
       const result = await response.json();
-      if (!response.ok || !result.success) {
+      // Require a persisted inquiryId before celebrating — a honeypot/too-fast/
+      // gibberish drop (or a failed save) returns success:true without one.
+      if (!response.ok || !result.success || !result.inquiryId) {
         throw new Error(result.error || 'Submission failed');
       }
 
@@ -162,9 +165,19 @@ export default function VacationRentalLeadCapture({
         {status === 'submitting' ? 'Sending…' : 'Get the partner one-pager →'}
       </button>
 
-      {/* Honeypot fields */}
-      <input type="text" name="website_url" tabIndex={-1} autoComplete="off" className="hidden" aria-hidden />
-      <input type="text" name="fax_number" tabIndex={-1} autoComplete="off" className="hidden" aria-hidden />
+      {/* Honeypot — hidden from humans; bots that fill it are dropped. The name
+          carries no browser-autofill mapping so a real visitor is never trapped
+          (see @/lib/forms/honeypot). */}
+      <input
+        type="text"
+        name={HONEYPOT_FIELD}
+        value={honeypot}
+        onChange={(e) => setHoneypot(e.target.value)}
+        tabIndex={-1}
+        autoComplete="off"
+        aria-hidden
+        className="hidden"
+      />
 
       {status === 'error' && (
         <p className="mt-3 text-sm text-brand-yellow text-center">{errorMessage}</p>

--- a/src/lib/forms/__tests__/honeypot.test.ts
+++ b/src/lib/forms/__tests__/honeypot.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for the shared honeypot helper.
+ *
+ * The load-bearing guarantee: the canonical honeypot field name must NEVER
+ * match a browser/password-manager autofill heuristic, or iOS Safari / Chrome
+ * autofill fills the hidden trap for a real visitor and the server drops them
+ * as a bot (the PR #148 failure). The "no autofill token" test below is the
+ * regression guard that was missing when this class of bug shipped.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  HONEYPOT_FIELD,
+  LEGACY_HONEYPOT_FIELDS,
+  ALL_HONEYPOT_FIELDS,
+  isHoneypotTripped,
+  blankHoneypotFields,
+} from '../honeypot';
+
+// Tokens browsers / password managers map to autofill. The canonical trap name
+// must contain none of these as a substring.
+const AUTOFILL_TOKENS = [
+  'company',
+  'organization',
+  'website',
+  'url',
+  'email',
+  'name',
+  'phone',
+  'tel',
+  'address',
+  'fax',
+  'username',
+  'firstname',
+  'lastname',
+];
+
+describe('HONEYPOT_FIELD', () => {
+  it('carries no browser-autofill token (the missing regression guard)', () => {
+    const lower = HONEYPOT_FIELD.toLowerCase();
+    for (const token of AUTOFILL_TOKENS) {
+      expect(lower.includes(token), `honeypot name must not contain "${token}"`).toBe(false);
+    }
+  });
+
+  it('is included in the server-side trip list alongside the legacy names', () => {
+    expect(ALL_HONEYPOT_FIELDS).toContain(HONEYPOT_FIELD);
+    for (const legacy of LEGACY_HONEYPOT_FIELDS) {
+      expect(ALL_HONEYPOT_FIELDS).toContain(legacy);
+    }
+  });
+});
+
+describe('isHoneypotTripped', () => {
+  it('trips on the canonical field and reports which one fired', () => {
+    expect(isHoneypotTripped({ [HONEYPOT_FIELD]: 'http://spam.example' })).toEqual({
+      tripped: true,
+      field: HONEYPOT_FIELD,
+    });
+  });
+
+  it('still trips on legacy field names (zero rollout gap for old clients)', () => {
+    expect(isHoneypotTripped({ website_url: 'x' }).tripped).toBe(true);
+    expect(isHoneypotTripped({ fax_number: '555' }).tripped).toBe(true);
+  });
+
+  it('does NOT trip on empty / whitespace-only values', () => {
+    expect(isHoneypotTripped({ [HONEYPOT_FIELD]: '' }).tripped).toBe(false);
+    expect(isHoneypotTripped({ [HONEYPOT_FIELD]: '   ' }).tripped).toBe(false);
+  });
+
+  it('does NOT trip on real, legitimately-filled fields', () => {
+    // The exact failure mode we are guarding against: a real visitor's company
+    // name / website / email must never be treated as a honeypot.
+    expect(
+      isHoneypotTripped({
+        company: 'Acme Corp',
+        website: 'https://acme.example',
+        email: 'jane@acme.example',
+        name: 'Jane Smith',
+      }).tripped,
+    ).toBe(false);
+  });
+
+  it('is safe on null / undefined / non-object bodies', () => {
+    expect(isHoneypotTripped(null).tripped).toBe(false);
+    expect(isHoneypotTripped(undefined).tripped).toBe(false);
+  });
+
+  it('ignores non-string honeypot values (a numeric real field cannot trip it)', () => {
+    expect(isHoneypotTripped({ [HONEYPOT_FIELD]: 0 as unknown as string }).tripped).toBe(false);
+  });
+});
+
+describe('blankHoneypotFields', () => {
+  it('returns an empty value under the canonical field name', () => {
+    expect(blankHoneypotFields()).toEqual({ [HONEYPOT_FIELD]: '' });
+  });
+});

--- a/src/lib/forms/honeypot.ts
+++ b/src/lib/forms/honeypot.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared honeypot (spam-trap) field definition for public lead-capture forms.
+ *
+ * A honeypot is a hidden input a human never sees, so any non-empty value means
+ * a bot filled it and the submission can be dropped. The catch: if the field's
+ * `name` matches a browser / password-manager autofill heuristic (company,
+ * organization, website, url, email, name, phone, tel, address, fax, username),
+ * iOS Safari / Chrome autofill fills the hidden trap FOR A REAL VISITOR — and
+ * the server then drops that real person as a bot. That silent-drop is exactly
+ * what PR #148 fixed on the event RSVP form (honeypot `website_url` →
+ * `hp_event_notes`).
+ *
+ * So the canonical trap name here carries NO autofill token. Keep the rendered
+ * input `name`, the submitted payload key, and the server check
+ * (`isHoneypotTripped`) all pointed at {@link HONEYPOT_FIELD}.
+ */
+export const HONEYPOT_FIELD = 'hp_partner_notes';
+
+/**
+ * Legacy trap field names older clients still send. No real form field has ever
+ * used these names, so the server keeps checking them — it costs nothing and
+ * removes any rollout window where a not-yet-deployed page (still sending
+ * `website_url`) would have an inert trap. They are safe to keep checking
+ * precisely because no visible input renders them anymore, so a real visitor's
+ * autofill can never populate them.
+ */
+export const LEGACY_HONEYPOT_FIELDS = ['website_url', 'fax_number'] as const;
+
+/** Every field name treated as a honeypot on the server (new + legacy). */
+export const ALL_HONEYPOT_FIELDS: readonly string[] = [
+  HONEYPOT_FIELD,
+  ...LEGACY_HONEYPOT_FIELDS,
+];
+
+/**
+ * Whether any honeypot field carries a non-empty value — i.e. a field a human
+ * can't see got filled. Returns the tripped field name so the caller can log
+ * which trap fired; a real person caught here is then visible in logs instead
+ * of vanishing.
+ *
+ * Mirrors the event RSVP route: only a non-empty *string* trips it, so a future
+ * real field that happens to be numeric/boolean can never be mistaken for a
+ * bot.
+ */
+export function isHoneypotTripped(
+  body: Record<string, unknown> | null | undefined,
+): { tripped: boolean; field: string | null } {
+  if (!body || typeof body !== 'object') return { tripped: false, field: null };
+  for (const field of ALL_HONEYPOT_FIELDS) {
+    const value = (body as Record<string, unknown>)[field];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return { tripped: true, field };
+    }
+  }
+  return { tripped: false, field: null };
+}
+
+/**
+ * The honeypot key to spread into a form's JSON payload when the form sends an
+ * always-empty trap value (rather than rendering a live trap input). Keeps the
+ * payload key name unified with the server check, so no autofill-prone name
+ * (`website_url`/`fax_number`) ever appears in a form again.
+ */
+export function blankHoneypotFields(): Record<string, string> {
+  return { [HONEYPOT_FIELD]: '' };
+}


### PR DESCRIPTION
## Problem
Public partner lead-capture forms use a hidden honeypot the server rejects when filled. If the trap's field name is one browsers / password managers autofill, a real visitor's autofill fills it and the backend drops them as a bot — a silent lead loss (same class fixed for the RSVP form in #148).

The genuine live bug: **`AustinWeddingDjInquiryForm`** rendered a hidden `website_url` input **and read its value into the payload**, so iOS Safari / password-manager autofill could drop a real couple.

## ⚠️ Correction to the original report
The `company` / `website` fields flagged as "highest priority honeypots" are actually **real, visible inputs** — corporate **"Company Name"** (sent as `businessName`) and mobile-bartender **"Website/Instagram"** (sent as `website`). The backend trap only ever checked `website_url` / `fax_number`. Renaming those real fields — or adding them to the trap — would have *caused* the exact bug. **They are left untouched.**

The other 6 forms hardcoded the trap empty (inert, no live bug); `VacationRentalLeadCapture` rendered traps the handler ignored (dead code).

## Changes
- **`src/lib/forms/honeypot.ts`** — shared single source of truth. Canonical trap `hp_partner_notes` (no autofill token), `isHoneypotTripped()`, `blankHoneypotFields()`. Still checks legacy `website_url`/`fax_number` → **zero rollout gap**.
- **`/api/partners/inquiry`** — uses the helper; logs every trip with `ip` + which field fired (dropped real leads now visible in Vercel logs).
- **Wedding-DJ + vacation-rental components** — rendered trap renamed to the safe field (DJ form's was the live bug; rental form's traps were dead code → one functional safe-named trap).
- **All 8 forms** — success state (and the Meta `Lead` event) now requires a persisted `inquiryId`, so a honeypot / too-fast / gibberish drop — or a failed DB write — can no longer show a false "thank you".

## Tests
- `honeypot.test.ts` — asserts the trap name carries no autofill token (the regression guard that was missing) and that real fields never trip it.
- `api/partners/inquiry/route.test.ts` — real save returns `inquiryId`; honeypot trip (new **and** legacy names) writes nothing; failed save returns no `inquiryId`.
- `npm run test:run` → **300/300 pass**. `npx next lint` → clean (no errors in touched files). `tsc --noEmit` → no errors in touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
