### PR TITLE
feat(followups): Phase 3 — event-quiz nudge (+ post-purchase review, flag-off)

### DIFF
--- a/src/app/api/v1/event-quiz/submit/route.ts
+++ b/src/app/api/v1/event-quiz/submit/route.ts
@@ -22,6 +22,7 @@ import { sendEmail } from '@/lib/email/resend-client';
 import { eventQuizWelcomeEmail } from '@/lib/email/templates/event-quiz-welcome';
 import { upsertLead, recordEvent } from '@/lib/leads/leadCapture';
 import { targetUrlFor } from '@/lib/eventQuiz/routing';
+import { enqueueJourney } from '@/lib/followups/enqueue';
 import { EmailType } from '@prisma/client';
 import { prisma } from '@/lib/database/client';
 
@@ -156,6 +157,23 @@ export async function POST(req: NextRequest) {
     });
   } catch (err) {
     console.error('[event-quiz] email send failed', err);
+  }
+
+  // Queue the +96h "did the plan land?" nudge. The instant welcome above is
+  // touch #1, so this journey starts at step 2 (flag-gated, deduped on lead).
+  if (leadId) {
+    try {
+      await enqueueJourney('event-quiz', {
+        email: body.email,
+        entityId: leadId,
+        leadId,
+        phone: body.phone ?? null,
+        startAtStep: 2,
+        payload: { firstName: body.firstName, resumePath },
+      });
+    } catch (err) {
+      console.warn('[event-quiz] follow-up enqueue failed', err);
+    }
   }
 
   return NextResponse.json({


### PR DESCRIPTION
## Phase 3 of 5 — stacked on #185

- **/api/v1/event-quiz/submit**: queues the event-quiz journey at step 2 (+96h "did the plan land?") — the instant welcome email is touch #1. Cancels if the lead converts.
- **post-purchase-review**: the journey + engine sweep (DELIVERED, unstamped, last 14 days, +48h single ask) shipped in Phase 0 and stays **flag-OFF pending Allan's decision**: review asks via this email journey vs the existing manual GHL route (plan open item #3). Both paths mutually dedupe via `Order.reviewRequestSentAt` — whichever sends first stamps it, the other skips. Verify before enabling: exactly ONE review ask across both systems for a delivered test order.
- group-order-host stays deferred (documented in journeys.ts).

Gates: tsc clean, 416 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)