### PR TITLE
feat(ops): collapsible day tiles + Pack mode with live pack-progress

### DIFF
--- a/src/components/ops/orders/DaySectionHeader.tsx
+++ b/src/components/ops/orders/DaySectionHeader.tsx
@@ -5,8 +5,9 @@ import { fmtMoney } from './format';
 
 /**
  * Day banner: "WEDNESDAY, JUN 11 · 3 coolers · $1,234" with a tristate
- * select-all checkbox for the day's orders. `variant="overdue"` renders the
- * red past-due header.
+ * select-all checkbox for the day's orders and a collapse chevron. Clicking
+ * the bar toggles collapse (the checkbox stops propagation so selecting all
+ * doesn't also collapse). `variant="overdue"` renders the red past-due header.
  */
 export default function DaySectionHeader({
   label,
@@ -16,6 +17,8 @@ export default function DaySectionHeader({
   selected,
   onSetManySelected,
   variant = 'day',
+  collapsed = false,
+  onToggleCollapse,
 }: {
   label: string;
   cardCount: number;
@@ -24,6 +27,8 @@ export default function DaySectionHeader({
   selected: Set<string>;
   onSetManySelected: (ids: string[], on: boolean) => void;
   variant?: 'day' | 'overdue';
+  collapsed?: boolean;
+  onToggleCollapse?: () => void;
 }): ReactElement {
   const ref = useRef<HTMLInputElement>(null);
   const allSelected = orderIds.length > 0 && orderIds.every((id) => selected.has(id));
@@ -31,19 +36,24 @@ export default function DaySectionHeader({
   if (ref.current) ref.current.indeterminate = someSelected && !allSelected;
 
   const isOverdue = variant === 'overdue';
+  const clickable = !!onToggleCollapse;
 
   return (
     <div
       className={`flex items-center gap-3 rounded-t-lg px-3 py-2 text-white print:rounded-none print:py-1 ${
         isOverdue ? 'bg-red-700' : 'bg-brand-blue'
-      }`}
+      } ${clickable ? 'cursor-pointer select-none' : ''}`}
       style={{ breakAfter: 'avoid' }}
+      onClick={onToggleCollapse}
+      role={clickable ? 'button' : undefined}
+      aria-expanded={clickable ? !collapsed : undefined}
     >
       <input
         ref={ref}
         type="checkbox"
         checked={allSelected}
         onChange={() => onSetManySelected(orderIds, !allSelected)}
+        onClick={(e) => e.stopPropagation()}
         className="w-5 h-5 flex-shrink-0 rounded border-white/60 bg-white/10 text-blue-900 focus:ring-white cursor-pointer print:hidden touch-manipulation"
         aria-label={`Select all orders for ${label}`}
       />
@@ -53,6 +63,20 @@ export default function DaySectionHeader({
       <div className="text-sm font-medium opacity-90 whitespace-nowrap">
         {cardCount} cooler{cardCount === 1 ? '' : 's'} · {fmtMoney(total)}
       </div>
+      {clickable && (
+        <svg
+          className={`w-5 h-5 flex-shrink-0 transition-transform print:hidden ${collapsed ? '' : 'rotate-180'}`}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      )}
     </div>
   );
 }

--- a/src/components/ops/orders/DaySectionHeader.tsx
+++ b/src/components/ops/orders/DaySectionHeader.tsx
@@ -19,6 +19,7 @@ export default function DaySectionHeader({
   variant = 'day',
   collapsed = false,
   onToggleCollapse,
+  onPack,
 }: {
   label: string;
   cardCount: number;
@@ -29,6 +30,8 @@ export default function DaySectionHeader({
   variant?: 'day' | 'overdue';
   collapsed?: boolean;
   onToggleCollapse?: () => void;
+  /** Opens Pack mode for this day's orders. */
+  onPack?: () => void;
 }): ReactElement {
   const ref = useRef<HTMLInputElement>(null);
   const allSelected = orderIds.length > 0 && orderIds.every((id) => selected.has(id));
@@ -63,6 +66,32 @@ export default function DaySectionHeader({
       <div className="text-sm font-medium opacity-90 whitespace-nowrap">
         {cardCount} cooler{cardCount === 1 ? '' : 's'} · {fmtMoney(total)}
       </div>
+      {onPack && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onPack();
+          }}
+          className="print:hidden inline-flex items-center gap-1.5 rounded-md bg-white/15 hover:bg-white/25 px-2.5 py-1 text-sm font-semibold transition-colors"
+        >
+          <svg
+            className="w-4 h-4"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
+            <polyline points="3.27 6.96 12 12.01 20.73 6.96" />
+            <line x1="12" y1="22.08" x2="12" y2="12" />
+          </svg>
+          <span>Pack</span>
+        </button>
+      )}
       {clickable && (
         <svg
           className={`w-5 h-5 flex-shrink-0 transition-transform print:hidden ${collapsed ? '' : 'rotate-180'}`}

--- a/src/components/ops/orders/DayTiles.tsx
+++ b/src/components/ops/orders/DayTiles.tsx
@@ -2,15 +2,17 @@
 
 import { ReactElement } from 'react';
 import { timeOfDayAccent } from './format';
+import { orderPackProgress, usePickTick } from './usePickChecks';
 import type { OrderCardData } from '@/lib/ops/orders-view-data';
 
 /**
- * Collapsed-day overview: compact tiles showing just delivery time + name,
- * subtly color-accented by AM/PM/EVE and pre-sorted by delivery time.
+ * Collapsed-day overview: compact tiles showing delivery time + name, subtly
+ * color-accented by AM/PM/EVE and pre-sorted by delivery time. Each tile shows
+ * its pack progress (packed / total line items) and turns green when fully
+ * packed — live, via usePickTick, as items get checked off anywhere.
  *
- * Desktop (md+): tiles are grouped into per-time columns — orders sharing a
- * time stack vertically under that time. Mobile: a flat wrapping list of
- * time + name tiles (stacking into columns is too cramped on a phone).
+ * Desktop (md+): tiles group into per-time columns — orders sharing a time
+ * stack vertically. Mobile: a flat wrapping list of time + name tiles.
  *
  * Clicking a tile expands the day and scrolls to that card. Screen-only —
  * print always uses the full cards.
@@ -22,6 +24,8 @@ export default function DayTiles({
   cards: OrderCardData[];
   onTileClick: (cardKey: string) => void;
 }): ReactElement {
+  usePickTick(); // re-render when pick/pack state changes
+
   // Cards arrive sorted by delivery time, so same-time cards are adjacent.
   const groups: { time: string; cards: OrderCardData[] }[] = [];
   for (const c of cards) {
@@ -48,38 +52,104 @@ export default function DayTiles({
                 <span className="text-xs font-semibold text-gray-400">×{g.cards.length}</span>
               )}
             </div>
-            {g.cards.map((c) => (
-              <button
-                key={c.key}
-                type="button"
-                onClick={() => onTileClick(c.key)}
-                title={c.displayName}
-                className="text-left text-sm text-gray-800 rounded px-1.5 py-1 max-w-[16rem] truncate hover:bg-blue-50 hover:text-brand-blue transition-colors"
-              >
-                {c.displayName}
-              </button>
-            ))}
+            {g.cards.map((c) => {
+              const p = cardProgress(c);
+              const complete = p.total > 0 && p.packed === p.total;
+              return (
+                <button
+                  key={c.key}
+                  type="button"
+                  onClick={() => onTileClick(c.key)}
+                  title={c.displayName}
+                  className={`flex items-center justify-between gap-2 max-w-[18rem] rounded px-1.5 py-1 text-left text-sm transition-colors ${
+                    complete
+                      ? 'bg-green-100 text-green-900'
+                      : 'text-gray-800 hover:bg-blue-50 hover:text-brand-blue'
+                  }`}
+                >
+                  <span className="truncate">{c.displayName}</span>
+                  <PackBadge packed={p.packed} total={p.total} complete={complete} />
+                </button>
+              );
+            })}
           </div>
         ))}
       </div>
 
       {/* Mobile: flat wrapping list of time + name tiles */}
       <div className="flex flex-wrap gap-2 md:hidden">
-        {cards.map((c) => (
-          <button
-            key={c.key}
-            type="button"
-            onClick={() => onTileClick(c.key)}
-            title={`${c.deliveryTime || 'TBD'} · ${c.displayName}`}
-            className={`inline-flex items-center gap-2 max-w-full rounded-md border border-gray-200 border-l-[3px] ${timeOfDayAccent(c.deliveryTime)} bg-gray-50 px-2.5 py-1.5 hover:border-brand-blue hover:bg-blue-50 transition-colors`}
-          >
-            <span className="text-sm font-bold text-brand-blue tabular-nums whitespace-nowrap">
-              {c.deliveryTime || 'TBD'}
-            </span>
-            <span className="text-sm text-gray-800 truncate max-w-[12rem]">{c.displayName}</span>
-          </button>
-        ))}
+        {cards.map((c) => {
+          const p = cardProgress(c);
+          const complete = p.total > 0 && p.packed === p.total;
+          return (
+            <button
+              key={c.key}
+              type="button"
+              onClick={() => onTileClick(c.key)}
+              title={`${c.deliveryTime || 'TBD'} · ${c.displayName}`}
+              className={`inline-flex items-center gap-2 max-w-full rounded-md border border-gray-200 border-l-[3px] px-2.5 py-1.5 transition-colors ${
+                complete
+                  ? 'border-l-green-500 bg-green-50'
+                  : `${timeOfDayAccent(c.deliveryTime)} bg-gray-50 hover:border-brand-blue hover:bg-blue-50`
+              }`}
+            >
+              <span className="text-sm font-bold text-brand-blue tabular-nums whitespace-nowrap">
+                {c.deliveryTime || 'TBD'}
+              </span>
+              <span className="text-sm text-gray-800 truncate max-w-[12rem]">{c.displayName}</span>
+              <PackBadge packed={p.packed} total={p.total} complete={complete} />
+            </button>
+          );
+        })}
       </div>
     </div>
+  );
+}
+
+/** Sum top-level line-item pack progress across a cooler's orders. */
+function cardProgress(card: OrderCardData): { packed: number; total: number } {
+  let packed = 0;
+  let total = 0;
+  for (const o of card.orders) {
+    const p = orderPackProgress(o.id, o.items);
+    packed += p.packed;
+    total += p.total;
+  }
+  return { packed, total };
+}
+
+/** "3/5" while packing, a green check at 100%, hidden when there's nothing. */
+function PackBadge({
+  packed,
+  total,
+  complete,
+}: {
+  packed: number;
+  total: number;
+  complete: boolean;
+}): ReactElement | null {
+  if (total === 0) return null;
+  if (complete) {
+    return (
+      <svg
+        className="w-4 h-4 flex-shrink-0 text-green-600"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="3"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-label="Packed"
+      >
+        <path d="M5 13l4 4L19 7" />
+      </svg>
+    );
+  }
+  return (
+    <span
+      className={`flex-shrink-0 text-xs font-bold tabular-nums ${packed > 0 ? 'text-amber-700' : 'text-gray-400'}`}
+    >
+      {packed}/{total}
+    </span>
   );
 }

--- a/src/components/ops/orders/DayTiles.tsx
+++ b/src/components/ops/orders/DayTiles.tsx
@@ -1,13 +1,19 @@
 'use client';
 
 import { ReactElement } from 'react';
+import { timeOfDayAccent } from './format';
 import type { OrderCardData } from '@/lib/ops/orders-view-data';
 
 /**
- * Collapsed-day overview: one compact tile per cooler card, showing just the
- * delivery time and the order/group name, wrapping across the row. Cards
- * arrive pre-sorted by delivery time. Clicking a tile expands the day and
- * scrolls to that card. Screen-only — print always uses the full cards.
+ * Collapsed-day overview: compact tiles showing just delivery time + name,
+ * subtly color-accented by AM/PM/EVE and pre-sorted by delivery time.
+ *
+ * Desktop (md+): tiles are grouped into per-time columns — orders sharing a
+ * time stack vertically under that time. Mobile: a flat wrapping list of
+ * time + name tiles (stacking into columns is too cramped on a phone).
+ *
+ * Clicking a tile expands the day and scrolls to that card. Screen-only —
+ * print always uses the full cards.
  */
 export default function DayTiles({
   cards,
@@ -16,16 +22,56 @@ export default function DayTiles({
   cards: OrderCardData[];
   onTileClick: (cardKey: string) => void;
 }): ReactElement {
+  // Cards arrive sorted by delivery time, so same-time cards are adjacent.
+  const groups: { time: string; cards: OrderCardData[] }[] = [];
+  for (const c of cards) {
+    const time = c.deliveryTime || 'TBD';
+    const last = groups[groups.length - 1];
+    if (last && last.time === time) last.cards.push(c);
+    else groups.push({ time, cards: [c] });
+  }
+
   return (
     <div className="rounded-b-lg border border-t-0 border-gray-200 bg-white p-2 print:hidden">
-      <div className="flex flex-wrap gap-2">
+      {/* Desktop: per-time columns — same-time orders stacked together */}
+      <div className="hidden md:flex md:flex-wrap md:items-start gap-2">
+        {groups.map((g) => (
+          <div
+            key={g.time}
+            className={`flex flex-col gap-1 rounded-md border border-gray-200 border-l-[3px] ${timeOfDayAccent(g.time)} bg-white p-1.5`}
+          >
+            <div className="flex items-baseline gap-1.5 px-1">
+              <span className="text-sm font-bold text-brand-blue tabular-nums whitespace-nowrap">
+                {g.time}
+              </span>
+              {g.cards.length > 1 && (
+                <span className="text-xs font-semibold text-gray-400">×{g.cards.length}</span>
+              )}
+            </div>
+            {g.cards.map((c) => (
+              <button
+                key={c.key}
+                type="button"
+                onClick={() => onTileClick(c.key)}
+                title={c.displayName}
+                className="text-left text-sm text-gray-800 rounded px-1.5 py-1 max-w-[16rem] truncate hover:bg-blue-50 hover:text-brand-blue transition-colors"
+              >
+                {c.displayName}
+              </button>
+            ))}
+          </div>
+        ))}
+      </div>
+
+      {/* Mobile: flat wrapping list of time + name tiles */}
+      <div className="flex flex-wrap gap-2 md:hidden">
         {cards.map((c) => (
           <button
             key={c.key}
             type="button"
             onClick={() => onTileClick(c.key)}
             title={`${c.deliveryTime || 'TBD'} · ${c.displayName}`}
-            className="inline-flex items-center gap-2 max-w-full rounded-md border border-gray-200 bg-gray-50 px-2.5 py-1.5 hover:border-brand-blue hover:bg-blue-50 transition-colors"
+            className={`inline-flex items-center gap-2 max-w-full rounded-md border border-gray-200 border-l-[3px] ${timeOfDayAccent(c.deliveryTime)} bg-gray-50 px-2.5 py-1.5 hover:border-brand-blue hover:bg-blue-50 transition-colors`}
           >
             <span className="text-sm font-bold text-brand-blue tabular-nums whitespace-nowrap">
               {c.deliveryTime || 'TBD'}

--- a/src/components/ops/orders/DayTiles.tsx
+++ b/src/components/ops/orders/DayTiles.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { ReactElement } from 'react';
+import type { OrderCardData } from '@/lib/ops/orders-view-data';
+
+/**
+ * Collapsed-day overview: one compact tile per cooler card, showing just the
+ * delivery time and the order/group name, wrapping across the row. Cards
+ * arrive pre-sorted by delivery time. Clicking a tile expands the day and
+ * scrolls to that card. Screen-only — print always uses the full cards.
+ */
+export default function DayTiles({
+  cards,
+  onTileClick,
+}: {
+  cards: OrderCardData[];
+  onTileClick: (cardKey: string) => void;
+}): ReactElement {
+  return (
+    <div className="rounded-b-lg border border-t-0 border-gray-200 bg-white p-2 print:hidden">
+      <div className="flex flex-wrap gap-2">
+        {cards.map((c) => (
+          <button
+            key={c.key}
+            type="button"
+            onClick={() => onTileClick(c.key)}
+            title={`${c.deliveryTime || 'TBD'} · ${c.displayName}`}
+            className="inline-flex items-center gap-2 max-w-full rounded-md border border-gray-200 bg-gray-50 px-2.5 py-1.5 hover:border-brand-blue hover:bg-blue-50 transition-colors"
+          >
+            <span className="text-sm font-bold text-brand-blue tabular-nums whitespace-nowrap">
+              {c.deliveryTime || 'TBD'}
+            </span>
+            <span className="text-sm text-gray-800 truncate max-w-[12rem]">{c.displayName}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ops/orders/OrderGroupCard.tsx
+++ b/src/components/ops/orders/OrderGroupCard.tsx
@@ -17,6 +17,7 @@ export default function OrderGroupCard({
   onSetManySelected,
   onPrintOrder,
   onFilterByDashboard,
+  htmlId,
 }: {
   card: OrderCardData;
   selected: Set<string>;
@@ -24,6 +25,8 @@ export default function OrderGroupCard({
   onSetManySelected: (ids: string[], on: boolean) => void;
   onPrintOrder: (orderId: string) => void;
   onFilterByDashboard: (dashboardId: string) => void;
+  /** DOM id used as a scroll target when a collapsed-day tile is clicked. */
+  htmlId?: string;
 }): ReactElement {
   const pill = timeOfDayPill(c.deliveryTime);
   const tag = typeTagClasses(c.shortType);
@@ -42,6 +45,7 @@ export default function OrderGroupCard({
 
   return (
     <article
+      id={htmlId}
       data-share-code={c.shareCode || undefined}
       className={[
         'overflow-hidden border border-gray-200 bg-white break-inside-avoid rounded-lg print:rounded-none',

--- a/src/components/ops/orders/OrdersHeader.tsx
+++ b/src/components/ops/orders/OrdersHeader.tsx
@@ -14,12 +14,17 @@ export default function OrdersHeader({
   onPrintChecklist,
   onExportCsv,
   subtitle,
+  onToggleAll,
+  allExpanded = false,
 }: {
   onRefresh: () => void;
   refreshing: boolean;
   onPrintChecklist: () => void;
   onExportCsv: () => void;
   subtitle: string | null;
+  /** Expand-all / collapse-all the day sections. Omitted when there are none. */
+  onToggleAll?: () => void;
+  allExpanded?: boolean;
 }): ReactElement {
   return (
     <div className="print:hidden flex flex-wrap items-center gap-2 md:gap-3">
@@ -39,6 +44,21 @@ export default function OrdersHeader({
           </svg>
           <span>Create Invoice</span>
         </Link>
+        {onToggleAll && (
+          <button
+            type="button"
+            onClick={onToggleAll}
+            className="btn-ghost !min-h-[44px] inline-flex items-center gap-2"
+          >
+            <svg
+              className={`w-4 h-4 transition-transform ${allExpanded ? 'rotate-180' : ''}`}
+              viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"
+            >
+              <polyline points="6 9 12 15 18 9" />
+            </svg>
+            <span className="hidden sm:inline">{allExpanded ? 'Collapse all' : 'Expand all'}</span>
+          </button>
+        )}
         <button
           type="button"
           onClick={onRefresh}

--- a/src/components/ops/orders/PackModeOverlay.tsx
+++ b/src/components/ops/orders/PackModeOverlay.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { ReactElement, useEffect } from 'react';
+import OrderItemsChecklist from './OrderItemsChecklist';
+import { orderPackProgress, usePickTick } from './usePickChecks';
+import type { OrderCardData } from '@/lib/ops/orders-view-data';
+
+/**
+ * Full-screen "Pack mode" for one day: every cooler/order for that day with
+ * its In Stock / Packed / Short By checklist, in delivery-time order, so the
+ * whole day can be packed from one screen. Checking off writes through the
+ * same picks API (drives inventory) and updates the day-tile progress live.
+ */
+export default function PackModeOverlay({
+  label,
+  cards,
+  onClose,
+}: {
+  label: string;
+  cards: OrderCardData[];
+  onClose: () => void;
+}): ReactElement {
+  usePickTick(); // live day total as items get checked off
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const day = dayProgress(cards);
+  const complete = day.total > 0 && day.packed === day.total;
+
+  return (
+    <div className="fixed inset-0 z-[60] bg-black/40 print:hidden" onClick={onClose}>
+      <div
+        className="absolute inset-0 mx-auto flex max-w-3xl flex-col bg-white shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+      >
+        {/* Sticky header */}
+        <div className="sticky top-0 z-10 flex items-center gap-3 border-b border-gray-200 bg-white px-4 py-3">
+          <div className="min-w-0 flex-1">
+            <h2 className="font-heading text-lg font-bold uppercase tracking-[0.08em] text-gray-900 truncate">
+              Pack · {label}
+            </h2>
+            <p className={`text-sm font-semibold ${complete ? 'text-green-700' : 'text-gray-500'}`}>
+              {day.packed} / {day.total} items packed
+            </p>
+          </div>
+          <button type="button" onClick={onClose} className="btn-primary !min-h-[44px] !py-2 !px-5">
+            Done
+          </button>
+        </div>
+
+        {/* Scrollable body — one section per cooler */}
+        <div className="flex-1 overflow-y-auto px-4 py-3 space-y-4">
+          {cards.map((card) => (
+            <PackCard key={card.key} card={card} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PackCard({ card }: { card: OrderCardData }): ReactElement {
+  const prog = cardProgress(card);
+  const complete = prog.total > 0 && prog.packed === prog.total;
+  const multi = card.orders.length > 1;
+
+  return (
+    <section className={`rounded-lg border ${complete ? 'border-green-300' : 'border-gray-200'}`}>
+      <header
+        className={`flex items-baseline justify-between gap-2 rounded-t-lg border-b px-3 py-2 ${
+          complete ? 'border-green-200 bg-green-50' : 'border-gray-200 bg-gray-50'
+        }`}
+      >
+        <div className="min-w-0">
+          <span className="text-sm font-bold text-brand-blue tabular-nums">
+            {card.deliveryTime || 'TBD'}
+          </span>
+          <span className="mx-2 text-gray-300">·</span>
+          <span className="font-heading text-base font-bold tracking-[0.02em] text-gray-900">
+            {card.displayName}
+          </span>
+        </div>
+        <span
+          className={`flex-shrink-0 text-sm font-bold tabular-nums ${complete ? 'text-green-700' : 'text-gray-500'}`}
+        >
+          {prog.packed}/{prog.total}
+        </span>
+      </header>
+      <div className="space-y-3 p-3">
+        {card.orders.map((o) => (
+          <div key={o.id}>
+            {multi && (
+              <div className="mb-1 text-sm font-bold text-gray-900">
+                #{o.orderNumber} · {o.customerName}
+              </div>
+            )}
+            <OrderItemsChecklist orderId={o.id} items={o.items} />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+/** Sum top-level line-item pack progress across a cooler's orders. */
+function cardProgress(card: OrderCardData): { packed: number; total: number } {
+  let packed = 0;
+  let total = 0;
+  for (const o of card.orders) {
+    const p = orderPackProgress(o.id, o.items);
+    packed += p.packed;
+    total += p.total;
+  }
+  return { packed, total };
+}
+
+function dayProgress(cards: OrderCardData[]): { packed: number; total: number } {
+  return cards.reduce(
+    (acc, c) => {
+      const p = cardProgress(c);
+      acc.packed += p.packed;
+      acc.total += p.total;
+      return acc;
+    },
+    { packed: 0, total: 0 },
+  );
+}

--- a/src/components/ops/orders/UnifiedOrdersView.tsx
+++ b/src/components/ops/orders/UnifiedOrdersView.tsx
@@ -9,6 +9,7 @@ import OrderGroupCard from './OrderGroupCard';
 import OrdersFilterBar from './OrdersFilterBar';
 import OrdersHeader from './OrdersHeader';
 import OrdersStatsStrip from './OrdersStatsStrip';
+import PackModeOverlay from './PackModeOverlay';
 import PickSheetPrint from './print/PickSheetPrint';
 import ReviewRequestModal from './ReviewRequestModal';
 import ShortageListModal from './ShortageListModal';
@@ -58,6 +59,8 @@ export default function UnifiedOrdersView({
   // Day/overdue sections collapse to a compact tile overview. Keys present
   // here are EXPANDED; empty set = all collapsed (the default landing state).
   const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set());
+  // The day currently open in full-screen Pack mode (null = closed).
+  const [packSection, setPackSection] = useState<{ label: string; cards: OrderCardData[] } | null>(null);
 
   // Reset pick-sheet print mode after the dialog closes so subsequent
   // prints fall back to the checklist layout.
@@ -326,6 +329,7 @@ export default function UnifiedOrdersView({
           onSetManySelected={view.setManySelected}
           collapsed={collapsed}
           onToggleCollapse={() => toggleSection(args.key)}
+          onPack={() => setPackSection({ label: args.label, cards: sorted })}
         />
         {collapsed ? (
           <>
@@ -492,6 +496,14 @@ export default function UnifiedOrdersView({
           items={shortageList}
           selectedCount={shortageCount}
           onClose={() => setShortageList(null)}
+        />
+      )}
+
+      {packSection && (
+        <PackModeOverlay
+          label={packSection.label}
+          cards={packSection.cards}
+          onClose={() => setPackSection(null)}
         />
       )}
 

--- a/src/components/ops/orders/UnifiedOrdersView.tsx
+++ b/src/components/ops/orders/UnifiedOrdersView.tsx
@@ -3,6 +3,7 @@
 import { ReactElement, useCallback, useEffect, useMemo, useState } from 'react';
 import BulkActionBar from './BulkActionBar';
 import DaySectionHeader from './DaySectionHeader';
+import DayTiles from './DayTiles';
 import FilterSheet from './FilterSheet';
 import OrderGroupCard from './OrderGroupCard';
 import OrdersFilterBar from './OrdersFilterBar';
@@ -14,7 +15,7 @@ import ShortageListModal from './ShortageListModal';
 import { buildShortageList } from './shortage';
 import { EMPTY_FILTERS, useOrdersView } from './useOrdersView';
 import { cacheChecks, fetchChecks, loadCachedChecks } from './usePickChecks';
-import { fmtDateLong, formatDate, formatDateTime } from './format';
+import { deliveryTimeMinutes, fmtDateLong, formatDate, formatDateTime } from './format';
 import type { OrderCardData, OrdersViewOrder } from '@/lib/ops/orders-view-data';
 import type { Order, ShortageRow } from './types';
 
@@ -54,6 +55,9 @@ export default function UnifiedOrdersView({
   const [sendingReviews, setSendingReviews] = useState(false);
   const [shortageList, setShortageList] = useState<ShortageRow[] | null>(null);
   const [shortageCount, setShortageCount] = useState(0);
+  // Day/overdue sections collapse to a compact tile overview. Keys present
+  // here are EXPANDED; empty set = all collapsed (the default landing state).
+  const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set());
 
   // Reset pick-sheet print mode after the dialog closes so subsequent
   // prints fall back to the checklist layout.
@@ -261,6 +265,82 @@ export default function UnifiedOrdersView({
     onFilterByDashboard: (dashId: string) => view.setFilters({ groupOrderV2Id: dashId }),
   };
 
+  // --- Day collapse / expand ---
+
+  const allSectionKeys = useMemo(() => {
+    const keys: string[] = [];
+    if (data?.overdue) keys.push('overdue');
+    for (const d of data?.days ?? []) keys.push(d.date);
+    return keys;
+  }, [data]);
+
+  const allExpanded =
+    allSectionKeys.length > 0 && allSectionKeys.every((k) => expandedSections.has(k));
+
+  const toggleAll = useCallback(() => {
+    setExpandedSections(allExpanded ? new Set() : new Set(allSectionKeys));
+  }, [allExpanded, allSectionKeys]);
+
+  const toggleSection = useCallback((key: string) => {
+    setExpandedSections((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  const expandAndScroll = useCallback((sectionKey: string, cardKey: string) => {
+    setExpandedSections((prev) => new Set(prev).add(sectionKey));
+    // Let the day expand (cards leave the print-only wrapper) before scrolling.
+    setTimeout(() => {
+      document.getElementById(`cool-${cardKey}`)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }, 80);
+  }, []);
+
+  /**
+   * One day (or the overdue group). Collapsed → a time-sorted tile overview;
+   * expanded → the full cooler cards. The full cards always render for print,
+   * so "Print checklist" stays complete regardless of what's collapsed.
+   */
+  const renderSection = (args: {
+    key: string;
+    label: string;
+    variant: 'day' | 'overdue';
+    cards: OrderCardData[];
+    total: number;
+  }): ReactElement => {
+    const collapsed = !expandedSections.has(args.key);
+    const sorted = [...args.cards].sort(
+      (a, b) => deliveryTimeMinutes(a.deliveryTime) - deliveryTimeMinutes(b.deliveryTime),
+    );
+    return (
+      <section key={args.key} className="break-inside-avoid-page">
+        <DaySectionHeader
+          label={args.label}
+          variant={args.variant}
+          cardCount={args.cards.length}
+          total={args.total}
+          orderIds={args.cards.flatMap((c) => c.orders.map((o) => o.id))}
+          selected={selected}
+          onSetManySelected={view.setManySelected}
+          collapsed={collapsed}
+          onToggleCollapse={() => toggleSection(args.key)}
+        />
+        {collapsed ? (
+          <>
+            <DayTiles cards={sorted} onTileClick={(ck) => expandAndScroll(args.key, ck)} />
+            <div className="hidden print:block">
+              <CardGrid cards={sorted} {...cardActions} />
+            </div>
+          </>
+        ) : (
+          <CardGrid cards={sorted} {...cardActions} />
+        )}
+      </section>
+    );
+  };
+
   return (
     <>
     <div className={pickSheetMode ? 'print:hidden' : 'print:block'}>
@@ -286,6 +366,8 @@ export default function UnifiedOrdersView({
           onPrintChecklist={handlePrintChecklist}
           onExportCsv={handleExportCsv}
           subtitle={subtitle}
+          onToggleAll={allSectionKeys.length ? toggleAll : undefined}
+          allExpanded={allExpanded}
         />
 
         {data && <OrdersStatsStrip data={data} />}
@@ -348,35 +430,25 @@ export default function UnifiedOrdersView({
         )}
 
         {/* Overdue section */}
-        {data?.overdue && (
-          <section className="break-inside-avoid-page">
-            <DaySectionHeader
-              label="Overdue — unfulfilled"
-              variant="overdue"
-              cardCount={data.overdue.cards.length}
-              total={data.overdue.total}
-              orderIds={data.overdue.cards.flatMap((c) => c.orders.map((o) => o.id))}
-              selected={selected}
-              onSetManySelected={view.setManySelected}
-            />
-            <CardGrid cards={data.overdue.cards} {...cardActions} />
-          </section>
-        )}
+        {data?.overdue &&
+          renderSection({
+            key: 'overdue',
+            label: 'Overdue — unfulfilled',
+            variant: 'overdue',
+            cards: data.overdue.cards,
+            total: data.overdue.total,
+          })}
 
         {/* Day sections */}
-        {data?.days.map((day) => (
-          <section key={day.date} className="break-inside-avoid-page">
-            <DaySectionHeader
-              label={fmtDateLong(day.date)}
-              cardCount={day.cards.length}
-              total={day.total}
-              orderIds={day.cards.flatMap((c) => c.orders.map((o) => o.id))}
-              selected={selected}
-              onSetManySelected={view.setManySelected}
-            />
-            <CardGrid cards={day.cards} {...cardActions} />
-          </section>
-        ))}
+        {data?.days.map((day) =>
+          renderSection({
+            key: day.date,
+            label: fmtDateLong(day.date),
+            variant: 'day',
+            cards: day.cards,
+            total: day.total,
+          }),
+        )}
       </div>
 
       {/* Spacer so the fixed bulk bar never covers the last card */}
@@ -471,6 +543,7 @@ function CardGrid({
       {cards.map((c) => (
         <OrderGroupCard
           key={c.key}
+          htmlId={`cool-${c.key}`}
           card={c}
           selected={selected}
           onToggleOrder={onToggleOrder}

--- a/src/components/ops/orders/format.ts
+++ b/src/components/ops/orders/format.ts
@@ -86,6 +86,23 @@ export function timeOfDayPill(timeStr: string): TimePill {
   return { label: 'EVE', cls: 'bg-indigo-900 text-white' };
 }
 
+/**
+ * Start time of a delivery-time string as minutes since midnight, for
+ * chronological sorting. Handles "4:30 PM" and ranges like "4:30 PM - 5:00 PM"
+ * (uses the start). Blank / "TBD" / unparseable sort to the end.
+ */
+export function deliveryTimeMinutes(timeStr: string): number {
+  if (!timeStr) return Number.MAX_SAFE_INTEGER;
+  const m = timeStr.match(/(\d{1,2})(?::(\d{2}))?\s*(AM|PM)/i);
+  if (!m) return Number.MAX_SAFE_INTEGER;
+  let hour = parseInt(m[1], 10);
+  const min = m[2] ? parseInt(m[2], 10) : 0;
+  const isPM = m[3].toUpperCase() === 'PM';
+  if (isPM && hour !== 12) hour += 12;
+  if (!isPM && hour === 12) hour = 0;
+  return hour * 60 + min;
+}
+
 /** Disco/Private/House tag colors (matches weekly checklist). */
 export function typeTagClasses(t: 'DISCO' | 'PRIVATE' | 'HOUSE'): { label: string; cls: string; labelCls: string } {
   if (t === 'DISCO') {

--- a/src/components/ops/orders/format.ts
+++ b/src/components/ops/orders/format.ts
@@ -103,6 +103,23 @@ export function deliveryTimeMinutes(timeStr: string): number {
   return hour * 60 + min;
 }
 
+/**
+ * Very subtle AM/PM/EVE accent for the collapsed-day tiles — a left-border
+ * color class, mirroring timeOfDayPill's buckets. Unknown / TBD reads neutral.
+ */
+export function timeOfDayAccent(timeStr: string): string {
+  switch (timeOfDayPill(timeStr).label) {
+    case 'AM':
+      return 'border-l-amber-400';
+    case 'PM':
+      return 'border-l-sky-400';
+    case 'EVE':
+      return 'border-l-indigo-500';
+    default:
+      return 'border-l-gray-300';
+  }
+}
+
 /** Disco/Private/House tag colors (matches weekly checklist). */
 export function typeTagClasses(t: 'DISCO' | 'PRIVATE' | 'HOUSE'): { label: string; cls: string; labelCls: string } {
   if (t === 'DISCO') {

--- a/src/components/ops/orders/usePickChecks.ts
+++ b/src/components/ops/orders/usePickChecks.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
 import type { ItemCheckEntry, ItemChecks } from './types';
 
 // --- In Stock / Packed / Short By state ---
@@ -19,6 +19,49 @@ export function loadCachedChecks(orderId: string): ItemChecks {
   }
 }
 
+// --- Cross-component change signal ---
+// Pick state lives in localStorage + the server. This lets lightweight readers
+// (the day tiles' pack-progress badges, Pack mode's day total) re-render
+// whenever ANY order's pick state is written, without each owning a fetch.
+let pickVersion = 0;
+const pickListeners = new Set<() => void>();
+
+function notifyPickChange(): void {
+  pickVersion += 1;
+  pickListeners.forEach((fn) => fn());
+}
+
+function subscribePick(listener: () => void): () => void {
+  pickListeners.add(listener);
+  return () => {
+    pickListeners.delete(listener);
+  };
+}
+
+/** Re-render the caller whenever any order's pick state changes. */
+export function usePickTick(): number {
+  return useSyncExternalStore(
+    subscribePick,
+    () => pickVersion,
+    () => pickVersion,
+  );
+}
+
+/**
+ * Top-level line-item pack progress for one order, read from the cache.
+ * Counts how many of the order's line items are marked Packed (bundle
+ * components are tracked in the checklist but not counted here).
+ */
+export function orderPackProgress(
+  orderId: string,
+  items: { title: string }[],
+): { packed: number; total: number } {
+  const checks = loadCachedChecks(orderId);
+  let packed = 0;
+  for (const it of items) if (checks[it.title]?.packed) packed += 1;
+  return { packed, total: items.length };
+}
+
 /** Write-through cache an order's pick state to localStorage. */
 export function cacheChecks(orderId: string, data: ItemChecks): void {
   try {
@@ -26,6 +69,7 @@ export function cacheChecks(orderId: string, data: ItemChecks): void {
   } catch {
     // ignore quota / private-mode errors
   }
+  notifyPickChange();
 }
 
 /** Fetch authoritative pick state from the server. Returns null on failure. */


### PR DESCRIPTION
Reworks `/ops/orders` into a collapsed-first overview and brings the pick/pack inventory workflow into it.

## Collapsed day overview
- Each day (and Overdue) is collapsible; the page **opens collapsed by default**.
- Collapsed = one tile per cooler/dashboard, showing **delivery time + name**, **sorted by real clock time** (new `deliveryTimeMinutes()` — also fixes the old string sort that put 9 AM after 10 AM).
- Subtle **AM/PM/EVE** left-border accent (amber / sky / indigo).
- **Desktop:** tiles group into per-time columns — orders sharing a slot (e.g. three at 11:00) stack under that time. **Mobile:** flat wrapping list.
- Click a tile → expands the day and scrolls to its card. Day header toggles collapse; **Expand all / Collapse all** in the page header.

## Pack mode + inventory (new)
- **"Pack" button on each day header** → full-screen **Pack mode**: every cooler/order for that day with its **In Stock / Packed / Short By** checklist, in delivery-time order, packed from one screen.
- Checking off writes through the **same picks API → same real inventory transitions**. The server/localStorage write path is untouched; live UI updates ride a tiny pub/sub (`usePickTick`).
- **Tiles show pack progress** (packed / total line items) and **turn green** when fully packed — live, as items are checked anywhere (Pack mode or an expanded card).
- **Shortage list unchanged** (select orders → Shortage button).

## Print
Unaffected — collapsed days still render full cards into the print layer, so "Print checklist" and the pick sheets stay complete. Tiles and Pack mode are screen-only.

## Verification
- `next lint` + `tsc --noEmit`: clean
- `npm run test:run`: 285/285 pass
- ⚠️ Not visually verified (no screenshots on my end) — please test on the Vercel preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)