### PR TITLE
fix(analytics): map /wedding-drink-calculator into the Weddings hub tab

### DIFF
--- a/src/lib/analytics/landing-pages.ts
+++ b/src/lib/analytics/landing-pages.ts
@@ -67,7 +67,12 @@ export const LANDING_PAGES: LandingPageDef[] = [
     displayName: 'Weddings',
     navOrder: 2,
     canonicalPath: '/weddings',
-    aliasPaths: ['/austin-wedding-weekend-delivery'],
+    // /wedding-drink-calculator is the paid-ad landing for the wedding-bar
+    // calculator; its wedding_calc_* CTAs (and its traffic/conversion) are part
+    // of the weddings funnel — without it here the wedding_calc_package /
+    // wedding_calc_sticky sections declared below never receive any clicks
+    // (they only fire on the calculator route, not on /weddings itself).
+    aliasPaths: ['/austin-wedding-weekend-delivery', '/wedding-drink-calculator'],
     ctaSections: [
       { id: 'hero', label: 'Hero' },
       { id: 'packages', label: 'Packages' },


### PR DESCRIPTION
## What
The `weddings` registry entry declares `wedding_calc_hero` / `wedding_calc_package` / `wedding_calc_sticky` CTA sections, but those events fire on **`/wedding-drink-calculator`** — a route that was **not** a canonical or alias path of `weddings`. So `getCtaBreakdown` (which filters `path = ANY(weddings paths)`) never picked them up:

- `wedding_calc_package` and `wedding_calc_sticky` were **always empty** in `/admin/analytics`
- the calculator's GA4 traffic and `Order.landingPage` conversions were attributed to **no** tab

This adds `/wedding-drink-calculator` to `weddings.aliasPaths`, so its CTAs/traffic/conversion roll up into the Weddings tab — matching the calc sections already declared there.

## Verification
- Found during the landing-page tracking QA: live `wedding_calc_hero`/`package`/`sticky` clicks land on `path=/wedding-drink-calculator`, which the weddings path-union query excluded.
- `npx tsc --noEmit` → 0 errors; `eslint` clean; no registry tests reference these paths (CI runs the full Test & Lint gate).

## Trade-off (your call)
This **merges** the wedding-drink-calculator (a distinct paid-ad landing) into the **Weddings** tab's totals. If you'd rather see it as its **own** tab, the alternative is a separate registry key — easy switch, just say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)