### PR TITLE
fix(sms): list group-order + cart-reminder texts in /privacy + /terms

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -89,7 +89,7 @@ export default function PrivacyPage() {
             <div>
               <h2 className="font-heading text-2xl text-gray-900 mb-4 tracking-[0.1em]">Text Messaging (SMS)</h2>
               <p className="text-gray-600 leading-relaxed mb-4">
-                When you provide your mobile number &mdash; for example, during checkout after completing age verification &mdash; you consent to receive text messages from Party On Delivery related to your orders and customer service, including order confirmations, delivery status and scheduling updates, review requests, and replies to your questions. Consent to receive these texts is not a condition of any purchase.
+                When you provide your mobile number &mdash; for example, during checkout after completing age verification &mdash; you consent to receive text messages from Party On Delivery related to your orders and customer service, including order confirmations, delivery status and scheduling updates, group order coordination links, review requests, reminders to complete an unfinished order, and replies to your questions. Consent to receive these texts is not a condition of any purchase.
               </p>
               <ul className="text-gray-600 space-y-2 list-disc pl-6 mb-4">
                 <li>Message frequency varies based on your order activity.</li>

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -100,7 +100,7 @@ export default function TermsPage() {
             <div>
               <h2 className="font-heading text-2xl text-gray-900 mb-4 tracking-[0.1em]">9. Text Messaging (SMS)</h2>
               <p className="text-gray-600 leading-relaxed mb-4">
-                When you provide your mobile number, you consent to receive text messages from Party On Delivery related to your orders and customer service, including order confirmations, delivery status and scheduling updates, review requests, and replies to your questions. Consent is not a condition of purchase.
+                When you provide your mobile number, you consent to receive text messages from Party On Delivery related to your orders and customer service, including order confirmations, delivery status and scheduling updates, group order coordination links, review requests, reminders to complete an unfinished order, and replies to your questions. Consent is not a condition of purchase.
               </p>
               <ul className="text-gray-600 space-y-2 list-disc pl-6 mb-4">
                 <li>Message frequency varies based on your order activity.</li>


### PR DESCRIPTION
## What
Adds two message types — **"group order coordination links"** and **"reminders to complete an unfinished order"** — to the SMS message-types list in both the Privacy Policy (`/privacy`) and Terms of Service (`/terms`) pages.

## Why
Part of the CoreLinq CRM / Twilio A2P 10DLC migration. The A2P campaign is being **resubmitted** after a carrier-vetting rejection (errors 30886 + 30893). Carrier vetting cross-checks the live `/privacy` + `/terms` pages against the campaign description and sample messages. The resubmitted campaign declares group-order coordination texts (sample #5) and order-completion reminders (sample #4), so the live legal pages must name the same message types.

## Scope
- Two-line additive copy change; no logic, no schema, no new components.
- Lint clean (only pre-existing `<img>` warnings on these pages, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)