### PR TITLE
feat(seo): internal-linking sprint — landing→product + birthday→landing

### DIFF
--- a/content/blog/posts/15-unique-birthday-party-ideas-in-austin-for-adults.mdx
+++ b/content/blog/posts/15-unique-birthday-party-ideas-in-austin-for-adults.mdx
@@ -55,7 +55,7 @@ Instead of the typical dinner, why not try a hands-on activity that doubles as e
 ![Content Image](/images/blog/15-unique-birthday-party-ideas-in-austin-for-adults/15-unique-birthday-party-ideas-in-austin-for-adults-2.webp)
 
 
-For a truly unique Austin birthday experience, gather your crew and rent a party boat on the beautiful Lake Travis. [The Oasis on Lake Travis](https://www.oasis-austin.com/) has a fleet of pontoon boats and party barges that you can captain yourself or have a professional skipper handle the navigation. Spend the day swimming, sunbathing, and sipping drinks with the Austin skyline as your backdrop.
+For a truly unique Austin birthday experience, gather your crew and rent a party boat on the beautiful Lake Travis. [The Oasis on Lake Travis](https://www.oasis-austin.com/) has a fleet of pontoon boats and party barges that you can captain yourself or have a professional skipper handle the navigation. Spend the day swimming, sunbathing, and sipping drinks with the Austin skyline as your backdrop — our [Lake Travis boat party alcohol delivery](/boat-parties) loads the cooler dockside so no one has to run to the store.
 
 ## Enjoy a Dinner Theater Performance
 

--- a/content/blog/posts/how-to-rent-a-donut-boat-for-your-birthday-celebration.mdx
+++ b/content/blog/posts/how-to-rent-a-donut-boat-for-your-birthday-celebration.mdx
@@ -60,7 +60,7 @@ Donut boats typically accommodate 8-12 people, so make sure you have an accurate
 Beyond just renting the donut boat, you'll want to plan out how you'll spend your time on the water. Will you cruise the lake, anchor and swim, or play music and dance? Make sure to coordinate with your rental company on any special requests or add-ons.
 
 ### 5. Gather Essentials and Party Supplies
-Don't forget to pack everything you'll need for a day on the lake - swimsuits, towels, sunscreen, speakers, coolers, and any decorations or party favors. [Party On Delivery](https://partyondelivery.com/) can even handle the alcohol and mixers so you don't have to worry about stocking the boat.
+Don't forget to pack everything you'll need for a day on the lake - swimsuits, towels, sunscreen, speakers, coolers, and any decorations or party favors. Our [Austin boat party alcohol delivery](/boat-parties) can even handle the alcohol and mixers so you don't have to worry about stocking the boat.
 
 ### 6. Arrange for Transportation
 Most donut boat rentals require you to pick up and drop off the boat from the marina. Make sure you have a plan for getting your whole group to and from the lake, whether that's renting a [Longhorn Charter Bus](https://www.longhorncharterbus.com/) or coordinating personal vehicles.

--- a/content/blog/posts/outdoor-birthday-ideas-for-austin-s-parks-and-lakes.mdx
+++ b/content/blog/posts/outdoor-birthday-ideas-for-austin-s-parks-and-lakes.mdx
@@ -26,7 +26,7 @@ For a more elevated experience, the [Zilker Botanical Garden](https://www.zilker
 
 ## Party on the Water at Lake Austin
 
-[Lake Austin](https://www.austintexas.org/austin-insider-blog/blog/post/the-complete-guide-to-lake-life-in-the-austin-area/) is a stunning oasis just minutes from downtown, offering endless opportunities for on-the-water birthday festivities. Consider renting a pontoon boat or a luxurious yacht to host an unforgettable party with your closest friends and family.
+[Lake Austin](https://www.austintexas.org/austin-insider-blog/blog/post/the-complete-guide-to-lake-life-in-the-austin-area/) is a stunning oasis just minutes from downtown, offering endless opportunities for on-the-water birthday festivities. Consider renting a pontoon boat or a luxurious yacht to host an unforgettable party with your closest friends and family — and let our [Lake Travis boat party alcohol delivery](/boat-parties) stock the cooler before you push off.
 
 [The Oasis on Lake Travis](https://www.oasis-austin.com/) is a popular destination for Lake Austin celebrations, featuring multiple event spaces, an expansive deck, and stunning sunset views. Work with their event planners to curate the perfect package, complete with catering, music, and of course, Party On Delivery's premium beverage service.
 

--- a/content/blog/posts/ultimate-guide-austin-birthday-parties.mdx
+++ b/content/blog/posts/ultimate-guide-austin-birthday-parties.mdx
@@ -24,7 +24,7 @@ Austin's unique culture makes it perfect for birthday celebrations:
 - **Year-round outdoor weather** for pool parties and adventures
 - **World-class dining** for memorable birthday dinners
 - **Live music scene** for entertainment any night
-- **Lake Travis** for epic boat party birthdays
+- **Lake Travis** for epic [boat party birthdays with bar delivery to the dock](/boat-parties)
 - **Adventure activities** for thrill-seekers
 
 ## Choosing Your Birthday Style
@@ -46,7 +46,7 @@ Going big for your birthday? Consider:
 - Venue rentals with full bar service
 - Rooftop celebrations downtown
 - Backyard party with professional catering
-- Party barge on Lake Travis
+- [Party barge on Lake Travis](/boat-parties) with a stocked bar delivered dockside
 - Club VIP packages
 
 <div itemScope itemType="https://schema.org/Table">

--- a/src/app/boat-parties/page.tsx
+++ b/src/app/boat-parties/page.tsx
@@ -8,6 +8,7 @@ import Navigation from "@/components/Navigation";
 import LuxuryCard from '@/components/LuxuryCard';
 import ScrollRevealCSS from '@/components/ui/ScrollRevealCSS';
 import BoatPartiesSchemas from '@/components/seo/BoatPartiesSchemas';
+import PopularProductsStrip from '@/components/landing/PopularProductsStrip';
 import { trackPageView, ANALYTICS_EVENTS } from '@/lib/analytics/track';
 import { trackCTAClick } from '@/lib/analytics/ga4-events';
 import { useHeroExperiment } from '@/hooks/useHeroExperiment';
@@ -497,6 +498,43 @@ export default function BoatPartiesPage() {
           </ScrollRevealCSS>
         </div>
       </section>
+
+      {/* Popular Products — contextual internal links to Tier-1/Tier-3 product pages */}
+      <PopularProductsStrip
+        heading="Popular for Lake Travis boat days"
+        intro="The cans, kits, and party touches boat groups add most — loaded onto your cooler dockside before you push off."
+        sectionClassName="py-24 bg-white"
+        products={[
+          {
+            handle: 'pinthouse-electric-jellyfish-16oz-4-pack-can',
+            name: 'Pinthouse Electric Jellyfish IPA',
+            blurb:
+              "Austin's local hazy IPA in 16oz cans — the craft pour that makes a lake cooler feel like a Pinthouse patio.",
+            price: '$19.99',
+          },
+          {
+            handle: 'karbach-love-street-blonde-18-pack-12oz-can',
+            name: 'Karbach Love Street • 18-Pack',
+            blurb:
+              'Crushable Texas blonde by the 18-pack — the easy all-day beer for eight hours on the water.',
+            price: '$26.99',
+          },
+          {
+            handle: 'aperol-spritz-party-pitcher-kit-16-drinks',
+            name: 'Aperol Spritz Kit • Serves 16',
+            blurb:
+              'Pre-batched spritz for 16 — a real cocktail on the boat with nobody stuck playing bartender.',
+            price: '$67.99',
+          },
+          {
+            handle: 'pineapple-cup-with-straw',
+            name: 'Pineapple Cup with Straw',
+            blurb:
+              'The lake-day photo op — tropical cups that turn any drink into a sunset-on-Travis highlight.',
+            price: '$2.49',
+          },
+        ]}
+      />
 
       {/* Safety Notice */}
       <section className="py-24 bg-gray-50">

--- a/src/app/weddings/page.tsx
+++ b/src/app/weddings/page.tsx
@@ -9,6 +9,7 @@ import LuxuryCard from '@/components/LuxuryCard';
 import WeddingDrinkCalculator from '@/components/WeddingDrinkCalculator';
 import ScrollRevealCSS from '@/components/ui/ScrollRevealCSS';
 import WeddingsSchemas from '@/components/seo/WeddingsSchemas';
+import PopularProductsStrip from '@/components/landing/PopularProductsStrip';
 import { trackPageView, ANALYTICS_EVENTS } from '@/lib/analytics/track';
 import { trackCTAClick } from '@/lib/analytics/ga4-events';
 import { useHeroExperiment } from '@/hooks/useHeroExperiment';
@@ -656,6 +657,43 @@ export default function WeddingsPage() {
           </ScrollRevealCSS>
         </div>
       </section>
+
+      {/* Popular Products — contextual internal links to Tier-1/Tier-3 product pages */}
+      <PopularProductsStrip
+        heading="Popular for Austin weddings"
+        intro="The bubbly, cocktail kits, and local craft couples add most for toasts, cocktail hour, and the reception bar."
+        sectionClassName="py-24 bg-white"
+        products={[
+          {
+            handle: 'la-marca-prosecco-extra-dry-750ml-6-pack',
+            name: 'La Marca Prosecco • 6-Pack',
+            blurb:
+              'Crisp Italian prosecco by the six-pack — the toast and mimosa-bar staple for rehearsal dinner through send-off.',
+            price: '$99.99',
+          },
+          {
+            handle: 'aperol-spritz-party-pitcher-kit-16-drinks',
+            name: 'Aperol Spritz Kit • Serves 16',
+            blurb:
+              'A ready-to-pour spritz bar for 16 — the signature cocktail-hour drink that looks and tastes elevated.',
+            price: '$67.99',
+          },
+          {
+            handle: 'pinthouse-electric-jellyfish-16oz-4-pack-can',
+            name: 'Pinthouse Electric Jellyfish IPA',
+            blurb:
+              "Austin's local hazy IPA — the craft-beer pick that gives your reception bar a hometown touch.",
+            price: '$19.99',
+          },
+          {
+            handle: 'pineapple-cup-with-straw',
+            name: 'Pineapple Cup with Straw',
+            blurb:
+              'A playful serve for the welcome party or after-hours bar — signature sips guests remember.',
+            price: '$2.49',
+          },
+        ]}
+      />
 
       {/* Drink Calculator */}
       <section className="py-24">

--- a/src/components/landing/LandingPageTemplate.tsx
+++ b/src/components/landing/LandingPageTemplate.tsx
@@ -8,6 +8,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import PackageBuilderModal from './PackageBuilderModal';
 import QuickBuyModal from './QuickBuyModal';
+import PopularProductsStrip from './PopularProductsStrip';
 import HeroBackdrop from './sections/HeroBackdrop';
 import PackageCard from './sections/PackageCard';
 import { PhoneIcon, ChatIcon, CheckIcon } from './sections/icons';
@@ -488,6 +489,16 @@ export default function LandingPageTemplate({
           </p>
         </div>
       </section>
+
+      {/* POPULAR PRODUCTS — contextual internal links to Tier-1/Tier-3 product pages */}
+      {config.popularProducts && (
+        <PopularProductsStrip
+          heading={config.popularProducts.heading}
+          intro={config.popularProducts.intro}
+          products={config.popularProducts.items}
+          sectionClassName="py-16 md:py-20 bg-white"
+        />
+      )}
 
       {/* HOW IT WORKS — chevron accordion: stacked on mobile, staircase cascade on desktop */}
       <section className="py-12 md:py-20" style={{ background: T.cream }}>

--- a/src/components/landing/PopularProductsStrip.tsx
+++ b/src/components/landing/PopularProductsStrip.tsx
@@ -1,0 +1,89 @@
+import Link from 'next/link';
+import type { ReactElement } from 'react';
+
+/**
+ * A single product shown in the "popular for this event" strip. `handle`
+ * is the Postgres product handle — the card links to `/products/<handle>`.
+ * `blurb` is event-specific copy (why this product fits *this* occasion),
+ * which doubles as descriptive anchor context for internal-link SEO.
+ */
+export interface PopularProduct {
+  handle: string;
+  name: string;
+  blurb: string;
+  /** Display price string, e.g. "$19.99". Optional. */
+  price?: string;
+}
+
+interface PopularProductsStripProps {
+  /** Section heading, e.g. "Popular for Austin bachelor parties". */
+  heading: string;
+  /** Optional intro line under the heading. */
+  intro?: string;
+  products: PopularProduct[];
+  /**
+   * Section wrapper classes (background + padding). Defaults to a white
+   * band; pass `py-24 bg-gray-50` etc. to alternate against neighbours.
+   */
+  sectionClassName?: string;
+}
+
+/**
+ * Contextual "popular for this event" product strip.
+ *
+ * Drops crawlable, descriptive internal links from high-traffic landing
+ * pages down to Tier-1/Tier-3 product pages — the topic-graph signal the
+ * May 2026 Core Update rewards. Purely presentational (no data fetching),
+ * so it renders inside both the client `LandingPageTemplate` and the
+ * standalone `/boat-parties` and `/weddings` pages.
+ */
+export default function PopularProductsStrip({
+  heading,
+  intro,
+  products,
+  sectionClassName = 'py-16 md:py-20 bg-white',
+}: PopularProductsStripProps): ReactElement | null {
+  if (!products.length) return null;
+
+  return (
+    <section className={sectionClassName}>
+      <div className="container-custom">
+        <div className="text-center max-w-2xl mx-auto mb-10 md:mb-12">
+          <h2 className="font-heading text-3xl md:text-4xl text-gray-900 tracking-[0.1em] mb-3">
+            {heading}
+          </h2>
+          {intro && (
+            <p className="text-base text-gray-600 leading-relaxed">{intro}</p>
+          )}
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+          {products.map((product) => (
+            <Link
+              key={product.handle}
+              href={`/products/${product.handle}`}
+              className="card flex flex-col group focus:outline-none focus:ring-2 focus:ring-brand-blue"
+            >
+              <h3 className="font-heading text-lg font-bold text-gray-900 tracking-[0.08em] mb-2 group-hover:text-brand-blue transition-colors">
+                {product.name}
+              </h3>
+              <p className="text-sm text-gray-600 leading-relaxed flex-1">
+                {product.blurb}
+              </p>
+              <div className="mt-4 flex items-center justify-between">
+                {product.price && (
+                  <span className="text-base font-semibold text-gray-900">
+                    {product.price}
+                  </span>
+                )}
+                <span className="text-sm font-semibold tracking-[0.08em] text-brand-blue">
+                  View &amp; add &rarr;
+                </span>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/landing/configs/bachelor.ts
+++ b/src/components/landing/configs/bachelor.ts
@@ -227,6 +227,42 @@ export const bachelorConfig: LandingConfig = {
     },
   ],
 
+  popularProducts: {
+    heading: 'Crowd-pleasers for the bach weekend',
+    intro:
+      'The bottles and cans Austin bachelor groups add most — order any of them straight to the boat, Airbnb, or hotel.',
+    items: [
+      {
+        handle: 'pinthouse-electric-jellyfish-16oz-4-pack-can',
+        name: 'Pinthouse Electric Jellyfish IPA',
+        blurb:
+          "Austin's cult-favorite hazy IPA in 16oz cans — the local pour that makes a boat cooler feel like a brewery run.",
+        price: '$19.99',
+      },
+      {
+        handle: 'karbach-love-street-blonde-18-pack-12oz-can',
+        name: 'Karbach Love Street • 18-Pack',
+        blurb:
+          'Crushable Texas blonde by the 18-pack — the easy all-day beer for a Lake Travis dock day or Rainey pregame.',
+        price: '$26.99',
+      },
+      {
+        handle: 'aperol-spritz-party-pitcher-kit-16-drinks',
+        name: 'Aperol Spritz Kit • Serves 16',
+        blurb:
+          'Pre-batched spritz for 16 so nobody plays bartender at the Airbnb — pour, add ice, done.',
+        price: '$67.99',
+      },
+      {
+        handle: 'pineapple-cup-with-straw',
+        name: 'Pineapple Cup with Straw',
+        blurb:
+          'The boat-day photo op — tropical cups that turn any drink into a bachelor-trip highlight reel.',
+        price: '$2.49',
+      },
+    ],
+  },
+
   finalCtaHeadline: 'Lock it in.',
   finalCtaHeadlineAccent: 'Then go enjoy the trip you planned.',
   finalCtaSubhead:

--- a/src/components/landing/configs/bachelorette.ts
+++ b/src/components/landing/configs/bachelorette.ts
@@ -202,6 +202,42 @@ export const bacheloretteConfig: LandingConfig = {
     },
   ],
 
+  popularProducts: {
+    heading: 'Crowd-pleasers for the bachelorette weekend',
+    intro:
+      'The bubbly, spritzes, and party touches Austin bachelorette groups add most — delivered cold to your weekend home base or boat.',
+    items: [
+      {
+        handle: 'aperol-spritz-party-pitcher-kit-16-drinks',
+        name: 'Aperol Spritz Kit • Serves 16',
+        blurb:
+          'A ready-to-pour spritz bar for 16 — the golden-hour drink for the rooftop, patio, or bridal-shower brunch.',
+        price: '$67.99',
+      },
+      {
+        handle: 'la-marca-prosecco-extra-dry-750ml-6-pack',
+        name: 'La Marca Prosecco • 6-Pack',
+        blurb:
+          'Six bottles of crisp Italian prosecco — the mimosa-bar and toast staple for the whole weekend.',
+        price: '$99.99',
+      },
+      {
+        handle: 'pineapple-cup-with-straw',
+        name: 'Pineapple Cup with Straw',
+        blurb:
+          'The bachelorette photo prop — tropical cups that make every drink (and every pic) pop on the boat.',
+        price: '$2.49',
+      },
+      {
+        handle: 'pinthouse-electric-jellyfish-16oz-4-pack-can',
+        name: 'Pinthouse Electric Jellyfish IPA',
+        blurb:
+          "Austin's local hazy IPA in 16oz cans — the craft-beer pick for the crew that isn't drinking bubbly.",
+        price: '$19.99',
+      },
+    ],
+  },
+
   finalCtaHeadline: 'Lock it in.',
   finalCtaHeadlineAccent: 'Then enjoy the weekend you actually planned.',
   finalCtaSubhead:

--- a/src/components/landing/types.ts
+++ b/src/components/landing/types.ts
@@ -74,6 +74,17 @@ export type Review = {
 
 export type Faq = { q: string; a: string };
 
+/** One product in the "popular for this event" internal-link strip. */
+export type PopularProductLink = {
+  /** Postgres product handle — card links to /products/<handle>. */
+  handle: string;
+  name: string;
+  /** Event-specific reason this product fits (doubles as anchor context). */
+  blurb: string;
+  /** Display price string, e.g. "$19.99". */
+  price?: string;
+};
+
 export type ModalStep = {
   key: string;
   label: string;
@@ -171,6 +182,17 @@ export type LandingConfig = {
   // FAQ
   faqHeadline: string;
   faqs: Faq[];
+
+  /**
+   * Optional "popular for this event" product strip — contextual internal
+   * links from the landing page down to Tier-1/Tier-3 product pages. When
+   * unset, nothing renders (pages without it are unchanged).
+   */
+  popularProducts?: {
+    heading: string;
+    intro?: string;
+    items: PopularProductLink[];
+  };
 
   // Final CTA
   finalCtaHeadline: string;


### PR DESCRIPTION
## Lever 2 — Internal-linking sprint

Part of the 2026-07 SEO recovery sprint. On-page fixes on the homepage cluster are maxed out; the remaining organic lever is **authority + topic graph**. This PR builds the internal topic graph the May 2026 Core Update rewards by wiring contextual links from high-traffic pages down to the Tier-1/Tier-3 product pages, and from the birthday blog cluster out to the event landing pages.

### New component — `PopularProductsStrip`
A reusable, purely presentational "popular for this event" strip (no data fetching), so it renders inside both the client `LandingPageTemplate` and the standalone `/boat-parties` and `/weddings` pages. Design-system compliant (`.card`, `.container-custom`, brand-blue accents, `rounded-lg`, `text-sm`+ minimums). ~90 lines.

### Landing → product links
Adds a "popular for this event" strip linking the 5 target products with **event-specific, descriptive anchor copy**:

| Page | Products surfaced |
|---|---|
| `/austin-bachelor-party-delivery` | Electric Jellyfish, Karbach Love Street, Aperol Spritz kit, Pineapple Cup |
| `/austin-bachelorette-party-delivery` | Aperol Spritz kit, La Marca Prosecco, Pineapple Cup, Electric Jellyfish |
| `/boat-parties` | Electric Jellyfish, Karbach Love Street, Aperol Spritz kit, Pineapple Cup |
| `/weddings` | La Marca Prosecco, Aperol Spritz kit, Electric Jellyfish, Pineapple Cup |

Bachelor/bachelorette get it via a new optional `popularProducts` config field on `LandingConfig` (unset = nothing renders, so other event pages are unchanged). Boat/weddings get inline strips after their Packages section.

**Note:** sibling landing-page cross-linking (bachelor↔bachelorette↔corporate↔wedding-weekend) already exists in `LandingPageTemplate` (the `siblingLandingPages` section), so no new cross-linking was needed there.

### Birthday blog → landing pages
The birthday cluster previously linked **only to `/products`** — no landing-page links. Added descriptive head-term links to `/boat-parties` from the pillar guide + the 3 birthday posts that had no landing-page link at all:
- `ultimate-guide-austin-birthday-parties` (2 links)
- `how-to-rent-a-donut-boat-for-your-birthday-celebration`
- `outdoor-birthday-ideas-for-austin-s-parks-and-lakes`
- `15-unique-birthday-party-ideas-in-austin-for-adults`

The bachelor / boat / wedding / bachelorette posts already linked their landing pages with descriptive anchors, so they were left untouched.

### Verification
- All 5 product handles confirmed **ACTIVE + availableForSale** in Postgres; none appear in `ARCHIVED_PRODUCT_REDIRECTS`.
- `npx tsc --noEmit` — 0 errors project-wide.
- `npx eslint` on changed files — 0 errors (only pre-existing warnings on untouched lines).
- `npm run test:run` — 365 tests pass.
- Per Forbidden Actions, no `next build` / Playwright / screenshots.

### Not done here (deferred per brief)
No new `/alcohol-delivery-austin` landing page — that escalation is deferred to the 2026-08-05 re-measure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)