### PR TITLE
docs(claude): add 'verify before done' working-discipline rules

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -230,6 +230,29 @@ MDX-based blog stored in `content/blog/posts/` (134 posts). NOT database-backed.
 
 ---
 
+## Working Discipline — verify before "done"
+
+Skip all of this for trivial fixes (typos, renames, local one-liners — just do them).
+The bigger or riskier the change, the more of this is mandatory.
+
+- **Verify against the live code, not memory.** Re-read the actual file before
+  claiming what it does. Claims like "mirrors X", "ported verbatim", "matches old
+  behavior" assert equivalence — prove it by diffing/running both, or downgrade the
+  claim. (We have v1/v2 APIs, GroupOrderV2, and two revenue eras — easy to describe
+  the wrong one from memory.)
+- **A clean diff is not proof.** Before saying done, run the sanctioned gates and
+  paste failures: `npx tsc --noEmit`, `npm run lint`, `npm run test:run`.
+  (Per Forbidden Actions: never `next build`, Playwright, or screenshots.)
+- **Sweep beyond the diff.** A change to a shared type, webhook contract, config, or
+  helper can break files the diff never touches — check the other call sites.
+- **High-stakes → independent review.** Anything touching auth, Stripe/payments,
+  customer PII, affiliate payouts, or webhooks: run the `security-reviewer` agent and
+  `/code-review` before merge. Self-review can't see the framing error it's inside.
+- **Surface gaps honestly.** When done, name what you did NOT verify and what's out
+  of scope. A faithful "I couldn't test X" beats a confident wrong "done."
+
+---
+
 ## Analytics & Marketing Optimization
 
 - **Snapshot doc**: `docs/WEBSITE-ANALYTICS.md` — regenerated nightly by `/api/cron/analytics-snapshot` (07:00 UTC). Read this before any conversion/SEO/margin conversation.


### PR DESCRIPTION
Adds a compact, always-on **Working Discipline** section to `CLAUDE.md`, distilled from the [tale-mode](https://github.com/alicicek/tale-mode) methodology.

Captures the two disciplines plan mode / ultrathink don't provide — verification against ground truth, and an independent-review reflex for high-stakes changes — as standing rules so they don't depend on remembering to trigger anything:

- Verify against the live code, not memory (esp. "mirrors/ported/matches" parity claims)
- A clean diff is not proof — run the sanctioned gates (`tsc --noEmit`, `lint`, `test:run`) before "done"
- Sweep beyond the diff (shared types, webhook contracts, config, helpers → other call sites)
- High-stakes (auth/Stripe/PII/affiliate payouts/webhooks) → `security-reviewer` agent + `/code-review` before merge
- Surface gaps honestly

Docs-only change — no code, no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)