### PR TITLE
fix(refunds): serialize order returns to prevent concurrent over-refund

### DIFF
--- a/src/app/api/v1/admin/orders/[id]/return/route.ts
+++ b/src/app/api/v1/admin/orders/[id]/return/route.ts
@@ -19,12 +19,17 @@ interface RouteParams {
   params: Promise<{ id: string }>;
 }
 
+// We store/transmit the reason prefixed as `Return: ${reason}`. Stripe caps a
+// metadata value at 500 chars, so the raw reason must leave room for that
+// 8-char prefix — cap at 450 for a clean safety margin (no real return reason
+// approaches this).
+const REASON_MAX = 450;
+
 /**
  * Request body contract. Only `orderItemId` + a positive whole `returnQuantity`
  * are read per line; any extra price/product/variant fields are stripped and
  * ignored (the server is the sole source of those values — and stripping rather
  * than rejecting keeps a stale cached client working right after a deploy).
- * `reason` is length-capped to stay under Stripe's 500-char metadata limit.
  */
 const ReturnRequestSchema = z.object({
   items: z
@@ -35,7 +40,7 @@ const ReturnRequestSchema = z.object({
       }),
     )
     .min(1, 'No items specified for return'),
-  reason: z.string().max(500).optional(),
+  reason: z.string().max(REASON_MAX).optional(),
 });
 
 /** A return line after validation, carrying canonical server-side values. */
@@ -150,6 +155,30 @@ async function restoreInventoryForReturnItem(
   }
 }
 
