### PR TITLE
fix(refunds): make refund cap Stripe-authoritative + idempotent refund creates

### DIFF
--- a/src/app/api/v1/admin/orders/[id]/cancel/route.ts
+++ b/src/app/api/v1/admin/orders/[id]/cancel/route.ts
@@ -116,17 +116,29 @@ export async function POST(
         );
       }
 
-      // Process Stripe refund
-      const stripeRefund = await stripe.refunds.create({
-        payment_intent: order.stripePaymentIntentId,
-        amount: Math.round(refundAmount * 100),
-        reason: 'requested_by_customer',
-        metadata: {
-          orderId: id,
-          orderNumber: String(order.orderNumber),
-          reason: 'Order cancelled',
+      // Process Stripe refund.
+      // Idempotency key is derived from the order id + amount: a cancel is a
+      // one-shot terminal action, so if this request is retried after the Stripe
+      // refund succeeded but the DB write failed, Stripe replays the SAME refund
+      // instead of issuing a second one. The amount is included so that if the
+      // order is amended between a failed attempt and the retry (changing the
+      // computed refund), the retry gets a fresh key rather than colliding with
+      // the old amount and locking Stripe for 24h. Belt-and-suspenders with the
+      // Stripe-aware cap above (which already blocks re-refunding a refunded order).
+      const refundAmountCents = Math.round(refundAmount * 100);
+      const stripeRefund = await stripe.refunds.create(
+        {
+          payment_intent: order.stripePaymentIntentId,
+          amount: refundAmountCents,
+          reason: 'requested_by_customer',
+          metadata: {
+            orderId: id,
+            orderNumber: String(order.orderNumber),
+            reason: 'Order cancelled',
+          },
         },
-      });
+        { idempotencyKey: `order-cancel-refund-${id}-${refundAmountCents}` }
+      );
 
       // Create refund record in DB
       await createRefund(id, refundAmount, 'Order cancelled');

--- a/src/app/api/v1/admin/orders/[id]/refund/route.ts
+++ b/src/app/api/v1/admin/orders/[id]/refund/route.ts
@@ -75,17 +75,31 @@ export async function POST(
       }, { status: 400 });
     }
 
-    // Process Stripe refund
-    const refund = await stripe.refunds.create({
-      payment_intent: order.stripePaymentIntentId,
-      amount: Math.round(amount * 100), // Stripe uses cents
-      reason: 'requested_by_customer',
-      metadata: {
-        orderId: id,
-        orderNumber: String(order.orderNumber),
-        reason: reason || 'Order amendment refund',
+    // Process Stripe refund.
+    // The Stripe-aware cap above stops a FULL re-refund, but a partial refund
+    // would still fit under the (reduced) cap on retry — so we also pass an
+    // idempotency key. Scoped to (order, amendment, amount) so a retried request
+    // replays the same refund, while distinct amendments / amounts stay independent.
+    // CAVEAT (manual path, no amendmentId): two genuinely-distinct manual refunds
+    // of the SAME dollar amount on the SAME order within Stripe's 24h idempotency
+    // window will collide — the second replays the first instead of issuing new
+    // money. That's the safe direction (never double-pays); if a real second
+    // same-amount manual refund is needed within 24h, vary the amount by a cent or
+    // resolve it through an amendment so it gets a distinct key.
+    const amountCents = Math.round(amount * 100);
+    const refund = await stripe.refunds.create(
+      {
+        payment_intent: order.stripePaymentIntentId,
+        amount: amountCents, // Stripe uses cents
+        reason: 'requested_by_customer',
+        metadata: {
+          orderId: id,
+          orderNumber: String(order.orderNumber),
+          reason: reason || 'Order amendment refund',
+        },
       },
-    });
+      { idempotencyKey: `order-refund-${id}-${amendmentId ?? 'manual'}-${amountCents}` }
+    );
 
     // Create refund record in DB and update financial status
     await createRefund(id, amount, reason || 'Order amendment refund');

--- a/src/app/api/v1/admin/orders/[id]/return/route.ts
+++ b/src/app/api/v1/admin/orders/[id]/return/route.ts
@@ -5,6 +5,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { createHash } from 'crypto';
 import { requireOpsAuth } from '@/lib/auth/ops-session';
 import { prisma } from '@/lib/database/client';
 import { stripe } from '@/lib/stripe/client';
@@ -220,18 +221,27 @@ export async function POST(
       }, { status: 400 });
     }
 
