### PR TITLE
feat(crm): CoreLinq Phase-2 bridge — store fan-out + read-only CRM lookup API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,6 +123,19 @@ GHL_DASHBOARD_WEBHOOK_URL=your-ghl-dashboard-webhook
 GHL_WEBHOOK_URL=your-ghl-webhook
 
 # ==========================================
+# CORELINQ CRM (GHL replacement — ADR-0007)
+# ==========================================
+# Fan-out target for store events during the GHL -> CoreLinq migration.
+# Full ingest URL INCLUDING the token, e.g.
+# https://<crm-domain>/api/ingest/partyon?token=<long-random>
+# Unset = fan-out off (GHL-only behavior).
+CORELINQ_INGEST_URL=
+# Bearer key for the read-only GET /api/v1/crm/lookup API (consumed by the
+# CRM's Retell voice-agent tool). Unset = route returns 503. Generate with:
+# openssl rand -hex 32   — rotate periodically.
+CRM_API_KEY=
+
+# ==========================================
 # META / FACEBOOK PIXEL
 # ==========================================
 # Falls back to a baked-in ID if unset — set this to override.

--- a/prisma/migrations/manual/2026-07-04-crm-lookup-phone-indexes.sql
+++ b/prisma/migrations/manual/2026-07-04-crm-lookup-phone-indexes.sql
@@ -1,0 +1,15 @@
+-- CRM lookup phone indexes (Phase 2 CoreLinq bridge)
+--
+-- GET /api/v1/crm/lookup?phone= matches on the last 10 digits of
+-- orders.customer_phone / orders.delivery_phone via
+--   RIGHT(REGEXP_REPLACE(COALESCE(col, ''), '\D', '', 'g'), 10)
+-- Without these expression indexes every phone lookup is a full-table
+-- regex scan — a latency + enumeration-throughput problem as orders grows.
+-- The expressions below must stay byte-identical to the query in
+-- src/app/api/v1/crm/lookup/route.ts.
+
+CREATE INDEX IF NOT EXISTS idx_orders_customer_phone_last10
+  ON orders (RIGHT(REGEXP_REPLACE(COALESCE(customer_phone, ''), '\D', '', 'g'), 10));
+
+CREATE INDEX IF NOT EXISTS idx_orders_delivery_phone_last10
+  ON orders (RIGHT(REGEXP_REPLACE(COALESCE(delivery_phone, ''), '\D', '', 'g'), 10));

--- a/src/app/api/cron/event-abandoned-rsvps/route.ts
+++ b/src/app/api/cron/event-abandoned-rsvps/route.ts
@@ -21,6 +21,7 @@ import { prisma } from '@/lib/database/client';
 import { sendEmail } from '@/lib/email/resend-client';
 import { eventAbandonedCartEmail } from '@/lib/email/templates/event-abandoned-cart';
 import { getDemoEvent } from '@/lib/events/demoEvents';
+import { postToCoreLinq } from '@/lib/webhooks/ghl';
 import { EmailType } from '@prisma/client';
 
 export const runtime = 'nodejs';
@@ -131,27 +132,32 @@ export async function GET(req: NextRequest) {
         ],
       });
 
