### PR TITLE
feat(followups): Phase 0 — follow-up email engine foundation (all flags off)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -251,3 +251,12 @@ PLAID_ENV=sandbox
 NEXT_PUBLIC_GOOGLE_ADS_ID=
 NEXT_PUBLIC_GADS_QUOTE_CONVERSION_ID=
 NEXT_PUBLIC_GADS_PURCHASE_CONVERSION_ID=
+
+# --- Follow-up email system (src/lib/followups) ---
+# HMAC secret for unsubscribe tokens — the engine refuses to run without it.
+# Generate with: openssl rand -hex 32
+UNSUBSCRIBE_SECRET=
+# Personal from-address for follow-up emails (journeys send as
+# "Allan at Party On Delivery <info@partyondelivery.com>").
+FOLLOWUP_FROM_EMAIL=info@partyondelivery.com
+FOLLOWUP_FROM_NAME=

--- a/prisma/migrations/manual/2026-07-06-followups-emailtype.sql
+++ b/prisma/migrations/manual/2026-07-06-followups-emailtype.sql
@@ -1,0 +1,11 @@
+-- Site-wide follow-up email system — FOLLOW_UP EmailType enum value.
+--
+-- Deliberately its own file with NO BEGIN/COMMIT: ALTER TYPE ... ADD VALUE
+-- cannot share a transaction with statements that use the new value, and the
+-- migration runner executes each file as a single query. Keep this file to
+-- exactly this one statement.
+--
+-- Companion DDL (follow_up_jobs, email_suppressions) lives in
+-- 2026-07-06-followups-phase-0.sql.
+
+ALTER TYPE "EmailType" ADD VALUE IF NOT EXISTS 'FOLLOW_UP';

