### PR TITLE
feat(analytics): capture group-order attribution for per-landing-page hub

### DIFF
--- a/prisma/migrations/manual/2026-06-26-group-order-attribution.sql
+++ b/prisma/migrations/manual/2026-06-26-group-order-attribution.sql
@@ -1,0 +1,32 @@
+-- Group-order first-touch attribution — fix the analytics hub's ≈0 conversion/revenue per page.
+--
+-- ~95% of orders flow through the group-order dashboard, which never stamped
+-- Order.landingPage / Order.utm*. Only the DIRECT Stripe-checkout path did, so the
+-- per-landing-page hub (getLandingPageRollupForPaths / getConversionSummary) read ≈0 for
+-- every page. We now capture the HOST's first-touch attribution on the GroupOrderV2 at
+-- create time; the group-payment webhook reads it back from the group row and stamps it
+-- (plus the derived segment) onto every Order created from that group's SubOrder payments.
+--
+-- These columns are written once at group-create and only ever read by primary key in the
+-- webhook (src/lib/stripe/group-v2-payments.ts) — never filtered or grouped — so NO index is
+-- needed. The analytics rollups read Order.landingPage (already indexed), not these.
+--
+-- Per saved memory `prisma_schema_drift`, schema.prisma is intentionally drifted from prod, so
+-- `prisma db push` is unsafe. This file is additive + idempotent (ADD COLUMN IF NOT EXISTS) and
+-- is applied automatically on prod deploys by scripts/db/apply-manual-migrations.mjs (recorded
+-- once in the _manual_migrations ledger). To run by hand:
+--
+--     psql "$DATABASE_URL" -f prisma/migrations/manual/2026-06-26-group-order-attribution.sql
+--     npx prisma generate
+
+BEGIN;
+
+ALTER TABLE group_orders_v2 ADD COLUMN IF NOT EXISTS landing_page TEXT;
+ALTER TABLE group_orders_v2 ADD COLUMN IF NOT EXISTS utm_source   TEXT;
+ALTER TABLE group_orders_v2 ADD COLUMN IF NOT EXISTS utm_medium   TEXT;
+ALTER TABLE group_orders_v2 ADD COLUMN IF NOT EXISTS utm_campaign TEXT;
+ALTER TABLE group_orders_v2 ADD COLUMN IF NOT EXISTS utm_term     TEXT;
+ALTER TABLE group_orders_v2 ADD COLUMN IF NOT EXISTS utm_content  TEXT;
+ALTER TABLE group_orders_v2 ADD COLUMN IF NOT EXISTS referrer     TEXT;
+
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1850,6 +1850,21 @@ model GroupOrderV2 {
   externalBookingId String?           @map("external_booking_id")
   viewCount         Int               @default(0) @map("view_count")
   isLastMinute      Boolean           @default(false) @map("is_last_minute")
+
+  // Host's first-touch marketing attribution, captured when the host creates the
+  // group at /order (from the AttributionTracker localStorage payload). The
+  // group-payment webhook reads these back and stamps them onto every Order created
+  // from this group's SubOrder payments, so the per-landing-page analytics hub gets
+  // real conversion/revenue data for group orders (95% of volume). Written once at
+  // create, read only by PK in the webhook — no index needed.
+  landingPage String? @map("landing_page")
+  utmSource   String? @map("utm_source")
+  utmMedium   String? @map("utm_medium")
+  utmCampaign String? @map("utm_campaign")
+  utmTerm     String? @map("utm_term")
+  utmContent  String? @map("utm_content")
+  referrer    String? @map("referrer")
+
   expiresAt       DateTime           @map("expires_at")
   createdAt       DateTime           @default(now()) @map("created_at")
   updatedAt       DateTime           @updatedAt @map("updated_at")

--- a/src/app/api/cron/reconcile-orders/route.ts
+++ b/src/app/api/cron/reconcile-orders/route.ts
@@ -27,6 +27,7 @@ import {
 import { recordDiscountUsage } from '@/lib/discounts/discount-engine';
 import { linkOrderToAffiliate } from '@/lib/affiliates/commission-engine';
 import { createOrderCalendarEvent } from '@/lib/calendar/google-calendar';
+import { classifySegment } from '@/lib/analytics/segment-classifier';
 import { Prisma } from '@prisma/client';
 import { snapshotItemCost } from '@/lib/analytics/margin-service';
 import {
@@ -268,6 +269,22 @@ export async function GET(request: NextRequest) {
           }
         }
 
+        // Inherit the group's host first-touch attribution (mirrors
+        // handleGroupV2PaymentCompleted) so cron-recovered orders feed the
+        // per-landing-page hub too. Null group/attribution falls through to null.
+        const group = await prisma.groupOrderV2.findUnique({
+          where: { id: subOrder.groupOrderId },
+          select: {
+            landingPage: true,
+            utmSource: true,
+            utmMedium: true,
+            utmCampaign: true,
+            utmTerm: true,
+            utmContent: true,
+            referrer: true,
+          },
+        });
+
         // Create Order record
         const order = await prisma.order.create({
           data: {
@@ -291,6 +308,14 @@ export async function GET(request: NextRequest) {
             customerName: participant.guestName || 'Guest',
             groupOrderId: null,
             groupOrderV2Id: payment.subOrder.groupOrderId,
+            landingPage: group?.landingPage ?? null,
+            utmSource: group?.utmSource ?? null,
+            utmMedium: group?.utmMedium ?? null,
+            utmCampaign: group?.utmCampaign ?? null,
+            utmTerm: group?.utmTerm ?? null,
+            utmContent: group?.utmContent ?? null,
+            referrer: group?.referrer ?? null,
+            segment: classifySegment(group?.landingPage, group?.utmCampaign),
             items: {
               create: orderItemCreates,
             },

--- a/src/app/api/v1/quote/start/route.ts
+++ b/src/app/api/v1/quote/start/route.ts
@@ -211,6 +211,9 @@ export async function POST(req: NextRequest) {
       name: `${body.firstName}'s Order`,
       deliveryDate: body.deliveryDate,
       isLastMinute,
+      // Carry the lead's first-touch attribution onto the group so its Orders
+      // attribute back to the landing page (extra click-id/capturedAt fields ignored).
+      attribution: body.attribution ?? undefined,
     });
     shareCode = group.shareCode;
     const host = group.participants.find((p) => p.isHost);

--- a/src/app/order/last-minute/page.tsx
+++ b/src/app/order/last-minute/page.tsx
@@ -13,6 +13,7 @@ import Image from 'next/image';
 import { createDashboardOrderV2 } from '@/lib/group-orders-v2/api-client';
 import type { PartyType, DashboardSource, DeliveryContextType } from '@/lib/group-orders-v2/types';
 import { getAffiliateDefaultAddress } from '@/lib/affiliates/presets';
+import { getAttributionForDashboard } from '@/lib/analytics/attribution';
 
 const PARTY_TYPE_MAP: Record<string, PartyType> = {
   bachelor: 'BACHELOR',
@@ -127,6 +128,8 @@ function LastMinuteRedirectInner(): ReactElement {
           name: nameParam ? `${nameParam}'s Order` : undefined,
           deliveryAddress: premierAddress || undefined,
           tabName: premierAddress ? 'Marina Delivery' : undefined,
+          // Host's first-touch attribution → stamped onto every Order in this group.
+          attribution: getAttributionForDashboard(),
         });
 
         const host = group.participants.find((p) => p.isHost);

--- a/src/app/order/page.tsx
+++ b/src/app/order/page.tsx
@@ -28,6 +28,7 @@ import { createDashboardOrderV2 } from '@/lib/group-orders-v2/api-client';
 import type { PartyType, DashboardSource, DeliveryContextType } from '@/lib/group-orders-v2/types';
 import { getAffiliateOrderDefaults } from '@/lib/affiliates/presets';
 import { trackCTAClick } from '@/lib/analytics/ga4-events';
+import { getAttributionForDashboard } from '@/lib/analytics/attribution';
 import { getEventPreset } from '@/lib/events/event-presets';
 
 const PARTY_TYPE_MAP: Record<string, PartyType> = {
@@ -241,6 +242,8 @@ function OrderRedirectInner(): ReactElement {
         tabName: eventPreset?.tabName ?? presets?.tabName,
         deliveryDate: eventPreset?.deliveryDate,
         deliveryTime: eventPreset?.deliveryTime,
+        // Host's first-touch attribution → stamped onto every Order in this group.
+        attribution: getAttributionForDashboard(),
       });
 
       const host = group.participants.find((p) => p.isHost);

--- a/src/lib/analytics/attribution.ts
+++ b/src/lib/analytics/attribution.ts
@@ -109,6 +109,42 @@ export function captureFirstTouch(): void {
   }
 }
 
+/**
+ * First-touch attribution as the plain {landingPage, utm*, referrer} object the
+ * group-order create API expects (structurally matches DashboardAttributionInput).
+ * Returns undefined when nothing was captured, so the caller omits the field.
+ * Used by /order + /order/last-minute to stamp the host's first-touch onto the
+ * GroupOrderV2 (the webhook then propagates it to every Order in the group).
+ */
+export function getAttributionForDashboard():
+  | {
+      landingPage: string | null;
+      utmSource: string | null;
+      utmMedium: string | null;
+      utmCampaign: string | null;
+      utmTerm: string | null;
+      utmContent: string | null;
+      referrer: string | null;
+    }
+  | undefined {
+  const a = getAttribution();
+  if (!a) return undefined;
+  // Cap each field at 500 chars (same as attributionToMetadata) BEFORE it hits the
+  // create API. A real landingPage/referrer can exceed 500 (stacked UTM + gclid/fbclid,
+  // long referrer URLs); pre-slicing keeps the non-critical attribution from tripping
+  // validation and blocking order creation. cap() preserves null (absent field) as null.
+  const cap = (v: string | null): string | null => (v == null ? v : v.slice(0, 500));
+  return {
+    landingPage: cap(a.landingPage),
+    utmSource: cap(a.utmSource),
+    utmMedium: cap(a.utmMedium),
+    utmCampaign: cap(a.utmCampaign),
+    utmTerm: cap(a.utmTerm),
+    utmContent: cap(a.utmContent),
+    referrer: cap(a.referrer),
+  };
+}
+
 export function getAttribution(): AttributionPayload | null {
   if (!isClient()) return null;
   try {

--- a/src/lib/analytics/landing-page-metrics.ts
+++ b/src/lib/analytics/landing-page-metrics.ts
@@ -13,6 +13,15 @@
  * are separate sources joined only by path. Conversion uses first-touch
  * Order.landingPage, which has known attribution leaks — treat CVR as
  * approximate, not exact.
+ *
+ * Group-order caveat: ~95% of orders flow through the group dashboard, where every
+ * Order inherits the HOST's first-touch landing page (set on GroupOrderV2 at create,
+ * propagated in group-v2-payments.ts). This is accurate for REVENUE attribution — the
+ * page that drove the party gets credit for the whole party's spend, each Order counted
+ * once. But it can INFLATE conversion RATE (orders ÷ GA4 visitors): share-link
+ * participants pay without ever visiting the host's landing page, so a viral group can
+ * push orders above the page's visitor count. Read per-page revenue as solid, CVR as
+ * directional.
  */
 
 import { prisma } from '@/lib/database/client';

--- a/src/lib/group-orders-v2/service.ts
+++ b/src/lib/group-orders-v2/service.ts
@@ -998,6 +998,15 @@ export async function createDashboardOrder(
       affiliateId: input.affiliateId || null,
       source: input.source || 'DIRECT',
       isLastMinute: input.isLastMinute ?? false,
+      // Host's first-touch attribution — the webhook stamps these onto every Order
+      // created from this group's payments, feeding the per-landing-page analytics hub.
+      landingPage: input.attribution?.landingPage || null,
+      utmSource: input.attribution?.utmSource || null,
+      utmMedium: input.attribution?.utmMedium || null,
+      utmCampaign: input.attribution?.utmCampaign || null,
+      utmTerm: input.attribution?.utmTerm || null,
+      utmContent: input.attribution?.utmContent || null,
+      referrer: input.attribution?.referrer || null,
       expiresAt: defaultExpiresAt(deliveryDate),
       tabs: {
         create: {

--- a/src/lib/group-orders-v2/types.ts
+++ b/src/lib/group-orders-v2/types.ts
@@ -214,6 +214,23 @@ export interface UpdateDraftItemInput {
   quantity: number;
 }
 
+/**
+ * Host's first-touch marketing attribution, forwarded from the client's
+ * AttributionTracker localStorage payload when the host creates a dashboard.
+ * Persisted on the GroupOrderV2 and later stamped onto every Order created from
+ * the group's SubOrder payments. All fields optional/nullable — most groups
+ * (partner-page, AI-planner, organic) carry none.
+ */
+export interface DashboardAttributionInput {
+  landingPage?: string | null;
+  utmSource?: string | null;
+  utmMedium?: string | null;
+  utmCampaign?: string | null;
+  utmTerm?: string | null;
+  utmContent?: string | null;
+  referrer?: string | null;
+}
+
 export interface CreateDashboardInput {
   hostName: string;
   hostEmail?: string;
@@ -236,6 +253,8 @@ export interface CreateDashboardInput {
     zip: string;
     country?: string;
   };
+  /** Host's first-touch attribution (landingPage + UTMs + referrer). */
+  attribution?: DashboardAttributionInput;
 }
 
 export interface MultiTabPreset {

--- a/src/lib/group-orders-v2/validation.ts
+++ b/src/lib/group-orders-v2/validation.ts
@@ -122,6 +122,33 @@ export const UpdateGroupOrderSchema = z.object({
 });
 
 /** Create dashboard order (relaxed - no delivery details required) */
+/**
+ * Host first-touch attribution forwarded from the client. Untrusted external input —
+ * every field is a length-capped (500, matching the Stripe-metadata cap) optional/nullable
+ * string. `getAttribution()` sends explicit nulls for absent fields, so `.nullish()`.
+ *
+ * CRITICAL: this rides on the order-creation path. Attribution is a nice-to-have analytics
+ * field and must NEVER fail the parent schema — a real landingPage/referrer can exceed 500
+ * chars (stacked UTM + gclid/fbclid params, long referrer URLs), and a hard `.max()` reject
+ * would 400 the whole group-create and block the customer. `.catch(null)` coerces any
+ * over-long/malformed value to null instead of throwing (the client also pre-slices). The
+ * whole object is `.catch(undefined)` so a structurally bad payload drops attribution rather
+ * than failing the create.
+ */
+const attributionField = z.string().max(500).nullish().catch(null);
+const DashboardAttributionSchema = z
+  .object({
+    landingPage: attributionField,
+    utmSource: attributionField,
+    utmMedium: attributionField,
+    utmCampaign: attributionField,
+    utmTerm: attributionField,
+    utmContent: attributionField,
+    referrer: attributionField,
+  })
+  .optional()
+  .catch(undefined);
+
 export const CreateDashboardSchema = z.object({
   hostName: z.string().min(1, 'Name is required').max(100),
   hostEmail: z.string().email('Invalid email').optional().or(z.literal('')),
@@ -145,6 +172,7 @@ export const CreateDashboardSchema = z.object({
     )
     .optional(),
   deliveryTime: z.string().max(100).optional(),
+  attribution: DashboardAttributionSchema,
 });
 
 export {

--- a/src/lib/stripe/group-v2-payments.ts
+++ b/src/lib/stripe/group-v2-payments.ts
@@ -17,6 +17,7 @@ import { getAffiliateByCode } from '@/lib/affiliates/affiliate-service';
 import { createOrderCalendarEvent } from '@/lib/calendar/google-calendar';
 import { commitInventoryForOrderItem } from '@/lib/inventory/services/order-service';
 import { snapshotItemCost } from '@/lib/analytics/margin-service';
+import { classifySegment } from '@/lib/analytics/segment-classifier';
 import { assertVariantsPurchasable } from '@/lib/products/availability';
 import {
   buildChargedLineItems,
@@ -460,6 +461,24 @@ export async function handleGroupV2PaymentCompleted(
     throw new Error(`[Group V2 Payment] Participant or SubOrder not found: participant=${participantId} subOrder=${subOrderId}`);
   }
 
+  // Fetch the group once: its host first-touch attribution is inherited by this Order
+  // (so the per-landing-page analytics hub attributes group revenue/conversion to the
+  // page that drove the party), and its affiliate is the fallback for commission linking
+  // further down. Missing attribution is fine — older groups carry none (null columns).
+  const group = await prisma.groupOrderV2.findUnique({
+    where: { id: groupOrderId },
+    select: {
+      landingPage: true,
+      utmSource: true,
+      utmMedium: true,
+      utmCampaign: true,
+      utmTerm: true,
+      utmContent: true,
+      referrer: true,
+      affiliate: { select: { code: true } },
+    },
+  });
+
   const purchasedItems = await prisma.purchasedItem.findMany({
     where: { paymentId: payment.id },
   });
@@ -584,6 +603,19 @@ export async function handleGroupV2PaymentCompleted(
       customerPhone: customerPhone || null,
       groupOrderId: null, // V2 doesn't use v1 group order FK
       groupOrderV2Id: groupOrderId,
+      // Inherit the host's first-touch attribution + derived segment from the group, so
+      // this Order rolls up to the landing page that drove the party. Every Order in a
+      // group inherits the same host attribution — accurate for revenue (each Order is a
+      // distinct charge counted once), and it leaves the channel rollup untouched (group
+      // orders bucket as 'group' before 'utm_*'). See landing-page-metrics.ts caveat.
+      landingPage: group?.landingPage ?? null,
+      utmSource: group?.utmSource ?? null,
+      utmMedium: group?.utmMedium ?? null,
+      utmCampaign: group?.utmCampaign ?? null,
+      utmTerm: group?.utmTerm ?? null,
+      utmContent: group?.utmContent ?? null,
+      referrer: group?.referrer ?? null,
+      segment: classifySegment(group?.landingPage, group?.utmCampaign),
       items: {
         create: orderItemCreates,
       },
@@ -653,10 +685,6 @@ export async function handleGroupV2PaymentCompleted(
   //      checkout without coming through the partner page)
   let resolvedAffiliateCode = session.metadata?.affiliateCode;
   if (!resolvedAffiliateCode) {
-    const group = await prisma.groupOrderV2.findUnique({
-      where: { id: groupOrderId },
-      select: { affiliate: { select: { code: true } } },
-    });
     resolvedAffiliateCode = group?.affiliate?.code;
   }
   if (!resolvedAffiliateCode && order.discountCode) {


### PR DESCRIPTION
## Problem
The `/admin/analytics` per-landing-page hub read **~0 conversion + revenue** for every page because ~95% of orders flow through the group-order dashboard, which never stamped `Order.landingPage`/`utm*`. Only the direct Stripe-checkout path did (last 30d: 104/109 orders were GroupOrderV2, only 1 carried `landingPage`).

## Fix
Capture the **host's** first-touch attribution (`landingPage` + `utm*` + `referrer`) on `GroupOrderV2` at create, then propagate it onto **every** Order created from that group's SubOrder payments, plus a derived `segment`.

**Design decision:** all Orders in a group inherit the host's landing page. Accurate for revenue (each Order is a distinct Stripe charge, counted once) and leaves the channel rollup untouched (group buckets before `utm_*`). Caveat — share-link participants convert without visiting the page, so *conversion rate* can run high for viral groups — documented in `landing-page-metrics.ts`.

## Changes
- **Migration** `prisma/migrations/manual/2026-06-26-group-order-attribution.sql` — 7 nullable columns on `group_orders_v2`, additive + idempotent, auto-applied on prod deploy (no `db push`, per schema-drift policy)
- **Capture**: `/order`, `/order/last-minute` (client `getAttributionForDashboard()`), `/api/v1/quote/start` (server, from validated `body.attribution`)
- **Propagate**: `handleGroupV2PaymentCompleted` + `reconcile-orders` cron (so the missed-webhook recovery path stamps it too)
- **Non-fatal validation**: `.catch(null)` + client-side 500-char slice, so an over-long `landingPage`/`referrer` can never 400 the order-create path

## Reviews & verification
- `npx tsc --noEmit` clean · `npx eslint` (changed files) 0 errors · `npm run test:run` **353 passed**
- **security-reviewer**: SAFE TO MERGE, 0 critical / 0 high (confirmed null-group safety, idempotency guard untouched, migration safety, PII parity)
- `/code-review` caught + fixed the over-long-attribution 400 risk on the order-create path

## Notes
- Only affects **new** group orders created after deploy — no historical backfill (no first-touch data to recover). The hub populates going forward.
- The analytics hub itself needs no changes — it already reads `Order.landingPage`.

**Post-deploy verification** (run a day or two after deploy):
```sql
SELECT count(*) group_orders, count(landing_page) with_landing, count(utm_source) with_utm,
       count(*) FILTER (WHERE segment IS NOT NULL AND segment <> 'general') with_segment
FROM orders WHERE group_order_v2_id IS NOT NULL AND created_at >= now() - interval '7 days';
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)