### PR TITLE
fix(catalog): take variants off-sale on draft/archive + guard checkout against non-ACTIVE products

### DIFF
--- a/src/__tests__/group-orders-add-item.test.ts
+++ b/src/__tests__/group-orders-add-item.test.ts
@@ -1,0 +1,100 @@
+/**
+ * addDraftItem availability guard.
+ *
+ * addDraftItem is the shared service function behind BOTH the dashboard add-item endpoint
+ * (POST /api/v2/group-orders/[code]/tabs/[tabId]/items) and the /quote/start pre-loader, so the
+ * guard here covers both surfaces: a DRAFT/ARCHIVED product (or an off-sale variant) can never be
+ * added to a tab.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSubOrderFindUnique = vi.fn();
+const mockProductVariantFindMany = vi.fn();
+const mockDraftCartItemFindUnique = vi.fn();
+const mockDraftCartItemCreate = vi.fn();
+const mockDraftCartItemUpdate = vi.fn();
+
+vi.mock('@/lib/database/client', () => ({
+  prisma: {
+    subOrder: { findUnique: (...a: unknown[]) => mockSubOrderFindUnique(...a) },
+    productVariant: { findMany: (...a: unknown[]) => mockProductVariantFindMany(...a) },
+    draftCartItem: {
+      findUnique: (...a: unknown[]) => mockDraftCartItemFindUnique(...a),
+      create: (...a: unknown[]) => mockDraftCartItemCreate(...a),
+      update: (...a: unknown[]) => mockDraftCartItemUpdate(...a),
+    },
+  },
+}));
+
+import { addDraftItem } from '@/lib/group-orders-v2/service';
+import { ProductNotPurchasableError } from '@/lib/products/availability';
+
+// An OPEN tab whose order deadline is far in the future.
+const OPEN_TAB = { id: 'tab-1', status: 'OPEN', orderDeadline: new Date('2999-01-01') };
+
+const ITEM_INPUT = {
+  participantId: 'part-1',
+  productId: 'p1',
+  variantId: 'v1',
+  title: 'Beer',
+  price: 10,
+  quantity: 2,
+};
+
+describe('addDraftItem availability guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSubOrderFindUnique.mockResolvedValue(OPEN_TAB);
+  });
+
+  it('adds the item when the product is ACTIVE and the variant is available', async () => {
+    mockProductVariantFindMany.mockResolvedValue([
+      { id: 'v1', availableForSale: true, product: { id: 'p1', status: 'ACTIVE', title: 'Beer' } },
+    ]);
+    mockDraftCartItemFindUnique.mockResolvedValue(null);
+    mockDraftCartItemCreate.mockResolvedValue({
+      id: 'draft-1',
+      productId: 'p1',
+      variantId: 'v1',
+      title: 'Beer',
+      variantTitle: null,
+      price: 10,
+      imageUrl: null,
+      quantity: 2,
+      addedBy: { id: 'part-1', guestName: 'Host', isHost: true },
+      product: { handle: 'beer' },
+    });
+
+    const result = await addDraftItem('tab-1', ITEM_INPUT);
+
+    expect(result.id).toBe('draft-1');
+    expect(mockDraftCartItemCreate).toHaveBeenCalledOnce();
+  });
+
+  it('rejects a DRAFT product and never writes a draft item', async () => {
+    mockProductVariantFindMany.mockResolvedValue([
+      { id: 'v1', availableForSale: true, product: { id: 'p1', status: 'DRAFT', title: 'Bloody Mary Mix' } },
+    ]);
+
+    await expect(addDraftItem('tab-1', ITEM_INPUT)).rejects.toBeInstanceOf(ProductNotPurchasableError);
+    expect(mockDraftCartItemCreate).not.toHaveBeenCalled();
+    expect(mockDraftCartItemUpdate).not.toHaveBeenCalled();
+  });
+
+  it('rejects an ARCHIVED product', async () => {
+    mockProductVariantFindMany.mockResolvedValue([
+      { id: 'v1', availableForSale: true, product: { id: 'p1', status: 'ARCHIVED', title: 'Old Vodka' } },
+    ]);
+    await expect(addDraftItem('tab-1', ITEM_INPUT)).rejects.toThrow(/no longer available/);
+    expect(mockDraftCartItemCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects an ACTIVE product whose variant is no longer available for sale', async () => {
+    mockProductVariantFindMany.mockResolvedValue([
+      { id: 'v1', availableForSale: false, product: { id: 'p1', status: 'ACTIVE', title: 'Sold Out IPA' } },
+    ]);
+    await expect(addDraftItem('tab-1', ITEM_INPUT)).rejects.toBeInstanceOf(ProductNotPurchasableError);
+    expect(mockDraftCartItemCreate).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/group-v2-payments.test.ts
+++ b/src/__tests__/group-v2-payments.test.ts
@@ -19,6 +19,7 @@ const mockPrismaCustomerCreate = vi.fn();
 const mockPrismaOrderCreate = vi.fn();
 const mockPrismaDeliveryTaskCreate = vi.fn();
 const mockPrismaProductVariantFindUnique = vi.fn();
+const mockPrismaProductVariantFindMany = vi.fn();
 const mockPrismaGroupOrderV2FindUnique = vi.fn();
 
 vi.mock('@/lib/database/client', () => ({
@@ -49,6 +50,7 @@ vi.mock('@/lib/database/client', () => ({
     },
     productVariant: {
       findUnique: (...args: unknown[]) => mockPrismaProductVariantFindUnique(...args),
+      findMany: (...args: unknown[]) => mockPrismaProductVariantFindMany(...args),
     },
     groupOrderV2: {
       findUnique: (...args: unknown[]) => mockPrismaGroupOrderV2FindUnique(...args),
@@ -85,7 +87,8 @@ vi.mock('@/lib/tax', () => ({
 }));
 
 // Import after mocks are set up
-import { handleGroupV2PaymentCompleted } from '@/lib/stripe/group-v2-payments';
+import { handleGroupV2PaymentCompleted, createGroupV2CheckoutSession } from '@/lib/stripe/group-v2-payments';
+import { ProductNotPurchasableError } from '@/lib/products/availability';
 
 // --- Test helpers ---
 
@@ -446,5 +449,48 @@ describe('handleGroupV2PaymentCompleted', () => {
       expect(orderArg.data.items.create).toHaveLength(1);
       expect(orderArg.data.items.create[0]).toMatchObject({ productId: 'product-id-1' });
     });
+  });
+});
+
+describe('createGroupV2CheckoutSession availability guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const baseInput = {
+    groupOrderId: 'group-order-id-1',
+    subOrderId: 'sub-order-id-1',
+    participantId: 'participant-id-1',
+    participantName: 'Guest',
+    draftItems: [
+      {
+        id: 'draft-1',
+        productId: 'product-id-1',
+        variantId: 'variant-id-1',
+        title: 'Test Beer Pack',
+        variantTitle: '12 Pack',
+        price: 22.99,
+        imageUrl: null,
+        quantity: 1,
+      },
+    ],
+    successUrl: 'https://example.com/success',
+    cancelUrl: 'https://example.com/cancel',
+  };
+
+  it('refuses to create a checkout session for a DRAFT product, before any Stripe charge', async () => {
+    mockPrismaProductVariantFindMany.mockResolvedValue([
+      {
+        id: 'variant-id-1',
+        availableForSale: true,
+        product: { id: 'product-id-1', status: 'DRAFT', title: 'Test Beer Pack' },
+      },
+    ]);
+
+    // A ProductNotPurchasableError (rather than a Stripe/DB crash) proves the guard ran first:
+    // the stripe client is mocked as {}, so reaching the charge would throw a different error.
+    await expect(createGroupV2CheckoutSession(baseInput)).rejects.toBeInstanceOf(
+      ProductNotPurchasableError
+    );
   });
 });

--- a/src/__tests__/product-availability.test.ts
+++ b/src/__tests__/product-availability.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Product availability rules — the two layers that stop a DRAFT/ARCHIVED product from being sold:
+ *   1. cascadeVariantAvailabilityForStatus — when a product goes non-ACTIVE, its variants go off-sale.
+ *   2. assertVariantsPurchasable — checkout-time guard that refuses non-ACTIVE / off-sale items.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  cascadeVariantAvailabilityForStatus,
+  assertVariantsPurchasable,
+  isNonPurchasableStatus,
+  ProductNotPurchasableError,
+} from '@/lib/products/availability';
+
+// A fake transaction client exposing just the productVariant methods the helpers touch.
+function fakeTx(opts: {
+  updateManyCount?: number;
+  findManyResult?: Array<{
+    id: string;
+    availableForSale: boolean;
+    product: { id: string; status: string; title: string };
+  }>;
+}) {
+  const updateMany = vi.fn().mockResolvedValue({ count: opts.updateManyCount ?? 0 });
+  const findMany = vi.fn().mockResolvedValue(opts.findManyResult ?? []);
+  const tx = { productVariant: { updateMany, findMany } };
+  return { tx: tx as never, updateMany, findMany };
+}
+
+describe('isNonPurchasableStatus', () => {
+  it('is true for DRAFT and ARCHIVED, false for ACTIVE / null / undefined', () => {
+    expect(isNonPurchasableStatus('DRAFT')).toBe(true);
+    expect(isNonPurchasableStatus('ARCHIVED')).toBe(true);
+    expect(isNonPurchasableStatus('ACTIVE')).toBe(false);
+    expect(isNonPurchasableStatus(null)).toBe(false);
+    expect(isNonPurchasableStatus(undefined)).toBe(false);
+  });
+});
+
+describe('cascadeVariantAvailabilityForStatus', () => {
+  it('flips still-available variants off-sale for DRAFT', async () => {
+    const { tx, updateMany } = fakeTx({ updateManyCount: 3 });
+    const count = await cascadeVariantAvailabilityForStatus(tx, 'prod-1', 'DRAFT');
+    expect(count).toBe(3);
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { productId: 'prod-1', availableForSale: true },
+      data: { availableForSale: false },
+    });
+  });
+
+  it('flips still-available variants off-sale for ARCHIVED', async () => {
+    const { tx, updateMany } = fakeTx({ updateManyCount: 1 });
+    const count = await cascadeVariantAvailabilityForStatus(tx, 'prod-2', 'ARCHIVED');
+    expect(count).toBe(1);
+    expect(updateMany).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT touch variants for ACTIVE (re-activation is deliberate, never auto-re-enabled)', async () => {
+    const { tx, updateMany } = fakeTx({});
+    const count = await cascadeVariantAvailabilityForStatus(tx, 'prod-3', 'ACTIVE');
+    expect(count).toBe(0);
+    expect(updateMany).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when status is undefined (status not being changed)', async () => {
+    const { tx, updateMany } = fakeTx({});
+    const count = await cascadeVariantAvailabilityForStatus(tx, 'prod-4', undefined);
+    expect(count).toBe(0);
+    expect(updateMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('assertVariantsPurchasable', () => {
+  it('resolves when every item is an ACTIVE product with an available variant', async () => {
+    const { tx, findMany } = fakeTx({
+      findManyResult: [
+        { id: 'v1', availableForSale: true, product: { id: 'p1', status: 'ACTIVE', title: 'Beer' } },
+        { id: 'v2', availableForSale: true, product: { id: 'p2', status: 'ACTIVE', title: 'Wine' } },
+      ],
+    });
+    await expect(
+      assertVariantsPurchasable(tx, [
+        { productId: 'p1', variantId: 'v1', title: 'Beer' },
+        { productId: 'p2', variantId: 'v2', title: 'Wine' },
+      ])
+    ).resolves.toBeUndefined();
+    // De-duplicates variant ids when querying.
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: { in: ['v1', 'v2'] } } })
+    );
+  });
+
+  it('does not even query for an empty item list', async () => {
+    const { tx, findMany } = fakeTx({});
+    await expect(assertVariantsPurchasable(tx, [])).resolves.toBeUndefined();
+    expect(findMany).not.toHaveBeenCalled();
+  });
+
+  it('rejects a DRAFT product', async () => {
+    const { tx } = fakeTx({
+      findManyResult: [
+        { id: 'v1', availableForSale: true, product: { id: 'p1', status: 'DRAFT', title: 'Bloody Mary Mix' } },
+      ],
+    });
+    await expect(
+      assertVariantsPurchasable(tx, [{ productId: 'p1', variantId: 'v1', title: 'Bloody Mary Mix' }])
+    ).rejects.toBeInstanceOf(ProductNotPurchasableError);
+  });
+
+  it('rejects an ARCHIVED product', async () => {
+    const { tx } = fakeTx({
+      findManyResult: [
+        { id: 'v1', availableForSale: true, product: { id: 'p1', status: 'ARCHIVED', title: 'Old Vodka' } },
+      ],
+    });
+    await expect(
+      assertVariantsPurchasable(tx, [{ productId: 'p1', variantId: 'v1', title: 'Old Vodka' }])
+    ).rejects.toThrow(/Old Vodka/);
+  });
+
+  it('rejects an ACTIVE product whose variant is not availableForSale', async () => {
+    const { tx } = fakeTx({
+      findManyResult: [
+        { id: 'v1', availableForSale: false, product: { id: 'p1', status: 'ACTIVE', title: 'Sold Out IPA' } },
+      ],
+    });
+    await expect(
+      assertVariantsPurchasable(tx, [{ productId: 'p1', variantId: 'v1', title: 'Sold Out IPA' }])
+    ).rejects.toThrow(/no longer available/);
+  });
+
+  it('rejects a variant that no longer exists in the catalog', async () => {
+    const { tx } = fakeTx({ findManyResult: [] });
+    await expect(
+      assertVariantsPurchasable(tx, [{ productId: 'p1', variantId: 'ghost', title: 'Ghost' }])
+    ).rejects.toThrow(/no longer exists/);
+  });
+
+  it('lists every offending item (not just the first) so the caller can surface all of them', async () => {
+    const { tx } = fakeTx({
+      findManyResult: [
+        { id: 'ok', availableForSale: true, product: { id: 'pok', status: 'ACTIVE', title: 'Fine' } },
+        { id: 'draft', availableForSale: true, product: { id: 'pd', status: 'DRAFT', title: 'Drafted' } },
+        { id: 'off', availableForSale: false, product: { id: 'po', status: 'ACTIVE', title: 'OffSale' } },
+      ],
+    });
+    let caught: ProductNotPurchasableError | null = null;
+    try {
+      await assertVariantsPurchasable(tx, [
+        { productId: 'pok', variantId: 'ok', title: 'Fine' },
+        { productId: 'pd', variantId: 'draft', title: 'Drafted' },
+        { productId: 'po', variantId: 'off', title: 'OffSale' },
+      ]);
+    } catch (err) {
+      caught = err as ProductNotPurchasableError;
+    }
+    expect(caught).toBeInstanceOf(ProductNotPurchasableError);
+    expect(caught!.reasons).toHaveLength(2);
+    expect(caught!.reasons.join(' ')).toContain('Drafted');
+    expect(caught!.reasons.join(' ')).toContain('OffSale');
+    expect(caught!.reasons.join(' ')).not.toContain('Fine');
+  });
+});

--- a/src/__tests__/product-status-cascade.test.ts
+++ b/src/__tests__/product-status-cascade.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Product status → variant availability cascade at the service layer.
+ *
+ * Proves that drafting or archiving a product (updateProduct / deleteProduct) takes its variants
+ * off-sale in the SAME transaction — closing the leak where a non-ACTIVE product stayed
+ * purchasable via a stale cart or a direct/shared product link.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock tx client the service runs inside $transaction.
+const mockTxProductUpdate = vi.fn().mockResolvedValue({ id: 'prod-1', variants: [] });
+const mockTxVariantUpdateMany = vi.fn().mockResolvedValue({ count: 2 });
+const mockTx = {
+  product: { update: (...a: unknown[]) => mockTxProductUpdate(...a) },
+  productVariant: { updateMany: (...a: unknown[]) => mockTxVariantUpdateMany(...a) },
+};
+
+vi.mock('@/lib/database/client', () => ({
+  prisma: {
+    // Run the callback with our mock tx so we can assert what the cascade did.
+    $transaction: (cb: (tx: unknown) => unknown) => cb(mockTx),
+  },
+}));
+
+import { updateProduct, deleteProduct } from '@/lib/inventory/services/product-service';
+
+const OFF_SALE_CASCADE = {
+  where: { productId: 'prod-1', availableForSale: true },
+  data: { availableForSale: false },
+};
+
+describe('updateProduct status cascade', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTxProductUpdate.mockResolvedValue({ id: 'prod-1', variants: [] });
+    mockTxVariantUpdateMany.mockResolvedValue({ count: 2 });
+  });
+
+  it('flips variants off-sale when status is set to DRAFT', async () => {
+    await updateProduct({ id: 'prod-1', status: 'DRAFT' });
+    expect(mockTxVariantUpdateMany).toHaveBeenCalledWith(OFF_SALE_CASCADE);
+  });
+
+  it('flips variants off-sale when status is set to ARCHIVED', async () => {
+    await updateProduct({ id: 'prod-1', status: 'ARCHIVED' });
+    expect(mockTxVariantUpdateMany).toHaveBeenCalledWith(OFF_SALE_CASCADE);
+  });
+
+  it('does NOT touch variant availability when status is set to ACTIVE', async () => {
+    await updateProduct({ id: 'prod-1', status: 'ACTIVE' });
+    expect(mockTxVariantUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it('does NOT touch variant availability when status is not part of the update', async () => {
+    await updateProduct({ id: 'prod-1', title: 'New title' });
+    expect(mockTxVariantUpdateMany).not.toHaveBeenCalled();
+    expect(mockTxProductUpdate).toHaveBeenCalledOnce();
+  });
+});
+
+describe('deleteProduct (soft delete / archive) cascade', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTxProductUpdate.mockResolvedValue({ id: 'prod-1' });
+    mockTxVariantUpdateMany.mockResolvedValue({ count: 2 });
+  });
+
+  it('archives the product AND flips its variants off-sale', async () => {
+    await deleteProduct('prod-1');
+    expect(mockTxProductUpdate).toHaveBeenCalledWith({
+      where: { id: 'prod-1' },
+      data: { status: 'ARCHIVED' },
+    });
+    expect(mockTxVariantUpdateMany).toHaveBeenCalledWith(OFF_SALE_CASCADE);
+  });
+});

--- a/src/__tests__/stripe-integration.test.ts
+++ b/src/__tests__/stripe-integration.test.ts
@@ -38,6 +38,11 @@ const mockPaymentIntentRetrieve = vi.fn().mockResolvedValue({
   amount: 15000,
 });
 const mockCartUpdate = vi.fn().mockResolvedValue({});
+// createCheckoutSession now re-reads variant/product status (defense-in-depth). Default to the
+// cart's variant being a purchasable ACTIVE product; individual tests override for rejection cases.
+const mockProductVariantFindMany = vi.fn().mockResolvedValue([
+  { id: 'var-1', availableForSale: true, product: { id: 'prod-1', status: 'ACTIVE', title: 'Test Wine' } },
+]);
 
 // Mock the Stripe module with a proper class constructor
 vi.mock('stripe', () => {
@@ -70,6 +75,7 @@ vi.mock('stripe', () => {
 vi.mock('@/lib/database/client', () => ({
   prisma: {
     cart: { update: (...args: unknown[]) => mockCartUpdate(...args) },
+    productVariant: { findMany: (...args: unknown[]) => mockProductVariantFindMany(...args) },
   },
 }));
 
@@ -176,6 +182,7 @@ describe('Checkout Session Creation', () => {
     mockSessionRetrieve.mockClear();
     mockSessionExpire.mockClear();
     mockCartUpdate.mockClear();
+    mockProductVariantFindMany.mockClear();
   });
 
   it('should create checkout session with cart items', async () => {
@@ -231,6 +238,29 @@ describe('Checkout Session Creation', () => {
     );
     expect(productLine?.price_data?.unit_amount).toBe(2499);
     expect(productLine?.quantity).toBe(2);
+  });
+
+  it('rejects checkout when a cart product is no longer ACTIVE (drafted/archived after add-to-cart)', async () => {
+    const { createCheckoutSession } = await import('@/lib/stripe/checkout');
+    const { ProductNotPurchasableError } = await import('@/lib/products/availability');
+
+    // Same variant id as the cart, but the product has since been drafted.
+    mockProductVariantFindMany.mockResolvedValueOnce([
+      { id: 'var-1', availableForSale: true, product: { id: 'prod-1', status: 'DRAFT', title: 'Test Wine' } },
+    ]);
+
+    await expect(
+      createCheckoutSession({
+        cart: mockCart,
+        successUrl: 'https://example.com/success',
+        cancelUrl: 'https://example.com/cancel',
+        customerEmail: 'test@example.com',
+      })
+    ).rejects.toBeInstanceOf(ProductNotPurchasableError);
+
+    // The guard short-circuits BEFORE Stripe is charged or the snapshot is persisted.
+    expect(mockSessionCreate).not.toHaveBeenCalled();
+    expect(mockCartUpdate).not.toHaveBeenCalled();
   });
 
   it('should retrieve checkout session', async () => {

--- a/src/app/api/v1/admin/products/[id]/route.ts
+++ b/src/app/api/v1/admin/products/[id]/route.ts
@@ -8,6 +8,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/database/client';
 import { ProductStatus } from '@prisma/client';
+import { cascadeVariantAvailabilityForStatus } from '@/lib/products/availability';
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -220,9 +221,18 @@ export async function PUT(
       }
     }
 
-    const product = await prisma.product.update({
-      where: { id },
-      data: updateData,
+    // Update the product and, when its status is moving to DRAFT/ARCHIVED, cascade its variants
+    // off-sale in the SAME transaction (the browse catalog hides non-ACTIVE products, but
+    // cart/checkout key off the variant's availableForSale flag).
+    const product = await prisma.$transaction(async (tx) => {
+      const updated = await tx.product.update({
+        where: { id },
+        data: updateData,
+      });
+      if (typeof body.status === 'string') {
+        await cascadeVariantAvailabilityForStatus(tx, id, body.status);
+      }
+      return updated;
     });
 
     // Handle costPerUnit update (stored on ProductVariant)
@@ -316,10 +326,14 @@ export async function DELETE(
         message: 'Product permanently deleted',
       });
     } else {
-      // Archive the product
-      await prisma.product.update({
-        where: { id },
-        data: { status: 'ARCHIVED' },
+      // Archive the product and take its variants off-sale in one transaction so it can't be
+      // bought via a stale cart or a direct/shared product link.
+      await prisma.$transaction(async (tx) => {
+        await tx.product.update({
+          where: { id },
+          data: { status: 'ARCHIVED' },
+        });
+        await cascadeVariantAvailabilityForStatus(tx, id, 'ARCHIVED');
       });
 
       return NextResponse.json({

--- a/src/app/api/v1/checkout/route.ts
+++ b/src/app/api/v1/checkout/route.ts
@@ -14,6 +14,7 @@ import { notifyNewOrder, buildGhlPayload } from '@/lib/webhooks/ghl';
 import { getAffiliateByCode } from '@/lib/affiliates/affiliate-service';
 import { linkOrderToAffiliate } from '@/lib/affiliates/commission-engine';
 import { createOrderCalendarEvent } from '@/lib/calendar/google-calendar';
+import { ProductNotPurchasableError } from '@/lib/products/availability';
 import { prisma } from '@/lib/database/client';
 
 const CART_ID_COOKIE = 'cart_id';
@@ -293,6 +294,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     });
   } catch (error) {
     console.error('[Checkout API] POST error:', error);
+    // A since-drafted/archived product in the cart is a conflict with current catalog state.
+    if (error instanceof ProductNotPurchasableError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 409 }
+      );
+    }
     return NextResponse.json(
       {
         success: false,

--- a/src/app/api/v2/group-orders/[code]/tabs/[tabId]/checkout-all/route.ts
+++ b/src/app/api/v2/group-orders/[code]/tabs/[tabId]/checkout-all/route.ts
@@ -11,6 +11,7 @@ import {
   getParticipantById,
 } from '@/lib/group-orders-v2/service';
 import { createGroupV2CheckoutSession } from '@/lib/stripe/group-v2-payments';
+import { ProductNotPurchasableError } from '@/lib/products/availability';
 
 interface RouteParams {
   params: Promise<{ code: string; tabId: string }>;
@@ -148,6 +149,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     });
   } catch (error) {
     console.error('[Group V2] Checkout-all error:', error);
+    if (error instanceof ProductNotPurchasableError) {
+      return NextResponse.json({ success: false, error: error.message }, { status: 409 });
+    }
     const msg = error instanceof Error ? error.message : 'Failed to create checkout';
     return NextResponse.json({ success: false, error: msg }, { status: 500 });
   }

--- a/src/app/api/v2/group-orders/[code]/tabs/[tabId]/checkout/route.ts
+++ b/src/app/api/v2/group-orders/[code]/tabs/[tabId]/checkout/route.ts
@@ -11,6 +11,7 @@ import {
   getParticipantById,
 } from '@/lib/group-orders-v2/service';
 import { createGroupV2CheckoutSession } from '@/lib/stripe/group-v2-payments';
+import { ProductNotPurchasableError } from '@/lib/products/availability';
 
 interface RouteParams {
   params: Promise<{ code: string; tabId: string }>;
@@ -152,6 +153,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     });
   } catch (error) {
     console.error('[Group V2] Checkout error:', error);
+    if (error instanceof ProductNotPurchasableError) {
+      return NextResponse.json({ success: false, error: error.message }, { status: 409 });
+    }
     const msg = error instanceof Error ? error.message : 'Failed to create checkout';
     return NextResponse.json({ success: false, error: msg }, { status: 500 });
   }

--- a/src/app/api/v2/group-orders/[code]/tabs/[tabId]/items/route.ts
+++ b/src/app/api/v2/group-orders/[code]/tabs/[tabId]/items/route.ts
@@ -5,6 +5,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { AddDraftItemSchema } from '@/lib/group-orders-v2/validation';
 import { addDraftItem, getGroupOrderByCode } from '@/lib/group-orders-v2/service';
+import { ProductNotPurchasableError } from '@/lib/products/availability';
 import { prisma } from '@/lib/prisma';
 
 interface RouteParams {
@@ -61,6 +62,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       { status: 201 }
     );
   } catch (error) {
+    if (error instanceof ProductNotPurchasableError) {
+      return NextResponse.json({ success: false, error: error.message }, { status: 409 });
+    }
     const msg = error instanceof Error ? error.message : 'Failed to add item';
     const status = msg.includes('locked') || msg.includes('deadline') ? 403 : 500;
     return NextResponse.json({ success: false, error: msg }, { status });

--- a/src/lib/group-orders-v2/service.ts
+++ b/src/lib/group-orders-v2/service.ts
@@ -6,6 +6,7 @@
 import { prisma } from '@/lib/database/client';
 import { calculateDeliveryFee } from '@/lib/delivery/rates';
 import { isLastMinuteDate } from '@/lib/lastMinute/dates';
+import { assertVariantsPurchasable } from '@/lib/products/availability';
 import {
   generateShareCode,
   computeOrderDeadline,
@@ -625,6 +626,13 @@ export async function addDraftItem(
   if (new Date() > tab.orderDeadline) {
     throw new Error('Order deadline has passed');
   }
+
+  // Defense-in-depth: never add a DRAFT/ARCHIVED product (or an off-sale variant) to a tab.
+  // This is the shared guard behind both the add-item endpoint and the /quote/start pre-loader.
+  // Throws ProductNotPurchasableError.
+  await assertVariantsPurchasable(prisma, [
+    { productId: input.productId, variantId: input.variantId, title: input.title },
+  ]);
 
   // Upsert: if same variant exists for this participant, increment qty
   const existing = await prisma.draftCartItem.findUnique({

--- a/src/lib/inventory/services/product-service.ts
+++ b/src/lib/inventory/services/product-service.ts
@@ -5,6 +5,7 @@
 
 import { prisma } from '@/lib/database/client';
 import { Prisma, ProductStatus } from '@prisma/client';
+import { cascadeVariantAvailabilityForStatus } from '@/lib/products/availability';
 import type {
   ProductCreateInput,
   ProductUpdateInput,
@@ -186,24 +187,38 @@ export async function updateProduct(
     updateData.abv = data.abv ? new Prisma.Decimal(data.abv) : null;
   }
 
-  return prisma.product.update({
-    where: { id },
-    data: updateData,
-    include: {
-      variants: true,
-      images: { orderBy: { position: 'asc' } },
-      categories: { include: { category: true } },
-    },
+  // Cascade status → variant availability in the SAME transaction: a product moving to
+  // DRAFT/ARCHIVED must take its variants off-sale so it can't be bought via a stale cart or a
+  // direct/shared link. Cascade runs first so the product.update's `include` returns fresh variants.
+  return prisma.$transaction(async (tx) => {
+    if (data.status !== undefined) {
+      await cascadeVariantAvailabilityForStatus(tx, id, data.status);
+    }
+    return tx.product.update({
+      where: { id },
+      data: updateData,
+      include: {
+        variants: true,
+        images: { orderBy: { position: 'asc' } },
+        categories: { include: { category: true } },
+      },
+    });
   });
 }
 
 /**
  * Delete a product (soft delete by archiving)
+ *
+ * Archiving also takes the product's variants off-sale (in one transaction) so the archived
+ * product can't be bought via a stale cart or a direct/shared product link.
  */
 export async function deleteProduct(id: string): Promise<void> {
-  await prisma.product.update({
-    where: { id },
-    data: { status: 'ARCHIVED' },
+  await prisma.$transaction(async (tx) => {
+    await tx.product.update({
+      where: { id },
+      data: { status: 'ARCHIVED' },
+    });
+    await cascadeVariantAvailabilityForStatus(tx, id, 'ARCHIVED');
   });
 }
 

--- a/src/lib/products/availability.ts
+++ b/src/lib/products/availability.ts
@@ -1,0 +1,116 @@
+/**
+ * Product availability rules — keeps "is this product purchasable?" in one place.
+ *
+ * Background (the bug this closes): setting a product to DRAFT or ARCHIVED in the admin used
+ * to leave its variants' `availableForSale` flag untouched. The browse catalog hides non-ACTIVE
+ * products (it filters `status: 'ACTIVE'`), but cart and checkout key off the variant flag — so
+ * a drafted/archived product stayed purchasable through a direct/shared product link or a cart it
+ * was added to while still active.
+ *
+ * Two layers use this module:
+ *   1. WRITE layer — {@link cascadeVariantAvailabilityForStatus}: whenever a product moves to a
+ *      non-ACTIVE status, flip its variants' availableForSale to false in the same transaction.
+ *   2. CHECKOUT layer — {@link assertVariantsPurchasable}: defense-in-depth that re-reads product
+ *      status from the DB at purchase time and refuses any line item whose product isn't ACTIVE
+ *      (or whose variant isn't availableForSale), even if a stale flag slipped through.
+ */
+
+import { Prisma, ProductStatus, type PrismaClient } from '@prisma/client';
+
+type Tx = Prisma.TransactionClient | PrismaClient;
+
+/** Product statuses whose variants must never be purchasable. */
+export const NON_PURCHASABLE_STATUSES: ProductStatus[] = [
+  ProductStatus.DRAFT,
+  ProductStatus.ARCHIVED,
+];
+
+/** True when this status means the product (and all its variants) must be off-sale. */
+export function isNonPurchasableStatus(
+  status: ProductStatus | string | null | undefined
+): boolean {
+  return status === ProductStatus.DRAFT || status === ProductStatus.ARCHIVED;
+}
+
+/**
+ * Cascade a product's status onto its variants' availability.
+ *
+ * When a product is moving to DRAFT or ARCHIVED, flip every variant that is still
+ * `availableForSale: true` to false within the given transaction so it can't be bought via a
+ * stale cart or a direct/shared product link. Returns how many variants were flipped.
+ *
+ * Re-activating (status === ACTIVE) intentionally does NOT force availableForSale back to true:
+ * turning a product back on should be a deliberate, separate action so we never silently re-list
+ * a variant an operator meant to keep hidden. Calling this with ACTIVE (or undefined) is a no-op.
+ */
+export async function cascadeVariantAvailabilityForStatus(
+  tx: Tx,
+  productId: string,
+  newStatus: ProductStatus | string | null | undefined
+): Promise<number> {
+  if (!isNonPurchasableStatus(newStatus)) return 0;
+  const { count } = await tx.productVariant.updateMany({
+    where: { productId, availableForSale: true },
+    data: { availableForSale: false },
+  });
+  return count;
+}
+
+/** One line item to validate at purchase time. `title` is only used for error messages. */
+export interface PurchasabilityItem {
+  productId: string;
+  variantId: string;
+  title?: string | null;
+}
+
+/**
+ * Thrown by {@link assertVariantsPurchasable} when one or more items are no longer sellable.
+ * `reasons` lists each offending item so the caller can surface an actionable message.
+ */
+export class ProductNotPurchasableError extends Error {
+  constructor(public readonly reasons: string[]) {
+    super(`One or more items are no longer available for purchase: ${reasons.join('; ')}`);
+    this.name = 'ProductNotPurchasableError';
+  }
+}
+
+/**
+ * Defense-in-depth: verify every item references an ACTIVE product whose variant is
+ * `availableForSale`. Re-reads state from the DB (NOT the cart/draft snapshot, which can carry a
+ * stale flag) so a since-drafted/archived product can't slip a line item through checkout.
+ *
+ * Throws {@link ProductNotPurchasableError} listing every offending item. No-ops on an empty list.
+ */
+export async function assertVariantsPurchasable(
+  tx: Tx,
+  items: PurchasabilityItem[]
+): Promise<void> {
+  if (items.length === 0) return;
+
+  const variantIds = [...new Set(items.map((i) => i.variantId))];
+  const variants = await tx.productVariant.findMany({
+    where: { id: { in: variantIds } },
+    select: {
+      id: true,
+      availableForSale: true,
+      product: { select: { id: true, status: true, title: true } },
+    },
+  });
+  const byVariantId = new Map(variants.map((v) => [v.id, v]));
+
+  const reasons: string[] = [];
+  for (const item of items) {
+    const variant = byVariantId.get(item.variantId);
+    const label = item.title || variant?.product.title || item.variantId;
+    if (!variant) {
+      reasons.push(`${label}: product no longer exists`);
+      continue;
+    }
+    // Either gate failing means the same thing to the customer: not for sale.
+    if (variant.product.status !== ProductStatus.ACTIVE || !variant.availableForSale) {
+      reasons.push(`${label}: no longer available for purchase`);
+    }
+  }
+
+  if (reasons.length > 0) throw new ProductNotPurchasableError(reasons);
+}

--- a/src/lib/shopify/sync/product-sync.ts
+++ b/src/lib/shopify/sync/product-sync.ts
@@ -5,6 +5,7 @@
 
 import { PrismaClient, ProductStatus, Prisma } from '@prisma/client';
 import { paginatedAdminQuery } from './admin-client';
+import { cascadeVariantAvailabilityForStatus } from '@/lib/products/availability';
 
 const PRODUCTS_QUERY = `
   query getProducts($first: Int!, $after: String) {
@@ -257,6 +258,12 @@ async function syncSingleProduct(
 
   // Sync variants
   await syncProductVariants(prisma, productId, shopifyProduct.variants.edges.map(e => e.node));
+
+  // Cascade status → variant availability. Variant sync leaves availableForSale untouched (and
+  // new variants default to true), so a DRAFT/ARCHIVED Shopify product would otherwise sync in
+  // with purchasable variants. Run last so it overrides freshly-created variants. Mirrors the
+  // admin status-change cascade; no-ops for ACTIVE (we never auto-re-enable).
+  await cascadeVariantAvailabilityForStatus(prisma, productId, productData.status);
 
   return { isNew };
 }

--- a/src/lib/stripe/checkout.ts
+++ b/src/lib/stripe/checkout.ts
@@ -9,6 +9,7 @@ import { stripe } from './client';
 import { CartWithItems } from '@/lib/inventory/services/cart-service';
 import { prisma } from '@/lib/database/client'; // Used for getOrCreateStripeCustomer
 import { getTaxRateForZip, DEFAULT_TAX_RATE } from '@/lib/tax';
+import { assertVariantsPurchasable } from '@/lib/products/availability';
 import { buildChargedLineItems, chargedLineItemToStripe } from './charge-snapshot';
 
 /**
@@ -80,6 +81,19 @@ export async function createCheckoutSession(
   options: CreateCheckoutOptions
 ): Promise<Stripe.Checkout.Session> {
   const { cart, successUrl, cancelUrl, customerEmail, stripeCustomerId, affiliateCode, overrideDeliveryFee, tipAmount, attribution } = options;
+
+  // Defense-in-depth: refuse to charge for any product that isn't ACTIVE (or whose variant isn't
+  // availableForSale), re-read from the DB rather than trusting the cart snapshot. A product
+  // drafted/archived after it was added to the cart must not be purchasable here. Throws
+  // ProductNotPurchasableError, which the checkout route surfaces as a clear error.
+  await assertVariantsPurchasable(
+    prisma,
+    cart.items.map((item) => ({
+      productId: item.productId,
+      variantId: item.variantId,
+      title: item.product.title,
+    }))
+  );
 
   // Build the immutable charge snapshot from the cart's products, then derive the Stripe
   // product line items from it so the snapshot literally equals what's charged. OrderItems are

--- a/src/lib/stripe/group-v2-payments.ts
+++ b/src/lib/stripe/group-v2-payments.ts
@@ -17,6 +17,7 @@ import { getAffiliateByCode } from '@/lib/affiliates/affiliate-service';
 import { createOrderCalendarEvent } from '@/lib/calendar/google-calendar';
 import { commitInventoryForOrderItem } from '@/lib/inventory/services/order-service';
 import { snapshotItemCost } from '@/lib/analytics/margin-service';
+import { assertVariantsPurchasable } from '@/lib/products/availability';
 import {
   buildChargedLineItems,
   chargedLineItemToStripe,
@@ -82,6 +83,19 @@ export async function createGroupV2CheckoutSession(input: CreateCheckoutInput) {
     groupOrderId, subOrderId, participantId, participantEmail,
     draftItems, discountCode, successUrl, cancelUrl,
   } = input;
+
+  // Defense-in-depth: refuse to charge for any product that isn't ACTIVE (or whose variant isn't
+  // availableForSale), re-read from the DB. A product drafted/archived after a participant added
+  // it to their tab must not be purchasable here. Throws ProductNotPurchasableError, which the
+  // checkout route surfaces as a clear error listing the offending items.
+  await assertVariantsPurchasable(
+    prisma,
+    draftItems.map((item) => ({
+      productId: item.productId,
+      variantId: item.variantId,
+      title: item.title,
+    }))
+  );
 
   // Calculate subtotal
   const subtotal = draftItems.reduce(


### PR DESCRIPTION
## Problem

Setting a product to **DRAFT** or **ARCHIVED** in the admin did **not** flip its variants' `availableForSale` to `false`. The browse catalog (`/api/v1/products/catalog`) correctly filters `status: 'ACTIVE'`, so an off-browse product disappears from browsing — **but cart and checkout key off the variant's `availableForSale` flag, not the product status.** So a drafted/archived product stayed purchasable via a direct/shared product link, or via a cart it was added to while still active.

Real case: *"Fat E's Spicy Bloody Mary Mix"* was DRAFT since 6/08 yet was bought on 6/22.

A one-time manual cleanup already flipped the ~721 sellable variants across the ~700 DRAFT/ARCHIVED products. **This PR fixes the root cause** so the next product someone archives/drafts can't leak the same way.

## Fix — two layers

### 1. Cascade on status change (write layer)
When a product moves to DRAFT/ARCHIVED, all of its variants are set to `availableForSale = false` in the **same transaction**. Wired into every status-write path:
- `product-service.ts` → `updateProduct` (status change) and `deleteProduct` (soft-delete → ARCHIVED)
- Admin product route `PUT` / `DELETE` (`/api/v1/admin/products/[id]` — the path the ops UI status toggle uses)
- Shopify product sync (`syncSingleProduct`)

Re-activating to ACTIVE intentionally does **not** force `availableForSale` back to `true` — re-listing stays a deliberate, separate action.

### 2. Defense-in-depth at checkout (read/purchase layer)
The purchase paths now re-read product status **from the DB** (not the cart/draft snapshot, which can carry a stale flag) and reject any line item whose product isn't ACTIVE or whose variant is off-sale — surfaced as **409**:
- Solo checkout (`createCheckoutSession`)
- Group-v2 checkout (`createGroupV2CheckoutSession` — both single and "pay for all")
- Dashboard add-item + `/api/v1/quote/start` (shared guard in `addDraftItem`)

Shared logic: **`src/lib/products/availability.ts`** (`cascadeVariantAvailabilityForStatus`, `assertVariantsPurchasable`, `ProductNotPurchasableError`).

## Tests
- `product-availability.test.ts` — cascade + assertion unit tests (DRAFT/ARCHIVED/off-sale/missing).
- `product-status-cascade.test.ts` — `updateProduct`/`deleteProduct` flip variants off-sale (requirement: *archiving/drafting flips variants*).
- `group-orders-add-item.test.ts` — `addDraftItem` rejects non-ACTIVE / off-sale.
- `stripe-integration.test.ts` — solo checkout rejects a since-drafted cart product before charging.
- `group-v2-payments.test.ts` — group-v2 checkout rejects a DRAFT product before charging.

`npx tsc --noEmit` ✅ &nbsp; ESLint ✅ &nbsp; full vitest: **323 passing, 0 failing**.

> 🔄 **Rebased onto current `main`.** This branch was originally cut off #130 (`14783d99`), ~30 commits behind main — which surfaced 5 test failures that were *already fixed upstream* (the `financeRecommendation` test mock from #140, and the group-v2 `customerName` fix). The rebase pulled those in; the branch now sits on `c9e68f57` (#153) and the full suite is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