--- a/prisma/migrations/manual/2026-07-06-followups-phase-0.sql
+++ b/prisma/migrations/manual/2026-07-06-followups-phase-0.sql
@@ -1,0 +1,97 @@
+-- Site-wide follow-up email system — Phase 0 foundation
+--
+-- Backs the follow-up engine (/api/cron/follow-up-engine + src/lib/followups/):
+-- every email capture on the site gets a planned, automated follow-up
+-- (2-touch max, email-only for now, SMS-ready via phone + sms_consent).
+--
+--   follow_up_jobs     — the send queue. One row per journey step per entity.
+--                        dedupe_key ("<journey>:<step>:<entityId>") makes
+--                        re-enqueues from route hooks and engine sweeps free.
+--   email_suppressions — global do-not-email list (unsubscribe/bounce/
+--                        complaint/manual). Checked by the engine before every
+--                        follow-up send; transactional emails (invoices,
+--                        receipts) intentionally bypass it.
+--
+-- Per saved memory `prisma_schema_drift`: schema.prisma is intentionally
+-- drifted from prod, so `prisma db push` is unsafe. This file is applied
+-- automatically on prod deploys by scripts/db/apply-manual-migrations.mjs
+-- (recorded once in the _manual_migrations ledger). Apply locally with:
+--   npm run db:migrate:manual   (after sourcing .env.local)
+-- then regenerate the client:  npx prisma generate
+--
+-- The FOLLOW_UP EmailType enum value lives in its own migration file
+-- (2026-07-06-followups-emailtype.sql) because ALTER TYPE ADD VALUE cannot
+-- share a transaction with statements that use the new value.
+--
+-- All statements are idempotent (IF NOT EXISTS) — safe to re-run.
+
+BEGIN;
+
+-- =========================================================================
+-- follow_up_jobs — scheduled follow-up sends
+-- =========================================================================
+CREATE TABLE IF NOT EXISTS follow_up_jobs (
+  id                  TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  journey_key         TEXT NOT NULL,                    -- e.g. abandoned-quote (src/lib/followups/journeys.ts)
+  step                INTEGER NOT NULL DEFAULT 1,       -- 1 or 2 (2-touch max)
+  email               TEXT NOT NULL,                    -- always lowercased at enqueue
+  phone               TEXT,                             -- SMS-ready; unused until CoreLinq bridge exits shadow
+  sms_consent         BOOLEAN NOT NULL DEFAULT FALSE,
+
+  -- Entity references (scalar ids, no FKs — entities live in the same DB but
+  -- jobs must survive entity deletes for audit).
+  lead_id             TEXT,
+  draft_order_id      TEXT,
+  partner_inquiry_id  TEXT,
+  order_id            TEXT,
+
+  payload             JSONB,                            -- render context snapshot at enqueue
+  dedupe_key          TEXT NOT NULL UNIQUE,             -- "<journey>:<step>:<entityId>"
+
+  scheduled_for       TIMESTAMPTZ NOT NULL,             -- includes 0-45min jitter from enqueue
+  status              TEXT NOT NULL DEFAULT 'scheduled'
+                      CHECK (status IN ('scheduled','processing','sent','canceled','suppressed','failed')),
+  claimed_at          TIMESTAMPTZ,                      -- set when the engine claims the job
+  attempts            INTEGER NOT NULL DEFAULT 0,
+  sent_at             TIMESTAMPTZ,
+  canceled_at         TIMESTAMPTZ,
+  cancel_reason       TEXT,                             -- e.g. converted-order, invoice-paid, suppressed
+  last_error          TEXT,
+  email_log_id        TEXT,                             -- EmailLog.id of the sent email
+
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Engine tick: claim due jobs.
+CREATE INDEX IF NOT EXISTS idx_follow_up_jobs_status_scheduled
+  ON follow_up_jobs (status, scheduled_for);
+
+-- Cancel-by-email (Stripe webhook, suppression fan-out).
+CREATE INDEX IF NOT EXISTS idx_follow_up_jobs_email
+  ON follow_up_jobs (email);
+
+-- Admin dashboard: per-journey queue/sent counts.
+CREATE INDEX IF NOT EXISTS idx_follow_up_jobs_journey_status_created
+  ON follow_up_jobs (journey_key, status, created_at);
+
+-- Cancel-by-draft (invoice paid) / cancel-by-lead — partial: most rows null.
+CREATE INDEX IF NOT EXISTS idx_follow_up_jobs_draft_order
+  ON follow_up_jobs (draft_order_id) WHERE draft_order_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_follow_up_jobs_lead
+  ON follow_up_jobs (lead_id) WHERE lead_id IS NOT NULL;
+
+-- =========================================================================
+-- email_suppressions — global do-not-email list for follow-ups
+-- =========================================================================
+CREATE TABLE IF NOT EXISTS email_suppressions (
+  id          TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  email       TEXT NOT NULL UNIQUE,                     -- always lowercased
+  reason      TEXT NOT NULL
+              CHECK (reason IN ('unsubscribe','bounce','complaint','manual')),
+  source      TEXT,                                     -- e.g. one-click, preferences-page, resend-webhook, admin
+  note        TEXT,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1375,6 +1375,7 @@ enum EmailType {
   AFFILIATE_PAYOUT
   ORDER_CANCELLED
   RECEIPT
+  FOLLOW_UP
 }
 
 enum EmailStatus {
@@ -1385,6 +1386,67 @@ enum EmailStatus {
   BOUNCED
   COMPLAINED
   FAILED
+}
+
+/// Scheduled follow-up email send (site-wide follow-up system).
+/// One row per journey step per entity; dedupe_key makes re-enqueues free.
+/// Table created by prisma/migrations/manual/2026-07-06-followups-phase-0.sql.
+model FollowUpJob {
+  id         String @id @default(uuid())
+  journeyKey String @map("journey_key")
+  step       Int    @default(1)
+  /// Always lowercased at enqueue.
+  email      String
+  phone      String?
+  smsConsent Boolean @default(false) @map("sms_consent")
+
+  // Entity references (scalar ids, no FKs — jobs survive entity deletes).
+  leadId           String? @map("lead_id")
+  draftOrderId     String? @map("draft_order_id")
+  partnerInquiryId String? @map("partner_inquiry_id")
+  orderId          String? @map("order_id")
+
+  /// Render context snapshot at enqueue.
+  payload Json?
+  /// "<journey>:<step>:<entityId>"
+  dedupeKey String @unique @map("dedupe_key")
+
+  scheduledFor DateTime  @map("scheduled_for")
+  /// scheduled | processing | sent | canceled | suppressed | failed
+  status       String    @default("scheduled")
+  claimedAt    DateTime? @map("claimed_at")
+  attempts     Int       @default(0)
+  sentAt       DateTime? @map("sent_at")
+  canceledAt   DateTime? @map("canceled_at")
+  cancelReason String?   @map("cancel_reason")
+  lastError    String?   @map("last_error")
+  emailLogId   String?   @map("email_log_id")
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
+
+  @@index([status, scheduledFor])
+  @@index([email])
+  @@index([journeyKey, status, createdAt])
+  @@index([draftOrderId])
+  @@index([leadId])
+  @@map("follow_up_jobs")
+}
+
+/// Global do-not-email list for follow-up sends (transactional emails bypass).
+/// Table created by prisma/migrations/manual/2026-07-06-followups-phase-0.sql.
+model EmailSuppression {
+  id     String @id @default(uuid())
+  /// Always lowercased.
+  email  String @unique
+  /// unsubscribe | bounce | complaint | manual
+  reason String
+  source String?
+  note   String?
+
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@map("email_suppressions")
 }
 
 // ==========================================

--- a/src/app/api/cron/follow-up-engine/route.ts
+++ b/src/app/api/cron/follow-up-engine/route.ts
@@ -22,8 +22,11 @@ export const maxDuration = 300;
 const CRON_SECRET = process.env.CRON_SECRET;
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
+  // Fail CLOSED when CRON_SECRET is unset (stricter than the repo's usual
+  // cron pattern): this route can send real customer email, so a
+  // misconfigured environment must not leave it open.
   const auth = req.headers.get('authorization');
-  if (CRON_SECRET && auth !== `Bearer ${CRON_SECRET}`) {
+  if (!CRON_SECRET || auth !== `Bearer ${CRON_SECRET}`) {
     return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 });
   }
 

--- a/src/app/api/cron/follow-up-engine/route.ts
+++ b/src/app/api/cron/follow-up-engine/route.ts
@@ -1,0 +1,40 @@
+/**
+ * GET /api/cron/follow-up-engine
+ *
+ * Vercel cron, every 15 minutes. One tick of the follow-up email engine —
+ * see src/lib/followups/engine.ts for the full pipeline (kill switches,
+ * send window, sweeps, atomic claim, per-job cancel checks, send).
+ *
+ * All flags off → fast `{ paused: true }` no-op.
+ *
+ * Auth: requires CRON_SECRET in the Authorization header (Vercel sets this
+ * automatically for scheduled cron jobs).
+ */
+
+import { NextResponse, type NextRequest } from 'next/server';
+import { runFollowUpEngine } from '@/lib/followups/engine';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+// Up to 50 sends with ~600ms spacing plus sweeps — needs more than default.
+export const maxDuration = 300;
+
+const CRON_SECRET = process.env.CRON_SECRET;
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const auth = req.headers.get('authorization');
+  if (CRON_SECRET && auth !== `Bearer ${CRON_SECRET}`) {
+    return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const result = await runFollowUpEngine();
+    return NextResponse.json(result, { status: result.ok ? 200 : 500 });
+  } catch (error) {
+    console.error('[follow-up-engine] tick crashed:', error);
+    return NextResponse.json(
+      { ok: false, error: 'engine tick failed' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/email/unsubscribe/route.ts
+++ b/src/app/api/email/unsubscribe/route.ts
@@ -12,6 +12,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import { prisma } from '@/lib/database/client';
+import { checkRateLimit } from '@/lib/security/rate-limit';
 import {
   normalizeEmail,
   suppress,
@@ -26,6 +27,14 @@ const querySchema = z.object({
   email: z.string().email().max(320),
   token: z.string().min(16).max(128),
 });
+
+function clientIp(request: NextRequest): string {
+  return (
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    request.headers.get('x-real-ip') ||
+    'unknown'
+  );
+}
 
 /** Keep Customer.acceptsMarketing in step with the suppression list. */
 async function syncCustomerMarketing(email: string, accepts: boolean): Promise<void> {
@@ -45,6 +54,11 @@ function preferencesRedirect(request: NextRequest, email: string, token: string,
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
+  // Public endpoint with DB writes — throttle before any work.
+  if (!(await checkRateLimit('unsubscribe', clientIp(request), 20, 3600))) {
+    return NextResponse.json({ success: false, error: 'Too many requests' }, { status: 429 });
+  }
+
   const parsed = querySchema.safeParse({
     email: request.nextUrl.searchParams.get('email'),
     token: request.nextUrl.searchParams.get('token'),
@@ -93,6 +107,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 }
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
+  if (!(await checkRateLimit('unsubscribe-view', clientIp(request), 60, 3600))) {
+    return NextResponse.json({ success: false, error: 'Too many requests' }, { status: 429 });
+  }
+
   const email = request.nextUrl.searchParams.get('email') ?? '';
   const token = request.nextUrl.searchParams.get('token') ?? '';
   const url = new URL('/email/preferences', request.nextUrl.origin);

--- a/src/app/api/email/unsubscribe/route.ts
+++ b/src/app/api/email/unsubscribe/route.ts
@@ -1,0 +1,102 @@
+/**
+ * POST /api/email/unsubscribe — RFC 8058 one-click unsubscribe + the
+ * /email/preferences form target.
+ * GET  /api/email/unsubscribe — humans clicking the link → preferences page.
+ *
+ * Every request is authenticated by the HMAC token minted alongside the
+ * email (see src/lib/followups/suppression.ts) — nobody can unsubscribe an
+ * address they don't have an email for. Applies to FOLLOW-UP email only;
+ * transactional email (invoices, receipts) never consults the list.
+ */
+
+import { NextResponse, type NextRequest } from 'next/server';
+import { z } from 'zod';
+import { prisma } from '@/lib/database/client';
+import {
+  normalizeEmail,
+  suppress,
+  unsuppress,
+  verifyUnsubscribeToken,
+} from '@/lib/followups/suppression';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const querySchema = z.object({
+  email: z.string().email().max(320),
+  token: z.string().min(16).max(128),
+});
+
+/** Keep Customer.acceptsMarketing in step with the suppression list. */
+async function syncCustomerMarketing(email: string, accepts: boolean): Promise<void> {
+  await prisma.customer.updateMany({
+    where: { email: { equals: email, mode: 'insensitive' } },
+    data: { acceptsMarketing: accepts },
+  });
+}
+
+function preferencesRedirect(request: NextRequest, email: string, token: string, done: string): NextResponse {
+  const url = new URL('/email/preferences', request.nextUrl.origin);
+  url.searchParams.set('email', email);
+  url.searchParams.set('token', token);
+  url.searchParams.set('done', done);
+  // 303: turn the form POST into a GET.
+  return NextResponse.redirect(url, 303);
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const parsed = querySchema.safeParse({
+    email: request.nextUrl.searchParams.get('email'),
+    token: request.nextUrl.searchParams.get('token'),
+  });
+  if (!parsed.success) {
+    return NextResponse.json({ success: false, error: 'Invalid request' }, { status: 400 });
+  }
+
+  const email = normalizeEmail(parsed.data.email);
+  if (!verifyUnsubscribeToken(email, parsed.data.token)) {
+    return NextResponse.json({ success: false, error: 'Invalid token' }, { status: 403 });
+  }
+
+  // Browser form submissions carry an action + redirect flag in the form
+  // body; RFC 8058 one-click posts carry `List-Unsubscribe=One-Click`.
+  let action = 'unsubscribe';
+  let wantsRedirect = false;
+  const contentType = request.headers.get('content-type') ?? '';
+  if (contentType.includes('form')) {
+    try {
+      const form = await request.formData();
+      const rawAction = form.get('action');
+      if (rawAction === 'resubscribe') action = 'resubscribe';
+      wantsRedirect = form.get('redirect') === '1';
+    } catch {
+      // No parseable body (some one-click senders) — default unsubscribe.
+    }
+  }
+
+  if (action === 'resubscribe') {
+    // Public path never clears bounce/complaint rows.
+    const removed = await unsuppress(email);
+    if (removed) await syncCustomerMarketing(email, true);
+    if (wantsRedirect) {
+      return preferencesRedirect(request, email, parsed.data.token, removed ? 'resubscribed' : 'blocked');
+    }
+    return NextResponse.json({ success: true, resubscribed: removed });
+  }
+
+  await suppress(email, 'unsubscribe', wantsRedirect ? 'preferences-page' : 'one-click');
+  await syncCustomerMarketing(email, false);
+  if (wantsRedirect) {
+    return preferencesRedirect(request, email, parsed.data.token, 'unsubscribed');
+  }
+  return NextResponse.json({ success: true });
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const email = request.nextUrl.searchParams.get('email') ?? '';
+  const token = request.nextUrl.searchParams.get('token') ?? '';
+  const url = new URL('/email/preferences', request.nextUrl.origin);
+  if (email) url.searchParams.set('email', email);
+  if (token) url.searchParams.set('token', token);
+  return NextResponse.redirect(url, 302);
+}

--- a/src/app/api/webhooks/resend/route.ts
+++ b/src/app/api/webhooks/resend/route.ts
@@ -16,6 +16,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { Webhook } from 'svix';
 import { prisma } from '@/lib/database/client';
 import { EmailStatus } from '@prisma/client';
+import { suppress } from '@/lib/followups/suppression';
 
 interface ResendWebhookData {
   created_at: string;
@@ -105,6 +106,19 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       });
 
       console.log('[Resend Webhook] Updated email log:', emailLog.id, '->', newStatus);
+
+      // Auto-suppress on delivery problems: add the address to the follow-up
+      // suppression list and cancel its scheduled follow-up jobs. Idempotent,
+      // so webhook re-delivery is safe. Transactional email is unaffected —
+      // only the follow-up engine consults the suppression list.
+      if (type === 'email.bounced' || type === 'email.complained') {
+        const reason = type === 'email.bounced' ? 'bounce' : 'complaint';
+        const result = await suppress(emailLog.to, reason, 'resend-webhook', `resendId=${resendId}`);
+        console.log(
+          '[Resend Webhook] Suppressed', emailLog.to, `(${reason});`,
+          'canceled', result.canceledJobs, 'scheduled follow-up job(s)'
+        );
+      }
     } else {
       // delivery_delayed or unknown -- log but don't update status
       console.log('[Resend Webhook] Unhandled event type:', type);

--- a/src/app/email/preferences/page.tsx
+++ b/src/app/email/preferences/page.tsx
@@ -1,0 +1,158 @@
+/**
+ * /email/preferences — public email preference page linked from the
+ * CAN-SPAM footer of every follow-up email. Token-verified (HMAC minted with
+ * the email); shows current status and a one-button unsubscribe/resubscribe.
+ * Bounce/complaint suppressions are shown but NOT publicly reversible.
+ */
+
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import type { ReactElement } from 'react';
+import { prisma } from '@/lib/database/client';
+import {
+  normalizeEmail,
+  verifyUnsubscribeToken,
+} from '@/lib/followups/suppression';
+
+export const metadata: Metadata = {
+  title: 'Email Preferences | Party On Delivery',
+  robots: { index: false, follow: false },
+};
+
+export const dynamic = 'force-dynamic';
+
+interface PageProps {
+  searchParams: Promise<{ email?: string; token?: string; done?: string }>;
+}
+
+function InvalidLink(): ReactElement {
+  return (
+    <main className="pt-32 pb-16 px-8 min-h-[60vh] flex items-center justify-center">
+      <div className="max-w-md text-center">
+        <h1 className="font-heading text-3xl md:text-4xl tracking-[0.1em] text-gray-900 mb-4">
+          Link Not Valid
+        </h1>
+        <p className="text-gray-700 mb-8">
+          This preferences link is invalid or incomplete. Use the unsubscribe
+          link from the bottom of any email we sent you, or contact us at
+          info@partyondelivery.com and we&apos;ll sort it out.
+        </p>
+        <Link href="/" className="btn-primary inline-block">
+          Back to Home
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+export default async function EmailPreferencesPage({
+  searchParams,
+}: PageProps): Promise<ReactElement> {
+  const { email: rawEmail, token, done } = await searchParams;
+  if (!rawEmail || !token) return <InvalidLink />;
+
+  const email = normalizeEmail(rawEmail);
+  if (!verifyUnsubscribeToken(email, token)) return <InvalidLink />;
+
+  const suppression = await prisma.emailSuppression.findUnique({
+    where: { email },
+  });
+  const isHardSuppressed =
+    suppression !== null &&
+    (suppression.reason === 'bounce' || suppression.reason === 'complaint');
+  const isUnsubscribed = suppression !== null;
+
+  const formAction = `/api/email/unsubscribe?email=${encodeURIComponent(email)}&token=${encodeURIComponent(token)}`;
+
+  const banner =
+    done === 'unsubscribed'
+      ? { text: "You're unsubscribed. We won't send you any more follow-up emails.", tone: 'ok' as const }
+      : done === 'resubscribed'
+        ? { text: "You're back on the list.", tone: 'ok' as const }
+        : done === 'blocked'
+          ? { text: 'This address had delivery problems, so we can\'t re-enable it here — email us and we\'ll fix it.', tone: 'warn' as const }
+          : null;
+
+  return (
+    <main className="pt-32 pb-16 px-8 min-h-[60vh]">
+      <div className="max-w-lg mx-auto">
+        <h1 className="font-heading text-3xl md:text-4xl tracking-[0.1em] text-gray-900 mb-2 text-center">
+          Email Preferences
+        </h1>
+        <p className="text-gray-700 text-center mb-8">{email}</p>
+
+        {banner && (
+          <div
+            className={`rounded-lg border p-4 mb-6 text-sm ${
+              banner.tone === 'ok'
+                ? 'bg-green-50 border-green-200 text-green-900'
+                : 'bg-amber-50 border-amber-200 text-amber-900'
+            }`}
+          >
+            {banner.text}
+          </div>
+        )}
+
+        <div className="card">
+          {isHardSuppressed ? (
+            <>
+              <h2 className="text-lg font-bold tracking-[0.08em] text-gray-900 mb-2">
+                Delivery Problems on This Address
+              </h2>
+              <p className="text-gray-700 text-sm mb-4">
+                A previous email to this address bounced or was reported as
+                spam, so we&apos;ve stopped sending to it. If that was a
+                mistake, email us at info@partyondelivery.com and we&apos;ll
+                re-enable it manually.
+              </p>
+            </>
+          ) : isUnsubscribed ? (
+            <>
+              <h2 className="text-lg font-bold tracking-[0.08em] text-gray-900 mb-2">
+                You&apos;re Unsubscribed
+              </h2>
+              <p className="text-gray-700 text-sm mb-6">
+                We won&apos;t send follow-up or marketing email to this
+                address. Order receipts and invoices still arrive — those are
+                transactional.
+              </p>
+              <form method="POST" action={formAction}>
+                <input type="hidden" name="action" value="resubscribe" />
+                <input type="hidden" name="redirect" value="1" />
+                <button type="submit" className="btn-primary w-full">
+                  Resubscribe
+                </button>
+              </form>
+            </>
+          ) : (
+            <>
+              <h2 className="text-lg font-bold tracking-[0.08em] text-gray-900 mb-2">
+                You&apos;re Subscribed
+              </h2>
+              <p className="text-gray-700 text-sm mb-6">
+                We occasionally follow up on quotes, orders, and questions you
+                send us — always from a real person, never a blast. Unsubscribe
+                below and we&apos;ll stop; order receipts and invoices still
+                arrive.
+              </p>
+              <form method="POST" action={formAction}>
+                <input type="hidden" name="action" value="unsubscribe" />
+                <input type="hidden" name="redirect" value="1" />
+                <button type="submit" className="btn-secondary w-full">
+                  Unsubscribe
+                </button>
+              </form>
+            </>
+          )}
+        </div>
+
+        <p className="text-sm text-gray-500 text-center mt-6">
+          Questions? Email{' '}
+          <a href="mailto:info@partyondelivery.com" className="text-brand-blue underline">
+            info@partyondelivery.com
+          </a>
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/src/lib/email/resend-client.ts
+++ b/src/lib/email/resend-client.ts
@@ -54,10 +54,57 @@ export interface SendEmailOptions {
 }
 
 /**
+ * Extended options for sendEmailDetailed.
+ */
+export interface SendEmailDetailedOptions extends SendEmailOptions {
+  /** Override the From mailbox (default: RESEND_FROM_EMAIL / orders@). */
+  from?: { email: string; name?: string };
+  /**
+   * Skip the send entirely (no EmailLog row) when the recipient is on the
+   * follow-up suppression list. Leave unset for transactional email —
+   * invoices and receipts must send regardless.
+   */
+  respectSuppression?: boolean;
+}
+
+/**
+ * Result of sendEmailDetailed — exposes the EmailLog id (which sendEmail
+ * does not) so callers like the follow-up engine can link the log row.
+ */
+export interface SendEmailDetailedResult {
+  sent: boolean;
+  emailLogId: string | null;
+  resendId: string | null;
+  /** True when the send was skipped because the recipient is suppressed. */
+  suppressed?: boolean;
+  error?: string;
+}
+
+/**
  * Send an email and log it
  */
 export async function sendEmail(options: SendEmailOptions): Promise<string | null> {
-  const { to, cc, subject, html, text, type, orderId, customerId, draftOrderId, metadata, attachments, tags, headers } = options;
+  const result = await sendEmailDetailed(options);
+  return result.resendId;
+}
+
+/**
+ * Send an email and log it, returning the EmailLog id and Resend id.
+ * Superset of sendEmail: optional From override + suppression check.
+ */
+export async function sendEmailDetailed(
+  options: SendEmailDetailedOptions
+): Promise<SendEmailDetailedResult> {
+  const { to, cc, subject, html, text, type, orderId, customerId, draftOrderId, metadata, attachments, tags, headers, from, respectSuppression } = options;
+
+  if (respectSuppression) {
+    // Lazy import keeps the common transactional path free of the check.
+    const { isSuppressed } = await import('@/lib/followups/suppression');
+    if (await isSuppressed(to)) {
+      console.log('[Email] Skipped (suppressed):', { to, subject, type });
+      return { sent: false, emailLogId: null, resendId: null, suppressed: true };
+    }
+  }
 
   // Create email log entry
   const emailLog = await prisma.emailLog.create({
@@ -83,12 +130,15 @@ export async function sendEmail(options: SendEmailOptions): Promise<string | nul
         errorMessage: 'RESEND_API_KEY not configured',
       },
     });
-    return null;
+    return { sent: false, emailLogId: emailLog.id, resendId: null, error: 'RESEND_API_KEY not configured' };
   }
+
+  const fromEmail = sanitizeEnv(from?.email) || FROM_EMAIL;
+  const fromName = sanitizeEnv(from?.name) || FROM_NAME;
 
   try {
     const result = await resend.emails.send({
-      from: `${FROM_NAME} <${FROM_EMAIL}>`,
+      from: `${fromName} <${fromEmail}>`,
       to,
       ...(cc && cc.length > 0 ? { cc } : {}),
       subject,
@@ -108,7 +158,7 @@ export async function sendEmail(options: SendEmailOptions): Promise<string | nul
         data: { status: EmailStatus.FAILED, errorMessage },
       });
       console.error('[Email] Failed to send:', { to, subject, type, error: result.error });
-      return null;
+      return { sent: false, emailLogId: emailLog.id, resendId: null, error: errorMessage };
     }
 
     // Update log with success
@@ -122,7 +172,7 @@ export async function sendEmail(options: SendEmailOptions): Promise<string | nul
     });
 
     console.log('[Email] Sent successfully:', { to, subject, type, resendId: result.data?.id });
-    return result.data?.id || null;
+    return { sent: true, emailLogId: emailLog.id, resendId: result.data?.id || null };
   } catch (error) {
     // Update log with error
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -135,7 +185,7 @@ export async function sendEmail(options: SendEmailOptions): Promise<string | nul
     });
 
     console.error('[Email] Failed to send:', { to, subject, type, error: errorMessage });
-    return null;
+    return { sent: false, emailLogId: emailLog.id, resendId: null, error: errorMessage };
   }
 }
 

--- a/src/lib/features/feature-flags.ts
+++ b/src/lib/features/feature-flags.ts
@@ -28,6 +28,19 @@ export const FEATURE_FLAGS = {
   AI_INVENTORY_COUNTING: 'ai_inventory_counting',
   AI_STOCK_PREDICTIONS: 'ai_stock_predictions',
   AI_QUERY_ASSISTANT: 'ai_query_assistant',
+
+  // Follow-up email system (src/lib/followups) — master kill switch + one
+  // flag per journey. All auto-create disabled; the engine checks the master
+  // first, then the journey flag per job.
+  FOLLOWUPS_MASTER: 'followups_master',
+  FOLLOWUPS_ABANDONED_QUOTE: 'followups_abandoned_quote',
+  FOLLOWUPS_UNPAID_INVOICE: 'followups_unpaid_invoice',
+  FOLLOWUPS_PARTNER_INQUIRY: 'followups_partner_inquiry',
+  FOLLOWUPS_CONTACT_FORM: 'followups_contact_form',
+  FOLLOWUPS_NEWSLETTER_WELCOME: 'followups_newsletter_welcome',
+  FOLLOWUPS_AFFILIATE_APPLY: 'followups_affiliate_apply',
+  FOLLOWUPS_EVENT_QUIZ: 'followups_event_quiz',
+  FOLLOWUPS_POST_PURCHASE_REVIEW: 'followups_post_purchase_review',
 } as const;
 
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS];

--- a/src/lib/followups/__tests__/computeSendAt.test.ts
+++ b/src/lib/followups/__tests__/computeSendAt.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure scheduling math: jitter bounds on computeSendAt and the DST-safe
+ * 9am–7pm America/Chicago send window.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// Importing enqueue/engine pulls in the prisma singleton — stub it out so
+// this pure-math test never touches a database connection.
+vi.mock('@/lib/database/client', () => ({ prisma: {} }));
+
+import { computeSendAt } from '../enqueue';
+import { isWithinSendWindow } from '../engine';
+
+describe('computeSendAt', () => {
+  const base = new Date('2026-07-06T12:00:00Z');
+
+  it('adds the delay exactly when jitter is injected as 0', () => {
+    const result = computeSendAt(base, 24, 0);
+    expect(result.getTime()).toBe(base.getTime() + 24 * 3_600_000);
+  });
+
+  it('applies no jitter to immediate (0h) steps — acks go out on the next tick', () => {
+    const result = computeSendAt(base, 0, 45 * 60 * 1000);
+    expect(result.getTime()).toBe(base.getTime());
+  });
+
+  it('keeps random jitter within [0, 45min] across many samples', () => {
+    for (let i = 0; i < 200; i++) {
+      const result = computeSendAt(base, 24);
+      const offset = result.getTime() - base.getTime() - 24 * 3_600_000;
+      expect(offset).toBeGreaterThanOrEqual(0);
+      expect(offset).toBeLessThanOrEqual(45 * 60 * 1000);
+    }
+  });
+
+  it('clamps out-of-range injected jitter', () => {
+    const over = computeSendAt(base, 1, 10 * 3_600_000);
+    expect(over.getTime()).toBe(base.getTime() + 3_600_000 + 45 * 60 * 1000);
+    const negative = computeSendAt(base, 1, -5_000);
+    expect(negative.getTime()).toBe(base.getTime() + 3_600_000);
+  });
+});
+
+describe('isWithinSendWindow (America/Chicago, DST-safe)', () => {
+  // Winter: CST = UTC-6
+  it('9:00am CST is in the window', () => {
+    expect(isWithinSendWindow(new Date('2026-01-15T15:00:00Z'))).toBe(true);
+  });
+  it('8:59am CST is outside', () => {
+    expect(isWithinSendWindow(new Date('2026-01-15T14:59:00Z'))).toBe(false);
+  });
+  it('6:59pm CST is in, 7:00pm CST is out', () => {
+    expect(isWithinSendWindow(new Date('2026-01-16T00:59:00Z'))).toBe(true);
+    expect(isWithinSendWindow(new Date('2026-01-16T01:00:00Z'))).toBe(false);
+  });
+
+  // Summer: CDT = UTC-5 — same wall-clock window, different UTC offsets
+  it('9:00am CDT is in the window', () => {
+    expect(isWithinSendWindow(new Date('2026-07-15T14:00:00Z'))).toBe(true);
+  });
+  it('8:59am CDT is outside', () => {
+    expect(isWithinSendWindow(new Date('2026-07-15T13:59:00Z'))).toBe(false);
+  });
+  it('6:59pm CDT is in, 7:00pm CDT is out', () => {
+    expect(isWithinSendWindow(new Date('2026-07-15T23:59:00Z'))).toBe(true);
+    expect(isWithinSendWindow(new Date('2026-07-16T00:00:00Z'))).toBe(false);
+  });
+
+  it('midnight local is outside (h23 hour cycle, no "24" edge case)', () => {
+    expect(isWithinSendWindow(new Date('2026-07-15T05:00:00Z'))).toBe(false);
+  });
+});

--- a/src/lib/followups/__tests__/engine.test.ts
+++ b/src/lib/followups/__tests__/engine.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Engine pipeline: kill switches, suppression precedence, fresh-read cancels,
+ * the global paid-order guard, retry recovery via EmailLog jobId, and
+ * step-N+1 enqueueing only after step N sends.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { FollowUpJob } from '@prisma/client';
+import type { JourneyDef } from '../types';
+
+interface MockJob {
+  id: string;
+  status: string;
+  dedupeKey: string;
+  email: string;
+  attempts?: number;
+  cancelReason?: string | null;
+  emailLogId?: string | null;
+  lastError?: string | null;
+  [key: string]: unknown;
+}
+
+const mockDb: {
+  jobs: MockJob[];
+  suppressions: Array<{ email: string }>;
+  paidOrders: Array<{ customerEmail: string; createdAt: Date }>;
+  emailLogs: Array<{ id: string; metadata: Record<string, unknown>; status: string }>;
+  seq: number;
+} = { jobs: [], suppressions: [], paidOrders: [], emailLogs: [], seq: 0 };
+
+const flagState: Record<string, boolean> = {};
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+vi.mock('@/lib/database/client', () => ({
+  prisma: {
+    followUpJob: {
+      create: vi.fn(async ({ data }: any) => {
+        if (mockDb.jobs.some((j) => j.dedupeKey === data.dedupeKey)) {
+          const { Prisma } = await import('@prisma/client');
+          throw new Prisma.PrismaClientKnownRequestError('dup', { code: 'P2002', clientVersion: 'test' });
+        }
+        const job = { id: `job-${++mockDb.seq}`, status: 'scheduled', ...data };
+        mockDb.jobs.push(job);
+        return job;
+      }),
+      update: vi.fn(async ({ where, data }: any) => {
+        const job = mockDb.jobs.find((j) => j.id === where.id);
+        if (job) Object.assign(job, data);
+        return job;
+      }),
+      updateMany: vi.fn(async ({ where, data }: any) => {
+        let count = 0;
+        for (const job of mockDb.jobs) {
+          if (where.status && job.status !== where.status) continue;
+          if (where.email && job.email !== where.email) continue;
+          if (where.claimedAt?.lt && !(job.claimedAt instanceof Date && job.claimedAt < where.claimedAt.lt)) continue;
+          if (where.attempts?.gte !== undefined && !((job.attempts ?? 0) >= where.attempts.gte)) continue;
+          Object.assign(job, data);
+          count++;
+        }
+        return { count };
+      }),
+      findMany: vi.fn(async ({ where }: any) =>
+        mockDb.jobs.filter((j) => (where?.id?.in ? where.id.in.includes(j.id) : true))
+      ),
+      findFirst: vi.fn(async () => null),
+    },
+    emailSuppression: {
+      findUnique: vi.fn(async ({ where }: any) =>
+        mockDb.suppressions.find((s) => s.email === where.email) ?? null
+      ),
+    },
+    order: {
+      findFirst: vi.fn(async ({ where }: any) => {
+        const match = mockDb.paidOrders.find(
+          (o) =>
+            o.customerEmail.toLowerCase() === String(where.customerEmail.equals).toLowerCase() &&
+            o.createdAt >= where.createdAt.gte
+        );
+        return match ? { id: 'order-x' } : null;
+      }),
+    },
+    emailLog: {
+      findFirst: vi.fn(async ({ where }: any) => {
+        const jobId = where?.metadata?.path?.[0] === 'jobId' ? where.metadata.equals : undefined;
+        const row = mockDb.emailLogs.find(
+          (l) => l.metadata.jobId === jobId && l.status !== 'FAILED'
+        );
+        return row ?? null;
+      }),
+    },
+    $queryRaw: vi.fn(async () => []),
+  },
+}));
+
+const sendEmailDetailed = vi.fn();
+vi.mock('@/lib/email/resend-client', () => ({
+  sendEmailDetailed: (...args: unknown[]) => sendEmailDetailed(...args),
+}));
+
+vi.mock('@/lib/features/feature-flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/features/feature-flags')>();
+  return {
+    ...actual,
+    isFeatureEnabled: vi.fn(async (key: string) => flagState[key] ?? false),
+  };
+});
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+import { processJob, runFollowUpEngine, hasPaidOrderSince } from '../engine';
+
+const ENV_BACKUP = {
+  UNSUBSCRIBE_SECRET: process.env.UNSUBSCRIBE_SECRET,
+  FOLLOWUP_FROM_EMAIL: process.env.FOLLOWUP_FROM_EMAIL,
+};
+
+function makeJob(overrides: Partial<MockJob> = {}): FollowUpJob {
+  const job: MockJob = {
+    id: `job-${++mockDb.seq}`,
+    journeyKey: 'contact-form',
+    step: 1,
+    email: 'guest@example.com',
+    phone: null,
+    smsConsent: false,
+    leadId: 'lead-1',
+    draftOrderId: null,
+    partnerInquiryId: null,
+    orderId: null,
+    payload: null,
+    dedupeKey: 'contact-form:1:lead-1',
+    scheduledFor: new Date('2026-07-06T15:00:00Z'),
+    status: 'processing',
+    claimedAt: new Date(),
+    attempts: 1,
+    sentAt: null,
+    canceledAt: null,
+    cancelReason: null,
+    lastError: null,
+    emailLogId: null,
+    createdAt: new Date('2026-07-05T15:00:00Z'),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+  mockDb.jobs.push(job);
+  return job as unknown as FollowUpJob;
+}
+
+function makeJourney(overrides: Partial<JourneyDef> = {}): JourneyDef {
+  return {
+    key: 'contact-form',
+    label: 'Test journey',
+    description: '',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    featureFlag: 'followups_contact_form' as any,
+    phase: 2,
+    steps: [
+      { delayHours: 0, buildEmail: () => ({ subject: 's1', html: '<p>1</p>', text: '1' }) },
+      { delayHours: 72, buildEmail: () => ({ subject: 's2', html: '<p>2</p>', text: '2' }) },
+    ],
+    shouldCancel: async () => null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockDb.jobs = [];
+  mockDb.suppressions = [];
+  mockDb.paidOrders = [];
+  mockDb.emailLogs = [];
+  mockDb.seq = 0;
+  for (const key of Object.keys(flagState)) delete flagState[key];
+  process.env.UNSUBSCRIBE_SECRET = 'engine-test-secret';
+  process.env.FOLLOWUP_FROM_EMAIL = 'info@partyondelivery.com';
+  sendEmailDetailed.mockReset();
+  sendEmailDetailed.mockResolvedValue({ sent: true, emailLogId: 'log-1', resendId: 're-1' });
+});
+
+afterEach(() => {
+  process.env.UNSUBSCRIBE_SECRET = ENV_BACKUP.UNSUBSCRIBE_SECRET;
+  process.env.FOLLOWUP_FROM_EMAIL = ENV_BACKUP.FOLLOWUP_FROM_EMAIL;
+});
+
+describe('runFollowUpEngine gates', () => {
+  it('refuses to run without the required env', async () => {
+    delete process.env.UNSUBSCRIBE_SECRET;
+    const result = await runFollowUpEngine();
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('UNSUBSCRIBE_SECRET');
+  });
+
+  it('early-outs when the master kill switch is off', async () => {
+    const result = await runFollowUpEngine();
+    expect(result).toMatchObject({ ok: true, paused: true, claimed: 0, sent: 0 });
+  });
+
+  it('keeps jobs queued outside the 9a–7p CT send window', async () => {
+    flagState.followups_master = true;
+    const threeAmCt = new Date('2026-07-06T08:00:00Z'); // 3am CDT
+    const result = await runFollowUpEngine({ now: threeAmCt });
+    expect(result.inWindow).toBe(false);
+    expect(result.claimed).toBe(0);
+  });
+
+  it('claims nothing when no journey flags are enabled', async () => {
+    flagState.followups_master = true;
+    const noonCt = new Date('2026-07-06T17:00:00Z'); // 12pm CDT
+    const result = await runFollowUpEngine({ now: noonCt });
+    expect(result.inWindow).toBe(true);
+    expect(result.claimed).toBe(0);
+    expect(sendEmailDetailed).not.toHaveBeenCalled();
+  });
+});
+
+describe('processJob pipeline', () => {
+  it('suppression wins over everything — no send, job marked suppressed', async () => {
+    mockDb.suppressions.push({ email: 'guest@example.com' });
+    const job = makeJob();
+    const outcome = await processJob(job, makeJourney());
+    expect(outcome).toBe('suppressed');
+    expect(mockDb.jobs[0].status).toBe('suppressed');
+    expect(sendEmailDetailed).not.toHaveBeenCalled();
+  });
+
+  it('journey shouldCancel cancels with its reason', async () => {
+    const job = makeJob();
+    const outcome = await processJob(job, makeJourney({ shouldCancel: async () => 'lead-converted' }));
+    expect(outcome).toBe('canceled');
+    expect(mockDb.jobs[0].status).toBe('canceled');
+    expect(mockDb.jobs[0].cancelReason).toBe('lead-converted');
+    expect(sendEmailDetailed).not.toHaveBeenCalled();
+  });
+
+  it('global paid-order guard cancels converted customers', async () => {
+    mockDb.paidOrders.push({ customerEmail: 'Guest@Example.com', createdAt: new Date('2026-07-06T00:00:00Z') });
+    const job = makeJob();
+    const outcome = await processJob(job, makeJourney());
+    expect(outcome).toBe('canceled');
+    expect(mockDb.jobs[0].cancelReason).toBe('converted-order');
+  });
+
+  it('skipGlobalPaidGuard journeys still send to paying customers', async () => {
+    mockDb.paidOrders.push({ customerEmail: 'guest@example.com', createdAt: new Date('2026-07-06T00:00:00Z') });
+    const job = makeJob();
+    const outcome = await processJob(job, makeJourney({ skipGlobalPaidGuard: true }));
+    expect(outcome).toBe('sent');
+    expect(sendEmailDetailed).toHaveBeenCalledTimes(1);
+  });
+
+  it('paid order BEFORE the job was created does not cancel (guard is "since")', async () => {
+    mockDb.paidOrders.push({ customerEmail: 'guest@example.com', createdAt: new Date('2026-07-01T00:00:00Z') });
+    const job = makeJob(); // createdAt 2026-07-05
+    const outcome = await processJob(job, makeJourney());
+    expect(outcome).toBe('sent');
+    expect(await hasPaidOrderSince('guest@example.com', new Date('2026-06-30T00:00:00Z'))).toBe(true);
+  });
+
+  it('recovers a retried job whose email already went out — no double send', async () => {
+    const job = makeJob({ attempts: 2 });
+    mockDb.emailLogs.push({ id: 'log-9', metadata: { jobId: job.id }, status: 'SENT' });
+    const outcome = await processJob(job, makeJourney());
+    expect(outcome).toBe('recovered');
+    expect(sendEmailDetailed).not.toHaveBeenCalled();
+    expect(mockDb.jobs[0].status).toBe('sent');
+    expect(mockDb.jobs[0].emailLogId).toBe('log-9');
+    // step 2 still gets queued
+    expect(mockDb.jobs.some((j) => j.dedupeKey === 'contact-form:2:lead-1')).toBe(true);
+  });
+
+  it('a FAILED prior EmailLog does NOT count as sent — retry proceeds', async () => {
+    const job = makeJob({ attempts: 2 });
+    mockDb.emailLogs.push({ id: 'log-9', metadata: { jobId: job.id }, status: 'FAILED' });
+    const outcome = await processJob(job, makeJourney());
+    expect(outcome).toBe('sent');
+    expect(sendEmailDetailed).toHaveBeenCalledTimes(1);
+  });
+
+  it('successful send stamps the job and enqueues step 2 only after step 1', async () => {
+    const job = makeJob();
+    const outcome = await processJob(job, makeJourney());
+    expect(outcome).toBe('sent');
+    expect(mockDb.jobs[0]).toMatchObject({ status: 'sent', emailLogId: 'log-1' });
+
+    const step2 = mockDb.jobs.find((j) => j.dedupeKey === 'contact-form:2:lead-1');
+    expect(step2).toBeDefined();
+    expect(step2!.status).toBe('scheduled');
+
+    expect(sendEmailDetailed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'guest@example.com',
+        respectSuppression: true,
+        from: { email: 'info@partyondelivery.com', name: 'Allan at Party On Delivery' },
+        headers: expect.objectContaining({
+          'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+        }),
+        metadata: expect.objectContaining({ jobId: job.id, step: 1 }),
+      })
+    );
+  });
+
+  it('single-step journeys do not enqueue a step 2', async () => {
+    const journey = makeJourney({
+      steps: [{ delayHours: 1, buildEmail: () => ({ subject: 's', html: '<p>x</p>', text: 'x' }) }],
+    });
+    await processJob(makeJob(), journey);
+    expect(mockDb.jobs).toHaveLength(1);
+  });
+
+  it('buildEmail returning null cancels with no-content', async () => {
+    const journey = makeJourney({
+      steps: [{ delayHours: 0, buildEmail: () => null }],
+    });
+    const outcome = await processJob(makeJob(), journey);
+    expect(outcome).toBe('canceled');
+    expect(mockDb.jobs[0].cancelReason).toBe('no-content');
+  });
+
+  it('send failure with attempts left goes back to scheduled for retry', async () => {
+    sendEmailDetailed.mockResolvedValue({ sent: false, emailLogId: 'log-2', resendId: null, error: 'boom' });
+    const outcome = await processJob(makeJob({ attempts: 1 }), makeJourney());
+    expect(outcome).toBe('failed');
+    expect(mockDb.jobs[0].status).toBe('scheduled');
+    expect(mockDb.jobs[0].lastError).toBe('boom');
+  });
+
+  it('send failure on the final attempt marks the job failed', async () => {
+    sendEmailDetailed.mockResolvedValue({ sent: false, emailLogId: 'log-2', resendId: null, error: 'boom' });
+    const outcome = await processJob(makeJob({ attempts: 3 }), makeJourney());
+    expect(outcome).toBe('failed');
+    expect(mockDb.jobs[0].status).toBe('failed');
+  });
+});

--- a/src/lib/followups/__tests__/engine.test.ts
+++ b/src/lib/followups/__tests__/engine.test.ts
@@ -297,6 +297,31 @@ describe('processJob pipeline', () => {
     );
   });
 
+  it('ctx.link refuses absolute and protocol-relative URLs (open-redirect guard)', async () => {
+    let captured: string[] = [];
+    const journey = makeJourney({
+      steps: [
+        {
+          delayHours: 0,
+          buildEmail: (ctx) => {
+            captured = [
+              ctx.link('https://evil.example.com/phish'),
+              ctx.link('//evil.example.com/phish'),
+              ctx.link('/order'),
+            ];
+            return { subject: 's', html: '<p>x</p>', text: 'x' };
+          },
+        },
+      ],
+    });
+    await processJob(makeJob(), journey);
+    expect(captured[0]).not.toContain('evil.example.com');
+    expect(captured[1]).not.toContain('evil.example.com');
+    expect(captured[2]).toContain('partyondelivery.com/order');
+    expect(captured[2]).toContain('utm_campaign=contact-form');
+    expect(captured[2]).toContain('utm_content=step-1');
+  });
+
   it('single-step journeys do not enqueue a step 2', async () => {
     const journey = makeJourney({
       steps: [{ delayHours: 1, buildEmail: () => ({ subject: 's', html: '<p>x</p>', text: 'x' }) }],

--- a/src/lib/followups/__tests__/enqueue.test.ts
+++ b/src/lib/followups/__tests__/enqueue.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Queueing semantics: dedupe_key absorbs double-enqueues, emails are
+ * lowercased, cancels only touch scheduled jobs.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Prisma } from '@prisma/client';
+
+interface MockJob {
+  id: string;
+  journeyKey: string;
+  step: number;
+  email: string;
+  status: string;
+  dedupeKey: string;
+  scheduledFor: Date;
+  draftOrderId?: string | null;
+  cancelReason?: string | null;
+  [key: string]: unknown;
+}
+
+const mockDb: { jobs: MockJob[]; seq: number } = { jobs: [], seq: 0 };
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+vi.mock('@/lib/database/client', () => ({
+  prisma: {
+    followUpJob: {
+      create: vi.fn(async ({ data }: any) => {
+        if (mockDb.jobs.some((j) => j.dedupeKey === data.dedupeKey)) {
+          throw new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+            code: 'P2002',
+            clientVersion: 'test',
+          });
+        }
+        const job: MockJob = { id: `job-${++mockDb.seq}`, status: 'scheduled', ...data };
+        mockDb.jobs.push(job);
+        return job;
+      }),
+      updateMany: vi.fn(async ({ where, data }: any) => {
+        let count = 0;
+        for (const job of mockDb.jobs) {
+          const emailMatch = where.email === undefined || job.email === where.email;
+          const statusMatch = where.status === undefined || job.status === where.status;
+          const journeyMatch = where.journeyKey === undefined || job.journeyKey === where.journeyKey;
+          const draftMatch = where.draftOrderId === undefined || job.draftOrderId === where.draftOrderId;
+          if (emailMatch && statusMatch && journeyMatch && draftMatch) {
+            Object.assign(job, data);
+            count++;
+          }
+        }
+        return { count };
+      }),
+    },
+  },
+}));
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+import { enqueueJourney, cancelJobsForEmail, cancelJobsForDraft } from '../enqueue';
+import { entityIdFromDedupeKey } from '../types';
+
+beforeEach(() => {
+  mockDb.jobs = [];
+  mockDb.seq = 0;
+});
+
+describe('enqueueJourney dedupe', () => {
+  it('double-enqueue of the same journey/step/entity leaves exactly one row', async () => {
+    const first = await enqueueJourney('unpaid-invoice', {
+      email: 'guest@example.com',
+      entityId: 'draft-1',
+      draftOrderId: 'draft-1',
+    });
+    const second = await enqueueJourney('unpaid-invoice', {
+      email: 'guest@example.com',
+      entityId: 'draft-1',
+      draftOrderId: 'draft-1',
+    });
+
+    expect(first.enqueued).toBe(true);
+    expect(second).toEqual({ enqueued: false, reason: 'duplicate' });
+    expect(mockDb.jobs).toHaveLength(1);
+    expect(mockDb.jobs[0].dedupeKey).toBe('unpaid-invoice:1:draft-1');
+  });
+
+  it('a canceled job still blocks re-enqueue of that step (final answer)', async () => {
+    await enqueueJourney('unpaid-invoice', { email: 'a@b.com', entityId: 'draft-2', draftOrderId: 'draft-2' });
+    mockDb.jobs[0].status = 'canceled';
+    const again = await enqueueJourney('unpaid-invoice', { email: 'a@b.com', entityId: 'draft-2', draftOrderId: 'draft-2' });
+    expect(again.reason).toBe('duplicate');
+    expect(mockDb.jobs).toHaveLength(1);
+  });
+
+  it('lowercases the email and rejects garbage', async () => {
+    const ok = await enqueueJourney('contact-form', {
+      email: '  Guest@Example.COM ',
+      entityId: 'lead-1',
+    });
+    expect(ok.enqueued).toBe(true);
+    expect(mockDb.jobs[0].email).toBe('guest@example.com');
+
+    const bad = await enqueueJourney('contact-form', { email: 'not-an-email', entityId: 'lead-2' });
+    expect(bad).toEqual({ enqueued: false, reason: 'invalid-email' });
+  });
+
+  it('rejects unknown journeys and missing steps', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const unknown = await enqueueJourney('nope' as any, { email: 'a@b.com', entityId: 'x' });
+    expect(unknown.reason).toBe('unknown-journey');
+
+    const noStep = await enqueueJourney('newsletter-welcome', {
+      email: 'a@b.com',
+      entityId: 'lead-9',
+      startAtStep: 2, // single-step journey
+    });
+    expect(noStep.reason).toBe('no-such-step');
+  });
+
+  it('anchors the delay on baseTime (e.g. DraftOrder.sentAt)', async () => {
+    const sentAt = new Date('2026-07-01T12:00:00Z');
+    await enqueueJourney('unpaid-invoice', {
+      email: 'a@b.com',
+      entityId: 'draft-3',
+      draftOrderId: 'draft-3',
+      baseTime: sentAt,
+    });
+    const scheduled = mockDb.jobs[0].scheduledFor.getTime();
+    const noJitter = sentAt.getTime() + 24 * 3_600_000;
+    expect(scheduled).toBeGreaterThanOrEqual(noJitter);
+    expect(scheduled).toBeLessThanOrEqual(noJitter + 45 * 60 * 1000);
+  });
+});
+
+describe('cancel helpers', () => {
+  it('cancelJobsForEmail lowercases, only touches scheduled rows, honors journey filter', async () => {
+    await enqueueJourney('abandoned-quote', { email: 'x@y.com', entityId: 'lead-1', leadId: 'lead-1' });
+    await enqueueJourney('unpaid-invoice', { email: 'x@y.com', entityId: 'draft-1', draftOrderId: 'draft-1' });
+    mockDb.jobs[1].status = 'sent';
+
+    const count = await cancelJobsForEmail('X@Y.com', 'converted-order');
+    expect(count).toBe(1);
+    expect(mockDb.jobs[0].status).toBe('canceled');
+    expect(mockDb.jobs[0].cancelReason).toBe('converted-order');
+    expect(mockDb.jobs[1].status).toBe('sent');
+  });
+
+  it('cancelJobsForDraft cancels by draft id', async () => {
+    await enqueueJourney('unpaid-invoice', { email: 'x@y.com', entityId: 'draft-7', draftOrderId: 'draft-7' });
+    const count = await cancelJobsForDraft('draft-7', 'invoice-paid');
+    expect(count).toBe(1);
+    expect(mockDb.jobs[0].cancelReason).toBe('invoice-paid');
+  });
+});
+
+describe('entityIdFromDedupeKey', () => {
+  it('round-trips the entity id', () => {
+    expect(entityIdFromDedupeKey('abandoned-quote:1:lead-abc')).toBe('lead-abc');
+    expect(entityIdFromDedupeKey('unpaid-invoice:2:draft:with:colons')).toBe('draft:with:colons');
+  });
+});

--- a/src/lib/followups/__tests__/suppression.test.ts
+++ b/src/lib/followups/__tests__/suppression.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Suppression list + HMAC unsubscribe tokens: tamper resistance, the
+ * never-downgrade rule for bounces, and the public-resubscribe boundary.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+interface MockSuppression {
+  id: string;
+  email: string;
+  reason: string;
+  source?: string | null;
+  note?: string | null;
+}
+interface MockJob {
+  id: string;
+  email: string;
+  status: string;
+  cancelReason?: string | null;
+  [key: string]: unknown;
+}
+
+const mockDb: { suppressions: MockSuppression[]; jobs: MockJob[]; seq: number } = {
+  suppressions: [],
+  jobs: [],
+  seq: 0,
+};
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+vi.mock('@/lib/database/client', () => ({
+  prisma: {
+    emailSuppression: {
+      findUnique: vi.fn(async ({ where }: any) =>
+        mockDb.suppressions.find((s) => s.email === where.email) ?? null
+      ),
+      create: vi.fn(async ({ data }: any) => {
+        const row = { id: `sup-${++mockDb.seq}`, ...data };
+        mockDb.suppressions.push(row);
+        return row;
+      }),
+      update: vi.fn(async ({ where, data }: any) => {
+        const row = mockDb.suppressions.find((s) => s.email === where.email);
+        if (row) Object.assign(row, data);
+        return row;
+      }),
+      delete: vi.fn(async ({ where }: any) => {
+        const idx = mockDb.suppressions.findIndex((s) => s.email === where.email);
+        const [row] = idx >= 0 ? mockDb.suppressions.splice(idx, 1) : [null];
+        return row;
+      }),
+    },
+    followUpJob: {
+      updateMany: vi.fn(async ({ where, data }: any) => {
+        let count = 0;
+        for (const job of mockDb.jobs) {
+          if (job.email === where.email && job.status === where.status) {
+            Object.assign(job, data);
+            count++;
+          }
+        }
+        return { count };
+      }),
+    },
+  },
+}));
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+import {
+  unsubscribeToken,
+  verifyUnsubscribeToken,
+  isSuppressed,
+  suppress,
+  unsuppress,
+} from '../suppression';
+
+const ORIGINAL_SECRET = process.env.UNSUBSCRIBE_SECRET;
+
+beforeEach(() => {
+  process.env.UNSUBSCRIBE_SECRET = 'test-secret-for-suppression-tests';
+  mockDb.suppressions = [];
+  mockDb.jobs = [];
+  mockDb.seq = 0;
+});
+
+afterEach(() => {
+  process.env.UNSUBSCRIBE_SECRET = ORIGINAL_SECRET;
+});
+
+describe('unsubscribe tokens', () => {
+  it('verifies a valid token, case-insensitively on the email', () => {
+    const token = unsubscribeToken('Guest@Example.com')!;
+    expect(verifyUnsubscribeToken('guest@example.com', token)).toBe(true);
+    expect(verifyUnsubscribeToken('GUEST@EXAMPLE.COM', token)).toBe(true);
+  });
+
+  it('rejects tampered tokens and tokens for other emails', () => {
+    const token = unsubscribeToken('guest@example.com')!;
+    const tampered = token.slice(0, -1) + (token.endsWith('a') ? 'b' : 'a');
+    expect(verifyUnsubscribeToken('guest@example.com', tampered)).toBe(false);
+    expect(verifyUnsubscribeToken('other@example.com', token)).toBe(false);
+    expect(verifyUnsubscribeToken('guest@example.com', '')).toBe(false);
+    expect(verifyUnsubscribeToken('guest@example.com', 'short')).toBe(false);
+  });
+
+  it('returns null / false when the secret is not configured', () => {
+    delete process.env.UNSUBSCRIBE_SECRET;
+    expect(unsubscribeToken('guest@example.com')).toBeNull();
+    expect(verifyUnsubscribeToken('guest@example.com', 'anything')).toBe(false);
+  });
+});
+
+describe('suppress', () => {
+  it('adds a row, lowercases, and cancels scheduled jobs (suppression precedence)', async () => {
+    mockDb.jobs.push(
+      { id: 'j1', email: 'guest@example.com', status: 'scheduled' },
+      { id: 'j2', email: 'guest@example.com', status: 'sent' }
+    );
+    const result = await suppress('Guest@Example.COM', 'unsubscribe', 'one-click');
+    expect(result).toEqual({ suppressed: true, canceledJobs: 1 });
+    expect(mockDb.suppressions[0].email).toBe('guest@example.com');
+    expect(mockDb.jobs[0].status).toBe('suppressed');
+    expect(mockDb.jobs[0].cancelReason).toBe('suppressed-unsubscribe');
+    expect(mockDb.jobs[1].status).toBe('sent');
+    expect(await isSuppressed('GUEST@example.com')).toBe(true);
+  });
+
+  it('upgrades unsubscribe → bounce but never downgrades bounce → unsubscribe', async () => {
+    await suppress('a@b.com', 'unsubscribe');
+    await suppress('a@b.com', 'bounce', 'resend-webhook');
+    expect(mockDb.suppressions[0].reason).toBe('bounce');
+
+    await suppress('a@b.com', 'unsubscribe', 'one-click');
+    expect(mockDb.suppressions[0].reason).toBe('bounce');
+  });
+
+  it('ignores garbage emails', async () => {
+    const result = await suppress('   ', 'manual');
+    expect(result.suppressed).toBe(false);
+    expect(mockDb.suppressions).toHaveLength(0);
+  });
+});
+
+describe('unsuppress', () => {
+  it('publicly reverses unsubscribe rows but refuses bounces', async () => {
+    await suppress('soft@b.com', 'unsubscribe');
+    await suppress('hard@b.com', 'bounce');
+
+    expect(await unsuppress('soft@b.com')).toBe(true);
+    expect(await isSuppressed('soft@b.com')).toBe(false);
+
+    expect(await unsuppress('hard@b.com')).toBe(false);
+    expect(await isSuppressed('hard@b.com')).toBe(true);
+  });
+
+  it('allows hard-reason removal only with allowHardReasons (admin path)', async () => {
+    await suppress('hard@b.com', 'complaint');
+    expect(await unsuppress('hard@b.com', { allowHardReasons: true })).toBe(true);
+    expect(await isSuppressed('hard@b.com')).toBe(false);
+  });
+});

--- a/src/lib/followups/copy.ts
+++ b/src/lib/followups/copy.ts
@@ -1,0 +1,290 @@
+/**
+ * Follow-up email system — copy.
+ *
+ * DRAFT STUBS in Allan's voice — plain text, personal, no branded HTML.
+ * Allan does a copy pass on this file before journeys are enabled (open item
+ * #2 in the build plan). Copy is written to survive edge cases: it never
+ * asserts the reader hasn't ordered (they may have paid with another email)
+ * and step-2 contact copy tolerates Allan having already replied by hand.
+ *
+ * Every email gets the CAN-SPAM footer: sender identity + physical mailing
+ * address + unsubscribe link.
+ */
+
+import type { JourneyEmailContext, RenderedEmail } from './types';
+
+/**
+ * CAN-SPAM physical mailing address.
+ * TODO(Allan): replace with the real street address BEFORE enabling any
+ * journey feature flag — the engine sends this footer on every follow-up.
+ */
+export const POSTAL_ADDRESS = 'Austin, TX — TODO: full mailing address';
+
+/**
+ * Google review link for the post-purchase ask.
+ * TODO(Allan): confirm the canonical review URL before Phase 3 goes live
+ * (same target the GHL review.request flow uses today).
+ */
+export const GOOGLE_REVIEW_URL = 'https://g.page/party-on-delivery/review';
+
+const SIGNATURE = 'Allan\nParty On Delivery';
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/** Turn bare URLs into anchors AFTER escaping, so copy stays plain text. */
+function linkify(escaped: string): string {
+  return escaped.replace(
+    /https?:\/\/[^\s<]+/g,
+    (url) => `<a href="${url}" style="color:#0B74B8;">${url}</a>`
+  );
+}
+
+/**
+ * Wrap plain-text body copy into the minimal HTML + text pair every follow-up
+ * uses: paragraphs only, no branding, CAN-SPAM footer at the bottom.
+ */
+export function renderFollowUpEmail(
+  subject: string,
+  body: string,
+  unsubscribeUrl: string
+): RenderedEmail {
+  const fullText = `${body}\n\n${SIGNATURE}\n\n—\nParty On Delivery · ${POSTAL_ADDRESS}\nUnsubscribe: ${unsubscribeUrl}`;
+
+  const paragraphs = `${body}\n\n${SIGNATURE}`
+    .split(/\n{2,}/)
+    .map((p) => `<p style="margin:0 0 16px;">${linkify(escapeHtml(p)).replace(/\n/g, '<br/>')}</p>`)
+    .join('\n');
+
+  const html = `<div style="font-family:Arial,Helvetica,sans-serif;font-size:15px;line-height:1.6;color:#1f2937;max-width:600px;">
+${paragraphs}
+<p style="margin:24px 0 0;font-size:12px;color:#6b7280;">Party On Delivery · ${escapeHtml(POSTAL_ADDRESS)}<br/>
+<a href="${unsubscribeUrl}" style="color:#6b7280;">Unsubscribe</a></p>
+</div>`;
+
+  return { subject, html, text: fullText };
+}
+
+/** Defensive string read from an untrusted payload. */
+function str(payload: Record<string, unknown>, key: string): string | null {
+  const v = payload[key];
+  return typeof v === 'string' && v.trim() ? v.trim() : null;
+}
+
+function firstName(ctx: JourneyEmailContext): string {
+  return str(ctx.payload, 'firstName') ?? 'there';
+}
+
+// ---------------------------------------------------------------------------
+// abandoned-quote — calculator/package-builder email captured, no order
+// ---------------------------------------------------------------------------
+
+export function abandonedQuoteStep1(ctx: JourneyEmailContext): RenderedEmail {
+  const name = firstName(ctx);
+  const resumePath = str(ctx.payload, 'resumePath') ?? '/order';
+  const guestCount = str(ctx.payload, 'guestCount');
+  const numbersLine = guestCount
+    ? `You were running drink numbers for about ${guestCount} people — I saved where you left off so you don't have to start over.`
+    : `You were running drink numbers on our site — I saved where you left off so you don't have to start over.`;
+
+  const body = `Hey ${name},
+
+${numbersLine}
+
+Pick it back up here: ${ctx.link(resumePath)}
+
+Or skip the clicking entirely — reply with your event date and headcount and I'll price it out for you personally.`;
+
+  return renderFollowUpEmail(
+    'your drink numbers from Party On Delivery',
+    body,
+    ctx.unsubscribeUrl
+  );
+}
+
+export function abandonedQuoteStep2(ctx: JourneyEmailContext): RenderedEmail {
+  const name = firstName(ctx);
+  const body = `Hey ${name},
+
+Still planning? No pressure either way — but if a drink order is still on your list, reply with your date and I'll put a quote together myself. Takes me about ten minutes and you'll get real delivery pricing, not a guess.`;
+
+  return renderFollowUpEmail(
+    'want me to price it out for you?',
+    body,
+    ctx.unsubscribeUrl
+  );
+}
+
+// ---------------------------------------------------------------------------
+// unpaid-invoice — quote/invoice sent, not paid
+// ---------------------------------------------------------------------------
+
+export function unpaidInvoiceStep1(ctx: JourneyEmailContext): RenderedEmail {
+  const name = firstName(ctx);
+  const invoicePath = str(ctx.payload, 'invoicePath');
+  const eventLine = str(ctx.payload, 'deliveryDate')
+    ? ` for ${str(ctx.payload, 'deliveryDate')}`
+    : '';
+  const payLine = invoicePath
+    ? `Your quote is here whenever you're ready: ${ctx.link(invoicePath)}`
+    : `Reply here and I'll resend your quote.`;
+
+  const body = `Hey ${name},
+
+I sent over your quote${eventLine} — just checking it landed. Want me to keep holding things on my end?
+
+${payLine}
+
+If the date, headcount, or items changed, reply and I'll update it — takes two minutes.`;
+
+  return renderFollowUpEmail('holding your date?', body, ctx.unsubscribeUrl);
+}
+
+export function unpaidInvoiceStep2(ctx: JourneyEmailContext): RenderedEmail {
+  const name = firstName(ctx);
+  const invoicePath = str(ctx.payload, 'invoicePath');
+  const payLine = invoicePath ? `\n\nQuote's still here: ${ctx.link(invoicePath)}` : '';
+
+  const body = `Hey ${name},
+
+Should I close this one out? If plans changed, no worries at all — happens all the time.
+
+If you still want delivery, grab it before I release the slot.${payLine}
+
+Either way, a one-line reply helps me keep the calendar straight.`;
+
+  return renderFollowUpEmail('should I close this out?', body, ctx.unsubscribeUrl);
+}
+
+// ---------------------------------------------------------------------------
+// partner-inquiry — B2B partnership form
+// ---------------------------------------------------------------------------
+
+export function partnerInquiryStep1(ctx: JourneyEmailContext): RenderedEmail {
+  const name = firstName(ctx);
+  const businessName = str(ctx.payload, 'businessName');
+  const aboutLine = businessName
+    ? `I'll take a proper look at ${businessName} and get back to you within a day or two.`
+    : `I'll take a proper look and get back to you within a day or two.`;
+
+  const body = `Hey ${name},
+
+Thanks for reaching out about partnering — this lands directly with me, not a bot. ${aboutLine}
+
+In the meantime, if you have questions about how the program works (commissions, delivery zones, how guests order), just reply here.`;
+
+  return renderFollowUpEmail('got your partnership inquiry', body, ctx.unsubscribeUrl);
+}
+
+export function partnerInquiryStep2(ctx: JourneyEmailContext): RenderedEmail {
+  const name = firstName(ctx);
+  const body = `Hey ${name},
+
+Following up on your partnership inquiry — still interested? If it's easier to talk it through, reply with a couple of times that work and I'll call you.
+
+If the timing's just not right, tell me and I'll check back down the road instead of nudging you.`;
+
+  return renderFollowUpEmail('still interested in partnering?', body, ctx.unsubscribeUrl);
+}
+
+// ---------------------------------------------------------------------------
+// contact-form — general contact form ack + reply-check
+// ---------------------------------------------------------------------------
+
+export function contactFormStep1(ctx: JourneyEmailContext): RenderedEmail {
+  const name = firstName(ctx);
+  const body = `Hey ${name},
+
+Just confirming your message made it to me — I read these personally and I'll get back to you shortly.
+
+If it's time-sensitive (event this week, delivery question for an existing order), reply with "urgent" in the subject and I'll jump on it first.`;
+
+  return renderFollowUpEmail('got your message', body, ctx.unsubscribeUrl);
+}
+
+export function contactFormStep2(ctx: JourneyEmailContext): RenderedEmail {
+  const name = firstName(ctx);
+  const body = `Hey ${name},
+
+Quick check — did my reply reach you? Email filters eat things sometimes.
+
+If you didn't see anything from me, check spam or just reply here and I'll resend. If we already connected, ignore this one.`;
+
+  return renderFollowUpEmail('did my reply reach you?', body, ctx.unsubscribeUrl);
+}
+
+// ---------------------------------------------------------------------------
+// newsletter-welcome — post-double-opt-in welcome
+// ---------------------------------------------------------------------------
+
+export function newsletterWelcomeStep1(ctx: JourneyEmailContext): RenderedEmail {
+  const name = firstName(ctx);
+  const body = `Hey ${name},
+
+Thanks for confirming — you're on the list. Here's how this works: about once or twice a month I send party-planning ideas, seasonal picks, and early access to deals. No daily blasts, ever.
+
+Planning something right now? Reply and tell me about it — date, headcount, vibe — and I'll point you at the right setup.`;
+
+  return renderFollowUpEmail('welcome — here\'s how this works', body, ctx.unsubscribeUrl);
+}
+
+// ---------------------------------------------------------------------------
+// affiliate-apply — partner program application ack + check-in
+// ---------------------------------------------------------------------------
+
+export function affiliateApplyStep1(ctx: JourneyEmailContext): RenderedEmail {
+  const name = firstName(ctx);
+  const body = `Hey ${name},
+
+Got your partner program application — thanks for the interest. I review every application myself, so expect to hear from me within a couple of days.
+
+If you want to add anything (audience size, how you'd promote us, past partnerships), just reply to this email and it goes straight into your file.`;
+
+  return renderFollowUpEmail('got your application', body, ctx.unsubscribeUrl);
+}
+
+export function affiliateApplyStep2(ctx: JourneyEmailContext): RenderedEmail {
+  const name = firstName(ctx);
+  const body = `Hey ${name},
+
+Quick check-in on your partner application — it's still in my queue, not lost. If anything's changed on your end (or you have questions about commission structure), reply here.`;
+
+  return renderFollowUpEmail('your application — quick check-in', body, ctx.unsubscribeUrl);
+}
+
+// ---------------------------------------------------------------------------
+// event-quiz — quiz completed (instant welcome already exists; step 2 only)
+// ---------------------------------------------------------------------------
+
+export function eventQuizStep2(ctx: JourneyEmailContext): RenderedEmail {
+  const name = firstName(ctx);
+  const body = `Hey ${name},
+
+You grabbed a drink plan from our event quiz a few days back — how's it looking?
+
+If you want a second set of eyes on quantities, or real delivery pricing for your date, reply with the date and headcount and I'll sort it out personally.`;
+
+  return renderFollowUpEmail('did the plan land?', body, ctx.unsubscribeUrl);
+}
+
+// ---------------------------------------------------------------------------
+// post-purchase-review — delivered order, single review ask
+// ---------------------------------------------------------------------------
+
+export function postPurchaseReviewStep1(ctx: JourneyEmailContext): RenderedEmail {
+  const name = firstName(ctx);
+  const body = `Hey ${name},
+
+Delivery's done — hope the party was a good one.
+
+If we earned it, a quick Google review genuinely helps us more than any ad: ${GOOGLE_REVIEW_URL}
+
+And if anything was off — late, wrong item, anything — reply and tell me first. I'll make it right.`;
+
+  return renderFollowUpEmail('how\'d we do?', body, ctx.unsubscribeUrl);
+}

--- a/src/lib/followups/engine.ts
+++ b/src/lib/followups/engine.ts
@@ -281,7 +281,11 @@ export async function processJob(job: FollowUpJob, journey: JourneyDef): Promise
     job,
     payload: (job.payload as Record<string, unknown> | null) ?? {},
     link: (path: string) => {
-      const url = new URL(path, SITE_BASE_URL);
+      // Open-redirect guard (CWE-601): payload paths may echo public route
+      // input, and new URL(path, base) IGNORES the base for absolute and
+      // protocol-relative paths. Only site-relative paths survive.
+      const safePath = path.startsWith('/') && !path.startsWith('//') ? path : '/';
+      const url = new URL(safePath, SITE_BASE_URL);
       url.searchParams.set('utm_source', 'email');
       url.searchParams.set('utm_medium', 'followup');
       url.searchParams.set('utm_campaign', journey.key);

--- a/src/lib/followups/engine.ts
+++ b/src/lib/followups/engine.ts
@@ -1,0 +1,459 @@
+/**
+ * Follow-up email system — the engine.
+ *
+ * Runs every 15 minutes via /api/cron/follow-up-engine. One tick:
+ *   1. Refuse to run without UNSUBSCRIBE_SECRET + FOLLOWUP_FROM_EMAIL.
+ *   2. Master kill switch (followups_master) → early out.
+ *   3. Reap stuck 'processing' jobs (>30min → back to scheduled; 3+ attempts → failed).
+ *   4. Backstop sweeps for enabled journeys (dedupe_key makes re-sweeps free).
+ *   5. Only send 9am–7pm America/Chicago — outside the window jobs stay queued.
+ *   6. Claim ≤50 due jobs atomically (FOR UPDATE SKIP LOCKED), enabled journeys only.
+ *   7. Per job, sequentially: fresh-read cancel checks → suppression → global
+ *      paid-order guard → EmailLog jobId recovery lookup → render → send →
+ *      stamp sent → enqueue the next step.
+ *
+ * Double-send protection is layered: the atomic claim, the UNIQUE dedupe_key,
+ * and the pre-send EmailLog lookup. Residual risk is ≤1 duplicate, bounded by
+ * the attempts cap.
+ */
+
+import { Prisma, EmailStatus, EmailType, type FollowUpJob } from '@prisma/client';
+import { prisma } from '@/lib/database/client';
+import { sendEmailDetailed } from '@/lib/email/resend-client';
+import { FEATURE_FLAGS, isFeatureEnabled } from '@/lib/features/feature-flags';
+import { enqueueJourney, enqueueNextStep } from './enqueue';
+import { JOURNEYS } from './journeys';
+import {
+  buildOneClickUnsubscribeUrl,
+  buildPreferencesUrl,
+  isSuppressed,
+} from './suppression';
+import type { EngineRunResult, JourneyDef, JourneyKey } from './types';
+import { SITE_BASE_URL } from './types';
+
+const CLAIM_BATCH_SIZE = 50;
+const STUCK_PROCESSING_MINUTES = 30;
+const MAX_ATTEMPTS = 3;
+/** Spacing between sends — stays under Resend's rate limit. */
+const SEND_SPACING_MS = 600;
+
+/** 9am–7pm America/Chicago, DST-safe via Intl. Exported for tests. */
+export function isWithinSendWindow(date: Date, timeZone = 'America/Chicago'): boolean {
+  const hour = Number(
+    new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      hour: 'numeric',
+      hourCycle: 'h23',
+    }).format(date)
+  );
+  return hour >= 9 && hour < 19;
+}
+
+/**
+ * Global convert guard: has this email placed a paid order since the job was
+ * created? Case-insensitive because Order.customerEmail is stored as-typed.
+ * (No expression index — fine at current order volume; revisit if slow.)
+ */
+export async function hasPaidOrderSince(email: string, since: Date): Promise<boolean> {
+  const order = await prisma.order.findFirst({
+    where: {
+      customerEmail: { equals: email, mode: 'insensitive' },
+      financialStatus: { in: ['PAID', 'PARTIALLY_REFUNDED'] },
+      createdAt: { gte: since },
+    },
+    select: { id: true },
+  });
+  return order !== null;
+}
+
+function firstNameFrom(fullName: string | null | undefined): string | null {
+  const first = (fullName ?? '').trim().split(/\s+/)[0];
+  return first || null;
+}
+
+function fmtDeliveryDate(date: Date): string {
+  return date.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'America/Chicago',
+  });
+}
+
+/**
+ * Backstop sweep: unpaid invoices (SENT/VIEWED 24h–14d, non-group,
+ * non-amendment). Route fast-paths enqueue most of these at send time; the
+ * sweep catches invoices sent through other paths (e.g. /ops admin).
+ */
+async function sweepUnpaidInvoices(now: Date): Promise<number> {
+  const drafts = await prisma.draftOrder.findMany({
+    where: {
+      status: { in: ['SENT', 'VIEWED'] },
+      sentAt: {
+        gte: new Date(now.getTime() - 14 * 24 * 3_600_000),
+        lte: new Date(now.getTime() - 24 * 3_600_000),
+      },
+      paidAt: null,
+      groupOrderId: null,
+      amendmentForOrderId: null,
+    },
+    select: {
+      id: true,
+      customerEmail: true,
+      customerName: true,
+      sentAt: true,
+      deliveryDate: true,
+      token: true,
+    },
+    orderBy: { sentAt: 'desc' },
+    take: 200,
+  });
+
+  let enqueued = 0;
+  for (const draft of drafts) {
+    const result = await enqueueJourney('unpaid-invoice', {
+      email: draft.customerEmail,
+      entityId: draft.id,
+      draftOrderId: draft.id,
+      baseTime: draft.sentAt ?? now,
+      payload: {
+        firstName: firstNameFrom(draft.customerName),
+        deliveryDate: fmtDeliveryDate(draft.deliveryDate),
+        invoicePath: `/invoice/${draft.token}`,
+      },
+    });
+    if (result.enqueued) enqueued++;
+  }
+  return enqueued;
+}
+
+/**
+ * Backstop sweep: delivered orders with no review request yet. Bounded to
+ * deliveries in the last 14 days so flipping the flag on never blasts the
+ * whole history. Mutual dedupe with the manual GHL route via
+ * Order.reviewRequestSentAt (checked again at send time).
+ */
+async function sweepPostPurchaseReviews(now: Date): Promise<number> {
+  const orders = await prisma.order.findMany({
+    where: {
+      status: 'DELIVERED',
+      reviewRequestSentAt: null,
+      deliveryDate: {
+        gte: new Date(now.getTime() - 14 * 24 * 3_600_000),
+        lte: now,
+      },
+    },
+    select: {
+      id: true,
+      customerEmail: true,
+      customerName: true,
+      deliveryDate: true,
+    },
+    orderBy: { deliveryDate: 'desc' },
+    take: 200,
+  });
+
+  let enqueued = 0;
+  for (const order of orders) {
+    const result = await enqueueJourney('post-purchase-review', {
+      email: order.customerEmail,
+      entityId: order.id,
+      orderId: order.id,
+      baseTime: order.deliveryDate,
+      payload: { firstName: firstNameFrom(order.customerName) },
+    });
+    if (result.enqueued) enqueued++;
+  }
+  return enqueued;
+}
+
+/** Journey-key → sweep function. Only enabled journeys sweep. */
+const SWEEPS: Partial<Record<JourneyKey, (now: Date) => Promise<number>>> = {
+  'unpaid-invoice': sweepUnpaidInvoices,
+  'post-purchase-review': sweepPostPurchaseReviews,
+};
+
+/** Reap stuck processing jobs. Returns how many were touched. */
+async function reapStuckJobs(now: Date): Promise<number> {
+  const cutoff = new Date(now.getTime() - STUCK_PROCESSING_MINUTES * 60_000);
+  const failed = await prisma.followUpJob.updateMany({
+    where: {
+      status: 'processing',
+      claimedAt: { lt: cutoff },
+      attempts: { gte: MAX_ATTEMPTS },
+    },
+    data: { status: 'failed', lastError: 'stuck-in-processing (reaped)' },
+  });
+  const rescheduled = await prisma.followUpJob.updateMany({
+    where: { status: 'processing', claimedAt: { lt: cutoff } },
+    data: { status: 'scheduled' },
+  });
+  return failed.count + rescheduled.count;
+}
+
+/**
+ * Atomically claim due jobs for the enabled journeys. FOR UPDATE SKIP LOCKED
+ * makes concurrent ticks (cron overlap, manual runs) claim disjoint sets.
+ * Claiming counts as an attempt.
+ */
+async function claimDueJobs(enabledKeys: string[]): Promise<FollowUpJob[]> {
+  if (enabledKeys.length === 0) return [];
+  const claimed = await prisma.$queryRaw<Array<{ id: string }>>`
+    UPDATE follow_up_jobs
+    SET status = 'processing', claimed_at = now(), attempts = attempts + 1, updated_at = now()
+    WHERE id IN (
+      SELECT id FROM follow_up_jobs
+      WHERE status = 'scheduled'
+        AND scheduled_for <= now()
+        AND journey_key IN (${Prisma.join(enabledKeys)})
+      ORDER BY scheduled_for ASC
+      LIMIT ${CLAIM_BATCH_SIZE}
+      FOR UPDATE SKIP LOCKED
+    )
+    RETURNING id
+  `;
+  if (claimed.length === 0) return [];
+  return prisma.followUpJob.findMany({
+    where: { id: { in: claimed.map((row) => row.id) } },
+    orderBy: { scheduledFor: 'asc' },
+  });
+}
+
+type JobOutcome = 'sent' | 'canceled' | 'suppressed' | 'failed' | 'recovered';
+
+async function markCanceled(job: FollowUpJob, reason: string, status = 'canceled'): Promise<void> {
+  await prisma.followUpJob.update({
+    where: { id: job.id },
+    data: { status, canceledAt: new Date(), cancelReason: reason },
+  });
+}
+
+/** Process one claimed job through the full pre-send pipeline. Exported for tests. */
+export async function processJob(job: FollowUpJob, journey: JourneyDef): Promise<JobOutcome> {
+  // 1. Suppression list (unsubscribe/bounce/complaint).
+  if (await isSuppressed(job.email)) {
+    await markCanceled(job, 'suppressed', 'suppressed');
+    return 'suppressed';
+  }
+
+  // 2. Journey-specific fresh-DB cancel checks.
+  const cancelReason = await journey.shouldCancel(job);
+  if (cancelReason) {
+    await markCanceled(job, cancelReason);
+    return 'canceled';
+  }
+
+  // 3. Global guard: they became a paying customer since this was queued.
+  if (!journey.skipGlobalPaidGuard && (await hasPaidOrderSince(job.email, job.createdAt))) {
+    await markCanceled(job, 'converted-order');
+    return 'canceled';
+  }
+
+  // 4. Retry recovery: if a previous attempt already produced an EmailLog for
+  // this job, do NOT send again. Anything except FAILED (including PENDING,
+  // where the outcome is unknowable) counts as sent — err on no-duplicate.
+  const priorLog = await prisma.emailLog.findFirst({
+    where: {
+      metadata: { path: ['jobId'], equals: job.id },
+      status: { not: EmailStatus.FAILED },
+    },
+    select: { id: true },
+  });
+  if (priorLog) {
+    await prisma.followUpJob.update({
+      where: { id: job.id },
+      data: { status: 'sent', sentAt: new Date(), emailLogId: priorLog.id },
+    });
+    await enqueueNextStepIfAny(job, journey);
+    return 'recovered';
+  }
+
+  // 5. Render.
+  const stepDef = journey.steps[job.step - 1];
+  if (!stepDef) {
+    await prisma.followUpJob.update({
+      where: { id: job.id },
+      data: { status: 'failed', lastError: `no step ${job.step} on ${journey.key}` },
+    });
+    return 'failed';
+  }
+  const rendered = stepDef.buildEmail({
+    job,
+    payload: (job.payload as Record<string, unknown> | null) ?? {},
+    link: (path: string) => {
+      const url = new URL(path, SITE_BASE_URL);
+      url.searchParams.set('utm_source', 'email');
+      url.searchParams.set('utm_medium', 'followup');
+      url.searchParams.set('utm_campaign', journey.key);
+      url.searchParams.set('utm_content', `step-${job.step}`);
+      return url.toString();
+    },
+    unsubscribeUrl: buildPreferencesUrl(job.email),
+  });
+  if (!rendered) {
+    await markCanceled(job, 'no-content');
+    return 'canceled';
+  }
+
+  // 6. Send — personal from-address, RFC 8058 one-click unsubscribe headers.
+  const result = await sendEmailDetailed({
+    to: job.email,
+    subject: rendered.subject,
+    html: rendered.html,
+    text: rendered.text,
+    type: EmailType.FOLLOW_UP,
+    orderId: job.orderId ?? undefined,
+    draftOrderId: job.draftOrderId ?? undefined,
+    metadata: { jobId: job.id, journeyKey: journey.key, step: job.step },
+    tags: [
+      { name: 'journey', value: journey.key.replace(/[^a-zA-Z0-9_-]/g, '_') },
+      { name: 'step', value: String(job.step) },
+    ],
+    headers: {
+      'List-Unsubscribe': `<${buildOneClickUnsubscribeUrl(job.email)}>`,
+      'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+    },
+    from: {
+      email: process.env.FOLLOWUP_FROM_EMAIL as string,
+      name: process.env.FOLLOWUP_FROM_NAME || 'Allan at Party On Delivery',
+    },
+    respectSuppression: true,
+  });
+
+  if (result.suppressed) {
+    await markCanceled(job, 'suppressed', 'suppressed');
+    return 'suppressed';
+  }
+
+  if (!result.sent) {
+    const exhausted = job.attempts >= MAX_ATTEMPTS;
+    await prisma.followUpJob.update({
+      where: { id: job.id },
+      data: {
+        status: exhausted ? 'failed' : 'scheduled',
+        lastError: result.error ?? 'send failed',
+      },
+    });
+    return 'failed';
+  }
+
+  // 7. Stamp + follow-on work.
+  await prisma.followUpJob.update({
+    where: { id: job.id },
+    data: { status: 'sent', sentAt: new Date(), emailLogId: result.emailLogId },
+  });
+  if (journey.afterSend) {
+    await journey.afterSend(job);
+  }
+  await enqueueNextStepIfAny(job, journey);
+  return 'sent';
+}
+
+async function enqueueNextStepIfAny(job: FollowUpJob, journey: JourneyDef): Promise<void> {
+  if (journey.steps[job.step]) {
+    await enqueueNextStep(job);
+  }
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function emptyResult(now: Date): EngineRunResult {
+  return {
+    ok: true,
+    reaped: 0,
+    swept: {},
+    claimed: 0,
+    sent: 0,
+    canceled: 0,
+    suppressed: 0,
+    failed: 0,
+    recovered: 0,
+    at: now.toISOString(),
+  };
+}
+
+/**
+ * One engine tick. Called by the cron route; also directly invocable from
+ * tests and the admin test-send path.
+ */
+export async function runFollowUpEngine(opts: { now?: Date } = {}): Promise<EngineRunResult> {
+  const now = opts.now ?? new Date();
+  const result = emptyResult(now);
+
+  if (!process.env.UNSUBSCRIBE_SECRET || !process.env.FOLLOWUP_FROM_EMAIL) {
+    return {
+      ...result,
+      ok: false,
+      reason: 'missing env: UNSUBSCRIBE_SECRET and/or FOLLOWUP_FROM_EMAIL',
+    };
+  }
+
+  if (!(await isFeatureEnabled(FEATURE_FLAGS.FOLLOWUPS_MASTER))) {
+    return { ...result, paused: true };
+  }
+
+  result.reaped = await reapStuckJobs(now);
+
+  // Per-journey flags — checked once per tick.
+  const enabled: JourneyDef[] = [];
+  for (const journey of JOURNEYS) {
+    if (await isFeatureEnabled(journey.featureFlag)) enabled.push(journey);
+  }
+
+  // Backstop sweeps for enabled journeys (dedupe_key absorbs repeats).
+  for (const journey of enabled) {
+    const sweep = SWEEPS[journey.key];
+    if (sweep) {
+      try {
+        result.swept[journey.key] = await sweep(now);
+      } catch (error) {
+        console.error(`[followups] sweep failed for ${journey.key}:`, error);
+      }
+    }
+  }
+
+  if (!isWithinSendWindow(now)) {
+    return { ...result, inWindow: false };
+  }
+  result.inWindow = true;
+
+  const jobs = await claimDueJobs(enabled.map((j) => j.key));
+  result.claimed = jobs.length;
+
+  const journeyByKey = new Map(enabled.map((j) => [j.key as string, j]));
+  for (const job of jobs) {
+    const journey = journeyByKey.get(job.journeyKey);
+    if (!journey) {
+      // Shouldn't happen (claim filters on enabled keys) — release the claim.
+      await prisma.followUpJob.update({
+        where: { id: job.id },
+        data: { status: 'scheduled' },
+      });
+      continue;
+    }
+    try {
+      const outcome = await processJob(job, journey);
+      if (outcome === 'sent') result.sent++;
+      else if (outcome === 'canceled') result.canceled++;
+      else if (outcome === 'suppressed') result.suppressed++;
+      else if (outcome === 'recovered') result.recovered++;
+      else result.failed++;
+      if (outcome === 'sent') await sleep(SEND_SPACING_MS);
+    } catch (error) {
+      console.error(`[followups] job ${job.id} crashed:`, error);
+      result.failed++;
+      const message = error instanceof Error ? error.message : 'unknown error';
+      await prisma.followUpJob
+        .update({
+          where: { id: job.id },
+          data: {
+            status: job.attempts >= MAX_ATTEMPTS ? 'failed' : 'scheduled',
+            lastError: message,
+          },
+        })
+        .catch(() => undefined); // reaper will pick it up if even this fails
+    }
+  }
+
+  return result;
+}

--- a/src/lib/followups/enqueue.ts
+++ b/src/lib/followups/enqueue.ts
@@ -1,0 +1,170 @@
+/**
+ * Follow-up email system — job queueing.
+ *
+ * enqueueJourney is called from route hooks (lead-event, quote, contact, ...)
+ * and from the engine's backstop sweeps. The UNIQUE dedupe_key
+ * ("<journey>:<step>:<entityId>") makes re-enqueues free: the second insert
+ * is a no-op, so sweeps can re-scan the same drafts every 15 minutes safely.
+ *
+ * A canceled/suppressed job also blocks re-enqueue of that step by design —
+ * "we decided not to send this touch" is a final answer for that entity.
+ */
+
+import { Prisma, type FollowUpJob } from '@prisma/client';
+import { prisma } from '@/lib/database/client';
+import { getJourney } from './journeys';
+import { normalizeEmail } from './suppression';
+import { entityIdFromDedupeKey, type JourneyKey } from './types';
+
+const MAX_JITTER_MS = 45 * 60 * 1000;
+
+/**
+ * Send time for a step: base + delay + 0–45min jitter so sends don't all fire
+ * on the same cron tick (deliverability). Immediate steps (delayHours 0) get
+ * no jitter — acks should go out on the next in-window tick.
+ * jitterMs is injectable for tests.
+ */
+export function computeSendAt(
+  base: Date,
+  delayHours: number,
+  jitterMs?: number
+): Date {
+  const jitter =
+    delayHours <= 0
+      ? 0
+      : Math.max(0, Math.min(jitterMs ?? Math.random() * MAX_JITTER_MS, MAX_JITTER_MS));
+  return new Date(base.getTime() + delayHours * 3_600_000 + jitter);
+}
+
+export interface EnqueueJourneyOptions {
+  /** Recipient — lowercased before storage. */
+  email: string;
+  /** Stable id of the triggering entity (lead/draft/inquiry/order id) — drives dedupe. */
+  entityId: string;
+  /** 1 (default) or 2 — e.g. journeys whose first touch already exists elsewhere. */
+  startAtStep?: number;
+  /** Delay anchor. Defaults to now; pass e.g. DraftOrder.sentAt for unpaid-invoice. */
+  baseTime?: Date;
+  phone?: string | null;
+  smsConsent?: boolean;
+  leadId?: string;
+  draftOrderId?: string;
+  partnerInquiryId?: string;
+  orderId?: string;
+  /** Render context snapshot for copy.ts (names, links, numbers). */
+  payload?: Record<string, unknown>;
+}
+
+export interface EnqueueResult {
+  enqueued: boolean;
+  jobId?: string;
+  /** duplicate | invalid-email | unknown-journey | no-such-step */
+  reason?: string;
+}
+
+/**
+ * Queue one journey step for an entity. Safe to call repeatedly — duplicates
+ * are absorbed by dedupe_key. Never throws on duplicate; rethrows real errors.
+ */
+export async function enqueueJourney(
+  journeyKey: JourneyKey,
+  opts: EnqueueJourneyOptions
+): Promise<EnqueueResult> {
+  const journey = getJourney(journeyKey);
+  if (!journey) return { enqueued: false, reason: 'unknown-journey' };
+
+  const step = opts.startAtStep ?? 1;
+  const stepDef = journey.steps[step - 1];
+  if (!stepDef) return { enqueued: false, reason: 'no-such-step' };
+
+  const email = normalizeEmail(opts.email);
+  if (!email || !email.includes('@')) return { enqueued: false, reason: 'invalid-email' };
+
+  const scheduledFor = computeSendAt(opts.baseTime ?? new Date(), stepDef.delayHours);
+
+  try {
+    const job = await prisma.followUpJob.create({
+      data: {
+        journeyKey,
+        step,
+        email,
+        phone: opts.phone ?? null,
+        smsConsent: opts.smsConsent ?? false,
+        leadId: opts.leadId,
+        draftOrderId: opts.draftOrderId,
+        partnerInquiryId: opts.partnerInquiryId,
+        orderId: opts.orderId,
+        payload: opts.payload
+          ? (JSON.parse(JSON.stringify(opts.payload)) as Prisma.InputJsonValue)
+          : undefined,
+        dedupeKey: `${journeyKey}:${step}:${opts.entityId}`,
+        scheduledFor,
+      },
+    });
+    return { enqueued: true, jobId: job.id };
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2002'
+    ) {
+      return { enqueued: false, reason: 'duplicate' };
+    }
+    throw error;
+  }
+}
+
+/**
+ * Queue the next touch after a step sends. Called by the engine only —
+ * step N+1 is never enqueued before step N has actually gone out.
+ */
+export async function enqueueNextStep(
+  job: FollowUpJob,
+  now: Date = new Date()
+): Promise<EnqueueResult> {
+  return enqueueJourney(job.journeyKey as JourneyKey, {
+    email: job.email,
+    entityId: entityIdFromDedupeKey(job.dedupeKey),
+    startAtStep: job.step + 1,
+    baseTime: now,
+    phone: job.phone,
+    smsConsent: job.smsConsent,
+    leadId: job.leadId ?? undefined,
+    draftOrderId: job.draftOrderId ?? undefined,
+    partnerInquiryId: job.partnerInquiryId ?? undefined,
+    orderId: job.orderId ?? undefined,
+    payload: (job.payload as Record<string, unknown> | null) ?? undefined,
+  });
+}
+
+/**
+ * Cancel scheduled jobs for an email (all journeys, or one journey).
+ * Advisory call-sites: Stripe payment webhook, suppression, quote fast-path.
+ * Returns how many jobs were canceled.
+ */
+export async function cancelJobsForEmail(
+  email: string,
+  reason: string,
+  journeyKey?: JourneyKey
+): Promise<number> {
+  const result = await prisma.followUpJob.updateMany({
+    where: {
+      email: normalizeEmail(email),
+      status: 'scheduled',
+      ...(journeyKey ? { journeyKey } : {}),
+    },
+    data: { status: 'canceled', canceledAt: new Date(), cancelReason: reason },
+  });
+  return result.count;
+}
+
+/** Cancel scheduled jobs tied to a draft order (e.g. invoice paid/cancelled). */
+export async function cancelJobsForDraft(
+  draftOrderId: string,
+  reason: string
+): Promise<number> {
+  const result = await prisma.followUpJob.updateMany({
+    where: { draftOrderId, status: 'scheduled' },
+    data: { status: 'canceled', canceledAt: new Date(), cancelReason: reason },
+  });
+  return result.count;
+}

--- a/src/lib/followups/enqueue.ts
+++ b/src/lib/followups/enqueue.ts
@@ -17,6 +17,30 @@ import { normalizeEmail } from './suppression';
 import { entityIdFromDedupeKey, type JourneyKey } from './types';
 
 const MAX_JITTER_MS = 45 * 60 * 1000;
+const MAX_PAYLOAD_STRING = 200;
+const MAX_PAYLOAD_DEPTH = 3;
+
+/**
+ * Clamp untrusted payload values before storage: route hooks snapshot
+ * public-form input here, and copy.ts interpolates it into outbound email.
+ * Truncating strings bounds both stored-JSON bloat and what a visitor can
+ * make "Allan" say in a follow-up.
+ */
+function clampPayload(value: unknown, depth = 0): unknown {
+  if (typeof value === 'string') return value.slice(0, MAX_PAYLOAD_STRING);
+  if (Array.isArray(value)) {
+    return depth >= MAX_PAYLOAD_DEPTH ? [] : value.slice(0, 50).map((v) => clampPayload(v, depth + 1));
+  }
+  if (value && typeof value === 'object') {
+    if (depth >= MAX_PAYLOAD_DEPTH) return {};
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>).slice(0, 50)) {
+      out[k.slice(0, 100)] = clampPayload(v, depth + 1);
+    }
+    return out;
+  }
+  return value;
+}
 
 /**
  * Send time for a step: base + delay + 0–45min jitter so sends don't all fire
@@ -95,7 +119,7 @@ export async function enqueueJourney(
         partnerInquiryId: opts.partnerInquiryId,
         orderId: opts.orderId,
         payload: opts.payload
-          ? (JSON.parse(JSON.stringify(opts.payload)) as Prisma.InputJsonValue)
+          ? (JSON.parse(JSON.stringify(clampPayload(opts.payload))) as Prisma.InputJsonValue)
           : undefined,
         dedupeKey: `${journeyKey}:${step}:${opts.entityId}`,
         scheduledFor,

--- a/src/lib/followups/journeys.ts
+++ b/src/lib/followups/journeys.ts
@@ -74,7 +74,10 @@ export const JOURNEYS: JourneyDef[] = [
         if (lead.status !== 'PARTIAL') return `lead-${lead.status.toLowerCase()}`;
         if (lead.draftOrderId || lead.orderId) return 'lead-linked-to-order';
       }
-      if (await activeDraftExistsForEmail(job.email)) return 'draft-exists';
+      // Recent drafts only — a repeat customer's converted draft from months
+      // ago is not an active conversation and must not kill this journey.
+      const recentDraftSince = new Date(job.createdAt.getTime() - 30 * 24 * 3_600_000);
+      if (await activeDraftExistsForEmail(job.email, recentDraftSince)) return 'draft-exists';
       // Precedence: if an unpaid-invoice conversation is running for this
       // email, that journey owns the thread.
       const invoiceJob = await prisma.followUpJob.findFirst({

--- a/src/lib/followups/journeys.ts
+++ b/src/lib/followups/journeys.ts
@@ -1,0 +1,259 @@
+/**
+ * Follow-up email system — journey registry.
+ *
+ * Single source of truth for every follow-up journey (registry pattern like
+ * src/lib/analytics/landing-pages.ts). Each journey: a feature flag, up to
+ * two steps (Allan's locked 2-touch max), and a shouldCancel check the engine
+ * runs with FRESH database reads just before sending — the enqueue-time state
+ * of the world is never trusted at send time.
+ *
+ * Cancel reasons are short kebab-case strings stored on the job for the admin
+ * dashboard (Phase 4).
+ */
+
+import type { FollowUpJob } from '@prisma/client';
+import { prisma } from '@/lib/database/client';
+import { FEATURE_FLAGS } from '@/lib/features/feature-flags';
+import { entityIdFromDedupeKey, type JourneyDef, type JourneyKey } from './types';
+import {
+  abandonedQuoteStep1,
+  abandonedQuoteStep2,
+  unpaidInvoiceStep1,
+  unpaidInvoiceStep2,
+  partnerInquiryStep1,
+  partnerInquiryStep2,
+  contactFormStep1,
+  contactFormStep2,
+  newsletterWelcomeStep1,
+  affiliateApplyStep1,
+  affiliateApplyStep2,
+  eventQuizStep2,
+  postPurchaseReviewStep1,
+} from './copy';
+
+/** Draft statuses that mean "this email is already in an active sales motion". */
+const ACTIVE_DRAFT_STATUSES = ['SENT', 'VIEWED', 'PAID', 'CONVERTED'] as const;
+
+async function activeDraftExistsForEmail(
+  email: string,
+  since?: Date
+): Promise<boolean> {
+  const draft = await prisma.draftOrder.findFirst({
+    where: {
+      customerEmail: { equals: email, mode: 'insensitive' },
+      status: { in: [...ACTIVE_DRAFT_STATUSES] },
+      ...(since ? { createdAt: { gte: since } } : {}),
+    },
+    select: { id: true },
+  });
+  return draft !== null;
+}
+
+/**
+ * NOTE: group-order-host journey is intentionally ABSENT. Deferred in the
+ * approved plan (Phase-3 decision): hosts already convert to Orders, the
+ * journey overlaps post-purchase-review, and there is no Lead integration —
+ * needs a precedence rule from Allan before it exists.
+ */
+export const JOURNEYS: JourneyDef[] = [
+  {
+    key: 'abandoned-quote',
+    label: 'Abandoned quote',
+    description:
+      'Email captured in the drink calculator / package builder / quick buy, but no draft or order followed. Saved-numbers resume at +24h, personal offer at +96h.',
+    featureFlag: FEATURE_FLAGS.FOLLOWUPS_ABANDONED_QUOTE,
+    phase: 1,
+    steps: [
+      { delayHours: 24, buildEmail: abandonedQuoteStep1 },
+      { delayHours: 96, buildEmail: abandonedQuoteStep2 },
+    ],
+    shouldCancel: async (job: FollowUpJob) => {
+      if (job.leadId) {
+        const lead = await prisma.lead.findUnique({ where: { id: job.leadId } });
+        if (!lead) return 'lead-missing';
+        if (lead.status !== 'PARTIAL') return `lead-${lead.status.toLowerCase()}`;
+        if (lead.draftOrderId || lead.orderId) return 'lead-linked-to-order';
+      }
+      if (await activeDraftExistsForEmail(job.email)) return 'draft-exists';
+      // Precedence: if an unpaid-invoice conversation is running for this
+      // email, that journey owns the thread.
+      const invoiceJob = await prisma.followUpJob.findFirst({
+        where: {
+          journeyKey: 'unpaid-invoice',
+          email: job.email,
+          status: { in: ['scheduled', 'processing', 'sent'] },
+        },
+        select: { id: true },
+      });
+      if (invoiceJob) return 'unpaid-invoice-precedence';
+      return null;
+    },
+  },
+  {
+    key: 'unpaid-invoice',
+    label: 'Unpaid invoice',
+    description:
+      'Quote/invoice sent but not paid (non-group, non-amendment). "Holding your date?" at +24h from send, "closing this out?" at +120h.',
+    featureFlag: FEATURE_FLAGS.FOLLOWUPS_UNPAID_INVOICE,
+    phase: 1,
+    steps: [
+      { delayHours: 24, buildEmail: unpaidInvoiceStep1 },
+      { delayHours: 120, buildEmail: unpaidInvoiceStep2 },
+    ],
+    shouldCancel: async (job: FollowUpJob) => {
+      if (!job.draftOrderId) return 'missing-draft-ref';
+      const draft = await prisma.draftOrder.findUnique({
+        where: { id: job.draftOrderId },
+      });
+      if (!draft) return 'draft-missing';
+      if (['PAID', 'CONVERTED', 'CANCELLED', 'EXPIRED'].includes(draft.status)) {
+        return `draft-${draft.status.toLowerCase()}`;
+      }
+      if (draft.groupOrderId || draft.amendmentForOrderId) return 'group-or-amendment';
+      return null; // paid order under another email → engine's global guard
+    },
+  },
+  {
+    key: 'partner-inquiry',
+    label: 'Partner inquiry',
+    description:
+      'B2B partnership inquiry: personal ack on the next tick, calendar nudge at +96h. Vacation-rental one-pager placements start at step 2 (the one-pager email already sends).',
+    featureFlag: FEATURE_FLAGS.FOLLOWUPS_PARTNER_INQUIRY,
+    phase: 2,
+    // B2B thread — an unrelated consumer order from the same person must not
+    // kill the partnership conversation.
+    skipGlobalPaidGuard: true,
+    steps: [
+      { delayHours: 0, buildEmail: partnerInquiryStep1 },
+      { delayHours: 96, buildEmail: partnerInquiryStep2 },
+    ],
+    shouldCancel: async (job: FollowUpJob) => {
+      if (!job.partnerInquiryId) return 'missing-inquiry-ref';
+      const inquiry = await prisma.partnerInquiry.findUnique({
+        where: { id: job.partnerInquiryId },
+      });
+      if (!inquiry) return 'inquiry-missing';
+      if (inquiry.meetingBooked) return 'meeting-booked';
+      if (inquiry.status !== 'new') return `inquiry-${inquiry.status.toLowerCase()}`;
+      return null;
+    },
+  },
+  {
+    key: 'contact-form',
+    label: 'Contact form',
+    description:
+      'General /contact submissions: ack on the next tick, "did my reply reach you?" at +72h. Step 2 cannot see Allan\'s real replies — copy tolerates that, and the admin cancel button exists.',
+    featureFlag: FEATURE_FLAGS.FOLLOWUPS_CONTACT_FORM,
+    phase: 2,
+    steps: [
+      { delayHours: 0, buildEmail: contactFormStep1 },
+      { delayHours: 72, buildEmail: contactFormStep2 },
+    ],
+    shouldCancel: async (job: FollowUpJob) => {
+      if (job.leadId) {
+        const lead = await prisma.lead.findUnique({ where: { id: job.leadId } });
+        if (lead?.status === 'CONVERTED') return 'lead-converted';
+      }
+      // A draft sent after they wrote in means the conversation moved to the
+      // invoice flow.
+      if (await activeDraftExistsForEmail(job.email, job.createdAt)) {
+        return 'draft-in-flight';
+      }
+      return null;
+    },
+  },
+  {
+    key: 'newsletter-welcome',
+    label: 'Newsletter welcome',
+    description:
+      'Single welcome ~1h after double-opt-in confirmation. Cancels only on suppression.',
+    featureFlag: FEATURE_FLAGS.FOLLOWUPS_NEWSLETTER_WELCOME,
+    phase: 2,
+    steps: [{ delayHours: 1, buildEmail: newsletterWelcomeStep1 }],
+    shouldCancel: async () => null,
+  },
+  {
+    key: 'affiliate-apply',
+    label: 'Affiliate application',
+    description:
+      'Partner program application: ack on the next tick, check-in at +120h while still pending.',
+    featureFlag: FEATURE_FLAGS.FOLLOWUPS_AFFILIATE_APPLY,
+    phase: 2,
+    // B2B thread, same rationale as partner-inquiry.
+    skipGlobalPaidGuard: true,
+    steps: [
+      { delayHours: 0, buildEmail: affiliateApplyStep1 },
+      { delayHours: 120, buildEmail: affiliateApplyStep2 },
+    ],
+    shouldCancel: async (job: FollowUpJob) => {
+      const applicationId = entityIdFromDedupeKey(job.dedupeKey);
+      const application = await prisma.partnerApplication.findUnique({
+        where: { id: applicationId },
+      });
+      if (!application) return 'application-missing';
+      if (application.status !== 'PENDING') {
+        return `application-${application.status.toLowerCase()}`;
+      }
+      return null;
+    },
+  },
+  {
+    key: 'event-quiz',
+    label: 'Event quiz nudge',
+    description:
+      'Quiz submitters already get an instant welcome — this journey is the +96h "did the plan land?" nudge only (jobs start at step 2).',
+    featureFlag: FEATURE_FLAGS.FOLLOWUPS_EVENT_QUIZ,
+    phase: 3,
+    steps: [
+      // Step 1 slot exists for shape consistency but is never enqueued —
+      // the instant welcome in /api/v1/event-quiz/submit is touch #1.
+      { delayHours: 0, buildEmail: () => null },
+      { delayHours: 96, buildEmail: eventQuizStep2 },
+    ],
+    shouldCancel: async (job: FollowUpJob) => {
+      if (job.leadId) {
+        const lead = await prisma.lead.findUnique({ where: { id: job.leadId } });
+        if (lead?.status === 'CONVERTED') return 'lead-converted';
+      }
+      return null;
+    },
+  },
+  {
+    key: 'post-purchase-review',
+    label: 'Post-purchase review ask',
+    description:
+      'Single review ask +48h after delivery. Mutually deduped with the manual GHL review route via Order.reviewRequestSentAt — whichever sends first stamps it.',
+    featureFlag: FEATURE_FLAGS.FOLLOWUPS_POST_PURCHASE_REVIEW,
+    phase: 3,
+    // The trigger IS a paid order — the global paid guard would cancel every job.
+    skipGlobalPaidGuard: true,
+    steps: [{ delayHours: 48, buildEmail: postPurchaseReviewStep1 }],
+    shouldCancel: async (job: FollowUpJob) => {
+      if (!job.orderId) return 'missing-order-ref';
+      const order = await prisma.order.findUnique({ where: { id: job.orderId } });
+      if (!order) return 'order-missing';
+      if (order.status === 'CANCELLED' || order.status === 'REFUNDED') {
+        return `order-${order.status.toLowerCase()}`;
+      }
+      if (order.reviewRequestSentAt) return 'review-already-requested';
+      return null;
+    },
+    afterSend: async (job: FollowUpJob) => {
+      if (!job.orderId) return;
+      // Stamp only if still unstamped — the manual GHL route may have won the race.
+      await prisma.order.updateMany({
+        where: { id: job.orderId, reviewRequestSentAt: null },
+        data: { reviewRequestSentAt: new Date() },
+      });
+    },
+  },
+];
+
+const JOURNEY_MAP = new Map(JOURNEYS.map((j) => [j.key, j]));
+
+/** Look up a journey definition; undefined for unknown keys. */
+export function getJourney(key: string): JourneyDef | undefined {
+  return JOURNEY_MAP.get(key as JourneyKey);
+}
+
+export const JOURNEY_KEYS: JourneyKey[] = JOURNEYS.map((j) => j.key);

