### PR TITLE
feat(newsletter): make signup work + double opt-in + GHL sync

### DIFF
--- a/src/app/api/newsletter/confirm/route.ts
+++ b/src/app/api/newsletter/confirm/route.ts
@@ -1,0 +1,79 @@
+/**
+ * GET /api/newsletter/confirm?token=...
+ *
+ * Second half of the newsletter double opt-in. Verifies the single-use token
+ * issued at signup, marks the Lead's newsletter opt-in as `confirmed`, and ONLY
+ * THEN syncs the subscriber to GHL with the `newsletter` tag — so the CRM list
+ * only ever receives confirmed, consented addresses.
+ *
+ * Always redirects to /newsletter/confirmed with a status flag (never returns
+ * raw JSON — this URL is opened directly from an email client).
+ */
+import { NextResponse, type NextRequest } from 'next/server';
+import { recordEvent } from '@/lib/leads/leadCapture';
+import { notifyNewsletterSignup } from '@/lib/webhooks/ghl';
+import { prisma } from '@/lib/database/client';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'https://partyondelivery.com';
+const done = (status: string) =>
+  NextResponse.redirect(`${BASE_URL}/newsletter/confirmed?status=${status}`);
+
+export async function GET(request: NextRequest) {
+  const token = request.nextUrl.searchParams.get('token')?.trim();
+  if (!token) return done('invalid');
+
+  try {
+    const lead = await prisma.lead.findFirst({
+      where: { metadata: { path: ['newsletter', 'token'], equals: token } },
+    });
+    if (!lead) return done('invalid');
+
+    const meta = (lead.metadata as Record<string, unknown> | null) ?? {};
+    const nl = (meta.newsletter as Record<string, unknown> | undefined) ?? {};
+
+    // Idempotent: a second click on an already-confirmed link just succeeds.
+    if (nl.status === 'confirmed') return done('ok');
+
+    const confirmedAt = new Date().toISOString();
+    await prisma.lead.update({
+      where: { id: lead.id },
+      data: {
+        status: 'SUBMITTED',
+        metadata: {
+          ...meta,
+          newsletter: { ...nl, status: 'confirmed', confirmedAt },
+        } as never,
+      },
+    });
+
+    await recordEvent({
+      type: 'CONVERSION',
+      leadId: lead.id,
+      page: 'newsletter-confirm',
+      widget: 'EMAIL_SIGNUP',
+      fieldName: 'newsletter_confirmed',
+      metadata: { flow: 'newsletter' },
+    });
+
+    // Sync the confirmed subscriber to GHL with the `newsletter` tag.
+    // No-ops gracefully until GHL_NEWSLETTER_WEBHOOK_URL is configured.
+    await notifyNewsletterSignup({
+      event: 'newsletter.subscribed',
+      first_name: lead.firstName ?? '',
+      last_name: lead.lastName ?? '',
+      email: lead.email ?? '',
+      phone: lead.phone ?? '',
+      tag: 'newsletter',
+      source: typeof nl.source === 'string' ? nl.source : 'newsletter',
+      confirmedAt,
+    });
+
+    return done('ok');
+  } catch (err) {
+    console.error('[newsletter] confirm failed', err);
+    return done('error');
+  }
+}

