### PR TITLE
fix(ops): pick sheets print blank — move print tree out of print:hidden wrapper

### DIFF
--- a/src/components/ops/orders/UnifiedOrdersView.tsx
+++ b/src/components/ops/orders/UnifiedOrdersView.tsx
@@ -248,6 +248,7 @@ export default function UnifiedOrdersView({
   };
 
   return (
+    <>
     <div className={pickSheetMode ? 'print:hidden' : 'print:block'}>
       {/* Print-only checklist header */}
       <div className="hidden print:block pb-2 mb-2 border-b border-gray-300">
@@ -378,13 +379,6 @@ export default function UnifiedOrdersView({
         onClear={view.clearSelection}
       />
 
-      {/* Pick sheets print tree (only mounts in pick-sheet mode) */}
-      {pickSheetMode && (
-        <div className="hidden print:block">
-          <PickSheetPrint orders={printOrders} />
-        </div>
-      )}
-
       {reviewModalOrders && (
         <ReviewRequestModal
           orders={reviewModalOrders}
@@ -429,6 +423,17 @@ export default function UnifiedOrdersView({
         }
       `}</style>
     </div>
+
+    {/* Pick sheets print on their OWN surface — must be a SIBLING of the
+        print:hidden screen wrapper above, never a child. A child can't
+        un-hide itself once an ancestor is display:none, which is exactly
+        what silently blanked pick-sheet printing after #124. */}
+    {pickSheetMode && (
+      <div className="hidden print:block">
+        <PickSheetPrint orders={printOrders} />
+      </div>
+    )}
+    </>
   );
 }
 


### PR DESCRIPTION
## Problem
Printing **pick sheets** from `/ops/orders` produced a blank page. Only the plain "Print checklist" path worked. Broken since #124 (the unified cooler-card view), and never caught because the pick-sheet print path wasn't exercised end-to-end.

## Root cause
A CSS containment bug. In `UnifiedOrdersView.tsx` the whole component is wrapped in one div that flips to `print:hidden` in pick-sheet mode — and the `<PickSheetPrint>` tree was a **child** of that wrapper:

```
<div className={pickSheetMode ? 'print:hidden' : 'print:block'}>   // root
  ...
  {pickSheetMode && <div className="hidden print:block"><PickSheetPrint/></div>}  // ← child
</div>
```

Click Print → `pickSheetMode` true → root becomes `display:none` in print. Once an ancestor is `display:none`, a descendant **cannot** un-hide itself, so the `print:block` pick-sheet container never rendered. The checklist path worked only because it leaves the root as `print:block`.

## Fix
Hoist the pick-sheet tree to a **sibling** of the print-hidden wrapper (return wrapped in a fragment). No logic, data, or styling changes; the checklist print path is untouched.

## Verification
- `next lint` on the file: clean
- `tsc --noEmit`: no errors in the file
- Manual: select orders → Print → one formatted pick sheet per order instead of a blank page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)