### PR TITLE
feat(followups): Phase 2 — contact-form dead-end fix + ack journeys

### DIFF
--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,18 +1,95 @@
+/**
+ * POST /api/contact — general contact form.
+ *
+ * Historically this ONLY forwarded to a Zapier webhook: if Zapier was down
+ * or the env var missing, the message was lost with no trace. Now the
+ * submission is stored as a Lead (source CONTACT_FORM, full message in
+ * metadata.contactForm) FIRST, then forwarded to Zapier as before, and the
+ * contact-form follow-up journey is queued (ack on the next engine tick,
+ * "did my reply reach you?" at +72h — flag-gated, deduped per submission).
+ */
+
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { prisma } from '@/lib/database/client';
+import { upsertLead } from '@/lib/leads/leadCapture';
+import { enqueueJourney } from '@/lib/followups/enqueue';
+import { checkRateLimit } from '@/lib/security/rate-limit';
+
+const bodySchema = z.object({
+  name: z.string().trim().min(1, 'Name is required').max(120),
+  email: z.string().trim().email('Valid email is required').max(200),
+  phone: z.string().trim().max(40).optional().default(''),
+  eventType: z.string().trim().max(120).optional().default(''),
+  eventDate: z.string().trim().max(60).optional().default(''),
+  guestCount: z.union([z.string(), z.number()]).optional().default(''),
+  message: z.string().trim().max(5000).optional().default(''),
+});
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
-
-    // Validate required fields
-    if (!body.name || !body.email) {
+    // Storage made this route do real DB work per request — throttle it.
+    const ip =
+      request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+      request.headers.get('x-real-ip') ||
+      'unknown';
+    if (!(await checkRateLimit('contact-form', ip, 5, 60))) {
       return NextResponse.json(
-        { success: false, error: 'Name and email are required' },
+        { success: false, error: 'Too many submissions. Please try again in a minute.' },
+        { status: 429 }
+      );
+    }
+    const parsed = bodySchema.safeParse(await request.json());
+    if (!parsed.success) {
+      const firstIssue = parsed.error.issues[0]?.message ?? 'Invalid submission';
+      return NextResponse.json(
+        { success: false, error: firstIssue },
         { status: 400 }
       );
     }
+    const body = parsed.data;
+    const submittedAt = new Date().toISOString();
+    const [firstName, ...restName] = body.name.split(/\s+/);
 
-    // Send to Zapier webhook (use specific URL or fallback to shared URL)
+    // 1. Store the submission — this is the system of record now; Zapier is
+    // a best-effort mirror.
+    let leadId: string | null = null;
+    try {
+      const lead = await upsertLead(
+        {
+          email: body.email,
+          phone: body.phone || null,
+          firstName: firstName || null,
+          lastName: restName.join(' ') || null,
+        },
+        { sourcePage: '/contact', sourceWidget: 'CONTACT_FORM' }
+      );
+      if (lead) {
+        leadId = lead.id;
+        const existingMeta = (lead.metadata as Record<string, unknown> | null) ?? {};
+        await prisma.lead.update({
+          where: { id: lead.id },
+          data: {
+            metadata: {
+              ...existingMeta,
+              contactForm: {
+                eventType: body.eventType,
+                eventDate: body.eventDate,
+                guestCount: String(body.guestCount ?? ''),
+                message: body.message,
+                submittedAt,
+              },
+            },
+          },
+        });
+      }
+    } catch (storageError) {
+      // Storage must not block the customer — but log loudly, this was the
+      // whole point of the fix.
+      console.error('[Contact] FAILED to store lead:', storageError);
+    }
+
+    // 2. Forward to Zapier (kept for the existing GHL/notification flow).
     const zapierWebhookUrl = process.env.ZAPIER_CONTACT_WEBHOOK_URL || process.env.ZAPIER_WEBHOOK_URL;
 
     if (zapierWebhookUrl) {
@@ -28,9 +105,9 @@ export async function POST(request: NextRequest) {
             phone: body.phone || '',
             eventType: body.eventType || '',
             eventDate: body.eventDate || '',
-            guestCount: body.guestCount || '',
+            guestCount: String(body.guestCount ?? ''),
             message: body.message || '',
-            submittedAt: new Date().toISOString(),
+            submittedAt,
             formType: 'contact'
           }),
         });
