### PR TITLE
feat(followups): Phase 1 — abandoned-quote + unpaid-invoice revenue journeys

### DIFF
--- a/src/app/api/v1/landing/lead-event/route.ts
+++ b/src/app/api/v1/landing/lead-event/route.ts
@@ -24,11 +24,15 @@ import {
   markLeadStatus,
 } from '@/lib/leads/leadCapture';
 import { ensureVisitorCookie, COOKIE_NAME } from '@/lib/leads/cookie';
+import { enqueueJourney } from '@/lib/followups/enqueue';
 import type {
   LeadEventType,
   LeadSourceWidget,
   LeadStatus,
 } from '@prisma/client';
+
+/** Widgets whose partial captures feed the abandoned-quote follow-up journey. */
+const ABANDONED_QUOTE_WIDGETS = new Set(['DRINK_CALCULATOR', 'PACKAGE_BUILDER', 'QUICK_BUY']);
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -155,6 +159,44 @@ export async function POST(req: NextRequest) {
     await markLeadStatus(lead.id, parsed.setStatus as LeadStatus, {
       resumeCart: parsed.resumeCart,
     });
+  }
+
+  // Abandoned-quote follow-up: an email captured in a quote-building widget
+  // with no order behind it queues the +24h journey. Deduped on lead id, so
+  // repeated field-blur events are no-ops; the engine re-checks lead status,
+  // drafts, and orders with fresh reads before actually sending — and the
+  // journey's feature flag stays off until Allan enables it.
+  const email = lead?.email ?? parsed.identify?.email ?? null;
+  const promotedBeyondPartial = parsed.setStatus && parsed.setStatus !== 'PARTIAL';
+  if (
+    lead &&
+    email &&
+    lead.status === 'PARTIAL' &&
+    !promotedBeyondPartial &&
+    !lead.draftOrderId &&
+    !lead.orderId &&
+    parsed.widget &&
+    ABANDONED_QUOTE_WIDGETS.has(parsed.widget)
+  ) {
+    try {
+      const metadata = (parsed.metadata ?? {}) as Record<string, unknown>;
+      const rawGuestCount = String(metadata.guestCount ?? metadata.guests ?? '');
+      await enqueueJourney('abandoned-quote', {
+        email,
+        entityId: lead.id,
+        leadId: lead.id,
+        phone: lead.phone ?? parsed.identify?.phone ?? null,
+        payload: {
+          firstName: lead.firstName ?? parsed.identify?.firstName ?? null,
+          resumePath: parsed.page ?? '/order',
+          // Digits only — this value is quoted verbatim inside email copy.
+          guestCount: /^\d{1,4}$/.test(rawGuestCount) ? rawGuestCount : null,
+        },
+      });
+    } catch (err) {
+      // Follow-up queueing must never break lead capture.
+      console.warn('[lead-event] abandoned-quote enqueue failed', err);
+    }
   }
 
   const res = NextResponse.json({

--- a/src/app/api/v1/landing/quote/route.ts
+++ b/src/app/api/v1/landing/quote/route.ts
@@ -25,6 +25,7 @@ import { generateInvoiceEmail, generateInvoiceSubject } from '@/lib/email/templa
 import { getInvoiceTextOverrides } from '@/lib/email/template-content';
 import { sendEmail } from '@/lib/email/resend-client';
 import { attributionSchema, attributionNoteLine } from '@/lib/leads/attribution-schema';
+import { cancelJobsForEmail, enqueueJourney } from '@/lib/followups/enqueue';
 import { EmailType, DraftOrderStatus } from '@prisma/client';
 
 export const dynamic = 'force-dynamic';
@@ -208,10 +209,42 @@ export async function POST(request: NextRequest) {
           data: { status: DraftOrderStatus.SENT, sentAt: new Date() },
         });
         emailSent = true;
+
+        // Fast-path follow-up enqueue (the engine sweep would catch this
+        // draft anyway — this just gets the +24h clock started with a richer
+        // payload). Flag-gated at send time; deduped on draft id.
+        try {
+          await enqueueJourney('unpaid-invoice', {
+            email: draftOrder.customerEmail,
+            entityId: draftOrder.id,
+            draftOrderId: draftOrder.id,
+            phone: body.customerPhone || null,
+            payload: {
+              firstName: (draftOrder.customerName ?? '').trim().split(/\s+/)[0] || null,
+              deliveryDate: draftOrder.deliveryDate.toLocaleDateString('en-US', {
+                weekday: 'long',
+                month: 'long',
+                day: 'numeric',
+                timeZone: 'America/Chicago',
+              }),
+              invoicePath: `/invoice/${draftOrder.token}`,
+            },
+          });
+        } catch (err) {
+          console.warn('[landing/quote] unpaid-invoice enqueue failed:', err);
+        }
       } catch (err) {
         console.error('[landing/quote] Failed to send invoice email:', err);
         // Don't fail the request — the customer still got an invoiceUrl
       }
