### PR TITLE
feat(finance): bank-derived expense cleanup + income reconciliation (Part B)

### DIFF
--- a/prisma/migrations/manual/2026-06-19-finance-bank-derived-expense.sql
+++ b/prisma/migrations/manual/2026-06-19-finance-bank-derived-expense.sql
@@ -1,0 +1,31 @@
+-- Finance data cleanup — bank-derived expense columns on plaid_transactions
+--
+-- When QuickBooks has no (material) expenses for a month but the bank does, the bank
+-- outflows ARE the real expenses. The monthly rollup uses these two columns to source
+-- expenses from the bank feed for QB-dormant months (e.g. all of 2026) instead of
+-- showing a falsely-tiny OpEx from the ~$1,700/mo of auto-posted Shopify fees.
+--   - bank_derived_category   : the PartyOn CategorySlug (cogs / rent / ... / non_operating)
+--                               assigned to the outflow by src/lib/finance/plaid-category-map.ts
+--   - is_bank_derived_expense : true only for real business costs (cogs or an operating slug)
+--                               on PRODUCTION items with no QB match. Transfers / CC payments /
+--                               loan principal / owner draws are non_operating → false.
+-- See docs/finance/DATA-CLEANUP-PLAN.md (B0/B2/B4).
+--
+-- This file auto-applies on the next PRODUCTION deploy via the _manual_migrations ledger
+-- (`scripts/db/apply-manual-migrations.mjs --vercel-prod-only`, run from `npm run build`).
+-- To apply locally / out of band:
+--
+--     npm run db:migrate:manual        # applies every pending file in this dir
+--     npx prisma generate
+--
+-- Both statements are idempotent (`ADD COLUMN IF NOT EXISTS`) so the file is safe to re-run.
+
+BEGIN;
+
+ALTER TABLE plaid_transactions
+  ADD COLUMN IF NOT EXISTS bank_derived_category TEXT;
+
+ALTER TABLE plaid_transactions
+  ADD COLUMN IF NOT EXISTS is_bank_derived_expense BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2754,6 +2754,14 @@ model PlaidTransaction {
   matchedQbExpenseId              String?   @map("matched_qb_expense_id")
   qbTransactionId                 String?   @map("qb_transaction_id")
   qbCategoryAssigned              String?   @map("qb_category_assigned")
+  /// Finance data cleanup — the PartyOn CategorySlug assigned to this outflow by
+  /// plaid-category-map.ts during sync (production items only). Lets the monthly
+  /// rollup source expenses from the bank feed for QB-dormant months.
+  bankDerivedCategory             String?   @map("bank_derived_category")
+  /// True only for real business costs (cogs or an operating slug) on a production
+  /// item with no QB match. Transfers / CC payments / loan principal / owner draws
+  /// are non_operating → false, so they never count as expenses.
+  isBankDerivedExpense            Boolean   @default(false) @map("is_bank_derived_expense")
   reconciledAt                    DateTime? @map("reconciled_at")
   createdAt                       DateTime  @default(now()) @map("created_at")
   updatedAt                       DateTime  @updatedAt @map("updated_at")

--- a/scripts/finance/backfill-bank-categories.ts
+++ b/scripts/finance/backfill-bank-categories.ts
@@ -1,0 +1,87 @@
+/**
+ * Backfill bank-derived expense categories on existing PRODUCTION Plaid outflows
+ * (finance data cleanup, B6).
+ *
+ * Run AFTER Wells Fargo is connected + the sandbox is purged, once the first
+ * production sync has populated PlaidTransaction rows. Stamps bankDerivedCategory
+ * + isBankDerivedExpense via the exact logic the daily sync uses
+ * (`categorizeBankOutflows` — production items only, idempotent). Then re-run
+ * scripts/finance/backfill-monthly-rollups.ts so the rollups pick up the
+ * bank-sourced expenses and 2026 months flip to reliable.
+ *
+ * Usage:
+ *   set -a && source .env.local && set +a
+ *   npx tsx scripts/finance/backfill-bank-categories.ts [--dry-run]
+ */
+
+import { prisma } from '../../src/lib/database/client';
+import { categorizeBankOutflows } from '../../src/lib/finance/plaid-sync-service';
+
+const UNCATEGORIZED_OUTFLOW = {
+  pending: false,
+  matchedQbExpenseId: null,
+  bankDerivedCategory: null,
+  amount: { gt: 0 }, // Plaid convention: positive = outflow
+};
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes('--dry-run');
+  const items = await prisma.plaidItem.findMany({
+    where: { environment: 'production' },
+    select: { id: true, institutionName: true },
+  });
+
+  if (items.length === 0) {
+    console.log(
+      '[backfill-bank-categories] no production PlaidItems — connect Wells Fargo first ' +
+        '(docs/CONNECT-PRODUCTION-PLAID.md).'
+    );
+    return;
+  }
+
+  console.log(
+    `[backfill-bank-categories] ${items.length} production item(s)` +
+      (dryRun ? ' (dry-run — no writes)' : '')
+  );
+
+  let totalCategorized = 0;
+  let totalExpenses = 0;
+  for (const item of items) {
+    const label = item.institutionName ?? item.id.slice(0, 8);
+
+    if (dryRun) {
+      const pending = await prisma.plaidTransaction.count({
+        where: { plaidItemId: item.id, ...UNCATEGORIZED_OUTFLOW },
+      });
+      console.log(`  ${label}: ${pending} uncategorized outflow(s) would be stamped`);
+      totalCategorized += pending;
+      continue;
+    }
+
+    // categorizeBankOutflows handles up to 1000 rows per call — drain the backlog.
+    let itemCategorized = 0;
+    let itemExpenses = 0;
+    for (;;) {
+      const res = await categorizeBankOutflows(item.id);
+      itemCategorized += res.categorized;
+      itemExpenses += res.expenseCount;
+      if (res.categorized < 1000) break;
+    }
+    console.log(`  ${label}: ${itemCategorized} categorized (${itemExpenses} expenses)`);
+    totalCategorized += itemCategorized;
+    totalExpenses += itemExpenses;
+  }
+
+  console.log(
+    `[backfill-bank-categories] done — ${totalCategorized} ` +
+      (dryRun ? 'pending' : `categorized (${totalExpenses} expenses)`) +
+      (dryRun ? '' : '. Next: re-run scripts/finance/backfill-monthly-rollups.ts')
+  );
+}
+
+main()
+  .catch((err) => {
+    console.error('[backfill-bank-categories] FATAL:', err);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/app/admin/finance/connect-bank/page.tsx
+++ b/src/app/admin/finance/connect-bank/page.tsx
@@ -38,6 +38,9 @@ export default function ConnectBankPage(): ReactElement {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [exchanging, setExchanging] = useState(false);
+  const [receivedRedirectUri, setReceivedRedirectUri] = useState<string | undefined>(
+    undefined
+  );
 
   async function fetchHealth(): Promise<void> {
     setLoading(true);
@@ -65,6 +68,8 @@ export default function ConnectBankPage(): ReactElement {
       const body = (await res.json()) as ApiResponse<{ linkToken: string }>;
       if (body.success) {
         setLinkToken(body.data.linkToken);
+        // Persist so the SAME token survives an OAuth redirect to the bank.
+        window.localStorage.setItem('plaid_link_token', body.data.linkToken);
       } else {
         setError(body.error);
       }
@@ -75,7 +80,17 @@ export default function ConnectBankPage(): ReactElement {
 
   useEffect(() => {
     void fetchHealth();
-    void fetchLinkToken();
+    // OAuth banks (Wells Fargo) redirect back here with ?oauth_state_id=… . On
+    // return, reuse the link_token that started the flow (Plaid requires the same
+    // one) and let the auto-open effect below resume Link.
+    if (window.location.href.includes('oauth_state_id=')) {
+      setReceivedRedirectUri(window.location.href);
+      const saved = window.localStorage.getItem('plaid_link_token');
+      if (saved) setLinkToken(saved);
+      else void fetchLinkToken();
+    } else {
+      void fetchLinkToken();
+    }
   }, []);
 
   const onSuccess = useCallback(
@@ -91,6 +106,7 @@ export default function ConnectBankPage(): ReactElement {
         if (!body.success) {
           setError(body.error);
         } else {
+          window.localStorage.removeItem('plaid_link_token');
           await fetchHealth();
         }
       } catch (e) {
@@ -105,7 +121,13 @@ export default function ConnectBankPage(): ReactElement {
   const { open, ready } = usePlaidLink({
     token: linkToken,
     onSuccess,
+    receivedRedirectUri,
   });
+
+  // Resume the OAuth flow automatically once Link is ready after the bank redirect.
+  useEffect(() => {
+    if (receivedRedirectUri && ready) open();
+  }, [receivedRedirectUri, ready, open]);
 
   return (
     <div className="p-4 md:p-8 max-w-3xl">

--- a/src/app/api/admin/finance/plaid/purge-non-prod/route.ts
+++ b/src/app/api/admin/finance/plaid/purge-non-prod/route.ts
@@ -1,0 +1,28 @@
+/**
+ * POST /api/admin/finance/plaid/purge-non-prod
+ *
+ * Deletes every NON-production PlaidItem and its dependent rows (accounts,
+ * transactions, sync cursor). Used once on the Wells Fargo cutover to clear the
+ * Plaid sandbox "Platypus" data after real production is connected. Keyed on
+ * `environment != 'production'` so it can never touch the live bank connection.
+ *
+ * Mirrors the QuickBooks realm purge. Operator-only (requireOpsAuth).
+ */
+
+import { NextResponse } from 'next/server';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
+import { purgeNonProdPlaidData } from '@/lib/finance/plaid-sync-service';
+
+export async function POST(): Promise<NextResponse> {
+  try {
+    const auth = await requireOpsAuth();
+    if (auth instanceof NextResponse) return auth;
+
+    const result = await purgeNonProdPlaidData();
+    return NextResponse.json({ success: true, data: result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('[Plaid Purge Non-Prod] Error:', message);
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}

--- a/src/lib/finance/__tests__/bank-income-recon.test.ts
+++ b/src/lib/finance/__tests__/bank-income-recon.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Income reconciliation core (finance data cleanup, B3 / risk #3): deposits up
+ * to known Stripe revenue must count as Stripe-explained even when NO StripePayout
+ * rows exist (the Jan–May 2026 payout-sync gap), while deposits that exceed known
+ * revenue surface as unexplained "other income".
+ */
+
+import { describe, it, expect } from 'vitest';
+import { explainDeposits } from '@/lib/finance/bank-income-recon';
+
+describe('explainDeposits', () => {
+  it('explains deposits via the revenue proxy when NO payouts matched (payout gap)', () => {
+    // $10k deposits, 0 explicitly matched, but $10k known Stripe revenue.
+    const r = explainDeposits({
+      totalDepositsCents: 1_000_000,
+      matchedToStripeCents: 0,
+      stripeRevenueProxyCents: 1_000_000,
+    });
+    expect(r.stripeExplainedCents).toBe(1_000_000);
+    expect(r.otherIncomeCents).toBe(0);
+    expect(r.reconciled).toBe(true);
+  });
+
+  it('flags deposits that exceed known Stripe revenue as other income', () => {
+    // $10k deposits but only $6k known revenue → $4k unexplained (> 15% tolerance).
+    const r = explainDeposits({
+      totalDepositsCents: 1_000_000,
+      matchedToStripeCents: 0,
+      stripeRevenueProxyCents: 600_000,
+    });
+    expect(r.otherIncomeCents).toBe(400_000);
+    expect(r.reconciled).toBe(false);
+  });
+
+  it('uses explicit payout matches when present', () => {
+    const r = explainDeposits({
+      totalDepositsCents: 1_000_000,
+      matchedToStripeCents: 1_000_000,
+      stripeRevenueProxyCents: 0,
+    });
+    expect(r.stripeExplainedCents).toBe(1_000_000);
+    expect(r.reconciled).toBe(true);
+  });
+
+  it('tolerates small unexplained amounts within 15%', () => {
+    // $10k deposits, $9k explained → $1k (10%) unexplained ≤ 15% → still reconciled.
+    const r = explainDeposits({
+      totalDepositsCents: 1_000_000,
+      matchedToStripeCents: 0,
+      stripeRevenueProxyCents: 900_000,
+    });
+    expect(r.otherIncomeCents).toBe(100_000);
+    expect(r.reconciled).toBe(true);
+  });
+
+  it('is not reconciled when there are no deposits', () => {
+    const r = explainDeposits({
+      totalDepositsCents: 0,
+      matchedToStripeCents: 0,
+      stripeRevenueProxyCents: 0,
+    });
+    expect(r.reconciled).toBe(false);
+  });
+});

--- a/src/lib/finance/__tests__/monthly-rollup.test.ts
+++ b/src/lib/finance/__tests__/monthly-rollup.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Precedence-trap guard (finance data cleanup, B4 / risk #1): the per-month
+ * "use QB vs bank-derived expenses" decision must hinge on QB having MATERIAL
+ * data — NOT on `qbExpenses.length > 0`, or 2026's auto-posted Shopify-fee rows
+ * falsely win and hide the real bank expenses.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isQbMaterial } from '@/lib/finance/monthly-rollup';
+
+describe('isQbMaterial', () => {
+  it('is FALSE when QB has only auto-posted payment_fees (2026 dormant month)', () => {
+    const qb = [
+      { amountCents: 90_000, categorySlug: 'payment_fees' }, // ~$900 Shopify fee
+      { amountCents: 80_000, categorySlug: 'payment_fees' }, // ~$800 Shopify fee
+    ];
+    expect(isQbMaterial(qb)).toBe(false);
+  });
+
+  it('is TRUE when QB has real operating expenses above the floor', () => {
+    const qb = [
+      { amountCents: 250_000, categorySlug: 'rent' },
+      { amountCents: 50_000, categorySlug: 'payment_fees' },
+    ];
+    expect(isQbMaterial(qb)).toBe(true);
+  });
+
+  it('is FALSE for an empty month', () => {
+    expect(isQbMaterial([])).toBe(false);
+  });
+
+  it('is FALSE when non-fee expenses are below the $500 floor', () => {
+    const qb = [
+      { amountCents: 30_000, categorySlug: 'office' }, // $300 < $500 floor
+      { amountCents: 200_000, categorySlug: 'payment_fees' },
+    ];
+    expect(isQbMaterial(qb)).toBe(false);
+  });
+
+  it('counts cogs toward materiality', () => {
+    const qb = [{ amountCents: 600_000, categorySlug: 'cogs' }];
+    expect(isQbMaterial(qb)).toBe(true);
+  });
+});

--- a/src/lib/finance/__tests__/plaid-category-map.test.ts
+++ b/src/lib/finance/__tests__/plaid-category-map.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Bank-outflow categorization (finance data cleanup, B2). The distributor
+ * allowlist → cogs is the highest-risk rule (Plaid has no wholesale-alcohol
+ * signal), and transfers/card-payments must never count as expenses.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  categorizeBankOutflow,
+  isBankExpenseCategory,
+} from '@/lib/finance/plaid-category-map';
+
+describe('categorizeBankOutflow', () => {
+  it('maps distributor merchants to cogs (allowlist wins over Plaid PFC)', () => {
+    expect(
+      categorizeBankOutflow({
+        name: 'RNDC AUSTIN TX',
+        merchantName: 'RNDC',
+        personalFinanceCategoryPrimary: 'GENERAL_MERCHANDISE', // would be 'office' without the allowlist
+        personalFinanceCategoryDetailed: null,
+      })
+    ).toBe('cogs');
+    expect(
+      categorizeBankOutflow({ name: "SOUTHERN GLAZER'S WINE & SPIRITS", merchantName: null })
+    ).toBe('cogs');
+    expect(
+      categorizeBankOutflow({ name: 'TOTAL WINE #123', merchantName: 'Total Wine & More' })
+    ).toBe('cogs');
+    expect(categorizeBankOutflow({ name: "SPEC'S #45 AUSTIN", merchantName: null })).toBe('cogs');
+  });
+
+  it('maps transfers / card payments / loans to non_operating (never an expense)', () => {
+    expect(
+      categorizeBankOutflow({
+        name: 'Online Transfer',
+        merchantName: null,
+        personalFinanceCategoryPrimary: 'TRANSFER_OUT',
+        personalFinanceCategoryDetailed: 'TRANSFER_OUT_ACCOUNT_TRANSFER',
+      })
+    ).toBe('non_operating');
+    expect(
+      categorizeBankOutflow({
+        name: 'CREDIT CARD PAYMENT',
+        merchantName: null,
+        personalFinanceCategoryPrimary: 'LOAN_PAYMENTS',
+        personalFinanceCategoryDetailed: 'LOAN_PAYMENTS_CREDIT_CARD_PAYMENT',
+      })
+    ).toBe('non_operating');
+  });
+
+  it('uses Plaid PFC detailed to split rent vs utilities', () => {
+    expect(
+      categorizeBankOutflow({
+        name: 'PROPERTY MGMT',
+        merchantName: null,
+        personalFinanceCategoryPrimary: 'RENT_AND_UTILITIES',
+        personalFinanceCategoryDetailed: 'RENT_AND_UTILITIES_RENT',
+      })
+    ).toBe('rent');
+    expect(
+      categorizeBankOutflow({
+        name: 'CITY OF AUSTIN UTILITIES',
+        merchantName: null,
+        personalFinanceCategoryPrimary: 'RENT_AND_UTILITIES',
+        personalFinanceCategoryDetailed: 'RENT_AND_UTILITIES_GAS_AND_ELECTRICITY',
+      })
+    ).toBe('utilities');
+  });
+
+  it('falls back PFC primary → name keywords → other', () => {
+    // PFC primary fallback (no detailed match)
+    expect(
+      categorizeBankOutflow({
+        name: 'SHELL OIL',
+        merchantName: null,
+        personalFinanceCategoryPrimary: 'TRANSPORTATION',
+        personalFinanceCategoryDetailed: null,
+      })
+    ).toBe('fuel');
+    // name-keyword fallback (no PFC at all)
+    expect(categorizeBankOutflow({ name: 'STATE FARM INSURANCE', merchantName: null })).toBe(
+      'insurance'
+    );
+    // total fallback
+    expect(categorizeBankOutflow({ name: 'MYSTERY VENDOR LLC', merchantName: null })).toBe('other');
+  });
+});
+
+describe('isBankExpenseCategory', () => {
+  it('counts cogs + operating categories, excludes only non_operating', () => {
+    expect(isBankExpenseCategory('cogs')).toBe(true);
+    expect(isBankExpenseCategory('rent')).toBe(true);
+    expect(isBankExpenseCategory('other')).toBe(true); // conservative: unknown costs still count
+    expect(isBankExpenseCategory('non_operating')).toBe(false);
+  });
+});

--- a/src/lib/finance/bank-income-recon.ts
+++ b/src/lib/finance/bank-income-recon.ts
@@ -1,0 +1,168 @@
+/**
+ * Income reconciliation against real bank deposits (finance data cleanup, B3).
+ *
+ * The operator's source of truth for income is **actual Wells Fargo deposits**.
+ * This module does NOT replace the itemized revenue line (Order + Shopify, which
+ * every SKU/segment/customer/affiliate breakdown depends on) — it's a CROSS-CHECK:
+ * do the month's production bank deposits line up with known Stripe revenue?
+ *
+ * It splits production bank inflows into:
+ *   - matched to a StripePayout (via the existing reconciliation), and
+ *   - everything else, "explained" by the month's aggregate Stripe revenue.
+ *
+ * ⚠️ StripePayout gap: there are no StripePayout rows before 2026-05-26, so
+ * Jan–May 2026 deposits would look non-Stripe purely from the sync gap. The
+ * caller passes the month's known Stripe revenue (gross, from Order + Shopify)
+ * as `stripeRevenueProxyCents`; deposits up to that amount are treated as
+ * Stripe-explained even without a payout match. Only deposits that EXCEED known
+ * revenue surface as `otherIncome` (genuinely unexplained — possible owner
+ * injection, loan proceeds, or missing orders). Backfilling earlier payouts is
+ * deferred.
+ */
+
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/database/client';
+
+/** Share of deposits allowed to be unexplained before the month is "unreconciled". */
+const OTHER_INCOME_TOLERANCE = 0.15;
+
+export interface BankIncomeReconInput {
+  year: number;
+  month: number;
+  /**
+   * The month's known Stripe-processed revenue (gross, from Order + Shopify),
+   * used to explain deposits when StripePayout rows are missing. Pass the
+   * rollup's computed `revenueCents`.
+   */
+  stripeRevenueProxyCents: number;
+}
+
+export interface BankIncomeRecon {
+  hasProductionBank: boolean;
+  totalDepositsCents: number;
+  matchedToStripeCents: number;
+  stripeExplainedCents: number;
+  otherIncomeCents: number;
+  reconciled: boolean;
+  flags: string[];
+}
+
+export interface DepositExplanation {
+  stripeExplainedCents: number;
+  otherIncomeCents: number;
+  reconciled: boolean;
+}
+
+/**
+ * Pure core of the income reconciliation. Given a month's total bank deposits,
+ * the portion explicitly matched to Stripe payouts, and the month's known Stripe
+ * revenue (proxy), decide how much is Stripe-explained vs genuinely "other".
+ *
+ * Deposits up to known revenue count as Stripe even WITHOUT a payout match —
+ * this is what defends the Jan–May 2026 payout-sync gap (no StripePayout rows
+ * before 2026-05-26). Only deposits exceeding known revenue surface as other
+ * income (possible owner injection / loan / missing orders).
+ */
+export function explainDeposits(args: {
+  totalDepositsCents: number;
+  matchedToStripeCents: number;
+  stripeRevenueProxyCents: number;
+}): DepositExplanation {
+  const { totalDepositsCents, matchedToStripeCents, stripeRevenueProxyCents } = args;
+  const explainable = Math.max(matchedToStripeCents, Math.max(0, stripeRevenueProxyCents));
+  const stripeExplainedCents = Math.min(totalDepositsCents, explainable);
+  const otherIncomeCents = totalDepositsCents - stripeExplainedCents;
+  const reconciled =
+    totalDepositsCents > 0 &&
+    otherIncomeCents <= totalDepositsCents * OTHER_INCOME_TOLERANCE;
+  return { stripeExplainedCents, otherIncomeCents, reconciled };
+}
+
+function decToCents(d: Prisma.Decimal | null | undefined): number {
+  if (d === null || d === undefined) return 0;
+  return Math.round(Number(d) * 100);
+}
+
+function monthWindow(year: number, month: number): { start: Date; end: Date } {
+  return {
+    start: new Date(Date.UTC(year, month - 1, 1)),
+    end: new Date(Date.UTC(year, month, 1)),
+  };
+}
+
+/**
+ * Reconcile a month's production bank deposits against known Stripe revenue.
+ * Read-only. Returns zeros + a flag when no production bank is connected yet.
+ */
+export async function reconcileBankIncome(
+  input: BankIncomeReconInput
+): Promise<BankIncomeRecon> {
+  const { year, month, stripeRevenueProxyCents } = input;
+  const { start, end } = monthWindow(year, month);
+  const flags: string[] = [];
+
+  const prodBankCount = await prisma.plaidItem.count({
+    where: { environment: 'production' },
+  });
+  if (prodBankCount === 0) {
+    return {
+      hasProductionBank: false,
+      totalDepositsCents: 0,
+      matchedToStripeCents: 0,
+      stripeExplainedCents: 0,
+      otherIncomeCents: 0,
+      reconciled: false,
+      flags: ['no production bank connected — income not reconciled to deposits'],
+    };
+  }
+
+  // Plaid convention: negative amount = inflow / deposit.
+  const inflowWhere = {
+    item: { environment: 'production' },
+    date: { gte: start, lt: end },
+    pending: false,
+    amount: { lt: 0 },
+  } satisfies Prisma.PlaidTransactionWhereInput;
+
+  const [allInflows, matchedInflows] = await Promise.all([
+    prisma.plaidTransaction.aggregate({ where: inflowWhere, _sum: { amount: true } }),
+    prisma.plaidTransaction.aggregate({
+      where: { ...inflowWhere, matchedStripePayoutId: { not: null } },
+      _sum: { amount: true },
+    }),
+  ]);
+
+  const totalDepositsCents = Math.abs(decToCents(allInflows._sum.amount));
+  const matchedToStripeCents = Math.abs(decToCents(matchedInflows._sum.amount));
+
+  // Deposits up to known Stripe revenue are Stripe-explained even without a
+  // payout match (covers the Jan–May payout-sync gap).
+  const { stripeExplainedCents, otherIncomeCents, reconciled } = explainDeposits({
+    totalDepositsCents,
+    matchedToStripeCents,
+    stripeRevenueProxyCents,
+  });
+
+  if (totalDepositsCents > 0 && matchedToStripeCents === 0) {
+    flags.push(
+      'no deposits matched to Stripe payouts (payout-sync gap before 2026-05-26) — ' +
+        'explained via aggregate Stripe revenue'
+    );
+  }
+  if (otherIncomeCents > totalDepositsCents * OTHER_INCOME_TOLERANCE) {
+    flags.push(
+      `$${(otherIncomeCents / 100).toFixed(0)} of bank deposits exceed known Stripe ` +
+        'revenue — possible other income (owner injection / loan) or missing orders'
+    );
+  }
+
+  return {
+    hasProductionBank: true,
+    totalDepositsCents,
+    matchedToStripeCents,
+    stripeExplainedCents,
+    otherIncomeCents,
+    reconciled,
+    flags,
+  };
+}

--- a/src/lib/finance/monthly-rollup.ts
+++ b/src/lib/finance/monthly-rollup.ts
@@ -19,9 +19,37 @@ import {
   CATEGORY_LABELS,
   type CategorySlug,
 } from './qb-account-map';
+import { reconcileBankIncome, type BankIncomeRecon } from './bank-income-recon';
 
 const SEGMENTS: readonly Segment[] = ['bach', 'wedding', 'corporate', 'boat', 'kegs', 'general'];
 const TOP_N = 10;
+
+/**
+ * QB is the expense source for a month only when it has MATERIAL expenses — the
+ * sum of QB expenses in categories OTHER than auto-posted `payment_fees` must
+ * clear this floor. Below it (e.g. 2026's ~$1,700/mo of Shopify selling fees),
+ * the bank feed is the real expense source. Without this guard those auto-posted
+ * fee rows would falsely "win" a `qbExpenses.length > 0` test and hide the real
+ * bank expenses. Never blend the two — QB's own bank feed sees the same
+ * transactions Plaid does, so blending would double-count.
+ */
+const QB_MATERIAL_FLOOR_CENTS = 50_000; // $500
+
+/**
+ * Whether QuickBooks has MATERIAL expense data for a month — the test that picks
+ * QB vs the bank feed as the expense source. Sums QB expenses in categories OTHER
+ * than auto-posted `payment_fees`; a bare `qbExpenses.length > 0` would let
+ * 2026's ~$1,700/mo of Shopify-fee rows falsely win and hide the real bank
+ * expenses (the precedence trap — risk #1).
+ */
+export function isQbMaterial(
+  qbExpenses: { amountCents: number; categorySlug: string | null }[]
+): boolean {
+  const materialCents = qbExpenses
+    .filter((e) => e.categorySlug !== 'payment_fees')
+    .reduce((s, e) => s + e.amountCents, 0);
+  return materialCents >= QB_MATERIAL_FLOOR_CENTS;
+}
 
 export interface SkuRow { sku: string | null; title: string; revenueCents: number; qty: number }
 export interface CustomerRow { name: string; email: string; revenueCents: number; orderCount: number }
@@ -195,7 +223,53 @@ export async function computeMonthlyRollup(
   const segmentBreakdown = buildSegments(orders, archiveDeduped);
   const topCustomers = buildTopCustomers(orders);
   const topAffiliates = buildTopAffiliates(commissions);
-  const { expenseCategories, cogsCents, opexCents } = buildExpenses(qbExpenses);
+  // --- Expense source: QB where MATERIAL, else bank-derived (never blend) -----
+  const qb = buildExpenses(qbExpenses);
+  const qbMaterial = isQbMaterial(qbExpenses);
+
+  // Bank-derived expenses: production outflows stamped as real costs (B2).
+  // Queried every month so QB-sourced months can still cross-check (B5).
+  const bankRows = await prisma.plaidTransaction.findMany({
+    where: {
+      item: { environment: 'production' },
+      date: { gte: start, lt: end },
+      pending: false,
+      isBankDerivedExpense: true,
+    },
+    select: { amount: true, bankDerivedCategory: true, merchantName: true, name: true },
+  });
+  const bank = buildExpenses(
+    bankRows.map((r) => ({
+      amountCents: decToCents(r.amount),
+      categorySlug: r.bankDerivedCategory,
+      vendorName: r.merchantName ?? r.name,
+    }))
+  );
+  const bankExpenseTotalCents = (bank.cogsCents ?? 0) + (bank.opexCents ?? 0);
+
+  let expenseSource: 'qb' | 'bank' | 'none';
+  let cogsCents: number | null;
+  let opexCents: number | null;
+  let expenseCategories: ExpenseCatRow[];
+  if (qbMaterial) {
+    expenseSource = 'qb';
+    ({ cogsCents, opexCents, expenseCategories } = qb);
+  } else if (bankRows.length > 0) {
+    expenseSource = 'bank';
+    ({ cogsCents, opexCents, expenseCategories } = bank);
+  } else {
+    expenseSource = 'none';
+    cogsCents = null;
+    opexCents = null;
+    expenseCategories = [];
+  }
+
+  // Income cross-check against real bank deposits (does NOT replace revenue).
+  const bankIncome = await reconcileBankIncome({
+    year,
+    month,
+    stripeRevenueProxyCents: revenueCents,
+  });
 
   // Per-order COGS from OrderItem cost (sparse, ~4% coverage) — only used as a
   // fallback signal; QB inventory cogs is the primary cost source.
@@ -215,8 +289,11 @@ export async function computeMonthlyRollup(
     revenueCents,
     revenueFromShopifyCents,
     qbExpenseCount: qbExpenses.length,
+    expenseSource,
     cogsCents,
     opexCents,
+    bankExpenseTotalCents,
+    bankIncome,
     orderItemCostCents,
     orderCount: orders.length,
     archiveCount: archiveDeduped.length,
@@ -394,8 +471,11 @@ interface HealthInput {
   revenueCents: number;
   revenueFromShopifyCents: number;
   qbExpenseCount: number;
+  expenseSource: 'qb' | 'bank' | 'none';
   cogsCents: number | null;
   opexCents: number | null;
+  bankExpenseTotalCents: number;
+  bankIncome: BankIncomeRecon;
   orderItemCostCents: number;
   orderCount: number;
   archiveCount: number;
@@ -403,36 +483,77 @@ interface HealthInput {
 
 /**
  * Flags every reason a month's profit number can't be trusted, and sets
- * `netIncomeReliable` accordingly. The Phase 5D briefing renders net income
- * only when reliable; otherwise it shows "pending" + these flags.
+ * `netIncomeReliable` accordingly. The briefing renders net income only when
+ * reliable; otherwise it shows "pending" + these flags.
+ *
+ * Net income is reliable via EITHER path: QB (the books are material + complete)
+ * OR bank-derived (expenses sourced from the real bank feed AND income
+ * reconciled to deposits). 2026 months flip to reliable once Wells Fargo is
+ * connected + the bank-category backfill runs; thin pre-2023 months stay
+ * unreliable.
  */
 function buildDataHealth(h: HealthInput): Record<string, unknown> {
   const flags: string[] = [];
   const expensesTotalCents = (h.cogsCents ?? 0) + (h.opexCents ?? 0);
 
-  if (h.qbExpenseCount === 0) {
-    flags.push('no QB expenses recorded this month — OpEx + net income unavailable');
+  // 1. Expense completeness, per chosen source.
+  if (h.expenseSource === 'none') {
+    flags.push(
+      'no expense source this month — QB not material and no production bank data → OpEx + net income unavailable'
+    );
   } else if (h.revenueCents > 0 && expensesTotalCents < h.revenueCents * 0.1) {
-    flags.push('QB expenses trivial vs revenue — books likely incomplete this month');
+    flags.push(
+      h.expenseSource === 'qb'
+        ? 'QB expenses trivial vs revenue — books likely incomplete this month'
+        : 'bank-derived expenses trivial vs revenue — bank feed likely incomplete this month'
+    );
   }
-  // For a liquor-delivery business every revenue month has alcohol cost, so a
-  // zero COGS month means it wasn't recorded (the sparse OrderItem cost data
-  // is too thin to count as real COGS). Always flag it.
+
+  // 2. COGS completeness — a liquor business has alcohol cost every revenue month,
+  // so a zero-COGS month means it wasn't recorded (incl. a distributor-allowlist
+  // miss on the bank path). The sparse OrderItem cost data is too thin to count.
   if ((h.cogsCents ?? 0) === 0 && h.revenueCents > 0) {
     flags.push('no COGS recorded — gross profit unreliable');
   }
-  if (h.revenueFromShopifyCents > h.revenueCents * 0.5) {
+
+  // 3. Shopify-era understatement (only when QB-sourced and revenue is mostly Shopify).
+  if (h.expenseSource === 'qb' && h.revenueFromShopifyCents > h.revenueCents * 0.5) {
     flags.push('Shopify-era revenue is net-of-refund and understated vs real expenses');
   }
 
+  // 4. Income reconciliation to bank deposits (bank-sourced months only).
+  if (h.expenseSource === 'bank' && !h.bankIncome.reconciled) {
+    flags.push(...h.bankIncome.flags);
+  }
+
+  // 5. Discrepancy (surface, don't auto-fix): bank shows materially more spending
+  // than QB booked, in a QB-sourced month with bank coverage → QB likely incomplete.
+  if (
+    h.expenseSource === 'qb' &&
+    h.bankExpenseTotalCents > expensesTotalCents * 1.5 &&
+    h.bankExpenseTotalCents - expensesTotalCents > QB_MATERIAL_FLOOR_CENTS
+  ) {
+    flags.push(
+      `bank outflows ($${(h.bankExpenseTotalCents / 100).toFixed(0)}) materially exceed QB expenses ` +
+        `($${(expensesTotalCents / 100).toFixed(0)}) — QB books may be incomplete this month`
+    );
+  }
+
   const netIncomeReliable =
-    flags.length === 0 && h.cogsCents !== null && h.opexCents !== null;
+    flags.length === 0 &&
+    h.cogsCents !== null &&
+    h.opexCents !== null &&
+    (h.expenseSource === 'qb' ||
+      (h.expenseSource === 'bank' && h.bankIncome.reconciled));
 
   return {
     hasOrders: h.orderCount > 0,
     hasArchive: h.archiveCount > 0,
     hasQbExpenses: h.qbExpenseCount > 0,
+    expenseSource: h.expenseSource,
     netIncomeReliable,
+    incomeReconciled: h.bankIncome.hasProductionBank ? h.bankIncome.reconciled : null,
+    otherIncomeCents: h.bankIncome.hasProductionBank ? h.bankIncome.otherIncomeCents : null,
     flags,
   };
 }

--- a/src/lib/finance/plaid-category-map.ts
+++ b/src/lib/finance/plaid-category-map.ts
@@ -1,0 +1,133 @@
+/**
+ * Maps a Plaid bank OUTFLOW to a PartyOn dashboard category (the shared
+ * `CategorySlug` taxonomy from qb-account-map.ts).
+ *
+ * Used by the monthly rollup's bank-derived expense path: when QuickBooks is
+ * dormant for a month (e.g. all of 2026), the bank outflow IS the expense.
+ *
+ * Precedence (first match wins):
+ *   1. Distributor / wholesale-alcohol merchant allowlist → `cogs`.
+ *      Plaid's category taxonomy has NO wholesale-alcohol signal, so without
+ *      this, alcohol buys land in GENERAL_MERCHANDISE → wrong. This is the
+ *      single biggest threat to a trustworthy 2026 gross-margin number — extend
+ *      `COGS_MERCHANT_RULES` against real bank-statement names after the first
+ *      production sync.
+ *   2. Plaid Personal Finance Category — detailed (most specific).
+ *   3. Plaid Personal Finance Category — primary (coarser).
+ *   4. Merchant / name keywords (reuses qb-account-map's NAME_KEYWORD_RULES).
+ *   5. Fallback → `other`.
+ *
+ * Transfers, credit-card payments, loan principal, and owner draws map to
+ * `non_operating` so they are NEVER counted as expenses (bank data is noisy).
+ *
+ * Plaid PFC reference: https://plaid.com/docs/api/products/transactions/#personal-finance-category
+ */
+
+import { type CategorySlug, NAME_KEYWORD_RULES } from './qb-account-map';
+
+/**
+ * Wholesale-alcohol distributors + retail buys → `cogs`. Seeded with the
+ * operator's distributor list (2026-06-19); refine against real Wells Fargo
+ * statement descriptors after the first production sync.
+ */
+export const COGS_MERCHANT_RULES: readonly RegExp[] = [
+  /\brndc\b|republic\s*national/i,
+  /southern\s*glazer'?s?/i,
+  /total\s*wine/i,
+  /spec'?s\b/i,
+];
+
+/**
+ * Plaid PFC `detailed` → CategorySlug. Only the business-relevant
+ * disambiguations live here (rent vs utilities, card payment → non_operating,
+ * gas → fuel, etc.); everything else falls through to the primary map.
+ */
+const PFC_DETAILED_MAP: Readonly<Record<string, CategorySlug>> = {
+  // Rent vs utilities — the primary RENT_AND_UTILITIES can't tell them apart.
+  RENT_AND_UTILITIES_RENT: 'rent',
+  RENT_AND_UTILITIES_GAS_AND_ELECTRICITY: 'utilities',
+  RENT_AND_UTILITIES_INTERNET_AND_CABLE: 'utilities',
+  RENT_AND_UTILITIES_TELEPHONE: 'utilities',
+  RENT_AND_UTILITIES_WATER: 'utilities',
+  RENT_AND_UTILITIES_SEWAGE_AND_WASTE: 'utilities',
+  RENT_AND_UTILITIES_OTHER_UTILITIES: 'utilities',
+  // Financing / movements — never an operating expense.
+  LOAN_PAYMENTS_CREDIT_CARD_PAYMENT: 'non_operating',
+  LOAN_PAYMENTS_CAR_PAYMENT: 'non_operating',
+  LOAN_PAYMENTS_PERSONAL_LOAN_PAYMENT: 'non_operating',
+  LOAN_PAYMENTS_MORTGAGE_PAYMENT: 'non_operating',
+  LOAN_PAYMENTS_STUDENT_LOAN_PAYMENT: 'non_operating',
+  LOAN_PAYMENTS_OTHER_PAYMENT: 'non_operating',
+  // Services that map to specific PartyOn buckets.
+  GENERAL_SERVICES_INSURANCE: 'insurance',
+  GENERAL_SERVICES_ACCOUNTING_AND_FINANCIAL_PLANNING: 'professional',
+  GENERAL_SERVICES_CONSULTING_AND_LEGAL: 'professional',
+  GENERAL_SERVICES_ADVERTISING_AND_MARKETING: 'advertising',
+  GENERAL_SERVICES_SHIPPING_AND_FREIGHT: 'shipping',
+  GENERAL_SERVICES_POSTAGE_AND_SHIPPING: 'shipping',
+  GENERAL_SERVICES_AUTOMOTIVE: 'vehicle',
+  // Transportation — fuel vs the vehicle itself.
+  TRANSPORTATION_GAS: 'fuel',
+  TRANSPORTATION_PARKING: 'vehicle',
+  TRANSPORTATION_TOLLS: 'vehicle',
+  // Merchandise that's clearly office supplies.
+  GENERAL_MERCHANDISE_OFFICE_SUPPLIES: 'office',
+  GENERAL_MERCHANDISE_ELECTRONICS: 'office',
+};
+
+/** Plaid PFC `primary` → CategorySlug. Coarse fallback after the detailed map. */
+const PFC_PRIMARY_MAP: Readonly<Record<string, CategorySlug>> = {
+  INCOME: 'non_operating', // an inflow mislabeled on an outflow — not an expense
+  TRANSFER_IN: 'non_operating',
+  TRANSFER_OUT: 'non_operating',
+  LOAN_PAYMENTS: 'non_operating',
+  BANK_FEES: 'bank_fees',
+  ENTERTAINMENT: 'meals',
+  FOOD_AND_DRINK: 'meals',
+  GENERAL_MERCHANDISE: 'office',
+  HOME_IMPROVEMENT: 'repairs',
+  GENERAL_SERVICES: 'professional',
+  GOVERNMENT_AND_NON_PROFIT: 'taxes_fees',
+  TRANSPORTATION: 'fuel',
+  TRAVEL: 'travel',
+  RENT_AND_UTILITIES: 'utilities',
+};
+
+export interface BankOutflowLike {
+  name: string;
+  merchantName?: string | null;
+  personalFinanceCategoryPrimary?: string | null;
+  personalFinanceCategoryDetailed?: string | null;
+}
+
+/** Resolve a Plaid outflow to a PartyOn CategorySlug. See file header for precedence. */
+export function categorizeBankOutflow(txn: BankOutflowLike): CategorySlug {
+  const text = `${txn.merchantName ?? ''} ${txn.name ?? ''}`.trim();
+
+  // 1. Distributor / wholesale-alcohol allowlist → cogs (Plaid has no such signal).
+  for (const re of COGS_MERCHANT_RULES) {
+    if (re.test(text)) return 'cogs';
+  }
+  // 2. Plaid PFC detailed.
+  const detailed = txn.personalFinanceCategoryDetailed;
+  if (detailed && PFC_DETAILED_MAP[detailed]) return PFC_DETAILED_MAP[detailed];
+  // 3. Plaid PFC primary.
+  const primary = txn.personalFinanceCategoryPrimary;
+  if (primary && PFC_PRIMARY_MAP[primary]) return PFC_PRIMARY_MAP[primary];
+  // 4. Merchant / name keywords (shared with QB account-name categorization).
+  for (const rule of NAME_KEYWORD_RULES) {
+    if (rule.pattern.test(text)) return rule.slug;
+  }
+  // 5. Fallback.
+  return 'other';
+}
+
+/**
+ * Whether a categorized bank outflow counts as a real business cost (COGS or an
+ * operating expense) vs a transfer / financing / owner draw. `non_operating` is
+ * the only category excluded — everything else (including the conservative
+ * `other` bucket) counts, so we never understate expenses.
+ */
+export function isBankExpenseCategory(slug: CategorySlug): boolean {
+  return slug !== 'non_operating';
+}

--- a/src/lib/finance/plaid-client.ts
+++ b/src/lib/finance/plaid-client.ts
@@ -120,11 +120,22 @@ function getWebhookUrl(): string {
 }
 
 /**
+ * OAuth redirect URI. Required for OAuth institutions (e.g. Wells Fargo), which
+ * send the user to the bank's own site and back. Must be registered in the Plaid
+ * dashboard (Team Settings → API → Allowed redirect URIs) and match exactly.
+ * Returns undefined when unset so the non-OAuth sandbox flow is unaffected.
+ */
+function getRedirectUri(): string | undefined {
+  return process.env.PLAID_REDIRECT_URI || undefined;
+}
+
+/**
  * Create a link_token the browser SDK exchanges for a public_token.
- * Phase 0 only requests `Transactions` since that's all Phase 2C uses.
+ * Only requests `Transactions` since that's all the sync path uses.
  */
 export async function createLinkToken(userId: string): Promise<string> {
   const client = createClient();
+  const redirectUri = getRedirectUri();
   const response = await client.linkTokenCreate({
     user: { client_user_id: userId },
     client_name: 'Party On Delivery',
@@ -132,6 +143,9 @@ export async function createLinkToken(userId: string): Promise<string> {
     country_codes: [CountryCode.Us],
     language: 'en',
     webhook: getWebhookUrl(),
+    // OAuth banks (Wells Fargo) require a registered redirect_uri; omit it
+    // entirely for the non-OAuth sandbox bank so that flow is unchanged.
+    ...(redirectUri ? { redirect_uri: redirectUri } : {}),
   });
   return response.data.link_token;
 }

--- a/src/lib/finance/plaid-sync-service.ts
+++ b/src/lib/finance/plaid-sync-service.ts
@@ -19,6 +19,7 @@
 
 import { prisma } from '@/lib/database/client';
 import { syncTransactions, type SyncTransactionsResult } from './plaid-client';
+import { categorizeBankOutflow, isBankExpenseCategory } from './plaid-category-map';
 
 const ONE_DAY_MS = 86_400_000;
 
@@ -46,6 +47,8 @@ export interface ItemSyncResult {
   inflowsMatched: number;
   outflowsMatched: number;
   unmatched: number;
+  /** Outflows stamped with a bank-derived expense category (production only). */
+  bankCategorized: number;
 }
 
 export async function syncItem(plaidItemId: string): Promise<ItemSyncResult> {
@@ -160,6 +163,10 @@ export async function syncItem(plaidItemId: string): Promise<ItemSyncResult> {
   // Auto-reconcile in the same call so the dashboard reflects the new state.
   const reconcile = await reconcileItem(plaidItemId);
 
+  // Stamp bank-derived expense categories on unmatched outflows (production
+  // items only) so QB-dormant months can source expenses from the bank feed.
+  const bankCat = await categorizeBankOutflows(plaidItemId);
+
   return {
     plaidItemId,
     itemId: item.itemId,
@@ -172,6 +179,7 @@ export async function syncItem(plaidItemId: string): Promise<ItemSyncResult> {
     inflowsMatched: reconcile.inflowsMatched,
     outflowsMatched: reconcile.outflowsMatched,
     unmatched: reconcile.unmatched,
+    bankCategorized: bankCat.categorized,
   };
 }
 
@@ -189,6 +197,49 @@ export async function syncAllItems(): Promise<ItemSyncResult[]> {
     }
   }
   return results;
+}
+
+export interface PurgeNonProdResult {
+  itemsDeleted: number;
+  accountsDeleted: number;
+  transactionsDeleted: number;
+  cursorsDeleted: number;
+}
+
+/**
+ * Delete every NON-production PlaidItem and its dependent rows. Used on the
+ * Wells Fargo cutover to clear the Plaid sandbox "Platypus" data once real
+ * production is connected (mirrors the QB realm purge). PlaidAccount +
+ * PlaidTransaction cascade from PlaidItem, but PlaidSyncCursor has no FK cascade
+ * — all are deleted explicitly inside one transaction so the counts are exact.
+ */
+export async function purgeNonProdPlaidData(): Promise<PurgeNonProdResult> {
+  const nonProd = await prisma.plaidItem.findMany({
+    where: { environment: { not: 'production' } },
+    select: { id: true },
+  });
+  const ids = nonProd.map((i) => i.id);
+  if (ids.length === 0) {
+    return { itemsDeleted: 0, accountsDeleted: 0, transactionsDeleted: 0, cursorsDeleted: 0 };
+  }
+  return prisma.$transaction(async (tx) => {
+    const transactions = await tx.plaidTransaction.deleteMany({
+      where: { plaidItemId: { in: ids } },
+    });
+    const accounts = await tx.plaidAccount.deleteMany({
+      where: { plaidItemId: { in: ids } },
+    });
+    const cursors = await tx.plaidSyncCursor.deleteMany({
+      where: { plaidItemId: { in: ids } },
+    });
+    const items = await tx.plaidItem.deleteMany({ where: { id: { in: ids } } });
+    return {
+      itemsDeleted: items.count,
+      accountsDeleted: accounts.count,
+      transactionsDeleted: transactions.count,
+      cursorsDeleted: cursors.count,
+    };
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -262,6 +313,8 @@ export async function reconcileItem(plaidItemId: string): Promise<ReconcileResul
             qbTransactionId: expense.qbTransactionId,
             qbCategoryAssigned: expense.categorySlug ?? null,
             reconciledAt: new Date(),
+            // QB is the source for this outflow — never also a bank-derived expense.
+            isBankDerivedExpense: false,
           },
         });
         outflowsMatched++;
@@ -273,6 +326,64 @@ export async function reconcileItem(plaidItemId: string): Promise<ReconcileResul
   }
 
   return { inflowsMatched, outflowsMatched, unmatched };
+}
+
+export interface BankCategorizeResult {
+  categorized: number;
+  expenseCount: number;
+}
+
+/**
+ * Stamp bank-derived expense categories on this item's UNMATCHED outflows
+ * (outflows with no QB expense match). PRODUCTION items only — sandbox data must
+ * never count as a real expense, even before the sandbox PlaidItem is purged.
+ *
+ * The monthly rollup uses these for QB-dormant months (e.g. 2026), where the
+ * bank outflow IS the expense because QB has no real expense rows. Idempotent:
+ * only touches rows not yet categorized (bankDerivedCategory IS NULL), so it's
+ * safe to run on every sync and from the backfill script.
+ */
+export async function categorizeBankOutflows(
+  plaidItemId: string
+): Promise<BankCategorizeResult> {
+  const item = await prisma.plaidItem.findUnique({
+    where: { id: plaidItemId },
+    select: { environment: true },
+  });
+  if (!item || item.environment !== 'production') {
+    return { categorized: 0, expenseCount: 0 };
+  }
+
+  const txns = await prisma.plaidTransaction.findMany({
+    where: {
+      plaidItemId,
+      pending: false,
+      matchedQbExpenseId: null,
+      bankDerivedCategory: null,
+      amount: { gt: 0 }, // Plaid convention: positive = outflow / debit
+    },
+    take: 1000,
+    orderBy: { date: 'desc' },
+  });
+
+  let categorized = 0;
+  let expenseCount = 0;
+  for (const txn of txns) {
+    const slug = categorizeBankOutflow({
+      name: txn.name,
+      merchantName: txn.merchantName,
+      personalFinanceCategoryPrimary: txn.personalFinanceCategoryPrimary,
+      personalFinanceCategoryDetailed: txn.personalFinanceCategoryDetailed,
+    });
+    const isExpense = isBankExpenseCategory(slug);
+    await prisma.plaidTransaction.update({
+      where: { id: txn.id },
+      data: { bankDerivedCategory: slug, isBankDerivedExpense: isExpense },
+    });
+    categorized++;
+    if (isExpense) expenseCount++;
+  }
+  return { categorized, expenseCount };
 }
 
 async function findStripePayoutMatch(

--- a/src/lib/finance/qb-account-map.ts
+++ b/src/lib/finance/qb-account-map.ts
@@ -143,8 +143,9 @@ const SUB_TYPE_MAP: Record<string, CategorySlug> = {
 };
 
 // Free-text fallback — when a QB account has no recognised sub-type we
-// look for keywords in the account name.
-const NAME_KEYWORD_RULES: Array<{ pattern: RegExp; slug: CategorySlug }> = [
+// look for keywords in the account name. Exported so the Plaid bank-outflow
+// categorizer (plaid-category-map.ts) can reuse the same merchant-name rules.
+export const NAME_KEYWORD_RULES: Array<{ pattern: RegExp; slug: CategorySlug }> = [
   // High-priority disambiguators FIRST — these must win over generic rules.
   // Non-operating: loans, owner draws/contributions, inter-company transfers.
   // Never count these as expenses.


### PR DESCRIPTION
**Part B of the finance data-cleanup work.** Makes monthly **net income trustworthy** by sourcing expenses from the real bank feed when QuickBooks is dormant (all of 2026) and reconciling income to bank deposits. Builds on Phase 5C ([#146](https://github.com/allan-cmyk/PartyOn2/pull/146)/[#147](https://github.com/allan-cmyk/PartyOn2/pull/147)). Companion to docs PR [#154](https://github.com/allan-cmyk/PartyOn2/pull/154).

> **Lands dormant.** All bank-derived logic gates on `PlaidItem.environment = 'production'`, and there is no production bank connected yet. Nothing changes for existing months until the operator connects Wells Fargo — so this is safe to merge ahead of the connect step.

## What's in here
- **B0 schema** — `PlaidTransaction` +`bank_derived_category` +`is_bank_derived_expense`. Idempotent manual migration (`2026-06-19-finance-bank-derived-expense.sql`) auto-applies on prod deploy via the `_manual_migrations` ledger.
- **B1 Wells Fargo OAuth** — `createLinkToken` now sends `redirect_uri` (env `PLAID_REDIRECT_URI`) and the connect-bank page handles the `receivedRedirectUri` re-init. WF is OAuth-only at Plaid; the flow was previously only exercised against the non-OAuth sandbox bank. New `POST /api/admin/finance/plaid/purge-non-prod` (`requireOpsAuth`) clears the sandbox PlaidItem on cutover.
- **B2 categorization** — `plaid-category-map.ts`: distributor allowlist→`cogs`, transfers/card-payments/loans→`non_operating`, Plaid PFC→slug, name-keyword fallback (reuses the now-exported `NAME_KEYWORD_RULES`). Stamped during the existing sync (production only) via `categorizeBankOutflows()`.
- **B3 income recon** — `bank-income-recon.ts`: production deposits vs known Stripe revenue; deposits up to known revenue count as Stripe-explained even with no payout match (defends the Jan–May 2026 `StripePayout` sync gap).
- **B4/B5 rollup** — `monthly-rollup.ts`: per-month expense source = **QB if material** (the materiality floor **excludes auto-posted `payment_fees`** — the precedence trap) **else bank-derived**, never blended. `netIncomeReliable` now flips via the bank path; discrepancy flags surfaced into `dataHealth`.
- **B6 backfill** — `scripts/finance/backfill-bank-categories.ts`.

## ⚠️ Operator action required before this does anything (after merge)
1. Connect production Wells Fargo per **`docs/CONNECT-PRODUCTION-PLAID.md`** (Plaid prod keys + `PLAID_ENV=production` + register the `PLAID_REDIRECT_URI` redirect + reconnect at `/admin/finance/connect-bank`).
2. `POST /api/admin/finance/plaid/purge-non-prod` to clear the sandbox data.
3. Let the first prod sync populate transactions, then run `scripts/finance/backfill-bank-categories.ts` and re-run `scripts/finance/backfill-monthly-rollups.ts`.
4. Verify `finance_monthly_rollup`: 2026 months show non-zero `opex_cents` (source `bank`) and `dataHealth.netIncomeReliable` flips true.

## New env var
- `PLAID_REDIRECT_URI` = `https://partyondelivery.com/admin/finance/connect-bank` (Production), also registered in the Plaid dashboard.

## Verification
- `npx tsc --noEmit` clean · `npx next lint` clean · `npm run test:run` 315 passing (15 new finance unit tests: category map, materiality gate, deposit explanation).
- Backfill dry-run runs read-only and correctly reports no production bank yet.
- Integration (sync stamping, source selection, purge) exercises post-WF-connect — out of scope to verify until the operator connects the real bank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)