### PR TITLE
fix(analytics): tag bach/bachelorette quick-buy CTA as quick_buy section

### DIFF
--- a/src/components/landing/LandingPageTemplate.tsx
+++ b/src/components/landing/LandingPageTemplate.tsx
@@ -449,7 +449,7 @@ export default function LandingPageTemplate({
                   openBuilder();
                 }}
                 onBuyNow={(p) => {
-                  trackCTAClick(p.name, '#quickbuy', 'package_card');
+                  trackCTAClick(p.name, '#quickbuy', 'quick_buy');
                   onPackageClick(p, 'quickbuy');
                   setQuickBuyPkg(p);
                 }}


### PR DESCRIPTION
## What

In `LandingPageTemplate.tsx`, the package card's **"Buy this package now"** CTA (`onBuyNow`) fired `trackCTAClick(..., 'package_card')` — the same `section` as the card's main "build package" CTA (`onCta`). The landing-page registry (`src/lib/analytics/landing-pages.ts`) declares a **separate `quick_buy` section** for the **bachelor** and **bachelorette** pages, so:

- the `quick_buy` section never received a single click (declared but never emitted), and
- quick-buy vs. build-package clicks were indistinguishable in `/admin/analytics`.

This points `onBuyNow` at the `'quick_buy'` section (one-line, type-safe — `quick_buy` is already in the `CtaSection` union).

```diff
- trackCTAClick(p.name, '#quickbuy', 'package_card');
+ trackCTAClick(p.name, '#quickbuy', 'quick_buy');
```

## Why it matters
`LandingPageTemplate` powers `/austin-bachelor-party-delivery` and `/austin-bachelorette-party-delivery`, whose registry entries both list `quick_buy` as an expected CTA section. Without this, that row is always empty and the quick-buy funnel can't be measured separately from the build-package funnel.

## Verification
- **Live prod QA**: before the fix, clicking "Buy this package now" on `/austin-bachelor-party-delivery` landed in `analytics_events` as `section=package_card`, `button_text="Austin Bach Starter"` (confirmed via DB).
- `npx tsc --noEmit` → 0 errors
- `npx eslint src/components/landing/LandingPageTemplate.tsx` → clean
- No tests assert the old section value.

Part of a full landing-page CTA/conversion/A-B tracking QA; the broader findings (conversion attribution coverage, cocktail-kit card tracking, wedding-calculator path mapping, duplicate experiment-assign request) are reported separately for triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)