### PR TITLE
feat(followups): Phase 4 — admin dashboard, ops API, conversion attribution

### DIFF
--- a/src/app/admin/emails/followups/page.tsx
+++ b/src/app/admin/emails/followups/page.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+/**
+ * /admin/emails/followups — control panel for the site-wide follow-up email
+ * system: master kill switch + per-journey flags, upcoming queue, sent log,
+ * suppression management, conversion stats, and test sends.
+ *
+ * Auth comes from the shared /admin layout (ops session); every API route
+ * this page calls also gates itself with requireOpsAuth.
+ */
+
+import Link from 'next/link';
+import type { ReactElement } from 'react';
+import FlagsPanel from '@/components/admin/followups/FlagsPanel';
+import QueuePanel from '@/components/admin/followups/QueuePanel';
+import SentLogPanel from '@/components/admin/followups/SentLogPanel';
+import SuppressionsPanel from '@/components/admin/followups/SuppressionsPanel';
+import StatsPanel from '@/components/admin/followups/StatsPanel';
+import TestSendPanel from '@/components/admin/followups/TestSendPanel';
+
+export default function FollowupsAdminPage(): ReactElement {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <div>
+          <h1 className="font-heading text-3xl tracking-[0.1em] text-gray-900">Follow-Ups</h1>
+          <p className="text-sm text-gray-500">
+            Automated follow-up emails (2-touch max, 9am–7pm CT, personal voice from info@).
+            Engine runs every 15 minutes.
+          </p>
+        </div>
+        <Link href="/admin/emails" className="btn-ghost">
+          ← Email Templates
+        </Link>
+      </div>
+
+      <FlagsPanel />
+      <TestSendPanel />
+      <StatsPanel />
+      <QueuePanel />
+      <SentLogPanel />
+      <SuppressionsPanel />
+    </div>
+  );
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -171,6 +171,7 @@ export default function AdminLayout({ children }: AdminLayoutProps): ReactElemen
     { href: '/admin/analytics', label: 'Analytics' },
     { href: '/admin/customers', label: 'Customers' },
     { href: '/admin/emails', label: 'Emails' },
+    { href: '/admin/emails/followups', label: 'Follow-Ups' },
     { href: '/admin/email-signups', label: 'Email Signups' },
     { href: '/admin/sync', label: 'Sync' },
     { href: '/admin/reports', label: 'Reports' },

--- a/src/app/api/ops/followups/flags/route.ts
+++ b/src/app/api/ops/followups/flags/route.ts
@@ -1,0 +1,98 @@
+/**
+ * GET  /api/ops/followups/flags — master + per-journey flag states with
+ *                                 queue counts for the admin dashboard.
+ * POST /api/ops/followups/flags — toggle one flag { key, enabled }.
+ *
+ * Ops-auth only (/api/ops is NOT middleware-guarded — every route here must
+ * gate itself).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
+import { prisma } from '@/lib/database/client';
+import {
+  FEATURE_FLAGS,
+  enableFeature,
+  disableFeature,
+  type FeatureFlagKey,
+} from '@/lib/features/feature-flags';
+import { JOURNEYS } from '@/lib/followups/journeys';
+import { getJourneyQueueCounts } from '@/lib/followups/attribution';
+
+const TOGGLEABLE_KEYS = [
+  FEATURE_FLAGS.FOLLOWUPS_MASTER,
+  ...JOURNEYS.map((j) => j.featureFlag),
+] as const;
+
+const toggleSchema = z.object({
+  key: z.enum(TOGGLEABLE_KEYS as unknown as [string, ...string[]]),
+  enabled: z.boolean(),
+});
+
+export async function GET() {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  try {
+    const [flags, counts] = await Promise.all([
+      prisma.featureFlag.findMany({
+        where: { key: { in: [...TOGGLEABLE_KEYS] } },
+      }),
+      getJourneyQueueCounts(),
+    ]);
+    const enabledByKey = new Map(flags.map((f) => [f.key, f.enabled]));
+    const countsByJourney = new Map(counts.map((c) => [c.journeyKey, c]));
+
+    return NextResponse.json({
+      success: true,
+      master: {
+        key: FEATURE_FLAGS.FOLLOWUPS_MASTER,
+        enabled: enabledByKey.get(FEATURE_FLAGS.FOLLOWUPS_MASTER) ?? false,
+      },
+      journeys: JOURNEYS.map((j) => ({
+        key: j.key,
+        label: j.label,
+        description: j.description,
+        phase: j.phase,
+        steps: j.steps.length,
+        featureFlag: j.featureFlag,
+        enabled: enabledByKey.get(j.featureFlag) ?? false,
+        counts: countsByJourney.get(j.key) ?? {
+          journeyKey: j.key,
+          scheduled: 0,
+          sent: 0,
+          canceled: 0,
+          suppressed: 0,
+          failed: 0,
+        },
+      })),
+    });
+  } catch (error) {
+    console.error('[ops/followups/flags GET] Error:', error);
+    return NextResponse.json({ success: false, error: 'Failed to load flags' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  try {
+    const parsed = toggleSchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return NextResponse.json({ success: false, error: 'Invalid body' }, { status: 400 });
+    }
+    const { key, enabled } = parsed.data;
+    if (enabled) {
+      await enableFeature(key as FeatureFlagKey);
+    } else {
+      await disableFeature(key as FeatureFlagKey);
+    }
+    console.log(`[ops/followups] flag ${key} -> ${enabled ? 'ON' : 'OFF'}`);
+    return NextResponse.json({ success: true, key, enabled });
+  } catch (error) {
+    console.error('[ops/followups/flags POST] Error:', error);
+    return NextResponse.json({ success: false, error: 'Failed to toggle flag' }, { status: 500 });
+  }
+}

--- a/src/app/api/ops/followups/log/route.ts
+++ b/src/app/api/ops/followups/log/route.ts
@@ -1,0 +1,56 @@
+/**
+ * GET /api/ops/followups/log — recent FOLLOW_UP sends with delivery status
+ * (from EmailLog, which the Resend webhook keeps current).
+ *
+ * Ops-auth only.
+ */
+
+import { NextResponse } from 'next/server';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
+import { prisma } from '@/lib/database/client';
+import { maskEmail } from '@/lib/followups/attribution';
+
+export async function GET() {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  try {
+    const logs = await prisma.emailLog.findMany({
+      where: { type: 'FOLLOW_UP' },
+      orderBy: { createdAt: 'desc' },
+      take: 100,
+      select: {
+        id: true,
+        to: true,
+        subject: true,
+        status: true,
+        sentAt: true,
+        openedAt: true,
+        bouncedAt: true,
+        metadata: true,
+        createdAt: true,
+      },
+    });
+    return NextResponse.json({
+      success: true,
+      logs: logs.map((log) => {
+        const meta = (log.metadata as Record<string, unknown> | null) ?? {};
+        return {
+          id: log.id,
+          to: maskEmail(log.to),
+          subject: log.subject,
+          status: log.status,
+          sentAt: log.sentAt,
+          openedAt: log.openedAt,
+          bouncedAt: log.bouncedAt,
+          createdAt: log.createdAt,
+          journeyKey: typeof meta.journeyKey === 'string' ? meta.journeyKey : null,
+          step: typeof meta.step === 'number' ? meta.step : null,
+        };
+      }),
+    });
+  } catch (error) {
+    console.error('[ops/followups/log GET] Error:', error);
+    return NextResponse.json({ success: false, error: 'Failed to load log' }, { status: 500 });
+  }
+}