-    // Process Stripe refund first (can't roll back if it succeeds)
-    const stripeRefund = await stripe.refunds.create({
-      payment_intent: order.stripePaymentIntentId,
-      amount: Math.round(totalRefundAmount * 100), // Stripe uses cents
-      reason: 'requested_by_customer',
-      metadata: {
-        orderId: id,
-        orderNumber: String(order.orderNumber),
-        reason: reason ? `Return: ${reason}` : 'Return: items returned',
-        type: 'return',
+    // Process Stripe refund first (can't roll back if it succeeds).
+    // Idempotency key is derived from the order + the exact set of returned
+    // items, so retrying after the Stripe refund succeeded but the DB
+    // transaction failed replays the same refund instead of double-refunding.
+    const returnFingerprint = createHash('sha1')
+      .update(items.map((it) => `${it.orderItemId}:${it.returnQuantity}`).sort().join(','))
+      .digest('hex');
+    const stripeRefund = await stripe.refunds.create(
+      {
+        payment_intent: order.stripePaymentIntentId,
+        amount: Math.round(totalRefundAmount * 100), // Stripe uses cents
+        reason: 'requested_by_customer',
+        metadata: {
+          orderId: id,
+          orderNumber: String(order.orderNumber),
+          reason: reason ? `Return: ${reason}` : 'Return: items returned',
+          type: 'return',
+        },
       },
-    });
+      { idempotencyKey: `order-return-${id}-${returnFingerprint}` }
+    );
 
     // DB transaction for all writes
     await prisma.$transaction(async (tx: TransactionClient) => {

--- a/src/app/api/v1/admin/orders/__tests__/cancel-refund-retry.test.ts
+++ b/src/app/api/v1/admin/orders/__tests__/cancel-refund-retry.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Cancel-route refund retry regression.
+ *
+ * Scenario from prod (order #365 era): the cancel route creates the Stripe
+ * refund FIRST, then writes the DB Refund record. If the process dies in
+ * between, the DB shows 0 prior refunds while Stripe has already refunded.
+ * A retry must NOT issue a second Stripe refund.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NextRequest } from 'next/server';
+
+// --- Stripe mock (shared by the route and by refund-utils) ---
+const mockPiRetrieve = vi.fn();
+const mockRefundsList = vi.fn();
+const mockRefundsCreate = vi.fn();
+
+vi.mock('@/lib/stripe/client', () => ({
+  stripe: {
+    paymentIntents: { retrieve: (...a: unknown[]) => mockPiRetrieve(...a) },
+    refunds: {
+      list: (...a: unknown[]) => mockRefundsList(...a),
+      create: (...a: unknown[]) => mockRefundsCreate(...a),
+    },
+  },
+}));
+
+// --- Auth: pass through (not a NextResponse) ---
+vi.mock('@/lib/auth/ops-session', () => ({
+  requireOpsAuth: vi.fn().mockResolvedValue({ sub: 'admin', role: 'ADMIN' }),
+}));
+
+// --- Prisma ---
+const mockOrderFindUnique = vi.fn();
+const mockOrderUpdate = vi.fn().mockResolvedValue({});
+const mockRefundFindFirst = vi.fn().mockResolvedValue({ id: 'rf_db_1' });
+const mockRefundUpdate = vi.fn().mockResolvedValue({});
+
+vi.mock('@/lib/database/client', () => ({
+  prisma: {
+    order: {
+      findUnique: (...a: unknown[]) => mockOrderFindUnique(...a),
+      update: (...a: unknown[]) => mockOrderUpdate(...a),
+    },
+    refund: {
+      findFirst: (...a: unknown[]) => mockRefundFindFirst(...a),
+      update: (...a: unknown[]) => mockRefundUpdate(...a),
+    },
+  },
+}));
+
+// --- Side-effectful services (no-ops here) ---
+vi.mock('@/lib/inventory/services/order-service', () => ({
+  createRefund: vi.fn().mockResolvedValue(undefined),
+  releaseCommittedInventory: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@/lib/email/email-service', () => ({
+  sendOrderCancellationEmail: vi.fn().mockResolvedValue(undefined),
+  sendRefundProcessedEmail: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@/lib/email/templates/order-cancellation', () => ({
+  generateOrderCancellationEmail: vi.fn().mockReturnValue('<html></html>'),
+}));
+
+/** Build the async-iterable that stripe.refunds.list() returns. */
+function listOf(refunds: Array<{ amount: number; status: string }>): AsyncIterable<unknown> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const r of refunds) yield r;
+    },
+  };
+}
+
+function baseOrder() {
+  return {
+    id: 'order-1',
+    orderNumber: 365,
+    customerName: 'Test Customer',
+    customerEmail: 'test@example.com',
+    total: 150,
+    status: 'PAID',
+    financialStatus: 'PAID',
+    fulfillmentStatus: 'PENDING',
+    deliveryDate: null,
+    stripePaymentIntentId: 'pi_1',
+    items: [],
+    refunds: [], // DB shows NO prior refunds
+  };
+}
+
+function makeRequest(body: unknown): NextRequest {
+  return { json: async () => body } as unknown as NextRequest;
+}
+
+const routeParams = { params: Promise.resolve({ id: 'order-1' }) };
+
+describe('POST /cancel — refund retry safety', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOrderFindUnique.mockResolvedValue(baseOrder());
+    mockOrderUpdate.mockResolvedValue({});
+    mockRefundFindFirst.mockResolvedValue({ id: 'rf_db_1' });
+    mockRefundUpdate.mockResolvedValue({});
+    mockPiRetrieve.mockResolvedValue({ amount_received: 15000 }); // $150 captured
+  });
+
+  it('REGRESSION: Stripe already refunded but DB empty → retry does NOT create a second refund', async () => {
+    // Stripe already shows the full refund (the DB write that should have
+    // recorded it never landed).
+    mockRefundsList.mockReturnValue(listOf([{ amount: 15000, status: 'succeeded' }]));
+
+    const { POST } = await import('@/app/api/v1/admin/orders/[id]/cancel/route');
+    const res = await POST(makeRequest({ issueRefund: true }), routeParams);
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error).toMatch(/already been fully refunded/i);
+    // The critical assertion: no second Stripe refund was issued.
+    expect(mockRefundsCreate).not.toHaveBeenCalled();
+  });
+
+  it('happy path: issues the refund once, with an order-derived idempotency key', async () => {
+    mockRefundsList.mockReturnValue(listOf([])); // nothing refunded yet
+    mockRefundsCreate.mockResolvedValue({ id: 're_1', status: 'succeeded' });
+
+    const { POST } = await import('@/app/api/v1/admin/orders/[id]/cancel/route');
+    const res = await POST(makeRequest({ issueRefund: true }), routeParams);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.data.refund.amount).toBe(150);
+
+    expect(mockRefundsCreate).toHaveBeenCalledTimes(1);
+    const [params, options] = mockRefundsCreate.mock.calls[0];
+    expect(params.amount).toBe(15000);
+    // Key includes the amount so an amended retry gets a fresh key instead of
+    // colliding with the old amount and locking Stripe for 24h.
+    expect(options).toEqual({ idempotencyKey: 'order-cancel-refund-order-1-15000' });
+  });
+});