+    }
+
+    // Either mode: this email now has a real draft order, so any pending
+    // abandoned-quote nudge is moot — the invoice conversation owns the thread.
+    try {
+      await cancelJobsForEmail(body.customerEmail, 'draft-created', 'abandoned-quote');
+    } catch (err) {
+      console.warn('[landing/quote] abandoned-quote cancel failed:', err);
     }
 
     return NextResponse.json({

--- a/src/lib/stripe/webhooks.ts
+++ b/src/lib/stripe/webhooks.ts
@@ -30,6 +30,22 @@ import {
   upsertDispute,
   upsertPayout,
 } from '@/lib/finance/stripe-extended';
+import { cancelJobsForDraft, cancelJobsForEmail } from '@/lib/followups/enqueue';
+
+/**
+ * Advisory follow-up cleanup on payment success: the customer converted, so
+ * scheduled follow-up nudges to them are moot. The engine re-checks with
+ * fresh reads before every send anyway — this just tidies the queue early.
+ * Never throws; order creation must not depend on it.
+ */
+async function cancelFollowUpsForConversion(email: string | null | undefined, draftOrderId?: string): Promise<void> {
+  try {
+    if (draftOrderId) await cancelJobsForDraft(draftOrderId, 'invoice-paid');
+    if (email) await cancelJobsForEmail(email, 'converted-order');
+  } catch (err) {
+    console.warn('[Stripe Webhook] follow-up cancel failed:', err);
+  }
+}
 
 /**
  * Verify webhook signature and construct event
@@ -107,6 +123,8 @@ async function handleCheckoutSessionCompleted(
   try {
     const order = await createOrderFromCheckout(fullSession, cart);
     console.log('[Stripe Webhook] Order created:', order.orderNumber);
+
+    await cancelFollowUpsForConversion(order.customerEmail);
 
     // Link order to affiliate. Two paths:
     //   1. Cookie/ref attribution from session metadata (affiliateCode)
@@ -298,6 +316,8 @@ async function handleDraftOrderPayment(
       convertedOrderId: order.id,
     });
     console.log('[Stripe Webhook] Draft order marked as converted:', draftOrderId);
+
+    await cancelFollowUpsForConversion(order.customerEmail, draftOrderId);
 
     // Link order to affiliate. Try ref/draft-attached code first; fall back to
     // the discount code if the customer typed an affiliate code at checkout.


### PR DESCRIPTION
## Phase 1 of 5 — stacked on #183

Route hooks for the two revenue journeys. Flags still OFF — nothing sends until `followups_master` + the journey flags are enabled.

- **lead-event**: partial email capture in DRINK_CALCULATOR / PACKAGE_BUILDER / QUICK_BUY queues abandoned-quote (+24h saved-numbers resume, +96h "reply with your date, I'll price it"), deduped on lead id; skipped when the lead already has a draft/order or is promoted beyond PARTIAL in the same request; guestCount digits-only before it can reach copy
- **landing quote**: after the invoice-email SENT stamp, fast-path enqueue of unpaid-invoice (+24h "holding your date?", +120h "closing this out?") with the /invoice/[token] link; both modes cancel pending abandoned-quote for the email (invoice conversation owns the thread)
- **stripe webhooks**: payment success cancels scheduled follow-ups (standard checkout by email; draft payment by draft id + email) — advisory only; the engine re-checks with fresh reads before every send. Security review confirmed the helper cannot throw into the order-creation path and touches only follow_up_jobs rows

The engine-side backstop sweep for unpaid invoices (24h–14d, non-group, non-amendment) shipped in Phase 0.

**Before enabling `followups_abandoned_quote`**: Allan decides backfill — seed the ~56 existing calculator leads vs use the one-off send staged 2026-07-04 (plan open item #4). Self-test to allan@ 48h before flag-flip.

Gates: tsc clean, 416 tests green. Security review (Phases 1–4 combined): 0 critical/high/medium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)