--- a/src/app/api/newsletter/route.ts
+++ b/src/app/api/newsletter/route.ts
@@ -1,37 +1,115 @@
-import { NextRequest, NextResponse } from 'next/server';
+/**
+ * POST /api/newsletter
+ *
+ * Backs the footer + blog "Subscribe" forms with a DOUBLE OPT-IN flow:
+ *   1. Persist the email as a Lead (canonical lead store), EMAIL_SIGNUP widget.
+ *   2. Stamp a `metadata.newsletter` opt-in record with status 'pending' + a
+ *      single-use confirm token.
+ *   3. Email the subscriber a confirmation link. They are NOT marked confirmed
+ *      and NOT synced to the CRM until they click it (see ./confirm).
+ *
+ * Idempotent: re-subscribing updates the existing Lead; an already-confirmed
+ * address is acknowledged without re-sending.
+ *
+ * (Previously this route was a stub that only console.log'd the email, so every
+ * newsletter signup from the live site was silently discarded.)
+ */
+import { NextResponse, type NextRequest } from 'next/server';
+import { z } from 'zod';
+import { randomBytes } from 'crypto';
+import { upsertLead, recordEvent } from '@/lib/leads/leadCapture';
+import { sendEmail } from '@/lib/email/resend-client';
+import { newsletterConfirmEmail } from '@/lib/email/templates/newsletter-confirm';
+import { prisma } from '@/lib/database/client';
+import { EmailType } from '@prisma/client';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'https://partyondelivery.com';
+
+const schema = z.object({
+  email: z.string().email().max(200),
+  /** Which form the signup came from (e.g. "footer", "blog"). */
+  source: z.string().max(60).optional(),
+});
 
 export async function POST(request: NextRequest) {
+  let body: z.infer<typeof schema>;
   try {
-    const { email } = await request.json();
+    body = schema.parse(await request.json());
+  } catch {
+    return NextResponse.json({ error: 'Invalid email address' }, { status: 400 });
+  }
 
-    // Validate email
-    if (!email || !email.includes('@')) {
-      return NextResponse.json(
-        { error: 'Invalid email address' },
-        { status: 400 }
-      );
+  const source = body.source?.trim() || 'newsletter';
+
+  try {
+    const lead = await upsertLead(
+      { email: body.email },
+      { sourcePage: source, sourceWidget: 'EMAIL_SIGNUP' },
+    );
+    if (!lead) {
+      return NextResponse.json({ error: 'Invalid email address' }, { status: 400 });
     }
 
-    // In production, you would:
-    // 1. Add to your email service (Mailchimp, SendGrid, etc.)
-    // 2. Store in database
-    // 3. Send welcome email
-    
-    // For now, we'll just log it
-    console.log('Newsletter signup:', email);
+    const meta = (lead.metadata as Record<string, unknown> | null) ?? {};
+    const nl = meta.newsletter as { status?: string } | undefined;
 
-    // Mock delay to simulate API call
-    await new Promise(resolve => setTimeout(resolve, 500));
+    // Already confirmed — nothing to do, don't re-send.
+    if (nl?.status === 'confirmed') {
+      return NextResponse.json({
+        success: true,
+        message: "You're already subscribed — thanks!",
+      });
+    }
+
+    // (Re)issue a single-use pending opt-in token.
+    const token = randomBytes(16).toString('hex');
+    await prisma.lead.update({
+      where: { id: lead.id },
+      data: {
+        metadata: {
+          ...meta,
+          newsletter: {
+            status: 'pending',
+            token,
+            source,
+            optedInAt: new Date().toISOString(),
+          },
+        } as never,
+      },
+    });
+
+    await recordEvent({
+      type: 'FORM_SUBMIT',
+      leadId: lead.id,
+      page: source,
+      widget: 'EMAIL_SIGNUP',
+      fieldName: 'newsletter_optin',
+      fieldValue: body.email,
+      metadata: { flow: 'newsletter', source, status: 'pending' },
+    });
+
+    // Send the double opt-in confirmation email (non-blocking on failure).
+    const confirmUrl = `${BASE_URL}/api/newsletter/confirm?token=${token}`;
+    const tpl = newsletterConfirmEmail({ confirmUrl });
+    await sendEmail({
+      to: body.email,
+      subject: tpl.subject,
+      html: tpl.html,
+      text: tpl.text,
+      type: EmailType.WELCOME,
+      metadata: { flow: 'newsletter_confirm', leadId: lead.id, source },
+      tags: [{ name: 'flow', value: 'newsletter_confirm' }],
+    });
 
     return NextResponse.json({
       success: true,
-      message: 'Successfully subscribed to newsletter'
+      message: 'Almost there! Check your email to confirm your subscription.',
     });
-  } catch (error) {
-    console.error('Newsletter signup error:', error);
-    return NextResponse.json(
-      { error: 'Failed to subscribe' },
-      { status: 500 }
-    );
+  } catch (err) {
+    console.error('[newsletter] signup failed', err);
+    return NextResponse.json({ error: 'Failed to subscribe' }, { status: 500 });
   }
 }

--- a/src/app/blog/BlogPageClient.tsx
+++ b/src/app/blog/BlogPageClient.tsx
@@ -6,6 +6,7 @@ export default function BlogPageClient() {
   const [email, setEmail] = useState('')
   const [loading, setLoading] = useState(false)
   const [message, setMessage] = useState('')
+  const [ok, setOk] = useState(false)
 
   const handleNewsletterSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -22,12 +23,15 @@ export default function BlogPageClient() {
       const data = await response.json()
 
       if (response.ok) {
-        setMessage('Thank you for subscribing!')
+        setOk(true)
+        setMessage(data.message || 'Almost there! Check your email to confirm.')
         setEmail('')
       } else {
+        setOk(false)
         setMessage(data.error || 'Something went wrong')
       }
     } catch {
+      setOk(false)
       setMessage('Failed to subscribe. Please try again.')
     } finally {
       setLoading(false)
@@ -63,7 +67,7 @@ export default function BlogPageClient() {
             </button>
           </form>
           {message && (
-            <p className={`text-sm mt-4 ${message.includes('Thank you') ? 'text-green-400' : 'text-red-400'}`}>
+            <p className={`text-sm mt-4 ${ok ? 'text-green-400' : 'text-red-400'}`}>
               {message}
             </p>
           )}

--- a/src/app/newsletter/confirmed/page.tsx
+++ b/src/app/newsletter/confirmed/page.tsx
@@ -1,0 +1,47 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Newsletter Subscription | Party On Delivery',
+  robots: { index: false, follow: false },
+}
+
+export const dynamic = 'force-dynamic'
+
+const COPY: Record<string, { title: string; body: string }> = {
+  ok: {
+    title: "You're In",
+    body: 'Your subscription is confirmed. Keep an eye on your inbox for exclusive deals and party-planning tips.',
+  },
+  invalid: {
+    title: 'Link Expired',
+    body: 'This confirmation link is invalid or has already been used. Try subscribing again from the bottom of any page.',
+  },
+  error: {
+    title: 'Something Went Wrong',
+    body: "We couldn't confirm your subscription just now. Please try again in a moment.",
+  },
+}
+
+export default async function NewsletterConfirmedPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ status?: string }>
+}) {
+  const { status = 'ok' } = await searchParams
+  const { title, body } = COPY[status] ?? COPY.ok
+
+  return (
+    <main className="pt-32 pb-16 px-8 min-h-[60vh] flex items-center justify-center">
+      <div className="max-w-md text-center">
+        <h1 className="font-heading text-3xl md:text-4xl tracking-[0.1em] text-gray-900 mb-4">
+          {title}
+        </h1>
+        <p className="text-gray-700 mb-8">{body}</p>
+        <Link href="/" className="btn-primary inline-block">
+          Back to Home
+        </Link>
+      </div>
+    </main>
+  )
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import NewsletterSignup from './NewsletterSignup'
 
 export default function Footer() {
   const currentYear = new Date().getFullYear()
@@ -225,19 +226,7 @@ export default function Footer() {
             <p className="font-sans text-sm text-gray-200">
               Get exclusive deals and party tips delivered to your inbox
             </p>
-            <form className="flex flex-col sm:flex-row gap-4 max-w-md mx-auto">
-              <input
-                type="email"
-                placeholder="Enter your email"
-                className="flex-grow px-4 py-3 bg-white/10 border border-white/20 rounded-full text-white placeholder:text-gray-200 focus:outline-none focus:border-yellow-500 transition-colors duration-300"
-              />
-              <button
-                type="submit"
-                className="btn-primary whitespace-nowrap"
-              >
-                Subscribe
-              </button>
-            </form>
+            <NewsletterSignup />
           </div>
         </div>
       </div>

--- a/src/components/NewsletterSignup.tsx
+++ b/src/components/NewsletterSignup.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useState, type FormEvent } from 'react'
+
+/**
+ * Footer newsletter signup form. Posts to /api/newsletter, which persists the
+ * email as a Lead. Replaces the previous static <form> in Footer.tsx that had
+ * no submit handler and silently discarded every email typed into it.
+ *
+ * Styling is kept identical to the original footer form (dark background) so
+ * this is a behavior-only fix, not a redesign.
+ */
+export default function NewsletterSignup() {
+  const [email, setEmail] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [message, setMessage] = useState('')
+  const [ok, setOk] = useState(false)
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    setMessage('')
+    try {
+      const res = await fetch('/api/newsletter', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, source: 'footer' }),
+      })
+      const data = await res.json()
+      if (res.ok) {
+        setOk(true)
+        setMessage(data.message || 'Almost there! Check your email to confirm.')
+        setEmail('')
+      } else {
+        setOk(false)
+        setMessage(data.error || 'Something went wrong')
+      }
+    } catch {
+      setOk(false)
+      setMessage('Failed to subscribe. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <>
+      <form
+        onSubmit={handleSubmit}
+        className="flex flex-col sm:flex-row gap-4 max-w-md mx-auto"
+      >
+        <input
+          type="email"
+          placeholder="Enter your email"
+          className="flex-grow px-4 py-3 bg-white/10 border border-white/20 rounded-full text-white placeholder:text-gray-200 focus:outline-none focus:border-yellow-500 transition-colors duration-300"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          disabled={loading}
+        />
+        <button
+          type="submit"
+          className="btn-primary whitespace-nowrap disabled:opacity-50"
+          disabled={loading}
+        >
+          {loading ? 'Subscribing…' : 'Subscribe'}
+        </button>
+      </form>
+      {message && (
+        <p
+          role="status"
+          aria-live="polite"
+          className={`text-sm mt-4 ${ok ? 'text-green-400' : 'text-red-400'}`}
+        >
+          {message}
+        </p>
+      )}
+    </>
+  )
+}

