### PR TITLE
fix(july4): nav + working cart on landing page + homepage CTA (missed by #158)

### DIFF
--- a/src/app/austin-4th-of-july-delivery/July4KitCards.tsx
+++ b/src/app/austin-4th-of-july-delivery/July4KitCards.tsx
@@ -57,7 +57,7 @@ const CheckIcon = () => (
 
 function KitCard({ product }: { product: Product }) {
   const meta: KitMeta = KIT_META[product.handle] ?? { hook: '', ingredients: [], accent: '#0B74B8' };
-  const { addToCart, loading } = useCartContext();
+  const { addToCart, openCart, loading } = useCartContext();
   const [isAdding, setIsAdding] = useState(false);
   const [justAdded, setJustAdded] = useState(false);
   const [showAge, setShowAge] = useState(false);
@@ -74,6 +74,7 @@ function KitCard({ product }: { product: Product }) {
       await addToCart(variant.id, 1);
       setJustAdded(true);
       window.setTimeout(() => setJustAdded(false), 2200);
+      openCart(); // slide the cart drawer open so the add is visible + checkout-ready
     } catch (error) {
       console.error('Add to cart failed:', error);
     } finally {

--- a/src/app/austin-4th-of-july-delivery/page.tsx
+++ b/src/app/austin-4th-of-july-delivery/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { prisma } from '@/lib/database/client';
 import { transformToProduct } from '@/lib/products/transform';
 import { Product } from '@/lib/types';
+import Navigation from '@/components/Navigation';
 import FireworksCanvas from './FireworksCanvas';
 import July4KitCards from './July4KitCards';
 
@@ -111,6 +112,9 @@ export default async function Austin4thOfJulyDeliveryPage() {
 
   return (
     <>
+      {/* Global nav (cart button + count). Transparent over the hero via NAV_TRANSPARENT_ROUTES. */}
+      <Navigation />
+
       {/* z-0 — fixed navy night-sky backdrop */}
       <div
         className="fixed inset-0 z-0 pointer-events-none"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -56,6 +56,22 @@ export default function HomePage() {
       {/* Hero Section - Client Component with A/B Testing */}
       <HeroSectionExperimental />
 
+      {/* Seasonal: 4th of July landing-page CTA (sits directly under the hero) */}
+      <section className="bg-white py-8 border-b border-gray-100">
+        <div className="container-custom flex flex-col items-center justify-center gap-4 text-center sm:flex-row">
+          <span aria-hidden="true" className="hidden h-8 w-1.5 rounded-full bg-gradient-to-b from-red-600 via-white to-blue-600 sm:block" />
+          <p className="text-sm font-semibold tracking-[0.08em] text-gray-700">HOSTING FOR THE FOURTH?</p>
+          <TrackedLink href="/austin-4th-of-july-delivery" section="choose_path" buttonText="4th of July Drinks">
+            <button className="inline-flex items-center gap-2 rounded-lg bg-brand-blue px-8 py-4 text-sm font-semibold tracking-[0.08em] text-white transition-colors hover:bg-blue-700">
+              4th of July Drinks
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14 5l7 7m0 0l-7 7m7-7H3" />
+              </svg>
+            </button>
+          </TrackedLink>
+        </div>
+      </section>
+
       {/* Start Order CTA */}
       <section className="py-16 bg-gray-50">
         <div className="max-w-4xl mx-auto px-8 text-center">

--- a/src/components/AgeVerification.tsx
+++ b/src/components/AgeVerification.tsx
@@ -20,6 +20,7 @@ const AGE_GATE_EXEMPT_PATHS = [
   '/austin-corporate-event-delivery',
   '/austin-wedding-weekend-delivery',
   '/austin-wedding-venue-boats',
+  '/austin-4th-of-july-delivery',
   '/event-quiz',
 ]
 

--- a/src/components/gifts/FeaturedKitCard.tsx
+++ b/src/components/gifts/FeaturedKitCard.tsx
@@ -83,7 +83,7 @@ export default function FeaturedKitCard({
   showIngredients = true,
   onClickProduct
 }: FeaturedKitCardProps) {
-  const { addToCart, loading: cartLoading } = useCartContext();
+  const { addToCart, openCart, loading: cartLoading } = useCartContext();
   const [isAdding, setIsAdding] = useState(false);
   const [showAgeVerification, setShowAgeVerification] = useState(false);
   const imageUrl = getProductImageUrl(product);
@@ -113,6 +113,7 @@ export default function FeaturedKitCard({
     setIsAdding(true);
     try {
       await addToCart(variant.id, 1);
+      openCart(); // slide the cart open so the add is visible + checkout-ready
     } catch (error) {
       console.error('Error adding to cart:', error);
     } finally {
@@ -128,6 +129,7 @@ export default function FeaturedKitCard({
       setIsAdding(true);
       try {
         await addToCart(variant.id, 1);
+        openCart(); // slide the cart open so the add is visible + checkout-ready
       } catch (error) {
         console.error('Error adding to cart:', error);
       } finally {


### PR DESCRIPTION
## Why

The July 4th cart/nav fixes (verified on the `july4-prod` preview) **never reached `main`** — PR #158 squash-merged at its first commit, so these landed too late and got stranded. **Production's `/austin-4th-of-july-delivery` is currently the broken version: no cart button, and the first-visit Add-to-Cart fails.** This brings the fixes onto current `main`.

## What

- **Render `<Navigation/>`** on the landing page — it rendered no nav/cart button at all (the "can't see the cart" report).
- **Exempt the route from the global age gate** (`AGE_GATE_EXEMPT_PATHS`) so its own per-add 21+ modal is the single gate. The global entrance modal's `z-100` overlay was swallowing the Add-to-Cart clicks → "add does nothing." Matches every sibling `austin-*-delivery` page.
- **`openCart()` on a successful add** in `July4KitCards` + `FeaturedKitCard` — the cart drawer never opened, so adds were silent.
- **"4th of July Drinks" CTA** below the homepage hero → links to the landing page.

## Verified (on the july4-prod preview, same code)

First-visit: no double age gate, nav + cart button present → Add to Cart → 21+ modal → cart count 1, drawer opens, badge updates. `/cocktail-kits` adds open the cart too.

## Scope note

`cocktail-kits/page.tsx` is intentionally **not** touched — `main` already has a dedicated July 4th section there from separate work (`6ad03df7`). The `FeaturedKitCard` openCart fix here also benefits that page.

Diff: 5 files, +26/−2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)