### PR TITLE
fix(refunds): make charge.refunded webhook idempotent (no double Refund rows)

### DIFF
--- a/scripts/ops/reconcile-duplicate-refunds.mjs
+++ b/scripts/ops/reconcile-duplicate-refunds.mjs
@@ -1,0 +1,370 @@
+/**
+ * Reconcile duplicate Refund rows against Stripe (authoritative).
+ *
+ * Bug being repaired (see src/lib/stripe/webhooks.ts handleChargeRefunded):
+ * the charge.refunded webhook used to UNCONDITIONALLY create a Refund row, on
+ * top of the row the admin cancel/refund route had already written for the same
+ * Stripe refund. Result: every admin-initiated refund left TWO rows for ONE real
+ * Stripe refund —
+ *     row A: stripeRefundId set, processedBy='admin'  (the route's row, keep)
+ *     row B: stripeRefundId=NULL, reason='Stripe refund', processedBy=NULL (dupe)
+ * which double-counts refund totals in the DB and can drive getMaxRefundable
+ * negative.
+ *
+ * This script reconciles each order's DB Refund rows against the refunds Stripe
+ * ACTUALLY has for that order's PaymentIntent, then proposes the minimal change
+ * that makes the DB match Stripe exactly:
+ *
+ *   - MERGE: a real Stripe refund that has NO stamped row but DOES have a
+ *     matching-amount orphan → stamp the orphan with the Stripe refund id
+ *     (claim it) rather than deleting + re-creating.
+ *   - DELETE: an orphan row (stripeRefundId=NULL AND reason='Stripe refund')
+ *     whose amount is already covered by a stamped, Stripe-verified row → the
+ *     webhook duplicate. Deleted.
+ *
+ * SAFETY — it will only APPLY changes to an order when, AFTER the planned
+ * changes, the order's remaining DB refund rows map 1:1 onto Stripe's live
+ * refunds (same ids, same total within a cent). Any order that does not reconcile
+ * cleanly (stamped id missing from Stripe, DB total != Stripe total, orphan an
+ * amendment points to, manual DB-only refund with no Stripe record, etc.) is left
+ * UNTOUCHED and reported as NEEDS-MANUAL. It never deletes a row by reason alone
+ * and never touches a row an OrderAmendment.refundId points at.
+ *
+ * Dry-run is the DEFAULT. Nothing is written without --apply.
+ *
+ * Usage:
+ *   set -a && source .env.local && set +a
+ *   node scripts/ops/reconcile-duplicate-refunds.mjs                 # dry run, all orders
+ *   node scripts/ops/reconcile-duplicate-refunds.mjs --order=365     # dry run, one order #
+ *   node scripts/ops/reconcile-duplicate-refunds.mjs --json          # machine-readable plan
+ *   node scripts/ops/reconcile-duplicate-refunds.mjs --apply         # WRITE the reconciliation
+ */
+
+import { PrismaClient } from '@prisma/client';
+import Stripe from 'stripe';
+
+// Hard guard: without a LIVE Stripe key, refunds.list() silently returns empty
+// for every order and the script would "reconcile" against nothing — flagging
+// every order needs-manual while looking like it ran. Fail loudly instead.
+const STRIPE_KEY = process.env.STRIPE_SECRET_KEY;
+if (!STRIPE_KEY) {
+  console.error('ERROR: STRIPE_SECRET_KEY is not set. Run: set -a && source .env.local && set +a');
+  process.exit(1);
+}
+if (STRIPE_KEY.startsWith('sk_test_') || STRIPE_KEY.startsWith('rk_test_')) {
+  console.error('ERROR: STRIPE_SECRET_KEY is a TEST key. This reconciles LIVE refund data — refusing to run.');
+  process.exit(1);
+}
+
+const prisma = new PrismaClient();
+const stripe = new Stripe(STRIPE_KEY);
+
+const args = process.argv.slice(2);
+const APPLY = args.includes('--apply');
+const OUT_JSON = args.includes('--json');
+const ONLY_ORDER = num(flag('--order'), 0);
+const CENT_TOLERANCE = 1; // 1 cent of slack on total comparisons
+
+function flag(name) {
+  const a = args.find((x) => x.startsWith(`${name}=`));
+  return a ? a.split('=').slice(1).join('=') : undefined;
+}
+function num(v, d) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : d;
+}
+function cents(decimalLike) {
+  return Math.round(Number(decimalLike) * 100);
+}
+function usd(c) {
+  return `$${(c / 100).toFixed(2)}`;
+}
+function log(...a) {
+  if (OUT_JSON) console.error(...a);
+  else console.log(...a);
+}
+
+/** Live (money-moving) refunds Stripe has for a PaymentIntent. */
+async function liveStripeRefunds(paymentIntentId) {
+  const out = [];
+  for await (const r of stripe.refunds.list({ payment_intent: paymentIntentId, limit: 100 })) {
+    if (r.status === 'failed' || r.status === 'canceled') continue;
+    out.push({ id: r.id, amountCents: r.amount, status: r.status });
+  }
+  return out;
+}
+
+/**
+ * Plan the reconciliation for one order. Pure: returns the plan, writes nothing.
+ * plan.ok === true means the post-change DB state matches Stripe exactly and is
+ * safe to apply.
+ */
+function planOrder(order, dbRows, stripeRefunds, amendmentRefundIds) {
+  const merges = []; // { rowId, stripeRefundId, amountCents }
+  const deletes = []; // { rowId, amountCents, reason }
+  const notes = [];
+
+  const stripeById = new Map(stripeRefunds.map((r) => [r.id, r]));
+  const stripeTotalCents = stripeRefunds.reduce((s, r) => s + r.amountCents, 0);
+
+  const stamped = dbRows.filter((r) => r.stripeRefundId);
+  const orphans = dbRows.filter((r) => !r.stripeRefundId);
+
+  // Anomaly: a stamped row whose id Stripe doesn't recognize. Don't touch the order.
+  const ghostStamped = stamped.filter((r) => !stripeById.has(r.stripeRefundId));
+  if (ghostStamped.length > 0) {
+    notes.push(
+      `stamped row(s) reference refunds Stripe does not list: ${ghostStamped
+        .map((r) => `${r.id.slice(0, 8)}→${r.stripeRefundId}`)
+        .join(', ')}`
+    );
+    return { ok: false, merges, deletes, notes, stripeTotalCents };
+  }
+
+  // Which Stripe refunds already have a stamped row?
+  const stampedIds = new Set(stamped.map((r) => r.stripeRefundId));
+
+  // Working pool of orphans we can still claim/delete.
+  const pool = orphans.map((r) => ({ ...r, claimed: false }));
+
+  // Pass 1 — MERGE: a real Stripe refund with no stamped row but a matching-amount orphan.
+  for (const r of stripeRefunds) {
+    if (stampedIds.has(r.id)) continue;
+    const cand = pool.find((o) => !o.claimed && cents(o.amount) === r.amountCents);
+    if (cand) {
+      cand.claimed = true;
+      stampedIds.add(r.id);
+      merges.push({ rowId: cand.id, stripeRefundId: r.id, amountCents: r.amountCents });
+    } else {
+      notes.push(`Stripe refund ${r.id} (${usd(r.amountCents)}) has no DB row to claim — missing record`);
+    }
+  }
+
+  // Pass 2 — DELETE: leftover orphan duplicates. Strict signature: webhook-created
+  // ('Stripe refund'), null id, amount already covered by a stamped real refund.
+  const stampedAmountCounts = new Map(); // amountCents -> count of stamped rows of that amount
+  for (const r of stamped) {
+    const k = cents(r.amount);
+    stampedAmountCounts.set(k, (stampedAmountCounts.get(k) || 0) + 1);
+  }
+  for (const m of merges) {
+    stampedAmountCounts.set(m.amountCents, (stampedAmountCounts.get(m.amountCents) || 0) + 1);
+  }
+
+  for (const o of pool) {
+    if (o.claimed) continue;
+    const amt = cents(o.amount);
+    const isWebhookOrphan = o.reason === 'Stripe refund';
+    const coveredByStamped = (stampedAmountCounts.get(amt) || 0) > 0;
+    const referencedByAmendment = amendmentRefundIds.has(o.id);
+
+    if (isWebhookOrphan && coveredByStamped && !referencedByAmendment) {
+      deletes.push({ rowId: o.id, amountCents: amt, reason: o.reason });
+    } else if (referencedByAmendment) {
+      notes.push(`orphan ${o.id.slice(0, 8)} (${usd(amt)}) is referenced by an OrderAmendment — left as-is`);
+    } else {
+      notes.push(`orphan ${o.id.slice(0, 8)} (${usd(amt)}, reason="${o.reason}") not a safe webhook dupe — left as-is`);
+    }
+  }
+
+  // Post-condition: simulate the resulting rows and require an exact match to Stripe.
+  const deleteIds = new Set(deletes.map((d) => d.rowId));
+  const resultRows = dbRows.filter((r) => !deleteIds.has(r.id));
+  const resultStampedIds = new Set(
+    resultRows.map((r) => {
+      const merged = merges.find((m) => m.rowId === r.id);
+      return merged ? merged.stripeRefundId : r.stripeRefundId;
+    })
+  );
+  resultStampedIds.delete(null);
+  resultStampedIds.delete(undefined);
+
+  const resultTotalCents = resultRows.reduce((s, r) => {
+    const merged = merges.find((m) => m.rowId === r.id);
+    return s + (merged ? merged.amountCents : cents(r.amount));
+  }, 0);
+
+  const everyStripeRefundHasRow = stripeRefunds.every((r) => resultStampedIds.has(r.id));
+  const noExtraRows = resultRows.length === stripeRefunds.length;
+  const totalsMatch = Math.abs(resultTotalCents - stripeTotalCents) <= CENT_TOLERANCE;
+  const ok = everyStripeRefundHasRow && noExtraRows && totalsMatch && (merges.length > 0 || deletes.length > 0);
+
+  if (!ok && (merges.length > 0 || deletes.length > 0)) {
+    notes.push(
+      `post-change state would NOT match Stripe (rows ${resultRows.length} vs stripe ${stripeRefunds.length}, ` +
+        `total ${usd(resultTotalCents)} vs ${usd(stripeTotalCents)}) — not applying`
+    );
+  }
+
+  return { ok, merges, deletes, notes, stripeTotalCents };
+}
+
+async function main() {
+  log('=== Reconcile duplicate Refund rows against Stripe ===');
+  log('Mode:', APPLY ? 'APPLY (will write)' : 'DRY RUN (no writes)');
+  if (ONLY_ORDER) log('Scope: order #' + ONLY_ORDER);
+
+  // Candidate orders: any order that has at least one orphan 'Stripe refund' row.
+  // (We still verify EVERY such order against Stripe before touching anything.)
+  const orphanRows = await prisma.refund.findMany({
+    where: { stripeRefundId: null, reason: 'Stripe refund' },
+    select: { orderId: true },
+  });
+  let orderIds = [...new Set(orphanRows.map((r) => r.orderId))];
+
+  if (ONLY_ORDER) {
+    const target = await prisma.order.findFirst({ where: { orderNumber: ONLY_ORDER }, select: { id: true } });
+    orderIds = target ? orderIds.filter((id) => id === target.id) : [];
+    if (!target) log(`WARN: order #${ONLY_ORDER} not found`);
+  }
+
+  log(`Candidate orders with webhook-orphan refund rows: ${orderIds.length}`);
+
+  const report = [];
+  let totalDeletes = 0;
+  let totalMerges = 0;
+  let needsManual = 0;
+  let applied = 0;
+
+  for (const orderId of orderIds) {
+    const order = await prisma.order.findUnique({
+      where: { id: orderId },
+      select: { id: true, orderNumber: true, customerName: true, stripePaymentIntentId: true },
+    });
+    if (!order) continue;
+
+    const dbRows = await prisma.refund.findMany({
+      where: { orderId },
+      orderBy: { createdAt: 'asc' },
+      select: { id: true, stripeRefundId: true, amount: true, reason: true, processedBy: true, createdAt: true },
+    });
+
+    const entry = {
+      orderNumber: order.orderNumber,
+      customer: order.customerName,
+      orderId: order.id,
+      dbRows: dbRows.length,
+      merges: [],
+      deletes: [],
+      notes: [],
+      status: 'skip',
+    };
+
+    if (!order.stripePaymentIntentId) {
+      entry.notes.push('no stripePaymentIntentId — cannot verify against Stripe; skipped');
+      entry.status = 'needs-manual';
+      needsManual++;
+      report.push(entry);
+      continue;
+    }
+
+    let stripeRefunds;
+    try {
+      stripeRefunds = await liveStripeRefunds(order.stripePaymentIntentId);
+    } catch (err) {
+      entry.notes.push('Stripe lookup failed: ' + (err?.message || String(err)));
+      entry.status = 'needs-manual';
+      needsManual++;
+      report.push(entry);
+      continue;
+    }
+
+    // Which refund-row ids are pointed to by an OrderAmendment (never delete those).
+    const amendmentRefs = await prisma.orderAmendment.findMany({
+      where: { refundId: { in: dbRows.map((r) => r.id) } },
+      select: { refundId: true },
+    });
+    const amendmentRefundIds = new Set(amendmentRefs.map((a) => a.refundId));
+
+    const plan = planOrder(order, dbRows, stripeRefunds, amendmentRefundIds);
+    entry.merges = plan.merges;
+    entry.deletes = plan.deletes;
+    entry.notes = plan.notes;
+
+    const stripeTotal = usd(plan.stripeTotalCents);
+    const dbTotal = usd(dbRows.reduce((s, r) => s + cents(r.amount), 0));
+
+    log(`\n--- Order #${order.orderNumber} (${order.customerName}) ---`);
+    log(`  DB rows: ${dbRows.length} (total ${dbTotal}) | Stripe live refunds: ${stripeRefunds.length} (total ${stripeTotal})`);
+    for (const m of plan.merges) log(`  MERGE  row ${m.rowId.slice(0, 8)} <- stamp ${m.stripeRefundId} (${usd(m.amountCents)})`);
+    for (const d of plan.deletes) log(`  DELETE row ${d.rowId.slice(0, 8)} (${usd(d.amountCents)}, "${d.reason}")`);
+    for (const n of plan.notes) log(`  note: ${n}`);
+
+    if (!plan.ok) {
+      entry.status = 'needs-manual';
+      needsManual++;
+      report.push(entry);
+      continue;
+    }
+
+    entry.status = APPLY ? 'applied' : 'planned';
+    totalMerges += plan.merges.length;
+    totalDeletes += plan.deletes.length;
+
+    if (APPLY) {
+      await prisma.$transaction(async (tx) => {
+        for (const m of plan.merges) {
+          await tx.refund.update({
+            where: { id: m.rowId },
+            data: { stripeRefundId: m.stripeRefundId, status: 'SUCCEEDED' },
+          });
+        }
+        for (const d of plan.deletes) {
+          await tx.refund.delete({ where: { id: d.rowId } });
+        }
+      });
+      // Re-label financialStatus from the reconciled rows.
+      await recomputeFinancialStatus(order.id);
+      applied++;
+      log('  ✓ applied');
+    }
+
+    report.push(entry);
+  }
+
+  log('\n=== Summary ===');
+  log(`Orders inspected:   ${orderIds.length}`);
+  log(`Rows to MERGE:      ${totalMerges}`);
+  log(`Rows to DELETE:     ${totalDeletes}`);
+  log(`Needs manual review:${needsManual}`);
+  if (APPLY) log(`Orders applied:     ${applied}`);
+  else log('\n(DRY RUN — re-run with --apply to write these changes.)');
+
+  if (OUT_JSON) console.log(JSON.stringify({ mode: APPLY ? 'apply' : 'dry-run', report }, null, 2));
+}
+
+/**
+ * Mirror of recomputeOrderFinancialStatus (src/lib/inventory/services/order-service.ts)
+ * — scripts can't import from the @/ alias. Re-derives REFUNDED / PARTIALLY_REFUNDED
+ * from the order's remaining refund rows vs. the Stripe-captured amount.
+ */
+async function recomputeFinancialStatus(orderId) {
+  const order = await prisma.order.findUnique({ where: { id: orderId } });
+  if (!order) return;
+
+  const agg = await prisma.refund.aggregate({ where: { orderId }, _sum: { amount: true } });
+  const totalRefunded = Number(agg._sum.amount || 0);
+
+  let originallyCharged = Number(order.total);
+  if (order.stripePaymentIntentId) {
+    try {
+      const pi = await stripe.paymentIntents.retrieve(order.stripePaymentIntentId);
+      originallyCharged = pi.amount_received / 100;
+    } catch {
+      // keep order.total fallback
+    }
+  }
+
+  if (totalRefunded >= originallyCharged - 0.005) {
+    await prisma.order.update({ where: { id: orderId }, data: { financialStatus: 'REFUNDED' } });
+  } else if (totalRefunded > 0) {
+    await prisma.order.update({ where: { id: orderId }, data: { financialStatus: 'PARTIALLY_REFUNDED' } });
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/app/api/v1/admin/orders/[id]/cancel/route.ts
+++ b/src/app/api/v1/admin/orders/[id]/cancel/route.ts
@@ -140,24 +140,19 @@ export async function POST(
         { idempotencyKey: `order-cancel-refund-${id}-${refundAmountCents}` }
       );
 
-      // Create refund record in DB
-      await createRefund(id, refundAmount, 'Order cancelled');
-
-      // Update refund record with Stripe ID
-      const dbRefund = await prisma.refund.findFirst({
-        where: { orderId: id },
-        orderBy: { createdAt: 'desc' },
+      // Create refund record in DB and stamp it with the Stripe refund id.
+      // createRefund returns the new row's id so we stamp THAT row — looking it
+      // up afterward with findFirst(desc) could grab a different row if the
+      // charge.refunded webhook inserts one for this order in between.
+      const refundRowId = await createRefund(id, refundAmount, 'Order cancelled');
+      await prisma.refund.update({
+        where: { id: refundRowId },
+        data: {
+          stripeRefundId: stripeRefund.id,
+          processedBy: 'admin',
+          processedAt: new Date(),
+        },
       });
-      if (dbRefund) {
-        await prisma.refund.update({
-          where: { id: dbRefund.id },
-          data: {
-            stripeRefundId: stripeRefund.id,
-            processedBy: 'admin',
-            processedAt: new Date(),
-          },
-        });
-      }
 
       refundResult = {
         stripeRefundId: stripeRefund.id,

--- a/src/app/api/v1/admin/orders/[id]/refund/route.ts
+++ b/src/app/api/v1/admin/orders/[id]/refund/route.ts
@@ -101,24 +101,19 @@ export async function POST(
       { idempotencyKey: `order-refund-${id}-${amendmentId ?? 'manual'}-${amountCents}` }
     );
 
-    // Create refund record in DB and update financial status
-    await createRefund(id, amount, reason || 'Order amendment refund');
-
-    // Update the refund record with the Stripe refund ID
-    const dbRefund = await prisma.refund.findFirst({
-      where: { orderId: id },
-      orderBy: { createdAt: 'desc' },
+    // Create refund record in DB and stamp it with the Stripe refund id.
+    // createRefund returns the new row's id so we stamp THAT row — looking it up
+    // afterward with findFirst(desc) could grab a different row if the
+    // charge.refunded webhook inserts one for this order in between.
+    const refundRowId = await createRefund(id, amount, reason || 'Order amendment refund');
+    await prisma.refund.update({
+      where: { id: refundRowId },
+      data: {
+        stripeRefundId: refund.id,
+        processedBy: 'admin',
+        processedAt: new Date(),
+      },
     });
-    if (dbRefund) {
-      await prisma.refund.update({
-        where: { id: dbRefund.id },
-        data: {
-          stripeRefundId: refund.id,
-          processedBy: 'admin',
-          processedAt: new Date(),
-        },
-      });
-    }
 
     // Update OrderAmendment resolution if linked
     if (amendmentId) {
@@ -126,7 +121,7 @@ export async function POST(
         where: { id: amendmentId },
         data: {
           resolution: 'REFUNDED',
-          refundId: dbRefund?.id || null,
+          refundId: refundRowId,
           resolvedAt: new Date(),
         },
       });

--- a/src/app/api/v1/admin/orders/__tests__/cancel-refund-retry.test.ts
+++ b/src/app/api/v1/admin/orders/__tests__/cancel-refund-retry.test.ts
@@ -51,7 +51,8 @@ vi.mock('@/lib/database/client', () => ({
 
 // --- Side-effectful services (no-ops here) ---
 vi.mock('@/lib/inventory/services/order-service', () => ({
-  createRefund: vi.fn().mockResolvedValue(undefined),
+  // Returns the new Refund row id — the route stamps THAT row by id.
+  createRefund: vi.fn().mockResolvedValue('rf_db_1'),
   releaseCommittedInventory: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock('@/lib/email/email-service', () => ({

--- a/src/lib/inventory/index.ts
+++ b/src/lib/inventory/index.ts
@@ -104,5 +104,6 @@ export {
   updateOrderStatus,
   updateFulfillmentStatus,
   createRefund,
+  recomputeOrderFinancialStatus,
 } from './services/order-service';
 export type { OrderWithItems, OrderItemWithProduct } from './services/order-service';

--- a/src/lib/inventory/services/order-service.ts
+++ b/src/lib/inventory/services/order-service.ts
@@ -815,7 +815,10 @@ export async function updateFulfillmentStatus(
 }
 
 /**
- * Create a refund for an order.
+ * Create a refund for an order. Returns the id of the new Refund row so callers
+ * can stamp it (stripeRefundId / processedBy) by id — looking it up afterward
+ * with findFirst(orderBy createdAt desc) can grab the wrong row if a concurrent
+ * webhook inserts another refund for the same order in between.
  *
  * The financialStatus decision compares against the Stripe-captured amount
  * when available. order.total alone gets rewritten by OrderAmendment when
@@ -827,7 +830,7 @@ export async function createRefund(
   orderId: string,
   amount: number,
   reason?: string
-): Promise<void> {
+): Promise<string> {
   const order = await prisma.order.findUnique({
     where: { id: orderId },
   });
@@ -837,7 +840,7 @@ export async function createRefund(
   }
 
   // Create refund record
-  await prisma.refund.create({
+  const refund = await prisma.refund.create({
     data: {
       orderId,
       amount: new Prisma.Decimal(amount),
@@ -846,7 +849,25 @@ export async function createRefund(
     },
   });
 
-  // Update order financial status based on total refunds vs originally captured.
+  await recomputeOrderFinancialStatus(orderId);
+
+  return refund.id;
+}
+
+/**
+ * Recompute and persist an order's financialStatus from its current Refund rows.
+ *
+ * Compares total refunded against what Stripe actually captured (falling back to
+ * order.total when the PaymentIntent can't be read). Extracted so both
+ * createRefund and the charge.refunded webhook reconciler converge on the same
+ * label instead of duplicating the comparison.
+ */
+export async function recomputeOrderFinancialStatus(orderId: string): Promise<void> {
+  const order = await prisma.order.findUnique({
+    where: { id: orderId },
+  });
+  if (!order) return;
+
   const totalRefunds = await prisma.refund.aggregate({
     where: { orderId },
     _sum: { amount: true },

--- a/src/lib/stripe/__tests__/charge-refunded-idempotent.test.ts
+++ b/src/lib/stripe/__tests__/charge-refunded-idempotent.test.ts
@@ -1,0 +1,325 @@
+/**
+ * charge.refunded webhook idempotency.
+ *
+ * The webhook fires ~0.5s after the admin cancel/refund routes have ALREADY
+ * written (and stamped) a Refund row for the same Stripe refund, and Stripe can
+ * re-deliver it at any time. It must reconcile against Stripe's actual refunds,
+ * not blindly create a row. Core regression: an admin cancel-with-refund
+ * followed by charge.refunded leaves exactly ONE Refund row.
+ *
+ * order-service (createRefund / recomputeOrderFinancialStatus) is left REAL so
+ * the financial-status recompute is exercised against the same in-memory store.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type Stripe from 'stripe';
+
+// ---- shared in-memory store (mock-prefixed so vi.mock factories may close over it) ----
+interface MockRefund {
+  id: string;
+  orderId: string;
+  stripeRefundId: string | null;
+  amount: number;
+  reason: string | null;
+  status: string;
+  processedBy: string | null;
+  processedAt: Date | null;
+  createdAt: Date;
+}
+interface MockOrder {
+  id: string;
+  orderNumber: number;
+  customerName: string;
+  customerEmail: string;
+  total: number;
+  stripePaymentIntentId: string | null;
+  financialStatus: string;
+}
+const mockDb: { refunds: MockRefund[]; order: MockOrder; seq: number } = {
+  refunds: [],
+  order: freshOrder(),
+  seq: 0,
+};
+
+function freshOrder(): MockOrder {
+  return {
+    id: 'order-1',
+    orderNumber: 365,
+    customerName: 'Test Customer',
+    customerEmail: 'test@example.com',
+    total: 150,
+    stripePaymentIntentId: 'pi_1',
+    financialStatus: 'PAID',
+  };
+}
+
+function amtEquals(a: number, b: unknown): boolean {
+  return Math.abs(a - Number(b)) < 0.005;
+}
+
+function uniqueViolation(): Error {
+  const err = new Error('Unique constraint failed') as Error & { code: string };
+  err.code = 'P2002';
+  return err;
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+vi.mock('@/lib/database/client', () => ({
+  prisma: {
+    order: {
+      findFirst: vi.fn(async ({ where }: any) => {
+        if (where?.stripePaymentIntentId && where.stripePaymentIntentId !== mockDb.order.stripePaymentIntentId) return null;
+        return mockDb.order;
+      }),
+      findUnique: vi.fn(async ({ where }: any) => {
+        if (where?.id && where.id !== mockDb.order.id) return null;
+        return mockDb.order;
+      }),
+      update: vi.fn(async ({ where, data }: any) => {
+        if (where?.id === mockDb.order.id) Object.assign(mockDb.order, data);
+        return mockDb.order;
+      }),
+    },
+    refund: {
+      findUnique: vi.fn(async ({ where }: any) => {
+        if (where?.stripeRefundId !== undefined) {
+          return mockDb.refunds.find((r) => r.stripeRefundId === where.stripeRefundId) ?? null;
+        }
+        if (where?.id !== undefined) {
+          return mockDb.refunds.find((r) => r.id === where.id) ?? null;
+        }
+        return null;
+      }),
+      findFirst: vi.fn(async ({ where, orderBy }: any) => {
+        let rows = mockDb.refunds.filter((r) => {
+          if (where?.orderId !== undefined && r.orderId !== where.orderId) return false;
+          if (where?.stripeRefundId === null && r.stripeRefundId !== null) return false;
+          if (where?.amount !== undefined && !amtEquals(Number(where.amount), r.amount)) return false;
+          return true;
+        });
+        if (orderBy?.createdAt === 'desc') {
+          rows = rows.slice().sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+        }
+        return rows[0] ?? null;
+      }),
+      create: vi.fn(async ({ data }: any) => {
+        if (data.stripeRefundId && mockDb.refunds.some((r) => r.stripeRefundId === data.stripeRefundId)) {
+          throw uniqueViolation();
+        }
+        const row: MockRefund = {
+          id: `rf_${++mockDb.seq}`,
+          orderId: data.orderId,
+          stripeRefundId: data.stripeRefundId ?? null,
+          amount: Number(data.amount),
+          reason: data.reason ?? null,
+          status: data.status ?? 'PENDING',
+          processedBy: data.processedBy ?? null,
+          processedAt: data.processedAt ?? null,
+          createdAt: new Date(Date.now() + mockDb.seq),
+        };
+        mockDb.refunds.push(row);
+        return row;
+      }),
+      update: vi.fn(async ({ where, data }: any) => {
+        const row = mockDb.refunds.find((r) => r.id === where.id);
+        if (!row) throw new Error('Refund not found');
+        if (data.stripeRefundId && mockDb.refunds.some((r) => r.id !== row.id && r.stripeRefundId === data.stripeRefundId)) {
+          throw uniqueViolation();
+        }
+        Object.assign(row, data, { amount: data.amount !== undefined ? Number(data.amount) : row.amount });
+        return row;
+      }),
+      aggregate: vi.fn(async ({ where }: any) => {
+        const sum = mockDb.refunds
+          .filter((r) => r.orderId === where.orderId)
+          .reduce((s, r) => s + r.amount, 0);
+        return { _sum: { amount: sum } };
+      }),
+    },
+  },
+}));
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+const mockRefundsList = vi.fn();
+vi.mock('@/lib/stripe/client', () => ({
+  stripe: {
+    refunds: { list: (...a: unknown[]) => mockRefundsList(...a) },
+    paymentIntents: { retrieve: vi.fn(async () => ({ amount_received: 15000 })) }, // $150 captured
+  },
+  STRIPE_WEBHOOK_SECRET: 'whsec_test',
+}));
+
+const mockSendRefundEmail = vi.fn().mockResolvedValue(undefined);
+vi.mock('@/lib/email', () => ({
+  sendOrderConfirmationEmail: vi.fn().mockResolvedValue(undefined),
+  sendPaymentFailedEmail: vi.fn().mockResolvedValue(undefined),
+  sendRefundProcessedEmail: (...a: unknown[]) => mockSendRefundEmail(...a),
+}));
+
+const mockVoidCommission = vi.fn().mockResolvedValue(undefined);
+vi.mock('@/lib/affiliates/commission-engine', () => ({
+  voidCommissionForOrder: (...a: unknown[]) => mockVoidCommission(...a),
+}));
+
+// Heavy / side-effectful imports pulled in by webhooks.ts but unused on the
+// charge.refunded path — stub so importing the module stays cheap and isolated.
+vi.mock('@/lib/calendar/google-calendar', () => ({
+  createOrderCalendarEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+/** Build the async-iterable that stripe.refunds.list() returns. */
+function listOf(refunds: Array<{ id: string; amount: number; status: string }>): AsyncIterable<unknown> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const r of refunds) yield r;
+    },
+  };
+}
+
+function chargeRefundedEvent(): Stripe.Event {
+  return {
+    type: 'charge.refunded',
+    data: { object: { id: 'ch_1', payment_intent: 'pi_1', amount_refunded: 15000 } },
+  } as unknown as Stripe.Event;
+}
+
+/** Seed a Refund row exactly as the admin cancel route leaves it. */
+function seedAdminRefund(overrides: Partial<MockRefund> = {}): void {
+  mockDb.refunds.push({
+    id: `rf_${++mockDb.seq}`,
+    orderId: 'order-1',
+    stripeRefundId: 're_1',
+    amount: 150,
+    reason: 'Order cancelled',
+    status: 'SUCCEEDED',
+    processedBy: 'admin',
+    processedAt: new Date(),
+    createdAt: new Date(Date.now() + mockDb.seq),
+    ...overrides,
+  });
+}
+
+describe('charge.refunded webhook — idempotent reconciliation', () => {
+  let processWebhookEvent: (event: Stripe.Event) => Promise<void>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockSendRefundEmail.mockResolvedValue(undefined);
+    mockVoidCommission.mockResolvedValue(undefined);
+    mockDb.refunds = [];
+    mockDb.order = freshOrder();
+    mockDb.seq = 0;
+    ({ processWebhookEvent } = await import('@/lib/stripe/webhooks'));
+  });
+
+  it('REGRESSION: admin cancel-with-refund then charge.refunded leaves exactly ONE row', async () => {
+    seedAdminRefund(); // route already created + stamped re_1
+    mockRefundsList.mockReturnValue(listOf([{ id: 're_1', amount: 15000, status: 'succeeded' }]));
+
+    await processWebhookEvent(chargeRefundedEvent());
+
+    expect(mockDb.refunds).toHaveLength(1);
+    const [row] = mockDb.refunds;
+    expect(row.stripeRefundId).toBe('re_1');
+    expect(row.processedBy).toBe('admin'); // untouched — webhook did not overwrite
+    // No duplicate customer email: the route already emailed.
+    expect(mockSendRefundEmail).not.toHaveBeenCalled();
+    expect(mockDb.order.financialStatus).toBe('REFUNDED');
+  });
+
+  it('race: route created the row but webhook beat the stamping → webhook stamps, ONE row', async () => {
+    seedAdminRefund({ stripeRefundId: null, processedAt: null }); // unstamped
+    mockRefundsList.mockReturnValue(listOf([{ id: 're_1', amount: 15000, status: 'succeeded' }]));
+
+    await processWebhookEvent(chargeRefundedEvent());
+
+    expect(mockDb.refunds).toHaveLength(1);
+    const [row] = mockDb.refunds;
+    expect(row.stripeRefundId).toBe('re_1'); // claimed
+    expect(row.processedBy).toBe('admin'); // route's row, just stamped — not a new dashboard row
+    expect(mockSendRefundEmail).not.toHaveBeenCalled();
+  });
+
+  it('Stripe-dashboard refund (no prior row) → creates ONE row and emails the customer', async () => {
+    mockRefundsList.mockReturnValue(listOf([{ id: 're_dash', amount: 15000, status: 'succeeded' }]));
+
+    await processWebhookEvent(chargeRefundedEvent());
+
+    expect(mockDb.refunds).toHaveLength(1);
+    const [row] = mockDb.refunds;
+    expect(row.stripeRefundId).toBe('re_dash');
+    expect(row.processedBy).toBe('stripe');
+    expect(mockSendRefundEmail).toHaveBeenCalledTimes(1);
+    expect(mockSendRefundEmail.mock.calls[0][3]).toBeCloseTo(150); // amount
+    expect(mockVoidCommission).toHaveBeenCalledWith('order-1', 'refund');
+  });
+
+  it('re-delivery is idempotent → still ONE row, customer emailed only once', async () => {
+    mockRefundsList.mockReturnValue(listOf([{ id: 're_dash', amount: 15000, status: 'succeeded' }]));
+
+    await processWebhookEvent(chargeRefundedEvent());
+    await processWebhookEvent(chargeRefundedEvent());
+
+    expect(mockDb.refunds).toHaveLength(1);
+    expect(mockSendRefundEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('two same-amount refunds with two unstamped rows → each row claimed once, no third row', async () => {
+    // Two distinct $50 Stripe refunds; two unstamped $50 DB rows. Each loop
+    // iteration stamps one row, which leaves the unstamped pool, so the next
+    // iteration claims the OTHER row — never the same one twice, never a 3rd row.
+    seedAdminRefund({ stripeRefundId: null, processedAt: null, amount: 50 });
+    seedAdminRefund({ stripeRefundId: null, processedAt: null, amount: 50 });
+    mockRefundsList.mockReturnValue(
+      listOf([
+        { id: 're_A', amount: 5000, status: 'succeeded' },
+        { id: 're_B', amount: 5000, status: 'succeeded' },
+      ])
+    );
+
+    await processWebhookEvent(chargeRefundedEvent());
+
+    expect(mockDb.refunds).toHaveLength(2);
+    const stampedIds = mockDb.refunds.map((r) => r.stripeRefundId).sort();
+    expect(stampedIds).toEqual(['re_A', 're_B']); // 1:1, both claimed, distinct
+    expect(mockSendRefundEmail).not.toHaveBeenCalled(); // both matched existing rows
+  });
+
+  it('ignores failed/canceled refunds — no row, no email', async () => {
+    mockRefundsList.mockReturnValue(
+      listOf([
+        { id: 're_fail', amount: 15000, status: 'failed' },
+        { id: 're_cxl', amount: 15000, status: 'canceled' },
+      ])
+    );
+
+    await processWebhookEvent(chargeRefundedEvent());
+
+    expect(mockDb.refunds).toHaveLength(0);
+    expect(mockSendRefundEmail).not.toHaveBeenCalled();
+  });
+
+  it('partial admin refund + later dashboard refund → two distinct rows, no duplicates', async () => {
+    // Admin already refunded $50 (stamped re_1); Stripe now also shows a $25
+    // dashboard refund (re_2). amount_refunded would be cumulative ($75).
+    seedAdminRefund({ stripeRefundId: 're_1', amount: 50, reason: 'Order amendment refund' });
+    mockRefundsList.mockReturnValue(
+      listOf([
+        { id: 're_1', amount: 5000, status: 'succeeded' },
+        { id: 're_2', amount: 2500, status: 'succeeded' },
+      ])
+    );
+
+    await processWebhookEvent(chargeRefundedEvent());
+
+    expect(mockDb.refunds).toHaveLength(2);
+    const byId = Object.fromEntries(mockDb.refunds.map((r) => [r.stripeRefundId, r]));
+    expect(byId['re_1'].processedBy).toBe('admin');
+    expect(byId['re_2'].processedBy).toBe('stripe');
+    expect(byId['re_2'].amount).toBeCloseTo(25);
+    // Only the newly-recorded dashboard refund is emailed.
+    expect(mockSendRefundEmail).toHaveBeenCalledTimes(1);
+    expect(mockSendRefundEmail.mock.calls[0][3]).toBeCloseTo(25);
+    expect(mockDb.order.financialStatus).toBe('PARTIALLY_REFUNDED'); // 75 of 150
+  });
+});

--- a/src/lib/stripe/webhooks.ts
+++ b/src/lib/stripe/webhooks.ts
@@ -7,7 +7,7 @@ import Stripe from 'stripe';
 import { stripe, STRIPE_WEBHOOK_SECRET } from './client';
 import { getCheckoutSession } from './checkout';
 import { prisma } from '@/lib/database/client';
-import { createOrderFromCheckout, createRefund, getOrderByCheckoutSession, createOrderFromDraftOrder } from '@/lib/inventory/services/order-service';
+import { createOrderFromCheckout, getOrderByCheckoutSession, createOrderFromDraftOrder, recomputeOrderFinancialStatus } from '@/lib/inventory/services/order-service';
 import { getCartById } from '@/lib/inventory/services/cart-service';
 import { getDraftOrderById, updateDraftOrderStatus, DraftOrderWithTotal } from '@/lib/draft-orders';
 import {
@@ -434,8 +434,34 @@ async function handlePaymentIntentSucceeded(
 }
 
 /**
- * Handle charge.refunded event
- * Process refunds and update order status
+ * Postgres unique-constraint violation. We use it to treat a concurrent insert
+ * of the same stripeRefundId (admin route vs. this webhook racing) as
+ * "already recorded" rather than an error.
+ */
+function isUniqueViolation(err: unknown): boolean {
+  return Boolean(err && typeof err === 'object' && 'code' in err && (err as { code?: string }).code === 'P2002');
+}
+
+/**
+ * Handle charge.refunded event.
+ *
+ * IDEMPOTENT. This webhook fires ~0.5s after the admin cancel/refund routes have
+ * already created (and stamped) a Refund row for the same Stripe refund, and it
+ * can be re-delivered by Stripe at any time. So instead of blindly creating a
+ * row from charge.amount_refunded (a cumulative total, not a per-refund figure),
+ * we list the charge's actual refunds from Stripe — the source of truth — and
+ * reconcile each one into the DB exactly once:
+ *
+ *   1. A Refund row already carries this stripeRefundId  → nothing to do.
+ *   2. An unstamped row matches this order + amount (the route created it but the
+ *      webhook beat its stamping step, or a legacy orphan) → claim it by writing
+ *      the stripeRefundId. The route already emailed the customer.
+ *   3. No matching row → the refund was issued outside our app (Stripe
+ *      dashboard). Create a row AND notify the customer.
+ *
+ * Commission voiding is order-level and idempotent, so it runs whenever the
+ * charge has any live refund. The customer email is sent ONLY for refunds we
+ * newly recorded here, so admin-route refunds don't get double-emailed.
  */
 async function handleChargeRefunded(charge: Stripe.Charge): Promise<void> {
   console.log('[Stripe Webhook] Processing charge.refunded:', charge.id);
@@ -456,34 +482,119 @@ async function handleChargeRefunded(charge: Stripe.Charge): Promise<void> {
     return;
   }
 
-  // Calculate refund amount
-  const refundedAmount = charge.amount_refunded / 100; // Convert from cents
-
+  // Pull the authoritative per-refund breakdown from Stripe. We key off this
+  // charge (the event's subject) rather than the PaymentIntent so we reconcile
+  // exactly what this charge.refunded event is about; a sibling charge on the
+  // same PI gets its own event. Skip refunds that moved no money
+  // (failed/canceled) — they must not create rows or count.
+  const stripeRefunds: Stripe.Refund[] = [];
   try {
-    await createRefund(order.id, refundedAmount, 'Stripe refund');
-    console.log('[Stripe Webhook] Refund processed for order:', order.orderNumber);
+    for await (const r of stripe.refunds.list({ charge: charge.id, limit: 100 })) {
+      if (r.status === 'failed' || r.status === 'canceled') continue;
+      stripeRefunds.push(r);
+    }
+  } catch (error) {
+    console.error('[Stripe Webhook] Failed to list refunds for charge:', charge.id, error);
+    throw error;
+  }
 
-    // Void any affiliate commission for this order
-    try {
-      await voidCommissionForOrder(order.id, 'refund');
-    } catch (voidError) {
-      console.error('[Stripe Webhook] Failed to void affiliate commission:', voidError);
+  if (stripeRefunds.length === 0) {
+    console.log('[Stripe Webhook] No live refunds on charge:', charge.id);
+    return;
+  }
+
+  // Amounts newly recorded by THIS invocation (Stripe-dashboard refunds the
+  // routes never saw) — only these get a customer email.
+  const newlyRecorded: number[] = [];
+
+  for (const r of stripeRefunds) {
+    const amount = r.amount / 100;
+    const amountStr = amount.toFixed(2); // exact Decimal match, dodges float drift
+
+    // 1. Already reconciled (this id is unique in the DB) → idempotent no-op.
+    const existing = await prisma.refund.findUnique({
+      where: { stripeRefundId: r.id },
+    });
+    if (existing) continue;
+
+    // 2. Claim an unstamped row the admin route created for this same refund
+    //    (race) or a legacy orphan of the right amount, instead of duplicating.
+    const candidate = await prisma.refund.findFirst({
+      where: {
+        orderId: order.id,
+        stripeRefundId: null,
+        amount: amountStr,
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    if (candidate) {
+      try {
+        await prisma.refund.update({
+          where: { id: candidate.id },
+          data: {
+            stripeRefundId: r.id,
+            status: 'SUCCEEDED',
+            processedAt: candidate.processedAt ?? new Date(),
+          },
+        });
+      } catch (error) {
+        // Another writer stamped this id between our read and write — safe to skip.
+        if (!isUniqueViolation(error)) throw error;
+      }
+      continue;
     }
 
-    // Send refund notification email
+    // 3. Refund originated outside our app (Stripe dashboard). Record it.
     try {
-      // Get customer info from order
+      await prisma.refund.create({
+        data: {
+          orderId: order.id,
+          stripeRefundId: r.id,
+          amount: amountStr,
+          reason: 'Stripe refund',
+          status: 'SUCCEEDED',
+          processedBy: 'stripe',
+          processedAt: new Date(),
+        },
+      });
+      newlyRecorded.push(amount);
+    } catch (error) {
+      // Lost the create race; the id now exists, so it's recorded. Skip.
+      if (!isUniqueViolation(error)) throw error;
+    }
+  }
+
+  // Recompute REFUNDED / PARTIALLY_REFUNDED from the full set of rows.
+  try {
+    await recomputeOrderFinancialStatus(order.id);
+  } catch (error) {
+    console.error('[Stripe Webhook] Failed to recompute financial status:', error);
+  }
+
+  // Void any affiliate commission for this order (idempotent).
+  try {
+    await voidCommissionForOrder(order.id, 'refund');
+  } catch (voidError) {
+    console.error('[Stripe Webhook] Failed to void affiliate commission:', voidError);
+  }
+
+  // Email only for refunds we recorded here. Admin-route refunds already sent
+  // their own email, so re-sending would double-notify the customer.
+  if (newlyRecorded.length > 0) {
+    try {
       const orderWithCustomer = await prisma.order.findUnique({
         where: { id: order.id },
         include: { customer: true },
       });
 
       if (orderWithCustomer?.customerEmail) {
+        const total = newlyRecorded.reduce((sum, a) => sum + a, 0);
         await sendRefundProcessedEmail(
           orderWithCustomer.customerEmail,
           orderWithCustomer.customerName,
           orderWithCustomer.orderNumber,
-          refundedAmount,
+          total,
           'Stripe refund'
         );
         console.log('[Stripe Webhook] Refund email sent for order:', order.orderNumber);
@@ -491,10 +602,9 @@ async function handleChargeRefunded(charge: Stripe.Charge): Promise<void> {
     } catch (emailError) {
       console.error('[Stripe Webhook] Failed to send refund email:', emailError);
     }
-  } catch (error) {
-    console.error('[Stripe Webhook] Failed to process refund:', error);
-    throw error;
   }
+
+  console.log('[Stripe Webhook] Refund reconciled for order:', order.orderNumber);
 }
 
 /**


### PR DESCRIPTION
## Problem

`handleChargeRefunded` in `src/lib/stripe/webhooks.ts` created a `Refund` row **unconditionally** on every `charge.refunded` event, on top of the row the admin cancel/refund route had already written for the same Stripe refund. Result: **two rows per real refund** —

- row A — `stripeRefundId` set, `processedBy='admin'` (the route's row, keep)
- row B — ~0.5s later from the webhook, `stripeRefundId=NULL`, `reason='Stripe refund'` (dupe)

This double-counted DB refund totals and could drive `getMaxRefundable()` negative, wrongly **blocking legitimate partial refunds**; it also overstated finance/QB reporting. Prod scope (2026-06-26): **37 orphan rows across 33 orders**.

## Fix

**1. Idempotent webhook.** Lists the charge's actual refunds from Stripe (`stripe.refunds.list({ charge })`, skipping `failed`/`canceled`) and reconciles each:
1. row already has that `stripeRefundId` → no-op (handles Stripe re-delivery)
2. unstamped `orderId`+amount row → claim it (stamp the id) — the race where the webhook beats the route's stamping
3. no match → create a row (a true Stripe-dashboard refund) **and** email the customer

The customer email now fires **only for newly-recorded refunds**, which also fixes a pre-existing **duplicate refund email** on admin refunds (the routes already email). Commission voiding stays idempotent.

**2. Race hardening.** `createRefund()` now **returns the new row id**; the cancel + refund routes stamp *that* row by id instead of `findFirst(createdAt desc)`, which could grab the wrong row if the webhook inserts one mid-request. Financial-status recompute extracted to shared `recomputeOrderFinancialStatus()`.

**3. Operator-gated cleanup** — `scripts/ops/reconcile-duplicate-refunds.mjs`. Dry-run by default (`--apply` to write). Verifies each order against the **live Stripe API** and only deletes a webhook-orphan when the post-change rows map **1:1 to Stripe** (same ids, total within 1¢); never touches a row an `OrderAmendment` references; refuses to run on a missing/test Stripe key.

Prod dry-run (read-only): **33 deletes, 3 merges, 1 needs-manual (#197)** — flagged exactly the rows expected (#365 `cd1da13b`, #366 `2c1df020`). **Not applied** — operator runs `--apply` after reviewing the dry-run and manually resolving #197.

**4. Regression test** — `src/lib/stripe/__tests__/charge-refunded-idempotent.test.ts`, 7 cases including the required *admin cancel-with-refund → webhook leaves exactly ONE row*, re-delivery idempotency, dashboard-refund creates+emails, and two-same-amount-refunds → 1:1, no third row.

## Verification
- `tsc --noEmit`: 0 errors · `next lint`: clean · `vitest run`: **354 passed** (37 files)
- **security-reviewer**: 2 HIGH + 3 MEDIUM raised and addressed (wrong-row race fixed via returned id; same-amount handling covered by test + DB unique constraint; Stripe test-key guard added; charge-vs-PI axis documented). One residual sub-0.5s race documented and money-safe.

## Operator follow-up (not in this PR)
1. Review the dry-run, then run `node scripts/ops/reconcile-duplicate-refunds.mjs --apply`
2. Manually resolve order #197 (4 rows / 2 Stripe refunds — script correctly refuses to auto-touch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)