--- a/src/lib/stripe/__tests__/refund-utils.test.ts
+++ b/src/lib/stripe/__tests__/refund-utils.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Refund cap regression tests.
+ *
+ * Core invariant: the refund cap is computed from Stripe's ACTUAL refunded
+ * amount, not just the DB Refund table. This guards the partial-failure path —
+ * Stripe refund succeeds, then the DB write dies (e.g. a Neon cold-start drop) —
+ * where the DB shows 0 prior refunds but Stripe has already refunded. A retry
+ * must NOT compute the full captured amount as refundable again.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockRetrieve = vi.fn();
+const mockList = vi.fn();
+
+vi.mock('@/lib/stripe/client', () => ({
+  stripe: {
+    paymentIntents: { retrieve: (...args: unknown[]) => mockRetrieve(...args) },
+    refunds: { list: (...args: unknown[]) => mockList(...args) },
+  },
+}));
+
+/** Build the async-iterable that stripe.refunds.list() returns. */
+function listOf(refunds: Array<{ amount: number; status: string }>): AsyncIterable<unknown> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const r of refunds) yield r;
+    },
+  };
+}
+
+import {
+  getStripeRefundedAmount,
+  getMaxRefundable,
+} from '@/lib/stripe/refund-utils';
+
+describe('getStripeRefundedAmount', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sums succeeded and pending refunds, excludes failed and canceled', async () => {
+    mockList.mockReturnValue(
+      listOf([
+        { amount: 5000, status: 'succeeded' },
+        { amount: 2500, status: 'pending' },
+        { amount: 9999, status: 'failed' },
+        { amount: 8888, status: 'canceled' },
+      ])
+    );
+
+    // 5000 + 2500 = 7500 cents = $75 (failed/canceled don't move money)
+    await expect(getStripeRefundedAmount('pi_1')).resolves.toBe(75);
+  });
+
+  it('returns 0 when Stripe has no refunds', async () => {
+    mockList.mockReturnValue(listOf([]));
+    await expect(getStripeRefundedAmount('pi_1')).resolves.toBe(0);
+  });
+});
+
+describe('getMaxRefundable — retry must not double-refund', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('REGRESSION: Stripe already fully refunded but DB shows 0 → cap is 0', async () => {
+    // The partial-failure state: Stripe refunded the full $150, the DB Refund
+    // write failed, so the caller passes priorRefundsTotalDollars = 0.
+    mockRetrieve.mockResolvedValue({ amount_received: 15000 });
+    mockList.mockReturnValue(listOf([{ amount: 15000, status: 'succeeded' }]));
+
+    // Caller's DB sum is 0 — must NOT widen the cap back to the full amount.
+    await expect(getMaxRefundable('pi_1', 0)).resolves.toBe(0);
+  });
+
+  it('REGRESSION: Stripe partially refunded but DB shows 0 → cap excludes the Stripe refund', async () => {
+    mockRetrieve.mockResolvedValue({ amount_received: 15000 });
+    mockList.mockReturnValue(listOf([{ amount: 5000, status: 'succeeded' }]));
+
+    // captured 150 − stripeRefunded 50 = 100 (not 150)
+    await expect(getMaxRefundable('pi_1', 0)).resolves.toBe(100);
+  });
+
+  it('full cap available when neither Stripe nor DB show prior refunds', async () => {
+    mockRetrieve.mockResolvedValue({ amount_received: 15000 });
+    mockList.mockReturnValue(listOf([]));
+
+    await expect(getMaxRefundable('pi_1', 0)).resolves.toBe(150);
+  });
+
+  it('uses the LARGER of DB sum and Stripe refunded (DB ahead of Stripe)', async () => {
+    // Defensive: if the DB somehow records more than Stripe, never widen the cap.
+    mockRetrieve.mockResolvedValue({ amount_received: 15000 });
+    mockList.mockReturnValue(listOf([])); // Stripe shows nothing
+
+    // DB says $50 already refunded → cap = 150 − 50 = 100
+    await expect(getMaxRefundable('pi_1', 50)).resolves.toBe(100);
+  });
+
+  it('handles fractional dollars without floating-point drift', async () => {
+    mockRetrieve.mockResolvedValue({ amount_received: 10000 }); // $100.00
+    mockList.mockReturnValue(listOf([{ amount: 3333, status: 'succeeded' }])); // $33.33
+
+    await expect(getMaxRefundable('pi_1', 0)).resolves.toBe(66.67);
+  });
+});