--- a/src/lib/followups/suppression.ts
+++ b/src/lib/followups/suppression.ts
@@ -1,0 +1,140 @@
+/**
+ * Follow-up email system — suppression list + unsubscribe tokens.
+ *
+ * email_suppressions is the global do-not-email list for FOLLOW-UP sends.
+ * Transactional emails (invoices, receipts, order confirmations) deliberately
+ * bypass it — the pre-send check lives in the engine and in the optional
+ * respectSuppression flag on sendEmailDetailed, never inside plain sendEmail.
+ *
+ * Unsubscribe URLs are HMAC-signed with UNSUBSCRIBE_SECRET so nobody can
+ * unsubscribe someone else's address by guessing the URL.
+ */
+
+import { createHmac, timingSafeEqual } from 'crypto';
+import { prisma } from '@/lib/database/client';
+import { SITE_BASE_URL } from './types';
+
+export type SuppressionReason = 'unsubscribe' | 'bounce' | 'complaint' | 'manual';
+
+/** Reasons a customer may publicly reverse on the preferences page. Bounces/complaints stay. */
+const PUBLICLY_REVERSIBLE: SuppressionReason[] = ['unsubscribe', 'manual'];
+
+/** Canonical form used everywhere in the follow-up system. */
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+/**
+ * HMAC token binding an email address to UNSUBSCRIBE_SECRET.
+ * Returns null when the secret is not configured (engine refuses to run then).
+ */
+export function unsubscribeToken(email: string): string | null {
+  const secret = process.env.UNSUBSCRIBE_SECRET;
+  if (!secret) return null;
+  return createHmac('sha256', secret)
+    .update(normalizeEmail(email))
+    .digest('hex')
+    .slice(0, 32);
+}
+
+/** Constant-time verification of an unsubscribe token. */
+export function verifyUnsubscribeToken(email: string, token: string): boolean {
+  const expected = unsubscribeToken(email);
+  if (!expected || !token) return false;
+  const a = Buffer.from(expected, 'utf8');
+  const b = Buffer.from(token, 'utf8');
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+/** Human-facing preferences page URL (used in the CAN-SPAM footer). */
+export function buildPreferencesUrl(email: string): string {
+  const normalized = normalizeEmail(email);
+  const token = unsubscribeToken(normalized) ?? '';
+  return `${SITE_BASE_URL}/email/preferences?email=${encodeURIComponent(normalized)}&token=${token}`;
+}
+
+/** RFC 8058 one-click POST target (used in the List-Unsubscribe header). */
+export function buildOneClickUnsubscribeUrl(email: string): string {
+  const normalized = normalizeEmail(email);
+  const token = unsubscribeToken(normalized) ?? '';
+  return `${SITE_BASE_URL}/api/email/unsubscribe?email=${encodeURIComponent(normalized)}&token=${token}`;
+}
+
+/** Is this address on the follow-up suppression list? */
+export async function isSuppressed(email: string): Promise<boolean> {
+  const row = await prisma.emailSuppression.findUnique({
+    where: { email: normalizeEmail(email) },
+    select: { id: true },
+  });
+  return row !== null;
+}
+
+/**
+ * Add an address to the suppression list and cancel its scheduled follow-up
+ * jobs. Idempotent. A harder reason (bounce/complaint) is never downgraded to
+ * a softer one (unsubscribe) — resubscribing must not clear delivery problems.
+ */
+export async function suppress(
+  email: string,
+  reason: SuppressionReason,
+  source?: string,
+  note?: string
+): Promise<{ suppressed: boolean; canceledJobs: number }> {
+  const normalized = normalizeEmail(email);
+  if (!normalized || !normalized.includes('@')) {
+    return { suppressed: false, canceledJobs: 0 };
+  }
+
+  const existing = await prisma.emailSuppression.findUnique({
+    where: { email: normalized },
+  });
+
+  if (!existing) {
+    await prisma.emailSuppression.create({
+      data: { email: normalized, reason, source, note },
+    });
+  } else if (
+    PUBLICLY_REVERSIBLE.includes(existing.reason as SuppressionReason) &&
+    !PUBLICLY_REVERSIBLE.includes(reason)
+  ) {
+    // Upgrade unsubscribe/manual → bounce/complaint; never the other way.
+    await prisma.emailSuppression.update({
+      where: { email: normalized },
+      data: { reason, source, note },
+    });
+  }
+
+  const canceled = await prisma.followUpJob.updateMany({
+    where: { email: normalized, status: 'scheduled' },
+    data: {
+      status: 'suppressed',
+      canceledAt: new Date(),
+      cancelReason: `suppressed-${reason}`,
+    },
+  });
+
+  return { suppressed: true, canceledJobs: canceled.count };
+}
+
+/**
+ * Remove an address from the suppression list (resubscribe).
+ * Publicly only reverses unsubscribe/manual rows; pass allowHardReasons for
+ * admin-driven removal of bounce/complaint rows.
+ */
+export async function unsuppress(
+  email: string,
+  opts: { allowHardReasons?: boolean } = {}
+): Promise<boolean> {
+  const normalized = normalizeEmail(email);
+  const existing = await prisma.emailSuppression.findUnique({
+    where: { email: normalized },
+  });
+  if (!existing) return false;
+  const reversible =
+    opts.allowHardReasons ||
+    PUBLICLY_REVERSIBLE.includes(existing.reason as SuppressionReason);
+  if (!reversible) return false;
+  await prisma.emailSuppression.delete({ where: { email: normalized } });
+  return true;
+}

--- a/src/lib/followups/types.ts
+++ b/src/lib/followups/types.ts
@@ -1,0 +1,119 @@
+/**
+ * Follow-up email system — shared types.
+ *
+ * The follow-up engine sends personal, plain-text follow-ups (2-touch max)
+ * for every email capture on the site. Journeys are defined in journeys.ts,
+ * copy in copy.ts, queueing in enqueue.ts, and the cron-driven send loop in
+ * engine.ts. See docs in the Phase-0 migration:
+ * prisma/migrations/manual/2026-07-06-followups-phase-0.sql
+ */
+
+import type { FollowUpJob } from '@prisma/client';
+import type { FeatureFlagKey } from '@/lib/features/feature-flags';
+
+/** Absolute base URL for links in follow-up emails and unsubscribe URLs. */
+export const SITE_BASE_URL = (
+  process.env.NEXT_PUBLIC_APP_URL || 'https://partyondelivery.com'
+).replace(/\/+$/, '');
+
+/** The entity id a job was deduped on (dedupe_key = "<journey>:<step>:<entityId>"). */
+export function entityIdFromDedupeKey(dedupeKey: string): string {
+  return dedupeKey.split(':').slice(2).join(':');
+}
+
+/** Every journey the follow-up system knows about. */
+export type JourneyKey =
+  | 'abandoned-quote'
+  | 'unpaid-invoice'
+  | 'partner-inquiry'
+  | 'contact-form'
+  | 'newsletter-welcome'
+  | 'affiliate-apply'
+  | 'event-quiz'
+  | 'post-purchase-review';
+
+/** Follow-up job lifecycle states (mirrors the CHECK constraint on follow_up_jobs.status). */
+export type FollowUpJobStatus =
+  | 'scheduled'
+  | 'processing'
+  | 'sent'
+  | 'canceled'
+  | 'suppressed'
+  | 'failed';
+
+/** A fully rendered email ready to hand to Resend. */
+export interface RenderedEmail {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+/** Context handed to a journey step's buildEmail at send time. */
+export interface JourneyEmailContext {
+  job: FollowUpJob;
+  /** job.payload parsed as an object ({} when null). Values are untrusted — read defensively. */
+  payload: Record<string, unknown>;
+  /** Turns a site path into an absolute URL with follow-up UTM params appended. */
+  link: (path: string) => string;
+  /** Token-signed /email/preferences URL for the job's email (CAN-SPAM footer). */
+  unsubscribeUrl: string;
+}
+
+/** One touch in a journey (2-touch max per Allan's locked decision). */
+export interface JourneyStep {
+  /** Hours after the trigger (step 1) or after the previous send (step 2). */
+  delayHours: number;
+  /** Render the email, or return null to cancel the send (e.g. payload too thin to say anything useful). */
+  buildEmail: (ctx: JourneyEmailContext) => RenderedEmail | null;
+}
+
+/**
+ * A journey definition. Registered in journeys.ts (registry pattern like
+ * src/lib/analytics/landing-pages.ts).
+ */
+export interface JourneyDef {
+  key: JourneyKey;
+  label: string;
+  description: string;
+  /** Per-journey kill switch — auto-created disabled by the flags system. */
+  featureFlag: FeatureFlagKey;
+  /** Rollout phase from the build plan (1 = revenue, 2 = acks, 3 = post-purchase). */
+  phase: 1 | 2 | 3;
+  /** Max length 2. */
+  steps: JourneyStep[];
+  /**
+   * Fresh-DB-read cancellation check, run by the engine just before sending.
+   * Returns a short cancel reason, or null to proceed.
+   */
+  shouldCancel: (job: FollowUpJob) => Promise<string | null>;
+  /**
+   * Opt out of the engine's global "customer paid since job creation" guard.
+   * Only for journeys where a paid order is part of the trigger itself
+   * (post-purchase-review) or irrelevant to the conversation (partner-inquiry).
+   */
+  skipGlobalPaidGuard?: boolean;
+  /** Optional hook run after a step sends (e.g. stamp Order.reviewRequestSentAt). */
+  afterSend?: (job: FollowUpJob) => Promise<void>;
+}
+
+/** Result summary returned by one engine run (cron tick). */
+export interface EngineRunResult {
+  ok: boolean;
+  /** Set when the engine refused to run (missing env). */
+  reason?: string;
+  /** True when the master kill switch is off. */
+  paused?: boolean;
+  /** False when outside the 9am–7pm America/Chicago send window (jobs stay queued). */
+  inWindow?: boolean;
+  reaped: number;
+  /** Jobs enqueued by backstop sweeps this tick, per journey. */
+  swept: Record<string, number>;
+  claimed: number;
+  sent: number;
+  canceled: number;
+  suppressed: number;
+  failed: number;
+  /** Jobs recovered as already-sent via the EmailLog jobId pre-send lookup. */
+  recovered: number;
+  at: string;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -61,6 +61,10 @@
       "schedule": "*/15 * * * *"
     },
     {
+      "path": "/api/cron/follow-up-engine",
+      "schedule": "*/15 * * * *"
+    },
+    {
       "path": "/api/cron/finance-stripe-sync",
       "schedule": "15 7 * * *"
     },


### PR DESCRIPTION
## Site-Wide Follow-Up Email System — Phase 0 of 5 (stacked)

First PR of the follow-up build-out per the approved plan: every email capture on the site gets a planned, automated follow-up (2-touch max, personal plain-text voice from info@, email-only with SMS-ready schema). **Zero emails can send from this PR — the master kill switch and every journey flag auto-create disabled.**

### What's in here
- **DB**: `follow_up_jobs` (send queue, UNIQUE dedupe_key) + `email_suppressions` via the manual-migrations ledger (already applied to Neon + recorded; `FOLLOW_UP` EmailType in its own non-transactional file)
- **Engine** (`src/lib/followups/engine.ts`, cron `*/15min`): master + per-journey flags → reaper → backstop sweeps → 9am–7pm CT send window (DST-safe) → `FOR UPDATE SKIP LOCKED` claim → per-job fresh-read cancel checks → global paid-order guard → EmailLog jobId retry recovery → send → step N+1 enqueued only after step N sends
- **Journey registry**: all 8 journeys defined (registry pattern like landing-pages.ts) with copy stubs in Allan's voice; route hooks land in the stacked PRs
- **Suppression + unsubscribe**: HMAC tokens (UNSUBSCRIBE_SECRET, timingSafeEqual), RFC 8058 one-click POST `/api/email/unsubscribe` (rate-limited), public `/email/preferences` page (bounces NOT publicly reversible, syncs `Customer.acceptsMarketing`), Resend webhook auto-suppress + job cancel on bounce/complaint
- **resend-client**: additive `sendEmailDetailed` (from override, EmailLog id, respectSuppression) — `sendEmail` signature untouched; transactional email never consults the suppression list

### Security review (security-reviewer agent) — findings fixed in e3ac2b30
- HIGH: open redirect via payload paths in `ctx.link()` (`new URL` ignores base for absolute/`//` paths) → site-relative-only guard + regression test
- MED: rate limiting on unsubscribe endpoints; payload clamping at enqueue
- LOW: cron fails CLOSED without CRON_SECRET; `.env.example` entries added
- Cleared explicitly: token strength (128-bit HMAC, constant-time), enumeration, GET open-redirect, webhook forgery, SQLi in the claim query, HTML escaping order, from-header injection

### Verification
- 44 unit tests (`npx vitest run src/lib/followups`) — send window/DST, jitter bounds, dedupe, suppression precedence, token tamper, engine pipeline incl. open-redirect guard
- Engine tick vs real Neon → `{paused:true}`; svix-signed bounce → suppression row + job canceled + 400 on tampered signature; ledger `--check` clean
- `npx tsc --noEmit` / `npm run lint` / `npm run test:run` (416) all green

### Before any flag flips ON (not needed to merge)
1. `POSTAL_ADDRESS` in copy.ts is a TODO — CAN-SPAM needs the real mailing address
2. Copy pass on `copy.ts` stubs
3. `UNSUBSCRIBE_SECRET` + `FOLLOWUP_FROM_EMAIL` set in Vercel prod env (already in local .env.local)

Stacked PRs: Phase 1 (revenue journeys) → 2 (acks + contact fix) → 3 (event-quiz) → 4 (admin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)