--- a/src/lib/email/templates/newsletter-confirm.ts
+++ b/src/lib/email/templates/newsletter-confirm.ts
@@ -1,0 +1,92 @@
+/**
+ * Newsletter double opt-in confirmation email.
+ *
+ * Sent when someone submits the footer/blog "Subscribe" form. They must click
+ * the confirm button before we mark them confirmed and sync them to the CRM —
+ * this is what keeps the newsletter list clean and protects deliverability.
+ */
+
+const NAVY = '#0A1F33';
+const GOLD = '#D4AF37';
+
+export type NewsletterConfirmInput = {
+  /** Absolute URL to the confirm endpoint (carries the opt-in token). */
+  confirmUrl: string;
+};
+
+function escape(s: string) {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+export function newsletterConfirmEmail(input: NewsletterConfirmInput): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const url = escape(input.confirmUrl);
+  const subject = 'Confirm your Party On Delivery subscription';
+
+  const html = `<!doctype html>
+<html>
+  <body style="margin:0;padding:0;background:#f4f4f5;font-family:Arial,Helvetica,sans-serif;color:#1f2937;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f4f4f5;padding:24px 0;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;background:#ffffff;border-radius:12px;overflow:hidden;">
+            <tr>
+              <td style="background:${NAVY};padding:28px 32px;">
+                <h1 style="margin:0;color:#ffffff;font-size:22px;letter-spacing:0.08em;">PARTY ON DELIVERY</h1>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:32px;">
+                <h2 style="margin:0 0 12px;font-size:20px;color:${NAVY};">One quick step</h2>
+                <p style="margin:0 0 20px;font-size:15px;line-height:1.6;">
+                  Thanks for subscribing! Tap the button below to confirm you'd like exclusive deals
+                  and party-planning tips delivered to your inbox.
+                </p>
+                <table role="presentation" cellpadding="0" cellspacing="0">
+                  <tr>
+                    <td style="border-radius:8px;background:${GOLD};">
+                      <a href="${url}" style="display:inline-block;padding:14px 28px;font-size:15px;font-weight:bold;color:#1a1a1a;text-decoration:none;letter-spacing:0.06em;">
+                        Confirm my subscription
+                      </a>
+                    </td>
+                  </tr>
+                </table>
+                <p style="margin:24px 0 0;font-size:13px;line-height:1.6;color:#6b7280;">
+                  If the button doesn't work, copy and paste this link into your browser:<br />
+                  <a href="${url}" style="color:${NAVY};word-break:break-all;">${url}</a>
+                </p>
+                <p style="margin:20px 0 0;font-size:13px;line-height:1.6;color:#6b7280;">
+                  If you didn't sign up, you can safely ignore this email — nothing will happen.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td style="background:#f4f4f5;padding:16px 32px;font-size:12px;color:#9ca3af;">
+                Party On Delivery · Austin, TX
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+
+  const text = [
+    'Thanks for subscribing to Party On Delivery!',
+    '',
+    'Please confirm your subscription by opening this link:',
+    input.confirmUrl,
+    '',
+    "If you didn't sign up, you can safely ignore this email.",
+  ].join('\n');
+
+  return { subject, html, text };
+}

--- a/src/lib/stripe/charge-snapshot.ts
+++ b/src/lib/stripe/charge-snapshot.ts
@@ -229,7 +229,7 @@ export function assertOrderItemsMatchCharge(
       diffs.push(`unit-price mismatch "${li.title}": order ${oiUnitCents}¢ vs charged ${li.unitPriceCents}¢`);
     }
   }
-  for (const [k, oi] of itemsByKey) {
+  for (const k of itemsByKey.keys()) {
     if (!snapByKey.has(k)) {
       diffs.push(`OrderItem (${k}) was not in the Stripe charge`);
     }

--- a/src/lib/webhooks/ghl.ts
+++ b/src/lib/webhooks/ghl.ts
@@ -8,6 +8,7 @@
 const GHL_WEBHOOK_URL = process.env.GHL_ORDER_WEBHOOK_URL;
 const GHL_REVIEW_WEBHOOK_URL = process.env.GHL_REVIEW_WEBHOOK_URL;
 const GHL_DASHBOARD_WEBHOOK_URL = process.env.GHL_DASHBOARD_WEBHOOK_URL;
+const GHL_NEWSLETTER_WEBHOOK_URL = process.env.GHL_NEWSLETTER_WEBHOOK_URL;
 
 // ──────────────────────────────────────────────
 // Types
@@ -254,5 +255,50 @@ export async function notifyDashboardCreated(payload: GhlDashboardPayload): Prom
     }
   } catch (err) {
     console.error('[GHL Dashboard Webhook] Error:', err);
+  }
+}
+
+// ──────────────────────────────────────────────
+// Newsletter Subscription (double opt-in confirmed)
+// ──────────────────────────────────────────────
+
+export interface GhlNewsletterPayload {
+  event: 'newsletter.subscribed';
+  first_name: string;
+  last_name: string;
+  email: string;
+  phone: string;
+  /** The GHL tag the receiving workflow should apply. */
+  tag: 'newsletter';
+  /** Which form the signup came from (footer, blog, …). */
+  source: string;
+  confirmedAt: string;
+}
+
+/**
+ * POST a confirmed newsletter subscriber to the GHL newsletter webhook so the
+ * receiving GHL workflow can create/update the contact and apply the
+ * `newsletter` tag (matching the existing imported newsletter segment).
+ *
+ * Fire-and-forget: logs errors, never throws. No-ops silently when
+ * GHL_NEWSLETTER_WEBHOOK_URL is not set — so this is inert until Allan creates
+ * the GHL inbound webhook/workflow and sets the env var.
+ */
+export async function notifyNewsletterSignup(payload: GhlNewsletterPayload): Promise<void> {
+  if (!GHL_NEWSLETTER_WEBHOOK_URL) return;
+
+  try {
+    const res = await fetch(GHL_NEWSLETTER_WEBHOOK_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      console.error('[GHL Newsletter Webhook] Failed:', res.status, await res.text());
+    } else {
+      console.log('[GHL Newsletter Webhook] Subscriber synced:', payload.email);
+    }
+  } catch (err) {
+    console.error('[GHL Newsletter Webhook] Error:', err);
   }
 }


### PR DESCRIPTION
## Why

The newsletter signup was silently dropping every address:
- The footer **Subscribe** form (`Footer.tsx`) had **no submit handler** — emails typed there went nowhere.
- `/api/newsletter` was a **stub** that only `console.log`'d the email and returned success. The blog signup form posted to that same dead stub.

So any visitor who tried to subscribe since launch was lost. (Found while investigating where the existing ~1,400 "newsletter" GHL contacts came from — they're all from the old Shopify/Klaviyo import; the new site had contributed zero because of this bug.)

## What changed

**Double opt-in flow** (keeps the list clean / protects deliverability):
1. `POST /api/newsletter` — persists the signup as a `Lead` (`EMAIL_SIGNUP` widget) + a `metadata.newsletter` opt-in record with `status: 'pending'` and a single-use token, then emails a confirmation link. Idempotent; already-confirmed addresses aren't re-sent.
2. `GET /api/newsletter/confirm?token=…` — verifies the token, flips the lead to `confirmed`, records a `CONVERSION` event, and **only then** syncs the subscriber to GHL with a `newsletter` tag. Redirects to a thank-you page.
3. `notifyNewsletterSignup()` in `lib/webhooks/ghl.ts` — fire-and-forget GHL webhook push, **no-ops until `GHL_NEWSLETTER_WEBHOOK_URL` is set** (matches the existing GHL webhook pattern).
4. New confirmation email template + `/newsletter/confirmed` thank-you page.
5. Footer form extracted into a working `NewsletterSignup` client component; footer + blog now show "check your email to confirm."

## ⚠️ Manual step to finish the GHL sync
GHL sync is inert until you:
1. Create a GHL inbound webhook / workflow that creates-or-updates a contact and applies the **`newsletter`** tag.
2. Set **`GHL_NEWSLETTER_WEBHOOK_URL`** in Vercel (+ `.env.local`).

Until then, confirmed signups still persist to the `leads` table — nothing is lost; they just aren't pushed to GHL yet.

## Verification
- Ran the full flow against the DB: signup → pending token → JSON-path token lookup → confirmed (`status=SUBMITTED`, `metadata.newsletter.status=confirmed`) → GHL no-op → **test rows deleted**.
- `tsc --noEmit` and ESLint clean on all changed files.
- No email is sent until a user actually subscribes; GHL only receives confirmed, consented addresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)