@@ -46,6 +123,22 @@ export async function POST(request: NextRequest) {
       }
     } else {
       console.warn('ZAPIER_CONTACT_WEBHOOK_URL not configured');
+    }
+
+    // 3. Queue the follow-up journey (flag-gated; deduped on the lead id so
+    // repeat submissions never double-ack).
+    if (leadId) {
+      try {
+        await enqueueJourney('contact-form', {
+          email: body.email,
+          entityId: leadId,
+          leadId,
+          phone: body.phone || null,
+          payload: { firstName: firstName || null },
+        });
+      } catch (err) {
+        console.warn('[Contact] follow-up enqueue failed:', err);
+      }
     }
 
     return NextResponse.json({

--- a/src/app/api/newsletter/confirm/route.ts
+++ b/src/app/api/newsletter/confirm/route.ts
@@ -13,6 +13,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { recordEvent } from '@/lib/leads/leadCapture';
 import { notifyNewsletterSignup } from '@/lib/webhooks/ghl';
 import { prisma } from '@/lib/database/client';
+import { enqueueJourney } from '@/lib/followups/enqueue';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -70,6 +71,22 @@ export async function GET(request: NextRequest) {
       source: typeof nl.source === 'string' ? nl.source : 'newsletter',
       confirmedAt,
     });
+
+    // Queue the single welcome email (~1h after confirm; flag-gated,
+    // deduped on the lead id so a re-used link never double-welcomes).
+    if (lead.email) {
+      try {
+        await enqueueJourney('newsletter-welcome', {
+          email: lead.email,
+          entityId: lead.id,
+          leadId: lead.id,
+          phone: lead.phone ?? null,
+          payload: { firstName: lead.firstName ?? null },
+        });
+      } catch (err) {
+        console.warn('[newsletter] welcome enqueue failed', err);
+      }
+    }
 
     return done('ok');
   } catch (err) {

--- a/src/app/api/partners/inquiry/route.ts
+++ b/src/app/api/partners/inquiry/route.ts
@@ -5,6 +5,7 @@ import type { PartnerInquiryData } from '@/lib/email/email-service'
 import { addContactToAudience } from '@/lib/email/resend-audiences'
 import { kv, isKVConfigured, prisma } from '@/lib/database/client'
 import { isHoneypotTripped } from '@/lib/forms/honeypot'
+import { enqueueJourney } from '@/lib/followups/enqueue'
 
 // Sources that trigger an automated outbound email with the partner one-pager
 // PDF + Calendly CTA (in addition to the existing ops notification).
@@ -330,6 +331,29 @@ export async function POST(request: NextRequest) {
       } catch (oneErr) {
         console.error('[Partner One-Pager] Outbound send pipeline error:', oneErr);
         // Don't fail the request — the row is in the DB and can be re-fired manually.
+      }
+    }
+
+    // Queue the partner-inquiry follow-up journey (flag-gated, deduped on
+    // the inquiry id). One-pager placements already send a first touch, so
+    // they start at step 2 (the +96h calendar nudge); everything else gets
+    // the personal ack on the next engine tick.
+    if (dbResult?.id) {
+      try {
+        const isOnePagerPlacement = Boolean(inquiry.source && ONEPAGER_SOURCES.has(inquiry.source));
+        await enqueueJourney('partner-inquiry', {
+          email: inquiry.email,
+          entityId: dbResult.id,
+          partnerInquiryId: dbResult.id,
+          phone: inquiry.phone || null,
+          startAtStep: isOnePagerPlacement ? 2 : 1,
+          payload: {
+            firstName: inquiry.contactName.split(/\s+/)[0] || null,
+            businessName: inquiry.businessName || null,
+          },
+        });
+      } catch (err) {
+        console.warn('[Partner Inquiry] follow-up enqueue failed:', err);
       }
     }
 

--- a/src/app/api/v1/affiliate/apply/route.ts
+++ b/src/app/api/v1/affiliate/apply/route.ts
@@ -5,6 +5,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createPartnerApplication } from '@/lib/affiliates/affiliate-service';
+import { enqueueJourney } from '@/lib/followups/enqueue';
 import { AffiliateCategory } from '@prisma/client';
 
 const VALID_CATEGORIES: AffiliateCategory[] = ['BARTENDER', 'BOAT', 'VENUE', 'PLANNER', 'OTHER'];
@@ -48,6 +49,23 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       notes,
       consent,
     });
+
+    // Queue the affiliate-apply follow-up (ack next tick, +120h check-in
+    // while still PENDING). Flag-gated; deduped on the application id, which
+    // the journey's shouldCancel reads back from the dedupe key.
+    try {
+      await enqueueJourney('affiliate-apply', {
+        email,
+        entityId: application.id,
+        phone: phone || null,
+        payload: {
+          firstName: String(contactName).split(/\s+/)[0] || null,
+          businessName: businessName || null,
+        },
+      });
+    } catch (err) {
+      console.warn('[Affiliate Apply API] follow-up enqueue failed:', err);
+    }
 
     return NextResponse.json({
       success: true,


### PR DESCRIPTION
## Phase 2 of 5 — stacked on #184

- **/api/contact**: the form previously forwarded ONLY to Zapier — any Zapier drop lost the message forever. Now: Zod validation + rate limit (5/min/IP, shared checkRateLimit) + Lead storage (source CONTACT_FORM, full message in `metadata.contactForm`) BEFORE the kept Zapier forward. Queues contact-form journey (ack next tick, +72h "did my reply reach you?" — copy tolerates Allan having already replied; admin cancel exists in Phase 4)
- **/api/partners/inquiry**: partner-inquiry journey (+0h personal ack, +96h calendar nudge); vacation-rental one-pager placements start at step 2 (the one-pager email is already touch #1)
- **/api/v1/affiliate/apply**: affiliate-apply journey (+0h ack, +120h check-in while the PartnerApplication is still PENDING)
- **/api/newsletter/confirm**: single newsletter-welcome ~1h after double-opt-in confirm

All flag-gated (off), all enqueues try/caught so they can never break the host flow.

Gates: tsc clean, 416 tests green. Security review: 0 critical/high/medium (the contact rate limit resolves the one LOW it raised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)