--- a/src/lib/stripe/refund-utils.ts
+++ b/src/lib/stripe/refund-utils.ts
@@ -2,6 +2,14 @@
  * Refund cap helpers — source of truth is the Stripe charge, not Order.total.
  * Order.total can be mutated by OrderAmendment when items are added/removed,
  * so it cannot be used to cap refunds.
+ *
+ * The refund cap also cannot trust the DB Refund table alone. Every refund
+ * route creates the Stripe refund FIRST, then writes the DB Refund record. If
+ * the process dies in between (e.g. a Neon cold-start connection drop), Stripe
+ * has refunded but the DB shows 0 prior refunds — and a retry would compute the
+ * full captured amount as refundable again, double-refunding the customer.
+ * So the cap subtracts whatever Stripe has ACTUALLY refunded, falling back to a
+ * larger DB figure only if the DB somehow ran ahead.
  */
 
 import { stripe } from './client';
@@ -15,13 +23,41 @@ export async function getStripeCapturedAmount(paymentIntentId: string): Promise<
 }
 
 /**
+ * Returns the total amount Stripe has already refunded against a PaymentIntent,
+ * in dollars. This is the authoritative prior-refunds figure — it reflects money
+ * that has actually left (or is in-flight to leave) our Stripe balance, even when
+ * the corresponding DB Refund record was never written.
+ *
+ * Pending / in-flight refunds count against the cap; only `failed` and `canceled`
+ * refunds (no money moved) are excluded.
+ */
+export async function getStripeRefundedAmount(paymentIntentId: string): Promise<number> {
+  let totalCents = 0;
+  for await (const refund of stripe.refunds.list({ payment_intent: paymentIntentId, limit: 100 })) {
+    if (refund.status === 'failed' || refund.status === 'canceled') continue;
+    totalCents += refund.amount;
+  }
+  return totalCents / 100;
+}
+
+/**
  * Returns the maximum amount that can still be refunded against a PaymentIntent.
- * = (Stripe-captured) − (sum of prior refund amounts in dollars).
+ * = (Stripe-captured) − (prior refunds).
+ *
+ * Prior refunds are taken as the LARGER of Stripe's actual refunded total and the
+ * caller's DB-derived sum, so a DB write that lagged the Stripe refund can never
+ * widen the cap and let a retry double-refund.
+ *
+ * @param priorRefundsTotalDollars - sum of the order's DB Refund records, in dollars.
  */
 export async function getMaxRefundable(
   paymentIntentId: string,
   priorRefundsTotalDollars: number
 ): Promise<number> {
-  const captured = await getStripeCapturedAmount(paymentIntentId);
-  return Math.round((captured - priorRefundsTotalDollars) * 100) / 100;
+  const [captured, stripeRefunded] = await Promise.all([
+    getStripeCapturedAmount(paymentIntentId),
+    getStripeRefundedAmount(paymentIntentId),
+  ]);
+  const priorRefunds = Math.max(priorRefundsTotalDollars, stripeRefunded);
+  return Math.round((captured - priorRefunds) * 100) / 100;
 }


