### PR TITLE
fix(refunds): compute return refund from server price, not client unitPrice

### DIFF
--- a/src/app/api/v1/admin/orders/[id]/return/route.ts
+++ b/src/app/api/v1/admin/orders/[id]/return/route.ts
@@ -6,6 +6,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createHash } from 'crypto';
+import { z } from 'zod';
 import { requireOpsAuth } from '@/lib/auth/ops-session';
 import { prisma } from '@/lib/database/client';
 import { stripe } from '@/lib/stripe/client';
@@ -18,12 +19,31 @@ interface RouteParams {
   params: Promise<{ id: string }>;
 }
 
-interface ReturnItem {
+/**
+ * Request body contract. Only `orderItemId` + a positive whole `returnQuantity`
+ * are read per line; any extra price/product/variant fields are stripped and
+ * ignored (the server is the sole source of those values — and stripping rather
+ * than rejecting keeps a stale cached client working right after a deploy).
+ * `reason` is length-capped to stay under Stripe's 500-char metadata limit.
+ */
+const ReturnRequestSchema = z.object({
+  items: z
+    .array(
+      z.object({
+        orderItemId: z.string().min(1),
+        returnQuantity: z.number().int().positive(),
+      }),
+    )
+    .min(1, 'No items specified for return'),
+  reason: z.string().max(500).optional(),
+});
+
+/** A return line after validation, carrying canonical server-side values. */
+interface ValidatedReturn {
   orderItemId: string;
   productId: string;
   variantId: string | null;
   returnQuantity: number;
-  unitPrice: number;
 }
 
 type TransactionClient = Omit<typeof prisma, '$connect' | '$disconnect' | '$on' | '$transaction' | '$use' | '$extends'>;
@@ -139,18 +159,15 @@ export async function POST(
 
   try {
     const { id } = await params;
-    const body = await request.json();
-    const { items, reason } = body as {
-      items: ReturnItem[];
-      reason?: string;
-    };
 
-    if (!items || items.length === 0) {
+    const parsed = ReturnRequestSchema.safeParse(await request.json());
+    if (!parsed.success) {
       return NextResponse.json(
-        { success: false, error: 'No items specified for return' },
+        { success: false, error: parsed.error.issues[0]?.message || 'Invalid return request' },
         { status: 400 }
       );
     }
+    const { items, reason } = parsed.data;
 
     // Load order with items and existing refunds
     const order = await prisma.order.findUnique({
@@ -175,9 +192,24 @@ export async function POST(
       );
     }
 
-    // Validate each return item
+    // Validate each return item. The refund is computed ONLY from the stored
+    // OrderItem.price (server source of truth) — never from any price in the
+    // request body — so an inflated client value cannot enlarge the refund.
     let totalRefundAmount = 0;
+    const validatedReturns: ValidatedReturn[] = [];
+    const seenOrderItemIds = new Set<string>();
     for (const returnItem of items) {
+      // Reject a line that names the same order item twice: each pass reads the
+      // same `refundedQuantity` from the in-memory order, so duplicates would
+      // both clear the max-returnable check and stack into an over-refund.
+      if (seenOrderItemIds.has(returnItem.orderItemId)) {
+        return NextResponse.json(
+          { success: false, error: `Order item ${returnItem.orderItemId} listed more than once` },
+          { status: 400 }
+        );
+      }
+      seenOrderItemIds.add(returnItem.orderItemId);
+
       const orderItem = order.items.find((oi) => oi.id === returnItem.orderItemId);
       if (!orderItem) {
         return NextResponse.json(
@@ -187,12 +219,6 @@ export async function POST(
       }
 
       const maxReturnable = orderItem.quantity - orderItem.refundedQuantity;
-      if (returnItem.returnQuantity <= 0) {
-        return NextResponse.json(
-          { success: false, error: `Return quantity must be greater than 0 for ${orderItem.title}` },
-          { status: 400 }
-        );
-      }
       if (returnItem.returnQuantity > maxReturnable) {
         return NextResponse.json(
           { success: false, error: `Cannot return ${returnItem.returnQuantity} of ${orderItem.title} (max returnable: ${maxReturnable})` },
@@ -200,7 +226,13 @@ export async function POST(
         );
       }
 
-      totalRefundAmount += returnItem.returnQuantity * returnItem.unitPrice;
+      totalRefundAmount += returnItem.returnQuantity * Number(orderItem.price);
+      validatedReturns.push({
+        orderItemId: orderItem.id,
+        productId: orderItem.productId,
+        variantId: orderItem.variantId,
+        returnQuantity: returnItem.returnQuantity,
+      });
     }
 
     // Round to avoid floating point issues
@@ -250,7 +282,7 @@ export async function POST(
       // For unfulfilled orders: release committedQuantity instead
       const isFulfilled = order.fulfillmentStatus === 'DELIVERED';
 
-      for (const returnItem of items) {
+      for (const returnItem of validatedReturns) {
         await tx.orderItem.update({
           where: { id: returnItem.orderItemId },
           data: {
@@ -318,7 +350,7 @@ export async function POST(
       console.error('[Return API] Failed to send refund email:', emailError);
     }
 
-    const totalItemsReturned = items.reduce((sum, i) => sum + i.returnQuantity, 0);
+    const totalItemsReturned = validatedReturns.reduce((sum, i) => sum + i.returnQuantity, 0);
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/v1/admin/orders/__tests__/return-route.test.ts
+++ b/src/app/api/v1/admin/orders/__tests__/return-route.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests for POST /api/v1/admin/orders/[id]/return
+ *
+ * The load-bearing guarantee: the Stripe refund amount is computed from the
+ * STORED OrderItem.price, never from anything in the request body. An ops
+ * admin (or a compromised ops session) that posts an inflated `unitPrice`
+ * must not be able to enlarge the refund beyond what the customer paid for
+ * that line — even when the inflated total still fits under the whole-order
+ * Stripe cap.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
+
+// --- Mocks --------------------------------------------------------------
+
+const txMock = vi.hoisted(() => ({
+  orderItem: { update: vi.fn() },
+  refund: { create: vi.fn() },
+  order: { update: vi.fn() },
+}));
+
+const prismaMock = vi.hoisted(() => ({
+  order: { findUnique: vi.fn() },
+  $transaction: vi.fn(),
+}));
+
+const stripeMock = vi.hoisted(() => ({
+  refunds: { create: vi.fn() },
+}));
+
+const getMaxRefundableMock = vi.hoisted(() => vi.fn());
+const sendRefundProcessedEmailMock = vi.hoisted(() => vi.fn());
+const releaseCommittedInventoryMock = vi.hoisted(() => vi.fn());
+const requireOpsAuthMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/database/client', () => ({ prisma: prismaMock }));
+vi.mock('@/lib/stripe/client', () => ({ stripe: stripeMock }));
+vi.mock('@/lib/stripe/refund-utils', () => ({ getMaxRefundable: getMaxRefundableMock }));
+vi.mock('@/lib/email/email-service', () => ({ sendRefundProcessedEmail: sendRefundProcessedEmailMock }));
+vi.mock('@/lib/inventory/services/order-service', () => ({
+  releaseCommittedInventory: releaseCommittedInventoryMock,
+}));
+vi.mock('@/lib/auth/ops-session', () => ({ requireOpsAuth: requireOpsAuthMock }));
+
+import { POST } from '../[id]/return/route';
+
+// --- Fixtures -----------------------------------------------------------
+
+const ORDER_ID = 'order_1';
+
+/** A two-unit line that the customer actually paid $29.99/unit for. */
+function buildOrder() {
+  return {
+    id: ORDER_ID,
+    orderNumber: 1234,
+    stripePaymentIntentId: 'pi_test_123',
+    fulfillmentStatus: 'UNFULFILLED',
+    total: new Prisma.Decimal('100.00'),
+    customerEmail: 'customer@example.com',
+    customerName: 'Test Customer',
+    items: [
+      {
+        id: 'oi_1',
+        productId: 'p_1',
+        variantId: 'v_1',
+        title: 'Casamigos Blanco',
+        price: new Prisma.Decimal('29.99'),
+        quantity: 2,
+        refundedQuantity: 0,
+      },
+    ],
+    refunds: [],
+  };
+}
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest(`http://localhost/api/v1/admin/orders/${ORDER_ID}/return`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function callRoute(req: NextRequest) {
+  return POST(req, { params: Promise.resolve({ id: ORDER_ID }) });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireOpsAuthMock.mockResolvedValue({ role: 'admin' }); // not a NextResponse => authorized
+  prismaMock.order.findUnique.mockResolvedValue(buildOrder());
+  prismaMock.$transaction.mockImplementation(async (cb: (tx: typeof txMock) => unknown) => cb(txMock));
+  txMock.orderItem.update.mockResolvedValue({});
+  txMock.refund.create.mockResolvedValue({});
+  txMock.order.update.mockResolvedValue({});
+  // Cap is generous on purpose: an inflated single-line refund would still fit
+  // under it, so the cap is NOT what protects us — the server price is.
+  getMaxRefundableMock.mockResolvedValue(1000);
+  stripeMock.refunds.create.mockResolvedValue({ id: 're_test_1', status: 'succeeded' });
+  sendRefundProcessedEmailMock.mockResolvedValue(undefined);
+  releaseCommittedInventoryMock.mockResolvedValue(undefined);
+});
+
+describe('POST /api/v1/admin/orders/[id]/return — refund amount integrity', () => {
+  it('ignores an inflated client unitPrice and refunds the stored price', async () => {
+    // Malicious/compromised client: real price is $29.99, body claims $999.99.
+    // 1 unit * $999.99 = $999.99 still slips under the $1000 whole-order cap,
+    // so only the server-price computation stops the over-refund.
+    const res = await callRoute(
+      makeRequest({
+        items: [
+          {
+            orderItemId: 'oi_1',
+            returnQuantity: 1,
+            unitPrice: 999.99,
+            productId: 'p_1',
+            variantId: 'v_1',
+          },
+        ],
+        reason: 'tampered',
+      }),
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+
+    // Stripe is charged the STORED price (29.99 => 2999 cents), not 99999.
+    // Read the first call arg directly — the route also passes a second
+    // idempotency-options arg, which a single-arg matcher would trip on.
+    expect(stripeMock.refunds.create).toHaveBeenCalledTimes(1);
+    expect(stripeMock.refunds.create.mock.calls[0][0].amount).toBe(2999);
+    expect(stripeMock.refunds.create.mock.calls[0][0].amount).not.toBe(99999);
+
+    // Response and persisted refund record both reflect the server amount.
+    expect(json.data.amount).toBe(29.99);
+    expect(txMock.refund.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ amount: new Prisma.Decimal('29.99') }),
+      }),
+    );
+  });
+
+  it('refunds the correct server amount for a legitimate multi-unit return', async () => {
+    const res = await callRoute(
+      makeRequest({ items: [{ orderItemId: 'oi_1', returnQuantity: 2 }] }),
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    // 2 * 29.99 = 59.98 => 5998 cents
+    expect(stripeMock.refunds.create.mock.calls[0][0].amount).toBe(5998);
+    expect(json.data.amount).toBe(59.98);
+    expect(json.data.itemsReturned).toBe(2);
+  });
+
+  it('rejects a return quantity above what remains and never calls Stripe', async () => {
+    const res = await callRoute(
+      makeRequest({ items: [{ orderItemId: 'oi_1', returnQuantity: 3 }] }), // only 2 purchased
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.success).toBe(false);
+    expect(stripeMock.refunds.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-integer return quantity and never calls Stripe', async () => {
+    const res = await callRoute(
+      makeRequest({ items: [{ orderItemId: 'oi_1', returnQuantity: 1.5 }] }),
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.success).toBe(false);
+    expect(stripeMock.refunds.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects a body that lists the same order item twice (no stacked over-refund)', async () => {
+    // Both lines reference oi_1 (purchased qty 2). Read against the same
+    // in-memory refundedQuantity=0, each clears max-returnable, and they would
+    // stack to 3 units of refund without the duplicate guard.
+    const res = await callRoute(
+      makeRequest({
+        items: [
+          { orderItemId: 'oi_1', returnQuantity: 2 },
+          { orderItemId: 'oi_1', returnQuantity: 1 },
+        ],
+      }),
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.success).toBe(false);
+    expect(stripeMock.refunds.create).not.toHaveBeenCalled();
+  });
+
+  it('returns the auth response and never touches Stripe when unauthorized', async () => {
+    requireOpsAuthMock.mockResolvedValue(
+      NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 }),
+    );
+
+    const res = await callRoute(
+      makeRequest({ items: [{ orderItemId: 'oi_1', returnQuantity: 1 }] }),
+    );
+
+    expect(res.status).toBe(401);
+    expect(stripeMock.refunds.create).not.toHaveBeenCalled();
+    expect(prismaMock.order.findUnique).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/ops/orders/[id]/page.tsx
+++ b/src/app/ops/orders/[id]/page.tsx
@@ -660,14 +660,14 @@ export default function OrderDetailPage(): ReactElement {
     if (!order) return;
     setReturnProcessing(true);
     try {
+      // Only send the order-item id and quantity. Price, product, and variant
+      // are resolved server-side from the stored OrderItem, so there is nothing
+      // here a tampered client could use to inflate the refund.
       const itemsToReturn = order.items
         .filter((item) => (returnItems[item.id] || 0) > 0)
         .map((item) => ({
           orderItemId: item.id,
-          productId: item.product.id,
-          variantId: item.variant?.id || null,
           returnQuantity: returnItems[item.id],
-          unitPrice: item.price,
         }));
 
       const res = await fetch(`/api/v1/admin/orders/${orderId}/return`, {


### PR DESCRIPTION
## Problem

`POST /api/v1/admin/orders/[id]/return` computed the Stripe refund from the request body's `unitPrice`:

```ts
totalRefundAmount += returnItem.returnQuantity * returnItem.unitPrice; // client-supplied
```

An ops admin (or a compromised ops session) could post an inflated `unitPrice` and refund **more than the customer paid for that line**. The only backstop was the whole-order `maxRefundable` cap, so over-refunding a single line was possible as long as the inflated total still fit under the order cap.

## Fix

- Refund is now computed from the **stored** `OrderItem.price` (server source of truth), never the request body.
- The `ReturnItem` request contract is trimmed to `{ orderItemId, returnQuantity }`. `unitPrice`, `productId`, and `variantId` are dropped — product/variant for the inventory-restore step are read from the loaded `OrderItem` (new `ValidatedReturn` list). This also closes a smaller latent issue where a forged `productId`/`variantId` could restore stock to the wrong product.
- Added an integer guard on `returnQuantity` (a `NaN`/float previously slipped past the `<= 0` check and would reach Stripe with a `NaN` amount).
- Updated the only caller, `processReturn` in `src/app/ops/orders/[id]/page.tsx`, to send just the two trusted fields.

## Test

New `src/app/api/v1/admin/orders/__tests__/return-route.test.ts` (4 tests). The load-bearing one posts `unitPrice: 999.99` on a $29.99 line with the order cap set high on purpose, and asserts Stripe is charged **2999 cents, not 99999**.

## Verification

- `npm run test:run` → 342 passed
- `npx tsc --noEmit` clean on touched files; `npx next lint` clean (the two `<img>` warnings in page.tsx are pre-existing)
- Not exercised: live Stripe call (live keys); the delivered-order inventory-restore path is a pure refactor reading the same `orderItem`.

## Notes

Separate from the double-refund-on-retry idempotency work (PR #168). This branch predates #168 and touches different lines, so they merge cleanly — the return route ends up with both the server-price fix and the idempotency key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)