--- a/src/app/api/ops/followups/queue/route.ts
+++ b/src/app/api/ops/followups/queue/route.ts
@@ -1,0 +1,77 @@
+/**
+ * GET  /api/ops/followups/queue — next 50 scheduled jobs (masked emails).
+ * POST /api/ops/followups/queue — cancel one scheduled job { jobId }.
+ *
+ * Ops-auth only.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
+import { prisma } from '@/lib/database/client';
+import { maskEmail } from '@/lib/followups/attribution';
+
+const cancelSchema = z.object({
+  jobId: z.string().min(1).max(64),
+});
+
+export async function GET() {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  try {
+    const jobs = await prisma.followUpJob.findMany({
+      where: { status: { in: ['scheduled', 'processing'] } },
+      orderBy: { scheduledFor: 'asc' },
+      take: 50,
+      select: {
+        id: true,
+        journeyKey: true,
+        step: true,
+        email: true,
+        status: true,
+        scheduledFor: true,
+        attempts: true,
+        createdAt: true,
+      },
+    });
+    return NextResponse.json({
+      success: true,
+      jobs: jobs.map((job) => ({ ...job, email: maskEmail(job.email) })),
+    });
+  } catch (error) {
+    console.error('[ops/followups/queue GET] Error:', error);
+    return NextResponse.json({ success: false, error: 'Failed to load queue' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  try {
+    const parsed = cancelSchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return NextResponse.json({ success: false, error: 'Invalid body' }, { status: 400 });
+    }
+    // Only scheduled jobs are cancelable — a processing job is mid-send.
+    const result = await prisma.followUpJob.updateMany({
+      where: { id: parsed.data.jobId, status: 'scheduled' },
+      data: {
+        status: 'canceled',
+        canceledAt: new Date(),
+        cancelReason: 'admin-cancel',
+      },
+    });
+    if (result.count === 0) {
+      return NextResponse.json(
+        { success: false, error: 'Job not found or not cancelable' },
+        { status: 404 }
+      );
+    }
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('[ops/followups/queue POST] Error:', error);
+    return NextResponse.json({ success: false, error: 'Failed to cancel job' }, { status: 500 });
+  }
+}

--- a/src/app/api/ops/followups/stats/route.ts
+++ b/src/app/api/ops/followups/stats/route.ts
@@ -1,0 +1,26 @@
+/**
+ * GET /api/ops/followups/stats — per-journey sends/opens/conversions/revenue
+ * (30-day post-send attribution window; each order counts once, against the
+ * most recent send before it).
+ *
+ * Ops-auth only.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
+import { getFollowUpStats } from '@/lib/followups/attribution';
+
+export async function GET(request: NextRequest) {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  try {
+    const raw = Number(request.nextUrl.searchParams.get('windowDays') ?? 30);
+    const windowDays = Number.isFinite(raw) ? Math.min(Math.max(Math.trunc(raw), 1), 365) : 30;
+    const stats = await getFollowUpStats(windowDays);
+    return NextResponse.json({ success: true, windowDays, stats });
+  } catch (error) {
+    console.error('[ops/followups/stats GET] Error:', error);
+    return NextResponse.json({ success: false, error: 'Failed to load stats' }, { status: 500 });
+  }
+}

--- a/src/app/api/ops/followups/suppressions/route.ts
+++ b/src/app/api/ops/followups/suppressions/route.ts
@@ -1,0 +1,77 @@
+/**
+ * GET    /api/ops/followups/suppressions — list the do-not-email rows.
+ * POST   /api/ops/followups/suppressions — add one manually { email, note? }.
+ * DELETE /api/ops/followups/suppressions — remove one { email } (admin may
+ *        clear bounce/complaint rows — the public preferences page cannot).
+ *
+ * Ops-auth only. Full emails shown here (ops needs them to act on customer
+ * requests); everywhere else in the dashboard they're masked.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
+import { prisma } from '@/lib/database/client';
+import { suppress, unsuppress } from '@/lib/followups/suppression';
+
+const addSchema = z.object({
+  email: z.string().email().max(320),
+  note: z.string().max(500).optional(),
+});
+
+const removeSchema = z.object({
+  email: z.string().email().max(320),
+});
+
+export async function GET() {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  try {
+    const suppressions = await prisma.emailSuppression.findMany({
+      orderBy: { createdAt: 'desc' },
+      take: 200,
+    });
+    return NextResponse.json({ success: true, suppressions });
+  } catch (error) {
+    console.error('[ops/followups/suppressions GET] Error:', error);
+    return NextResponse.json({ success: false, error: 'Failed to load suppressions' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  try {
+    const parsed = addSchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return NextResponse.json({ success: false, error: 'Invalid body' }, { status: 400 });
+    }
+    const result = await suppress(parsed.data.email, 'manual', 'admin', parsed.data.note);
+    return NextResponse.json({ success: true, canceledJobs: result.canceledJobs });
+  } catch (error) {
+    console.error('[ops/followups/suppressions POST] Error:', error);
+    return NextResponse.json({ success: false, error: 'Failed to add suppression' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  try {
+    const parsed = removeSchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return NextResponse.json({ success: false, error: 'Invalid body' }, { status: 400 });
+    }
+    const removed = await unsuppress(parsed.data.email, { allowHardReasons: true });
+    if (!removed) {
+      return NextResponse.json({ success: false, error: 'Not on the list' }, { status: 404 });
+    }
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('[ops/followups/suppressions DELETE] Error:', error);
+    return NextResponse.json({ success: false, error: 'Failed to remove suppression' }, { status: 500 });
+  }
+}

--- a/src/app/api/ops/followups/test-send/route.ts
+++ b/src/app/api/ops/followups/test-send/route.ts
@@ -1,0 +1,120 @@
+/**
+ * POST /api/ops/followups/test-send — render a journey step with sample
+ * payload and send it immediately to the given address, [TEST]-prefixed.
+ * Bypasses feature flags and the send window (explicit ops action) but NOT
+ * the suppression list.
+ *
+ * Ops-auth only.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { EmailType, type FollowUpJob } from '@prisma/client';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
+import { sendEmailDetailed } from '@/lib/email/resend-client';
+import { getJourney, JOURNEY_KEYS } from '@/lib/followups/journeys';
+import { buildPreferencesUrl, normalizeEmail } from '@/lib/followups/suppression';
+import { SITE_BASE_URL } from '@/lib/followups/types';
+
+const bodySchema = z.object({
+  journeyKey: z.enum(JOURNEY_KEYS as [string, ...string[]]),
+  step: z.number().int().min(1).max(2).default(1),
+  email: z.string().email().max(320),
+});
+
+const SAMPLE_PAYLOAD: Record<string, unknown> = {
+  firstName: 'Allan',
+  guestCount: '25',
+  resumePath: '/order',
+  deliveryDate: 'Saturday, July 18',
+  invoicePath: '/invoice/sample-token',
+  businessName: 'Sample Rentals LLC',
+};
+
+export async function POST(request: NextRequest) {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  if (!process.env.UNSUBSCRIBE_SECRET || !process.env.FOLLOWUP_FROM_EMAIL) {
+    return NextResponse.json(
+      { success: false, error: 'UNSUBSCRIBE_SECRET / FOLLOWUP_FROM_EMAIL not configured' },
+      { status: 500 }
+    );
+  }
+
+  try {
+    const parsed = bodySchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return NextResponse.json({ success: false, error: 'Invalid body' }, { status: 400 });
+    }
+    const { journeyKey, step, email } = parsed.data;
+    const journey = getJourney(journeyKey);
+    const stepDef = journey?.steps[step - 1];
+    if (!journey || !stepDef) {
+      return NextResponse.json({ success: false, error: 'No such journey step' }, { status: 400 });
+    }
+
+    const to = normalizeEmail(email);
+    const fakeJob = {
+      id: 'test-send',
+      journeyKey,
+      step,
+      email: to,
+      dedupeKey: `${journeyKey}:${step}:test-send`,
+      payload: SAMPLE_PAYLOAD,
+    } as unknown as FollowUpJob;
+
+    const rendered = stepDef.buildEmail({
+      job: fakeJob,
+      payload: SAMPLE_PAYLOAD,
+      link: (path: string) => {
+        const safePath = path.startsWith('/') && !path.startsWith('//') ? path : '/';
+        const url = new URL(safePath, SITE_BASE_URL);
+        url.searchParams.set('utm_source', 'email');
+        url.searchParams.set('utm_medium', 'followup');
+        url.searchParams.set('utm_campaign', journeyKey);
+        url.searchParams.set('utm_content', `step-${step}-test`);
+        return url.toString();
+      },
+      unsubscribeUrl: buildPreferencesUrl(to),
+    });
+    if (!rendered) {
+      return NextResponse.json(
+        { success: false, error: 'This step renders no email (by design)' },
+        { status: 400 }
+      );
+    }
+
+    const result = await sendEmailDetailed({
+      to,
+      subject: `[TEST] ${rendered.subject}`,
+      html: rendered.html,
+      text: rendered.text,
+      type: EmailType.FOLLOW_UP,
+      metadata: { testSend: true, journeyKey, step },
+      tags: [{ name: 'journey', value: 'test_send' }],
+      from: {
+        email: process.env.FOLLOWUP_FROM_EMAIL,
+        name: process.env.FOLLOWUP_FROM_NAME || 'Allan at Party On Delivery',
+      },
+      respectSuppression: true,
+    });
+
+    if (result.suppressed) {
+      return NextResponse.json(
+        { success: false, error: 'That address is on the suppression list' },
+        { status: 409 }
+      );
+    }
+    if (!result.sent) {
+      return NextResponse.json(
+        { success: false, error: result.error ?? 'Send failed' },
+        { status: 500 }
+      );
+    }
+    return NextResponse.json({ success: true, emailLogId: result.emailLogId });
+  } catch (error) {
+    console.error('[ops/followups/test-send POST] Error:', error);
+    return NextResponse.json({ success: false, error: 'Test send failed' }, { status: 500 });
+  }
+}

--- a/src/components/admin/followups/FlagsPanel.tsx
+++ b/src/components/admin/followups/FlagsPanel.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+/**
+ * Master kill switch + per-journey flag toggles with queue counts.
+ * Data: GET/POST /api/ops/followups/flags.
+ */
+
+import { useCallback, useEffect, useState, type ReactElement } from 'react';
+
+interface JourneyCounts {
+  scheduled: number;
+  sent: number;
+  canceled: number;
+  suppressed: number;
+  failed: number;
+}
+
+interface JourneyFlag {
+  key: string;
+  label: string;
+  description: string;
+  phase: number;
+  steps: number;
+  featureFlag: string;
+  enabled: boolean;
+  counts: JourneyCounts;
+}
+
+interface FlagsResponse {
+  success: boolean;
+  master: { key: string; enabled: boolean };
+  journeys: JourneyFlag[];
+}
+
+function Toggle({
+  enabled,
+  busy,
+  onChange,
+}: {
+  enabled: boolean;
+  busy: boolean;
+  onChange: (next: boolean) => void;
+}): ReactElement {
+  return (
+    <button
+      type="button"
+      disabled={busy}
+      onClick={() => onChange(!enabled)}
+      className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors disabled:opacity-50 ${
+        enabled ? 'bg-brand-blue' : 'bg-gray-300'
+      }`}
+      aria-pressed={enabled}
+    >
+      <span
+        className={`inline-block h-4 w-4 rounded-full bg-white shadow transform transition-transform ${
+          enabled ? 'translate-x-6' : 'translate-x-1'
+        }`}
+      />
+    </button>
+  );
+}
+
+export default function FlagsPanel(): ReactElement {
+  const [data, setData] = useState<FlagsResponse | null>(null);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [error, setError] = useState('');
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch('/api/ops/followups/flags');
+      const json = (await res.json()) as FlagsResponse;
+      if (json.success) setData(json);
+      else setError('Failed to load flags');
+    } catch {
+      setError('Failed to load flags');
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const toggle = async (key: string, enabled: boolean): Promise<void> => {
+    setBusyKey(key);
+    setError('');
+    try {
+      const res = await fetch('/api/ops/followups/flags', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key, enabled }),
+      });
+      if (!res.ok) setError('Toggle failed');
+      await load();
+    } catch {
+      setError('Toggle failed');
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  if (!data) {
+    return <div className="card text-sm text-gray-500">Loading flags…</div>;
+  }
+
+  return (
+    <div className="card">
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          <h2 className="text-lg font-bold tracking-[0.08em] text-gray-900">Master Switch</h2>
+          <p className="text-sm text-gray-500">
+            Nothing sends while this is off, regardless of journey flags.
+          </p>
+        </div>
+        <Toggle
+          enabled={data.master.enabled}
+          busy={busyKey === data.master.key}
+          onChange={(next) => void toggle(data.master.key, next)}
+        />
+      </div>
+      {error && <p className="text-sm text-red-600 mb-3">{error}</p>}
+
+      <div className="divide-y divide-gray-100">
+        {data.journeys.map((j) => (
+          <div key={j.key} className="py-3 flex items-start justify-between gap-4">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="font-semibold text-gray-900 text-sm">{j.label}</span>
+                <span className="text-xs bg-gray-100 text-gray-600 rounded px-1.5 py-0.5">
+                  phase {j.phase} · {j.steps} touch{j.steps > 1 ? 'es' : ''}
+                </span>
+              </div>
+              <p className="text-sm text-gray-500 mt-0.5">{j.description}</p>
+              <p className="text-xs text-gray-400 mt-1">
+                queued {j.counts.scheduled} · sent {j.counts.sent} · canceled {j.counts.canceled} ·
+                suppressed {j.counts.suppressed} · failed {j.counts.failed}
+              </p>
+            </div>
+            <Toggle
+              enabled={j.enabled}
+              busy={busyKey === j.featureFlag}
+              onChange={(next) => void toggle(j.featureFlag, next)}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/followups/QueuePanel.tsx
+++ b/src/components/admin/followups/QueuePanel.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+/**
+ * Next 50 scheduled follow-up jobs (masked emails) with per-job cancel.
+ * Data: GET/POST /api/ops/followups/queue.
+ */
+
+import { useCallback, useEffect, useState, type ReactElement } from 'react';
+
+interface QueueJob {
+  id: string;
+  journeyKey: string;
+  step: number;
+  email: string;
+  status: string;
+  scheduledFor: string;
+  attempts: number;
+  createdAt: string;
+}
+
+export default function QueuePanel(): ReactElement {
+  const [jobs, setJobs] = useState<QueueJob[] | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState('');
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch('/api/ops/followups/queue');
+      const json = await res.json();
+      if (json.success) setJobs(json.jobs as QueueJob[]);
+      else setError('Failed to load queue');
+    } catch {
+      setError('Failed to load queue');
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const cancel = async (jobId: string): Promise<void> => {
+    setBusyId(jobId);
+    setError('');
+    try {
+      const res = await fetch('/api/ops/followups/queue', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ jobId }),
+      });
+      if (!res.ok) setError('Cancel failed');
+      await load();
+    } catch {
+      setError('Cancel failed');
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <div className="card">
+      <h2 className="text-lg font-bold tracking-[0.08em] text-gray-900 mb-1">Upcoming Queue</h2>
+      <p className="text-sm text-gray-500 mb-4">
+        Next 50 scheduled sends. The engine re-checks every cancel condition before sending.
+      </p>
+      {error && <p className="text-sm text-red-600 mb-3">{error}</p>}
+      {!jobs ? (
+        <p className="text-sm text-gray-500">Loading queue…</p>
+      ) : jobs.length === 0 ? (
+        <p className="text-sm text-gray-500">Nothing queued.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-gray-500 border-b border-gray-200">
+                <th className="py-2 pr-4 font-semibold">Journey</th>
+                <th className="py-2 pr-4 font-semibold">Step</th>
+                <th className="py-2 pr-4 font-semibold">To</th>
+                <th className="py-2 pr-4 font-semibold">Sends at</th>
+                <th className="py-2 pr-4 font-semibold">Status</th>
+                <th className="py-2" />
+              </tr>
+            </thead>
+            <tbody>
+              {jobs.map((job) => (
+                <tr key={job.id} className="border-b border-gray-100">
+                  <td className="py-2 pr-4 text-gray-900">{job.journeyKey}</td>
+                  <td className="py-2 pr-4 text-gray-700">{job.step}</td>
+                  <td className="py-2 pr-4 text-gray-700">{job.email}</td>
+                  <td className="py-2 pr-4 text-gray-700">
+                    {new Date(job.scheduledFor).toLocaleString('en-US', {
+                      timeZone: 'America/Chicago',
+                      month: 'short',
+                      day: 'numeric',
+                      hour: 'numeric',
+                      minute: '2-digit',
+                    })}
+                  </td>
+                  <td className="py-2 pr-4 text-gray-700">{job.status}</td>
+                  <td className="py-2 text-right">
+                    {job.status === 'scheduled' && (
+                      <button
+                        type="button"
+                        onClick={() => void cancel(job.id)}
+                        disabled={busyId === job.id}
+                        className="btn-ghost text-red-600 disabled:opacity-50"
+                      >
+                        Cancel
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/followups/SentLogPanel.tsx
+++ b/src/components/admin/followups/SentLogPanel.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+/**
+ * Recent FOLLOW_UP sends with delivery-status chips (EmailLog, kept current
+ * by the Resend webhook). Data: GET /api/ops/followups/log.
+ */
+
+import { useEffect, useState, type ReactElement } from 'react';
+
+interface LogRow {
+  id: string;
+  to: string;
+  subject: string;
+  status: string;
+  sentAt: string | null;
+  journeyKey: string | null;
+  step: number | null;
+  createdAt: string;
+}
+
+const STATUS_CHIP: Record<string, string> = {
+  SENT: 'bg-blue-50 text-blue-700 border-blue-200',
+  DELIVERED: 'bg-green-50 text-green-700 border-green-200',
+  OPENED: 'bg-emerald-50 text-emerald-800 border-emerald-200',
+  BOUNCED: 'bg-red-50 text-red-700 border-red-200',
+  COMPLAINED: 'bg-red-50 text-red-700 border-red-200',
+  FAILED: 'bg-amber-50 text-amber-800 border-amber-200',
+  PENDING: 'bg-gray-50 text-gray-600 border-gray-200',
+};
+
+export default function SentLogPanel(): ReactElement {
+  const [logs, setLogs] = useState<LogRow[] | null>(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    fetch('/api/ops/followups/log')
+      .then((res) => res.json())
+      .then((json) => {
+        if (json.success) setLogs(json.logs as LogRow[]);
+        else setError('Failed to load log');
+      })
+      .catch(() => setError('Failed to load log'));
+  }, []);
+
+  return (
+    <div className="card">
+      <h2 className="text-lg font-bold tracking-[0.08em] text-gray-900 mb-1">Sent Log</h2>
+      <p className="text-sm text-gray-500 mb-4">Last 100 follow-up emails.</p>
+      {error && <p className="text-sm text-red-600 mb-3">{error}</p>}
+      {!logs ? (
+        <p className="text-sm text-gray-500">Loading log…</p>
+      ) : logs.length === 0 ? (
+        <p className="text-sm text-gray-500">No follow-ups sent yet.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-gray-500 border-b border-gray-200">
+                <th className="py-2 pr-4 font-semibold">When</th>
+                <th className="py-2 pr-4 font-semibold">Journey</th>
+                <th className="py-2 pr-4 font-semibold">To</th>
+                <th className="py-2 pr-4 font-semibold">Subject</th>
+                <th className="py-2 font-semibold">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {logs.map((log) => (
+                <tr key={log.id} className="border-b border-gray-100">
+                  <td className="py-2 pr-4 text-gray-700 whitespace-nowrap">
+                    {new Date(log.sentAt ?? log.createdAt).toLocaleString('en-US', {
+                      timeZone: 'America/Chicago',
+                      month: 'short',
+                      day: 'numeric',
+                      hour: 'numeric',
+                      minute: '2-digit',
+                    })}
+                  </td>
+                  <td className="py-2 pr-4 text-gray-900">
+                    {log.journeyKey ?? '—'}
+                    {log.step ? ` · ${log.step}` : ''}
+                  </td>
+                  <td className="py-2 pr-4 text-gray-700">{log.to}</td>
+                  <td className="py-2 pr-4 text-gray-700 max-w-[280px] truncate">{log.subject}</td>
+                  <td className="py-2">
+                    <span
+                      className={`inline-block text-xs border rounded px-1.5 py-0.5 ${
+                        STATUS_CHIP[log.status] ?? STATUS_CHIP.PENDING
+                      }`}
+                    >
+                      {log.status}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/followups/StatsPanel.tsx
+++ b/src/components/admin/followups/StatsPanel.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+/**
+ * Per-journey attribution: sends, opens, conversions, revenue (30-day
+ * post-send window, one order per send max). Data: /api/ops/followups/stats.
+ */
+
+import { useEffect, useState, type ReactElement } from 'react';
+
+interface StatRow {
+  journeyKey: string;
+  sends: number;
+  opens: number;
+  conversions: number;
+  revenue: number;
+}
+
+export default function StatsPanel(): ReactElement {
+  const [stats, setStats] = useState<StatRow[] | null>(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    fetch('/api/ops/followups/stats')
+      .then((res) => res.json())
+      .then((json) => {
+        if (json.success) setStats(json.stats as StatRow[]);
+        else setError('Failed to load stats');
+      })
+      .catch(() => setError('Failed to load stats'));
+  }, []);
+
+  return (
+    <div className="card">
+      <h2 className="text-lg font-bold tracking-[0.08em] text-gray-900 mb-1">Conversion Stats</h2>
+      <p className="text-sm text-gray-500 mb-4">
+        Orders within 30 days of a send, matched by email; each order counts once.
+      </p>
+      {error && <p className="text-sm text-red-600 mb-3">{error}</p>}
+      {!stats ? (
+        <p className="text-sm text-gray-500">Loading stats…</p>
+      ) : stats.length === 0 ? (
+        <p className="text-sm text-gray-500">No sends yet — stats appear once journeys go live.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-gray-500 border-b border-gray-200">
+                <th className="py-2 pr-4 font-semibold">Journey</th>
+                <th className="py-2 pr-4 font-semibold text-right">Sends</th>
+                <th className="py-2 pr-4 font-semibold text-right">Opens</th>
+                <th className="py-2 pr-4 font-semibold text-right">Conversions</th>
+                <th className="py-2 font-semibold text-right">Revenue</th>
+              </tr>
+            </thead>
+            <tbody>
+              {stats.map((row) => (
+                <tr key={row.journeyKey} className="border-b border-gray-100">
+                  <td className="py-2 pr-4 text-gray-900">{row.journeyKey}</td>
+                  <td className="py-2 pr-4 text-gray-700 text-right">{row.sends}</td>
+                  <td className="py-2 pr-4 text-gray-700 text-right">{row.opens}</td>
+                  <td className="py-2 pr-4 text-gray-700 text-right">{row.conversions}</td>
+                  <td className="py-2 text-gray-900 text-right font-semibold">
+                    ${row.revenue.toLocaleString('en-US', { minimumFractionDigits: 2 })}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/followups/SuppressionsPanel.tsx
+++ b/src/components/admin/followups/SuppressionsPanel.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+/**
+ * Suppression-list management: view, add manually, remove (admin may clear
+ * bounce/complaint rows). Data: /api/ops/followups/suppressions.
+ */
+
+import { useCallback, useEffect, useState, type ReactElement } from 'react';
+
+interface SuppressionRow {
+  id: string;
+  email: string;
+  reason: string;
+  source: string | null;
+  note: string | null;
+  createdAt: string;
+}
+
+export default function SuppressionsPanel(): ReactElement {
+  const [rows, setRows] = useState<SuppressionRow[] | null>(null);
+  const [newEmail, setNewEmail] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch('/api/ops/followups/suppressions');
+      const json = await res.json();
+      if (json.success) setRows(json.suppressions as SuppressionRow[]);
+      else setError('Failed to load suppressions');
+    } catch {
+      setError('Failed to load suppressions');
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const add = async (): Promise<void> => {
+    if (!newEmail.includes('@')) return;
+    setBusy(true);
+    setError('');
+    try {
+      const res = await fetch('/api/ops/followups/suppressions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: newEmail, note: 'added from admin' }),
+      });
+      if (!res.ok) setError('Add failed');
+      setNewEmail('');
+      await load();
+    } catch {
+      setError('Add failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const remove = async (email: string): Promise<void> => {
+    setBusy(true);
+    setError('');
+    try {
+      const res = await fetch('/api/ops/followups/suppressions', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+      if (!res.ok) setError('Remove failed');
+      await load();
+    } catch {
+      setError('Remove failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="card">
+      <h2 className="text-lg font-bold tracking-[0.08em] text-gray-900 mb-1">Suppressions</h2>
+      <p className="text-sm text-gray-500 mb-4">
+        Do-not-email list for follow-ups. Transactional email (invoices, receipts) ignores this.
+      </p>
+      {error && <p className="text-sm text-red-600 mb-3">{error}</p>}
+
+      <div className="flex gap-2 mb-4">
+        <input
+          type="email"
+          value={newEmail}
+          onChange={(e) => setNewEmail(e.target.value)}
+          placeholder="email@example.com"
+          className="input-premium flex-1"
+        />
+        <button
+          type="button"
+          onClick={() => void add()}
+          disabled={busy || !newEmail.includes('@')}
+          className="btn-secondary disabled:opacity-50"
+        >
+          Suppress
+        </button>
+      </div>
+
+      {!rows ? (
+        <p className="text-sm text-gray-500">Loading…</p>
+      ) : rows.length === 0 ? (
+        <p className="text-sm text-gray-500">Nobody is suppressed.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-gray-500 border-b border-gray-200">
+                <th className="py-2 pr-4 font-semibold">Email</th>
+                <th className="py-2 pr-4 font-semibold">Reason</th>
+                <th className="py-2 pr-4 font-semibold">Source</th>
+                <th className="py-2 pr-4 font-semibold">Added</th>
+                <th className="py-2" />
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.id} className="border-b border-gray-100">
+                  <td className="py-2 pr-4 text-gray-900">{row.email}</td>
+                  <td className="py-2 pr-4 text-gray-700">{row.reason}</td>
+                  <td className="py-2 pr-4 text-gray-500">{row.source ?? '—'}</td>
+                  <td className="py-2 pr-4 text-gray-500 whitespace-nowrap">
+                    {new Date(row.createdAt).toLocaleDateString('en-US')}
+                  </td>
+                  <td className="py-2 text-right">
+                    <button
+                      type="button"
+                      onClick={() => void remove(row.email)}
+                      disabled={busy}
+                      className="btn-ghost text-red-600 disabled:opacity-50"
+                    >
+                      Remove
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/followups/TestSendPanel.tsx
+++ b/src/components/admin/followups/TestSendPanel.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+/**
+ * Send any journey step to an arbitrary address with sample payload,
+ * [TEST]-prefixed. Bypasses flags and the send window, not suppressions.
+ * Data: POST /api/ops/followups/test-send.
+ */
+
+import { useState, type ReactElement } from 'react';
+
+const JOURNEY_OPTIONS: Array<{ key: string; label: string; steps: number }> = [
+  { key: 'abandoned-quote', label: 'Abandoned quote', steps: 2 },
+  { key: 'unpaid-invoice', label: 'Unpaid invoice', steps: 2 },
+  { key: 'partner-inquiry', label: 'Partner inquiry', steps: 2 },
+  { key: 'contact-form', label: 'Contact form', steps: 2 },
+  { key: 'newsletter-welcome', label: 'Newsletter welcome', steps: 1 },
+  { key: 'affiliate-apply', label: 'Affiliate application', steps: 2 },
+  { key: 'event-quiz', label: 'Event quiz (step 2 only)', steps: 2 },
+  { key: 'post-purchase-review', label: 'Post-purchase review', steps: 1 },
+];
+
+export default function TestSendPanel(): ReactElement {
+  const [journeyKey, setJourneyKey] = useState('abandoned-quote');
+  const [step, setStep] = useState(1);
+  const [email, setEmail] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState('');
+
+  const maxSteps = JOURNEY_OPTIONS.find((j) => j.key === journeyKey)?.steps ?? 1;
+
+  const send = async (): Promise<void> => {
+    setBusy(true);
+    setResult('');
+    try {
+      const res = await fetch('/api/ops/followups/test-send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ journeyKey, step, email }),
+      });
+      const json = await res.json();
+      setResult(json.success ? `Sent to ${email}` : `Failed: ${json.error}`);
+    } catch {
+      setResult('Failed: network error');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="card">
+      <h2 className="text-lg font-bold tracking-[0.08em] text-gray-900 mb-1">Test Send</h2>
+      <p className="text-sm text-gray-500 mb-4">
+        Sends the real copy with sample data, subject prefixed [TEST]. Use your own inbox.
+      </p>
+      <div className="grid gap-3 md:grid-cols-4">
+        <select
+          value={journeyKey}
+          onChange={(e) => {
+            setJourneyKey(e.target.value);
+            setStep(1);
+          }}
+          className="input-premium md:col-span-1"
+        >
+          {JOURNEY_OPTIONS.map((j) => (
+            <option key={j.key} value={j.key}>
+              {j.label}
+            </option>
+          ))}
+        </select>
+        <select
+          value={step}
+          onChange={(e) => setStep(Number(e.target.value))}
+          className="input-premium md:col-span-1"
+        >
+          {Array.from({ length: maxSteps }, (_, i) => i + 1).map((n) => (
+            <option key={n} value={n}>
+              Step {n}
+            </option>
+          ))}
+        </select>
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="you@partyondelivery.com"
+          className="input-premium md:col-span-1"
+        />
+        <button
+          type="button"
+          onClick={() => void send()}
+          disabled={busy || !email.includes('@')}
+          className="btn-primary disabled:opacity-50 md:col-span-1"
+        >
+          {busy ? 'Sending…' : 'Send Test'}
+        </button>
+      </div>
+      {result && (
+        <p className={`text-sm mt-3 ${result.startsWith('Sent') ? 'text-green-700' : 'text-red-600'}`}>
+          {result}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/lib/followups/attribution.ts
+++ b/src/lib/followups/attribution.ts
@@ -1,0 +1,153 @@
+/**
+ * Follow-up email system — conversion attribution.
+ *
+ * A paid order counts as a follow-up conversion when it lands within
+ * `windowDays` (default 30) after a sent follow-up to the same lowercased
+ * email. Each order is attributed to AT MOST ONE sent job (the most recent
+ * send before the order) so a two-touch journey never double-counts revenue.
+ *
+ * Order.customerEmail is stored as-typed, so the join lowercases both sides
+ * (no expression index — fine at current order volume).
+ */
+
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/database/client';
+
+export interface JourneyStats {
+  journeyKey: string;
+  sends: number;
+  opens: number;
+  conversions: number;
+  revenue: number;
+}
+
+interface SendOpenRow {
+  journey_key: string;
+  sends: number;
+  opens: number;
+}
+
+interface ConversionRow {
+  journey_key: string;
+  conversions: number;
+  revenue: number;
+}
+
+/** Per-journey sends/opens/conversions/revenue. */
+export async function getFollowUpStats(windowDays = 30): Promise<JourneyStats[]> {
+  const sendsOpens = await prisma.$queryRaw<SendOpenRow[]>`
+    SELECT j.journey_key,
+           COUNT(*)::int AS sends,
+           COUNT(el.id) FILTER (WHERE el.opened_at IS NOT NULL)::int AS opens
+    FROM follow_up_jobs j
+    LEFT JOIN email_logs el ON el.id = j.email_log_id
+    WHERE j.status = 'sent'
+    GROUP BY j.journey_key
+  `;
+
+  // DISTINCT ON (o.id): attribute each order to exactly one job — the most
+  // recent send that preceded it.
+  const conversions = await prisma.$queryRaw<ConversionRow[]>`
+    WITH attributed AS (
+      SELECT DISTINCT ON (o.id) o.id AS order_id, o.total::float AS total, j.journey_key
+      FROM orders o
+      JOIN follow_up_jobs j
+        ON lower(o.customer_email) = j.email
+       AND j.status = 'sent'
+       AND o.created_at >= j.sent_at
+       AND o.created_at <= j.sent_at + make_interval(days => ${windowDays})
+      WHERE o.financial_status IN ('PAID', 'PARTIALLY_REFUNDED')
+      ORDER BY o.id, j.sent_at DESC
+    )
+    SELECT journey_key,
+           COUNT(*)::int AS conversions,
+           COALESCE(SUM(total), 0)::float AS revenue
+    FROM attributed
+    GROUP BY journey_key
+  `;
+
+  const byJourney = new Map<string, JourneyStats>();
+  for (const row of sendsOpens) {
+    byJourney.set(row.journey_key, {
+      journeyKey: row.journey_key,
+      sends: row.sends,
+      opens: row.opens,
+      conversions: 0,
+      revenue: 0,
+    });
+  }
+  for (const row of conversions) {
+    const entry = byJourney.get(row.journey_key) ?? {
+      journeyKey: row.journey_key,
+      sends: 0,
+      opens: 0,
+      conversions: 0,
+      revenue: 0,
+    };
+    entry.conversions = row.conversions;
+    entry.revenue = Math.round(row.revenue * 100) / 100;
+    byJourney.set(row.journey_key, entry);
+  }
+  return [...byJourney.values()].sort((a, b) => a.journeyKey.localeCompare(b.journeyKey));
+}
+
+export interface JourneyQueueCounts {
+  journeyKey: string;
+  scheduled: number;
+  sent: number;
+  canceled: number;
+  suppressed: number;
+  failed: number;
+}
+
+/** Per-journey job counts for the admin flags panel. */
+export async function getJourneyQueueCounts(): Promise<JourneyQueueCounts[]> {
+  const rows = await prisma.followUpJob.groupBy({
+    by: ['journeyKey', 'status'],
+    _count: { _all: true },
+  });
+  const byJourney = new Map<string, JourneyQueueCounts>();
+  for (const row of rows) {
+    const entry = byJourney.get(row.journeyKey) ?? {
+      journeyKey: row.journeyKey,
+      scheduled: 0,
+      sent: 0,
+      canceled: 0,
+      suppressed: 0,
+      failed: 0,
+    };
+    const n = row._count._all;
+    switch (row.status) {
+      case 'scheduled':
+      case 'processing': // in-flight reads as scheduled for display
+        entry.scheduled += n;
+        break;
+      case 'sent':
+        entry.sent += n;
+        break;
+      case 'canceled':
+        entry.canceled += n;
+        break;
+      case 'suppressed':
+        entry.suppressed += n;
+        break;
+      case 'failed':
+        entry.failed += n;
+        break;
+    }
+    byJourney.set(row.journeyKey, entry);
+  }
+  return [...byJourney.values()];
+}
+
+/** "guest@example.com" → "g***@example.com" for admin display. */
+export function maskEmail(email: string): string {
+  const [local, domain] = email.split('@');
+  if (!domain) return '***';
+  return `${(local ?? '').slice(0, 1)}***@${domain}`;
+}
+
+/** Serialization-safe Decimal → number for admin JSON responses. */
+export function decimalToNumber(value: Prisma.Decimal | number | null): number {
+  return value === null ? 0 : Number(value);
+}


### PR DESCRIPTION
## Phase 5 of 5 — stacked on #186

- **/admin/emails/followups** (new sub-route; existing /admin/emails untouched): master kill switch + per-journey toggles with live queue counts, test-send (sample payload, [TEST] prefix, bypasses flags/window but NOT suppressions), conversion stats, next-50 queue with cancel, sent log with delivery-status chips, suppression management. Nav link added to the admin layout.
- **Six ops routes** under `/api/ops/followups/**` (flags, queue, log, suppressions, stats, test-send): every exported method opens with `requireOpsAuth()` (verified 10/10 — /api/ops is NOT middleware-guarded), Zod on all mutating bodies, flag toggles restricted to followups keys only (cannot touch e.g. use_custom_checkout).
- **Attribution** (`src/lib/followups/attribution.ts`): paid order within 30d of a sent follow-up, matched on lowercased email; `DISTINCT ON` attributes each order to at most one send so two-touch journeys never double-count revenue. windowDays clamped [1,365] + parameterized.
- Emails masked everywhere except the suppression list (ops needs full addresses to act on customer requests).

Security review: 0 critical/high/medium. Cleared: ops-auth coverage, no XSS (no dangerouslySetInnerHTML), no caller-controlled email content in test-send, SQL parameterization.

Gates: tsc clean, lint clean, 416 tests green.

### After the stack merges
1. Set `UNSUBSCRIBE_SECRET` + `FOLLOWUP_FROM_EMAIL=info@partyondelivery.com` in Vercel prod env
2. Fill `POSTAL_ADDRESS` (CAN-SPAM) + copy pass in `src/lib/followups/copy.ts`
3. Self-test via the dashboard test-send, then flip `followups_master` + journeys one at a time (suggested order: unpaid-invoice → abandoned-quote after the backfill decision → phase-2 acks → phase-3 after the review-precedence decision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)