+/** Thrown inside the locked transaction when a concurrent return already
+ * consumed the returnable quantity of a line. Surfaced to the caller as 409. */
+class ConcurrentReturnError extends Error {
+  constructor(public readonly orderItemId: string) {
+    super(`Concurrent return conflict on order item ${orderItemId}`);
+    this.name = 'ConcurrentReturnError';
+  }
+}
+
+/** Thrown inside the locked transaction when the refund would exceed the
+ * Stripe-authoritative cap (re-checked under the lock). Surfaced as 400. */
+class RefundCapError extends Error {
+  constructor(public readonly amount: number, public readonly cap: number) {
+    super('Return refund exceeds maximum refundable');
+    this.name = 'RefundCapError';
+  }
+}
+
+type StripeRefund = Awaited<ReturnType<typeof stripe.refunds.create>>;
+
+/** Stripe refunds can take a beat; allow the locked transaction enough time to
+ * cover the round-trip without tripping Prisma's default 5s transaction limit. */
+const RETURN_TX_TIMEOUT_MS = 25_000;
+
 export async function POST(
   request: NextRequest,
   { params }: RouteParams
@@ -160,7 +189,19 @@ export async function POST(
   try {
     const { id } = await params;
 
-    const parsed = ReturnRequestSchema.safeParse(await request.json());
+    // Parse the body defensively: a malformed/empty body makes request.json()
+    // throw, which should be a 400 (bad input), not a 500.
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return NextResponse.json(
+        { success: false, error: 'Invalid JSON body' },
+        { status: 400 }
+      );
+    }
+
+    const parsed = ReturnRequestSchema.safeParse(rawBody);
     if (!parsed.success) {
       return NextResponse.json(
         { success: false, error: parsed.error.issues[0]?.message || 'Invalid return request' },
@@ -191,6 +232,7 @@ export async function POST(
         { status: 400 }
       );
     }
+    const paymentIntentId = order.stripePaymentIntentId;
 
     // Validate each return item. The refund is computed ONLY from the stored
     // OrderItem.price (server source of truth) — never from any price in the
@@ -238,102 +280,145 @@ export async function POST(
     // Round to avoid floating point issues
     totalRefundAmount = Math.round(totalRefundAmount * 100) / 100;
 
-    // Cap is based on what Stripe actually captured, not order.total —
-    // order.total gets rewritten by OrderAmendment when items are added/removed.
+    // Prior refunds from the snapshot. getMaxRefundable below takes the larger
+    // of this and Stripe's actual refunded total, so a stale value here can only
+    // make the cap MORE conservative, never looser.
     const totalPriorRefunds = order.refunds.reduce(
       (sum, r) => sum + Number(r.amount),
       0
     );
-    const maxRefundable = await getMaxRefundable(order.stripePaymentIntentId, totalPriorRefunds);
 
-    if (totalRefundAmount > maxRefundable) {
-      return NextResponse.json({
-        success: false,
-        error: `Return refund ($${totalRefundAmount.toFixed(2)}) exceeds maximum refundable ($${maxRefundable.toFixed(2)})`,
-      }, { status: 400 });
-    }
-
-    // Process Stripe refund first (can't roll back if it succeeds).
-    // Idempotency key is derived from the order + the exact set of returned
-    // items, so retrying after the Stripe refund succeeded but the DB
-    // transaction failed replays the same refund instead of double-refunding.
+    // Idempotency key = order + the exact set of returned items, so a retry
+    // after the Stripe refund succeeded but a DB write failed replays the same
+    // refund instead of double-refunding.
     const returnFingerprint = createHash('sha1')
       .update(items.map((it) => `${it.orderItemId}:${it.returnQuantity}`).sort().join(','))
       .digest('hex');
-    const stripeRefund = await stripe.refunds.create(
-      {
-        payment_intent: order.stripePaymentIntentId,
-        amount: Math.round(totalRefundAmount * 100), // Stripe uses cents
-        reason: 'requested_by_customer',
-        metadata: {
-          orderId: id,
-          orderNumber: String(order.orderNumber),
-          reason: reason ? `Return: ${reason}` : 'Return: items returned',
-          type: 'return',
-        },
-      },
-      { idempotencyKey: `order-return-${id}-${returnFingerprint}` }
-    );
 
-    // DB transaction for all writes
-    await prisma.$transaction(async (tx: TransactionClient) => {
-      // Update refundedQuantity on each returned item and restore inventory
-      // For fulfilled orders: restore inventoryQuantity (stock back on shelf)
-      // For unfulfilled orders: release committedQuantity instead
-      const isFulfilled = order.fulfillmentStatus === 'DELIVERED';
+    // Everything money-or-quantity-critical happens in ONE transaction that
+    // holds a row lock on this order's items across the Stripe call. That makes
+    // the critical section atomic (a mid-way failure rolls the DB writes back;
+    // the idempotency key replays Stripe on retry) AND serializes concurrent
+    // returns for the same order: a second request blocks on the lock, then
+    // re-reads the fresh refundedQuantity and bails out if its line was already
+    // consumed — so no two returns can ever over-refund a line.
+    //
+    // The lock is held across ~1-3 Stripe round-trips. This is an admin-only,
+    // low-volume endpoint intentionally serialized per order; it is not built
+    // for bulk concurrent returns of the same order.
+    let stripeRefund: StripeRefund;
+    try {
+      stripeRefund = await prisma.$transaction<StripeRefund>(async (tx: TransactionClient) => {
+        // Lock all of this order's item rows, in a stable order (prevents
+        // deadlock between concurrent returns), for the transaction's duration.
+        const lockedItems = await tx.$queryRaw<{ id: string; quantity: number; refunded_quantity: number }[]>(
+          Prisma.sql`SELECT id, quantity, refunded_quantity FROM order_items WHERE order_id = ${id} ORDER BY id FOR UPDATE`
+        );
 
-      for (const returnItem of validatedReturns) {
-        await tx.orderItem.update({
-          where: { id: returnItem.orderItemId },
+        // Re-validate each line against the CURRENT refundedQuantity (not the
+        // pre-lock snapshot). A line another request already consumed fails here
+        // and rolls the whole transaction back before any money moves.
+        for (const r of validatedReturns) {
+          const fresh = lockedItems.find((row) => row.id === r.orderItemId);
+          if (!fresh || r.returnQuantity > fresh.quantity - fresh.refunded_quantity) {
+            throw new ConcurrentReturnError(r.orderItemId);
+          }
+        }
+
+        // Re-check the money cap under the lock (Stripe-authoritative) so two
+        // concurrent returns of different lines can't both slip past it.
+        const maxRefundable = await getMaxRefundable(paymentIntentId, totalPriorRefunds);
+        if (totalRefundAmount > maxRefundable) {
+          throw new RefundCapError(totalRefundAmount, maxRefundable);
+        }
+
+        // Issue the refund, then apply all DB writes atomically with it.
+        const refund = await stripe.refunds.create(
+          {
+            payment_intent: paymentIntentId,
+            amount: Math.round(totalRefundAmount * 100), // Stripe uses cents
+            reason: 'requested_by_customer',
+            metadata: {
+              orderId: id,
+              orderNumber: String(order.orderNumber),
+              reason: reason ? `Return: ${reason}` : 'Return: items returned',
+              type: 'return',
+            },
+          },
+          { idempotencyKey: `order-return-${id}-${returnFingerprint}` }
+        );
+
+        // Update refundedQuantity and restore inventory.
+        // For fulfilled orders: restore inventoryQuantity (stock back on shelf)
+        // For unfulfilled orders: release committedQuantity instead (after the tx)
+        const isFulfilled = order.fulfillmentStatus === 'DELIVERED';
+        for (const r of validatedReturns) {
+          await tx.orderItem.update({
+            where: { id: r.orderItemId },
+            data: { refundedQuantity: { increment: r.returnQuantity } },
+          });
+          if (isFulfilled) {
+            // Order was delivered — restore physical stock
+            await restoreInventoryForReturnItem(
+              tx,
+              r.productId,
+              r.variantId,
+              r.returnQuantity,
+              order.orderNumber,
+              order.id,
+            );
+          }
+          // If not fulfilled, committedQuantity is released after the transaction
+        }
+
+        // Create refund record
+        await tx.refund.create({
           data: {
-            refundedQuantity: { increment: returnItem.returnQuantity },
+            orderId: id,
+            stripeRefundId: refund.id,
+            amount: new Prisma.Decimal(totalRefundAmount),
+            reason: reason ? `Return: ${reason}` : 'Return: items returned',
+            status: 'SUCCEEDED',
+            processedBy: 'admin',
+            processedAt: new Date(),
           },
         });
 
-        if (isFulfilled) {
-          // Order was delivered — restore physical stock
-          await restoreInventoryForReturnItem(
-            tx,
-            returnItem.productId,
-            returnItem.variantId,
-            returnItem.returnQuantity,
-            order.orderNumber,
-            order.id,
-          );
-        }
-        // If not fulfilled, committedQuantity will be released after the transaction
+        // Check if fully refunded
+        const newTotalRefunded = totalPriorRefunds + totalRefundAmount;
+        const newFinancialStatus = newTotalRefunded >= Number(order.total) ? 'REFUNDED' : 'PARTIALLY_REFUNDED';
+        await tx.order.update({
+          where: { id },
+          data: { financialStatus: newFinancialStatus },
+        });
+
+        return refund;
+      }, { timeout: RETURN_TX_TIMEOUT_MS });
+    } catch (err) {
+      if (err instanceof ConcurrentReturnError) {
+        return NextResponse.json(
+          { success: false, error: 'This order was just modified by another request. Please reload and try again.' },
+          { status: 409 }
+        );
       }
+      if (err instanceof RefundCapError) {
+        return NextResponse.json(
+          { success: false, error: `Return refund ($${err.amount.toFixed(2)}) exceeds maximum refundable ($${err.cap.toFixed(2)})` },
+          { status: 400 }
+        );
+      }
+      throw err;
+    }
 
-      // Create refund record
-      await tx.refund.create({
-        data: {
-          orderId: id,
-          stripeRefundId: stripeRefund.id,
-          amount: new Prisma.Decimal(totalRefundAmount),
-          reason: reason ? `Return: ${reason}` : 'Return: items returned',
-          status: 'SUCCEEDED',
-          processedBy: 'admin',
-          processedAt: new Date(),
-        },
-      });
-
-      // Check if fully refunded
-      const newTotalRefunded = totalPriorRefunds + totalRefundAmount;
-      const orderTotal = Number(order.total);
-      const newFinancialStatus = newTotalRefunded >= orderTotal ? 'REFUNDED' : 'PARTIALLY_REFUNDED';
-
-      await tx.order.update({
-        where: { id },
-        data: { financialStatus: newFinancialStatus },
-      });
-    });
-
-    // For unfulfilled orders, release committed inventory outside transaction
+    // For unfulfilled orders, release committed inventory outside transaction.
+    // The refund + refundedQuantity are already durably committed; a failure here
+    // only leaves committedQuantity slightly inflated (under-available, safe
+    // direction) — log with the orderId so it can be reconciled.
     if (order.fulfillmentStatus !== 'DELIVERED') {
       try {
         await releaseCommittedInventory(id);
       } catch (err) {
-        console.error('[Return API] Failed to release committed inventory:', err);
+        console.error(`[Return API] Failed to release committed inventory for order ${id}:`, err);
       }
     }
 

--- a/src/app/api/v1/admin/orders/__tests__/return-route.test.ts
+++ b/src/app/api/v1/admin/orders/__tests__/return-route.test.ts
@@ -16,6 +16,7 @@ import { Prisma } from '@prisma/client';
 // --- Mocks --------------------------------------------------------------
 
 const txMock = vi.hoisted(() => ({
+  $queryRaw: vi.fn(),
   orderItem: { update: vi.fn() },
   refund: { create: vi.fn() },
   order: { update: vi.fn() },
@@ -92,6 +93,9 @@ beforeEach(() => {
   requireOpsAuthMock.mockResolvedValue({ role: 'admin' }); // not a NextResponse => authorized
   prismaMock.order.findUnique.mockResolvedValue(buildOrder());
   prismaMock.$transaction.mockImplementation(async (cb: (tx: typeof txMock) => unknown) => cb(txMock));
+  // Locked re-read (SELECT ... FOR UPDATE) returns the order's items at their
+  // current, unconsumed state by default.
+  txMock.$queryRaw.mockResolvedValue([{ id: 'oi_1', quantity: 2, refunded_quantity: 0 }]);
   txMock.orderItem.update.mockResolvedValue({});
   txMock.refund.create.mockResolvedValue({});
   txMock.order.update.mockResolvedValue({});
@@ -210,5 +214,75 @@ describe('POST /api/v1/admin/orders/[id]/return — refund amount integrity', ()
     expect(res.status).toBe(401);
     expect(stripeMock.refunds.create).not.toHaveBeenCalled();
     expect(prismaMock.order.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('locks the order rows (SELECT ... FOR UPDATE) before refunding — the concurrency guard', async () => {
+    await callRoute(makeRequest({ items: [{ orderItemId: 'oi_1', returnQuantity: 1 }] }));
+
+    // The critical section must take a row lock and re-read fresh quantities
+    // inside the transaction before issuing the refund.
+    expect(txMock.$queryRaw).toHaveBeenCalledTimes(1);
+    const sqlArg = txMock.$queryRaw.mock.calls[0][0] as { sql?: string; strings?: string[] };
+    const sqlText = sqlArg.sql ?? (sqlArg.strings ?? []).join(' ');
+    expect(sqlText).toContain('FOR UPDATE');
+    // refundedQuantity is then incremented inside that same locked transaction.
+    expect(txMock.orderItem.update).toHaveBeenCalledWith({
+      where: { id: 'oi_1' },
+      data: { refundedQuantity: { increment: 1 } },
+    });
+  });
+
+  it('returns 409 and never refunds when the locked re-read shows the line already consumed', async () => {
+    // The snapshot loaded before the lock said oi_1 was unrefunded, but the
+    // locked re-read shows it now fully refunded (2 of 2) — a concurrent return
+    // won the race, so we must bail before any money moves.
+    txMock.$queryRaw.mockResolvedValue([{ id: 'oi_1', quantity: 2, refunded_quantity: 2 }]);
+
+    const res = await callRoute(
+      makeRequest({ items: [{ orderItemId: 'oi_1', returnQuantity: 1 }] }),
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(json.success).toBe(false);
+    expect(stripeMock.refunds.create).not.toHaveBeenCalled();
+    expect(txMock.refund.create).not.toHaveBeenCalled();
+  });
+
+  it('writes nothing when Stripe fails inside the transaction (atomic rollback, no compensation)', async () => {
+    stripeMock.refunds.create.mockRejectedValue({ type: 'api_error', message: 'boom' });
+
+    const res = await callRoute(
+      makeRequest({ items: [{ orderItemId: 'oi_1', returnQuantity: 1 }] }),
+    );
+
+    // The refund is issued inside the transaction, before the DB writes — a
+    // Stripe failure aborts the transaction, so refundedQuantity is never
+    // incremented and no Refund row is written. No manual compensation needed.
+    expect(stripeMock.refunds.create).toHaveBeenCalledTimes(1);
+    expect(txMock.orderItem.update).not.toHaveBeenCalled();
+    expect(txMock.refund.create).not.toHaveBeenCalled();
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a malformed JSON body with 400, not 500', async () => {
+    const req = new NextRequest(`http://localhost/api/v1/admin/orders/${ORDER_ID}/return`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'this is not json{',
+    });
+    const res = await POST(req, { params: Promise.resolve({ id: ORDER_ID }) });
+
+    expect(res.status).toBe(400);
+    expect(stripeMock.refunds.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects an over-long reason before refunding', async () => {
+    const res = await callRoute(
+      makeRequest({ items: [{ orderItemId: 'oi_1', returnQuantity: 1 }], reason: 'x'.repeat(451) }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(stripeMock.refunds.create).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Follow-up to #169, addressing findings from adversarial verification of that fix.

## Problem

After #169 closed the client-`unitPrice` over-refund, an adversarial review surfaced a **pre-existing concurrency race**: the return endpoint validated each line's returnable quantity against the order snapshot loaded once at the top, then issued the Stripe refund and wrote the DB with no lock. Two simultaneous returns of the same line could both pass the snapshot check and issue two Stripe refunds, over-refunding a line up to the whole-order cap.

## Fix

The whole money-or-quantity-critical section now runs in **one transaction holding a row lock** on the order's items (`SELECT ... ORDER BY id FOR UPDATE`) across the Stripe call:

1. Re-validate each line against the freshly-locked `refundedQuantity` (a line a concurrent return already consumed → **409**).
2. Re-check the Stripe-authoritative cap under the lock.
3. Issue the refund (idempotency key unchanged), then increment `refundedQuantity`, restore inventory, write the `Refund` row, update `financialStatus` — **all atomically**.

A second concurrent return for the same order blocks on the lock, re-reads fresh state, and bails if its line is gone. A mid-way failure rolls back cleanly; the idempotency key replays Stripe on retry. `refundedQuantity` can never exceed what was purchased.

Plus two low-severity fixes: `reason` capped at 450 chars (room for the 8-char `"Return: "` prefix under Stripe's 500-char metadata limit), and malformed JSON returns 400 instead of 500.

## Design notes (why a lock across the Stripe call)

The only way to *prevent* (not just detect) a concurrent double-refund is to serialize before Stripe — Stripe-first can never un-charge a second refund. An earlier "reserve quantities, compensate on failure" iteration was reviewed and **rejected**: blind compensation on a Stripe network-timeout could ghost-decrement and re-open the window. The single locked transaction restores atomicity and eliminates that whole class of partial-failure edges. The lock is held across ~1–3 Stripe round-trips; this is an admin-only, low-volume endpoint intentionally serialized per order. Interactive transactions already run in prod through the same Neon pooler (10+ call sites); transaction-mode pooling pins a connection per transaction, so `FOR UPDATE` holds correctly.

## Security review

Reviewed by the `security-reviewer` agent across both design iterations. The locked-transaction design moots the prior iteration's findings (no compensation, single ordered lock → no deadlock, atomic writes, no decrement → no underflow). Two items from the second review were assessed and **not** changed, with reasoning:

- **Cap-staleness-under-concurrency (rated HIGH) — refuted.** The lock fully serializes: request B can't read the cap until A *commits*, and A creates its Stripe refund before committing, so B's in-lock `getStripeRefundedAmount` always sees A's refund (pending refunds count). No interleaving reads a stale cap.
- **Stuck-retry on >50% refunds after a Stripe-success/tx-fail (MEDIUM) — pre-existing & money-safe.** Identical in #168's design; idempotency prevents a double charge and the webhook records the money. The residual gap (the `charge.refunded` webhook doesn't reconcile `OrderItem.refundedQuantity`) is webhook-side and pre-existing — tracked as a follow-up, not fixed here to avoid adding replay-detection complexity to a payment path.

## Tests

Cover the `FOR UPDATE` guard, the 409 race-loss (locked re-read shows the line consumed), atomic rollback on Stripe failure (no compensation), the reason cap, and malformed-JSON 400, alongside the #169 server-price/duplicate/auth tests. Full suite 365 passing, tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)