-      // Fire SMS via GHL if we have the webhook + a phone number.
-      if (GHL_WEBHOOK_URL && lead.phone) {
-        try {
-          await fetch(GHL_WEBHOOK_URL, {
-            method: 'POST',
-            headers: { 'content-type': 'application/json' },
-            body: JSON.stringify({
-              event: 'event.abandoned_cart',
-              first_name: lead.firstName ?? '',
-              last_name: lead.lastName ?? '',
-              email: lead.email,
-              phone: lead.phone,
-              sms_message: `Hey ${lead.firstName ?? 'there'} — your drink order for ${ac.eventTitle} isn't locked in yet. Finish here: ${resumeUrl}`,
-              event_slug: ac.eventSlug,
-              event_title: ac.eventTitle,
-              resume_url: resumeUrl,
-            }),
-          });
-        } catch (err) {
-          console.warn('[event-abandoned-cart] GHL SMS failed', err);
+      // Fire SMS via GHL if we have the webhook + a phone number
+      // (+ CoreLinq fan-out during the GHL → CoreLinq migration).
+      if (lead.phone) {
+        const smsPayload = {
+          event: 'event.abandoned_cart',
+          first_name: lead.firstName ?? '',
+          last_name: lead.lastName ?? '',
+          email: lead.email,
+          phone: lead.phone,
+          sms_message: `Hey ${lead.firstName ?? 'there'} — your drink order for ${ac.eventTitle} isn't locked in yet. Finish here: ${resumeUrl}`,
+          event_slug: ac.eventSlug,
+          event_title: ac.eventTitle,
+          resume_url: resumeUrl,
+        };
+        if (GHL_WEBHOOK_URL) {
+          try {
+            await fetch(GHL_WEBHOOK_URL, {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify(smsPayload),
+            });
+          } catch (err) {
+            console.warn('[event-abandoned-cart] GHL SMS failed', err);
+          }
         }
+        await postToCoreLinq(smsPayload);
       }
 
       await prisma.lead.update({

--- a/src/app/api/v1/crm/lookup/route.ts
+++ b/src/app/api/v1/crm/lookup/route.ts
@@ -1,0 +1,200 @@
+/**
+ * GET /api/v1/crm/lookup — read-only customer/order lookup for the CoreLinq CRM.
+ *
+ * Consumed by the CRM's Retell voice-agent tool route (`partyon_order_lookup`),
+ * which proxies on behalf of the AI receptionist — Retell never calls this
+ * directly. Part of the GHL → CoreLinq migration (ADR-0007).
+ *
+ * Query params (at least one required):
+ *   ?orderNumber=1234  — exact order number
+ *   ?email=x@y.com     — case-insensitive match on the order's customer email
+ *   ?phone=5125551234  — matched on the last 10 digits of customer/delivery phone
+ *
+ * Auth: `Authorization: Bearer ${CRM_API_KEY}` (same pattern as CRON_SECRET).
+ * Returns 503 when CRM_API_KEY is not configured, so the route is inert until
+ * the env var is set.
+ */
+import { NextResponse, type NextRequest } from 'next/server';
+import { createHash, timingSafeEqual } from 'crypto';
+import { z } from 'zod';
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/database/client';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const CRM_API_KEY = process.env.CRM_API_KEY;
+
+// Lightweight in-memory rate limit (per instance). The route is Bearer-key
+// authenticated; this is a backstop against a leaked key being used to
+// enumerate customers. Matches the pattern in /api/events/rsvp.
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = 60;
+const hits = new Map<string, { count: number; resetAt: number }>();
+
+function rateLimited(ip: string): boolean {
+  const now = Date.now();
+  const entry = hits.get(ip);
+  if (entry && now < entry.resetAt) {
+    if (entry.count >= RATE_LIMIT_MAX) return true;
+    entry.count++;
+    return false;
+  }
+  hits.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+  return false;
+}
+
+/** Constant-time comparison of the presented bearer token against CRM_API_KEY. */
+function isAuthorized(authHeader: string | null): boolean {
+  if (!CRM_API_KEY || !authHeader?.startsWith('Bearer ')) return false;
+  const presented = createHash('sha256').update(authHeader.slice(7)).digest();
+  const expected = createHash('sha256').update(CRM_API_KEY).digest();
+  return timingSafeEqual(presented, expected);
+}
+
+const QuerySchema = z
+  .object({
+    orderNumber: z.coerce.number().int().positive().optional(),
+    email: z.string().email().max(254).optional(),
+    phone: z
+      .string()
+      .max(24)
+      .transform((v) => v.replace(/\D/g, ''))
+      .pipe(z.string().min(10, 'Phone must contain at least 10 digits'))
+      .optional(),
+  })
+  .refine((q) => q.orderNumber || q.email || q.phone, {
+    message: 'Provide orderNumber, email, or phone',
+  });
+
+function formatAddress(addr: unknown): string {
+  if (!addr || typeof addr !== 'object') return '';
+  const a = addr as Record<string, string>;
+  const parts: string[] = [];
+  if (a.address1) parts.push(a.address1);
+  if (a.address2) parts.push(a.address2);
+  if (a.city) parts.push(a.city);
+  const stateZip = [a.province, a.zip].filter(Boolean).join(' ');
+  if (stateZip) parts.push(stateZip);
+  return parts.join(', ');
+}
+
+const orderInclude = {
+  items: { select: { title: true, variantTitle: true, quantity: true } },
+  groupOrderV2: { select: { shareCode: true } },
+} satisfies Prisma.OrderInclude;
+
+type OrderForLookup = Prisma.OrderGetPayload<{ include: typeof orderInclude }>;
+
+function serializeOrder(order: OrderForLookup) {
+  const shareCode = order.groupOrderV2?.shareCode ?? null;
+  return {
+    orderNumber: order.orderNumber,
+    status: order.status,
+    financialStatus: order.financialStatus,
+    fulfillmentStatus: order.fulfillmentStatus,
+    createdAt: order.createdAt.toISOString(),
+    deliveryDate: order.deliveryDate.toISOString().split('T')[0],
+    deliveryTime: order.deliveryTime,
+    deliveryAddress: formatAddress(order.deliveryAddress),
+    deliveryType: order.deliveryType,
+    total: Number(order.total),
+    items: order.items.map((i) => ({
+      title: i.title,
+      variantTitle: i.variantTitle,
+      quantity: i.quantity,
+    })),
+    dashboardUrl: shareCode ? `https://partyondelivery.com/dashboard/${shareCode}` : null,
+  };
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  if (!CRM_API_KEY) {
+    return NextResponse.json({ ok: false, error: 'not configured' }, { status: 503 });
+  }
+  if (!isAuthorized(req.headers.get('authorization'))) {
+    return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 });
+  }
+
+  const ip =
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    req.headers.get('x-real-ip') ||
+    'unknown';
+  if (rateLimited(ip)) {
+    return NextResponse.json({ ok: false, error: 'rate limited' }, { status: 429 });
+  }
+
+  const parsed = QuerySchema.safeParse({
+    orderNumber: req.nextUrl.searchParams.get('orderNumber') ?? undefined,
+    email: req.nextUrl.searchParams.get('email') ?? undefined,
+    phone: req.nextUrl.searchParams.get('phone') ?? undefined,
+  });
+  if (!parsed.success) {
+    return NextResponse.json(
+      { ok: false, error: 'Validation failed', details: parsed.error.flatten() },
+      { status: 400 }
+    );
+  }
+  const { orderNumber, email, phone } = parsed.data;
+
+  try {
+    let orders: OrderForLookup[] = [];
+
+    if (orderNumber) {
+      const order = await prisma.order.findUnique({
+        where: { orderNumber },
+        include: orderInclude,
+      });
+      orders = order ? [order] : [];
+    } else if (email) {
+      orders = await prisma.order.findMany({
+        where: { customerEmail: { equals: email, mode: 'insensitive' } },
+        include: orderInclude,
+        orderBy: { createdAt: 'desc' },
+        take: 5,
+      });
+    } else if (phone) {
+      // Phone formats vary across eras ("(512) 555-1234", "+15125551234", …) —
+      // compare the last 10 digits of the stored values in SQL, then hydrate
+      // the matches through Prisma.
+      const last10 = phone.slice(-10);
+      const rows = await prisma.$queryRaw<Array<{ id: string }>>(
+        Prisma.sql`
+          SELECT id FROM orders
+          WHERE RIGHT(REGEXP_REPLACE(COALESCE(customer_phone, ''), '\\D', '', 'g'), 10) = ${last10}
+             OR RIGHT(REGEXP_REPLACE(COALESCE(delivery_phone, ''), '\\D', '', 'g'), 10) = ${last10}
+          ORDER BY created_at DESC
+          LIMIT 5
+        `
+      );
+      if (rows.length > 0) {
+        orders = await prisma.order.findMany({
+          where: { id: { in: rows.map((r) => r.id) } },
+          include: orderInclude,
+          orderBy: { createdAt: 'desc' },
+        });
+      }
+    }
+
+    if (orders.length === 0) {
+      return NextResponse.json({ ok: true, found: false, customer: null, orders: [] });
+    }
+
+    // Customer info from the most recent order's snapshot — every order carries
+    // one, so this works even for guests with no Customer row.
+    const latest = orders[0];
+    return NextResponse.json({
+      ok: true,
+      found: true,
+      customer: {
+        name: latest.customerName,
+        email: latest.customerEmail,
+        phone: latest.customerPhone,
+      },
+      orders: orders.map(serializeOrder),
+    });
+  } catch (error) {
+    console.error('[CRM Lookup] Error:', error);
+    return NextResponse.json({ ok: false, error: 'lookup failed' }, { status: 500 });
+  }
+}

--- a/src/app/api/v1/crm/lookup/route.ts
+++ b/src/app/api/v1/crm/lookup/route.ts
@@ -19,30 +19,18 @@ import { createHash, timingSafeEqual } from 'crypto';
 import { z } from 'zod';
 import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/database/client';
+import { checkRateLimit } from '@/lib/security/rate-limit';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 const CRM_API_KEY = process.env.CRM_API_KEY;
 
-// Lightweight in-memory rate limit (per instance). The route is Bearer-key
-// authenticated; this is a backstop against a leaked key being used to
-// enumerate customers. Matches the pattern in /api/events/rsvp.
-const RATE_LIMIT_WINDOW_MS = 60_000;
-const RATE_LIMIT_MAX = 60;
-const hits = new Map<string, { count: number; resetAt: number }>();
-
-function rateLimited(ip: string): boolean {
-  const now = Date.now();
-  const entry = hits.get(ip);
-  if (entry && now < entry.resetAt) {
-    if (entry.count >= RATE_LIMIT_MAX) return true;
-    entry.count++;
-    return false;
-  }
-  hits.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
-  return false;
-}
+// KV-backed (global across instances) with in-memory fallback. The route is
+// Bearer-key authenticated; this is the backstop against a leaked key being
+// used to enumerate customers, so it must be a real cross-instance cap.
+const RATE_LIMIT_MAX = 60; // per IP per minute
+const RATE_LIMIT_WINDOW_SECONDS = 60;
 
 /** Constant-time comparison of the presented bearer token against CRM_API_KEY. */
 function isAuthorized(authHeader: string | null): boolean {
@@ -120,7 +108,8 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
     req.headers.get('x-real-ip') ||
     'unknown';
-  if (rateLimited(ip)) {
+  const allowed = await checkRateLimit('crm-lookup', ip, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_SECONDS);
+  if (!allowed) {
     return NextResponse.json({ ok: false, error: 'rate limited' }, { status: 429 });
   }
 

--- a/src/app/api/v2/group-orders/[code]/send-link/route.ts
+++ b/src/app/api/v2/group-orders/[code]/send-link/route.ts
@@ -9,6 +9,7 @@ import { prisma } from '@/lib/database/client';
 import { sendEmail } from '@/lib/email/resend-client';
 import { dashboardLinkEmail } from '@/lib/email/templates/dashboard-link';
 import { postToCoreLinq } from '@/lib/webhooks/ghl';
+import { checkRateLimit } from '@/lib/security/rate-limit';
 
 const SendLinkSchema = z.object({
   hostEmail: z.string().email('Valid email is required').optional().or(z.literal('')),
@@ -20,6 +21,24 @@ type RouteParams = { params: Promise<{ code: string }> };
 export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
     const { code } = await params;
+
+    // Public endpoint (keyed by shareCode) that sends real email/SMS — cap
+    // per IP and per dashboard so it can't be used as a send-spam primitive.
+    const ip =
+      request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+      request.headers.get('x-real-ip') ||
+      'unknown';
+    const [ipAllowed, codeAllowed] = await Promise.all([
+      checkRateLimit('send-link:ip', ip, 10, 60),
+      checkRateLimit('send-link:code', code, 6, 600),
+    ]);
+    if (!ipAllowed || !codeAllowed) {
+      return NextResponse.json(
+        { success: false, error: 'Too many requests — try again shortly' },
+        { status: 429 }
+      );
+    }
+
     const body = await request.json();
     const parsed = SendLinkSchema.safeParse(body);
 

--- a/src/app/api/v2/group-orders/[code]/send-link/route.ts
+++ b/src/app/api/v2/group-orders/[code]/send-link/route.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import { prisma } from '@/lib/database/client';
 import { sendEmail } from '@/lib/email/resend-client';
 import { dashboardLinkEmail } from '@/lib/email/templates/dashboard-link';
+import { postToCoreLinq } from '@/lib/webhooks/ghl';
 
 const SendLinkSchema = z.object({
   hostEmail: z.string().email('Valid email is required').optional().or(z.literal('')),
@@ -78,8 +79,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       }
     }
 
-    // Trigger GHL SMS if phone provided
+    // Trigger GHL SMS if phone provided (+ CoreLinq fan-out during migration)
     if (hostPhone) {
+      const smsMessage = `Here's your Party On Delivery dashboard link: ${dashboardUrl}`;
       try {
         const ghlWebhookUrl = process.env.GHL_WEBHOOK_URL;
         if (ghlWebhookUrl) {
@@ -88,7 +90,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
               phone: hostPhone,
-              message: `Here's your Party On Delivery dashboard link: ${dashboardUrl}`,
+              message: smsMessage,
               source: 'dashboard-share',
             }),
           });
@@ -96,6 +98,14 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       } catch (smsErr) {
         console.error('[SendLink] SMS webhook failed:', smsErr);
       }
+      await postToCoreLinq({
+        event: 'dashboard.share',
+        phone: hostPhone,
+        message: smsMessage,
+        source: 'dashboard-share',
+        dashboard_url: dashboardUrl,
+        share_code: code,
+      });
     }
 
     return NextResponse.json({ success: true, data: { sent: true } });

--- a/src/lib/security/rate-limit.ts
+++ b/src/lib/security/rate-limit.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared fixed-window rate limiter.
+ *
+ * Uses Vercel KV when configured — the counter is global across serverless
+ * instances, so the limit is a real cap. Falls back to an in-memory Map when
+ * KV is unavailable (dev, or a KV outage), which still limits per instance.
+ * Fails OPEN on KV errors: the caller's primary auth gate must stand on its
+ * own — this is a throttle, not an access control.
+ *
+ * Same get/set pattern as src/lib/auth/login-throttle.ts (the kv stub only
+ * exposes get/set).
+ */
+import { kv, isKVConfigured } from '@/lib/database/client';
+
+const memory = new Map<string, { count: number; resetAt: number }>();
+
+/**
+ * Count a hit against `scope:identifier` and report whether it is within
+ * `limit` per `windowSeconds`. Returns true when the request is allowed.
+ */
+export async function checkRateLimit(
+  scope: string,
+  identifier: string,
+  limit: number,
+  windowSeconds: number
+): Promise<boolean> {
+  const key = `ratelimit:${scope}:${identifier}`;
+
+  if (isKVConfigured()) {
+    try {
+      const current = ((await kv.get(key)) as number | null) ?? 0;
+      if (current >= limit) return false;
+      await kv.set(key, current + 1, { ex: windowSeconds });
+      return true;
+    } catch (error) {
+      console.error(`[Rate Limit] KV error for ${scope}, falling back to memory:`, error);
+    }
+  }
+
+  const now = Date.now();
+  const entry = memory.get(key);
+  if (entry && now < entry.resetAt) {
+    if (entry.count >= limit) return false;
+    entry.count++;
+    return true;
+  }
+  memory.set(key, { count: 1, resetAt: now + windowSeconds * 1000 });
+
+  // Bound fallback memory growth under identifier-rotating abuse.
+  if (memory.size > 10_000) {
+    for (const [k, v] of memory) {
+      if (now >= v.resetAt) memory.delete(k);
+    }
+  }
+  return true;
+}

--- a/src/lib/webhooks/ghl.ts
+++ b/src/lib/webhooks/ghl.ts
@@ -124,8 +124,8 @@ function buildItemsSummary(
  * Fire-and-forget: logs errors, never throws. No-ops silently when
  * CORELINQ_INGEST_URL is not set.
  */
-export async function postToCoreLinq(
-  payload: { event: string } & Record<string, unknown>
+export async function postToCoreLinq<T extends { event: string }>(
+  payload: T
 ): Promise<void> {
   if (!CORELINQ_INGEST_URL) return;
 

--- a/src/lib/webhooks/ghl.ts
+++ b/src/lib/webhooks/ghl.ts
@@ -9,6 +9,7 @@ const GHL_WEBHOOK_URL = process.env.GHL_ORDER_WEBHOOK_URL;
 const GHL_REVIEW_WEBHOOK_URL = process.env.GHL_REVIEW_WEBHOOK_URL;
 const GHL_DASHBOARD_WEBHOOK_URL = process.env.GHL_DASHBOARD_WEBHOOK_URL;
 const GHL_NEWSLETTER_WEBHOOK_URL = process.env.GHL_NEWSLETTER_WEBHOOK_URL;
+const CORELINQ_INGEST_URL = process.env.CORELINQ_INGEST_URL;
 
 // ──────────────────────────────────────────────
 // Types
@@ -110,6 +111,39 @@ function buildItemsSummary(
 }
 
 // ──────────────────────────────────────────────
+// CoreLinq CRM fan-out (GHL → CoreLinq migration)
+// ──────────────────────────────────────────────
+
+/**
+ * POST the same event to the CoreLinq CRM ingest route when
+ * CORELINQ_INGEST_URL is set. During the shadow-mode parallel run both GHL
+ * and CoreLinq receive every event; after cutover the GHL URLs are unset and
+ * only this fires. The payload must carry an `event` discriminator — the
+ * ingest route switches on it.
+ *
+ * Fire-and-forget: logs errors, never throws. No-ops silently when
+ * CORELINQ_INGEST_URL is not set.
+ */
+export async function postToCoreLinq(
+  payload: { event: string } & Record<string, unknown>
+): Promise<void> {
+  if (!CORELINQ_INGEST_URL) return;
+
+  try {
+    const res = await fetch(CORELINQ_INGEST_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      console.error('[CoreLinq Ingest] Failed:', payload.event, res.status, await res.text());
+    }
+  } catch (err) {
+    console.error('[CoreLinq Ingest] Error:', payload.event, err);
+  }
+}
+
+// ──────────────────────────────────────────────
 // Public API
 // ──────────────────────────────────────────────
 
@@ -177,6 +211,7 @@ export interface GhlReviewPayload {
 }
 
 export async function notifyNewOrder(payload: GhlOrderPayload): Promise<void> {
+  await postToCoreLinq(payload);
   if (!GHL_WEBHOOK_URL) return;
 
   try {
@@ -200,6 +235,7 @@ export async function notifyNewOrder(payload: GhlOrderPayload): Promise<void> {
  * Fire-and-forget: logs errors, never throws.
  */
 export async function sendReviewRequest(payload: GhlReviewPayload): Promise<void> {
+  await postToCoreLinq(payload);
   if (!GHL_REVIEW_WEBHOOK_URL) return;
 
   try {
@@ -240,6 +276,7 @@ export interface GhlDashboardPayload {
  * Fire-and-forget: logs errors, never throws.
  */
 export async function notifyDashboardCreated(payload: GhlDashboardPayload): Promise<void> {
+  await postToCoreLinq(payload);
   if (!GHL_DASHBOARD_WEBHOOK_URL) return;
 
   try {
@@ -285,6 +322,7 @@ export interface GhlNewsletterPayload {
  * the GHL inbound webhook/workflow and sets the env var.
  */
 export async function notifyNewsletterSignup(payload: GhlNewsletterPayload): Promise<void> {
+  await postToCoreLinq(payload);
   if (!GHL_NEWSLETTER_WEBHOOK_URL) return;
 
   try {


### PR DESCRIPTION
Part of the GHL → CoreLinq migration (ADR-0007). Twilio A2P campaign approved 2026-07-04, so this un-defers the bridge build.

## What
- **`postToCoreLinq()` fan-out** in `src/lib/webhooks/ghl.ts`: every store event (order.created, review.request, dashboard.created, newsletter.subscribed) also POSTs to `CORELINQ_INGEST_URL` when set. Inline sites covered too: dashboard.share (send-link) + event.abandoned_cart (cron). Fire-and-forget, never throws, **no behavior change while the env var is unset**.
- **New `GET /api/v1/crm/lookup`** — read-only customer/order lookup for the CRM's Retell voice-agent tool (Phase 5). Bearer `CRM_API_KEY` (constant-time compare), zod validation, KV-backed rate limit, 503 until the key is set.
- **Rate limiting hardening** (from security review): shared KV-backed limiter (`src/lib/security/rate-limit.ts`) on the lookup route and on send-link (per IP + per shareCode — that public route can now trigger real SMS).
- **Manual migration**: expression indexes on `orders` customer/delivery phone last-10-digits so phone lookups are indexed (auto-applies on prod deploy via the `_manual_migrations` ledger).

## Verification
- `npx tsc --noEmit` clean, `npm run lint` clean (pre-existing `<img>` warnings only), `npm run test:run` 372/372.
- security-reviewer agent ran on the diff; must-fix findings (cross-instance rate limit, phone index, send-link limiter) addressed in the second commit. Deferred: HMAC ingest auth (ADR-0007 Phase-2 hardening), per-destination-phone throttle fork-side, Phase-5 address minimization.

## Not verified
- No live end-to-end test against a deployed CoreLinq instance (the fork isn't deployed yet — Vercel/Supabase project creation is operator work). The fan-out is inert until `CORELINQ_INGEST_URL` is set.

Counterpart fork PR: allan-cmyk/partyon-crm#2

🤖 Generated with [Claude Code](https://claude.com/claude-code)