### PR DESCRIPTION
## Problem

The admin **cancel / refund / return** flow could **double-refund on retry**. All three routes create the Stripe refund **first**, then write the DB `Refund` record + update order status. If the process dies in between (e.g. a Neon cold-start connection drop — observed on order **#365**'s cancel on 2026-06-26), Stripe has already refunded but the DB shows **0 prior refunds**. The old `getMaxRefundable()` computed the cap as `stripeCaptured − dbPriorRefundsSum`, so a retry recomputed the full captured amount as refundable and issued a **second refund**.

## Fix — two layers

**1. Refund cap is now Stripe-authoritative** (`src/lib/stripe/refund-utils.ts`)
- New `getStripeRefundedAmount()` lists Stripe's actual refunds for the PaymentIntent, excluding `failed`/`canceled`.
- `getMaxRefundable()` now subtracts `max(dbPriorRefundsSum, stripeActuallyRefunded)`. Signature unchanged → the 3 callers needed no edits. Closes the **full-refund** retry (cap collapses to ~0).

**2. Idempotency keys on every `stripe.refunds.create`** — the cap alone doesn't stop a **partial** re-refund (same amount still fits under the reduced cap):
- cancel: `order-cancel-refund-${id}-${amountCents}`
- refund: `order-refund-${id}-${amendmentId ?? 'manual'}-${amountCents}`
- return: `order-return-${id}-${sha1(sorted orderItemId:qty)}`

Keys include the amount so an amended retry gets a fresh key instead of colliding with the old amount and locking Stripe for 24h.

## Tests
- `src/lib/stripe/__tests__/refund-utils.test.ts` — cap math, incl. the regression "Stripe refunded but DB shows 0 → cap is 0".
- `src/app/api/v1/admin/orders/__tests__/cancel-refund-retry.test.ts` — route-level: a retry issues **no** second Stripe refund; happy path passes the idempotency key.

## Verification
- `npm run test:run` → **347/347 pass** · `npx tsc --noEmit` clean · `npx next lint` clean on changed files
- Ran the `security-reviewer` agent; it caught the cancel key originally omitting the amount (24h lock risk) — fixed in this PR.

## Known gaps (NOT in this PR)
- **Return route trusts client `unitPrice`** instead of server `orderItem.price` → an admin could over-refund within the order cap. Pre-existing, tracked separately.
- Manual same-amount refunds within 24h collide by design (safe direction: never double-pays; documented inline).
- `/api/v1/orders/[id]` PATCH and the Stripe webhook handler call `createRefund` without the Stripe-aware cap — separate paths, neither issues new Stripe refunds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)