### PR TITLE
feat(claude): autonomy skill set from memory-vault synthesis

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,6 +21,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "input=$(cat); cmd=$(echo \"$input\" | jq -r '.tool_input.command // \"\"'); blocked=\"\"; case \"$cmd\" in *\"prisma db push\"*|*\"prisma migrate dev\"*|*\"npm run db:push\"*) blocked=1 ;; esac; if [ -z \"$blocked\" ]; then case \"$cmd\" in *\"db:migrate:\"*) : ;; *\"npm run db:migrate\"*) blocked=1 ;; esac; fi; if [ -n \"$blocked\" ]; then if [ -f \"$CLAUDE_PROJECT_DIR/.claude/.allow-prisma-migrate\" ]; then rm \"$CLAUDE_PROJECT_DIR/.claude/.allow-prisma-migrate\"; echo '[BYPASS] one-shot prisma push/migrate allowed (sentinel consumed)' >&2; exit 0; fi; echo '[BLOCK] prisma db push / prisma migrate dev (npm run db:push / db:migrate) are forbidden — prisma/schema.prisma is intentionally drifted and these would DROP production columns that still hold data (memory: prisma_schema_drift.md). Use the db-migration skill: additive SQL in prisma/migrations/manual/, then npm run db:migrate:manual + db:verify-schema. One-shot bypass: touch .claude/.allow-prisma-migrate' >&2; exit 2; fi",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/.claude/skills/db-migration/SKILL.md
+++ b/.claude/skills/db-migration/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: db-migration
+description: Make any Postgres schema change (new table, column, index, enum, backfill) via the ADR-0008 manual additive SQL pipeline. Use whenever a task requires modifying the database schema or prisma/schema.prisma, or when checking whether a migration has been applied to prod. NEVER use `prisma db push` or `prisma migrate dev` — the schema is intentionally drifted and they would DROP production columns that still hold data.
+---
+
+# DB migration — the manual additive SQL pipeline
+
+Schema changes here do NOT go through Prisma's migration tooling. `prisma/schema.prisma` is **intentionally drifted** from prod (columns removed from the schema still hold production data — memory: `prisma_schema_drift.md`), so `prisma db push` / `prisma migrate dev` would drop real data. A PreToolUse hook blocks those commands and direct `schema.prisma` edits; the sanctioned path is below.
+
+## Read first (canonical — do not work from memory)
+
+1. `prisma/migrations/manual/README.md` — the full mechanism, rules, and the PR #130 postmortem that created it.
+2. Vault ADR: `/Users/allan/Projects/Obsidian/Obsidian/PartyOn2/Memory/Decisions/0008-manual-migrations-autoapply-ledger.md`.
+
+## Recipe
+
+1. **Write the SQL** at `prisma/migrations/manual/YYYY-MM-DD-short-description.sql`:
+   - Additive + idempotent only: `CREATE TABLE IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`, `INSERT ... ON CONFLICT DO NOTHING`; wrap in `BEGIN; ... COMMIT;`.
+   - Never edit an already-applied file (the runner checksums them) — add a new dated file.
+2. **Update `prisma/schema.prisma` to match** so Prisma Client types include the change. The edit hook blocks schema.prisma by default; arm the one-shot bypass first:
+   ```bash
+   touch .claude/.allow-schema-edit
+   ```
+   Only add what your SQL adds — never "clean up" drifted models you didn't touch.
+3. `npx prisma generate`
+4. **Apply + verify locally** (against the DB in `.env.local`):
+   ```bash
+   set -a && source .env.local && set +a
+   npm run db:migrate:manual
+   npm run db:verify-schema
+   ```
+5. **Ship via the `ship` skill.** The production deploy applies the file automatically (guarded step at the front of `npm run build`, `_manual_migrations` ledger, exactly-once).
+6. **Post-deploy proof** (this is the check that would have caught #130):
+   ```bash
+   npm run db:migrate:check    # must report 0 pending
+   npm run db:verify-schema    # ground truth vs information_schema
+   ```
+
+## Out of scope — stop and ask
+
+Destructive changes (`DROP`, `ALTER COLUMN ... TYPE`, `NOT NULL` on a populated column) must NOT go in this pipeline — it runs during the build while old code still serves traffic. They need a separate hand-run expand/contract plan agreed with Allan first.

--- a/.claude/skills/landing-page-launch/SKILL.md
+++ b/.claude/skills/landing-page-launch/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: landing-page-launch
+description: Full checklist for launching a new marketing landing page — page build per design system, age-gate exemption, nav decision, registry entry in src/lib/analytics/landing-pages.ts, CTA instrumentation (GA4 + first-party AnalyticsEvent), optional A/B experiment, analytics-hub tab, and post-launch measurement task. Use whenever creating a new landing page, porting a design into a lander, or wiring an existing page into analytics. Not for editing existing pages' copy (that needs no checklist) or auditing screenshots (use landing-page-audit).
+---
+
+# Landing page launch — the sequenced checklist
+
+Every lander launched here (bachelor, bachelorette, wedding, July 4th, Buckaroo Rodeo) hit the same traps: pages that looked right but had no working add-to-cart (age gate), no nav (missing `<Navigation/>`), or zero analytics (instrumentation shipped late — and data only accrues from deploy forward, there is no backfill). Work the steps **in order**; each has a canonical source — read it, don't work from memory.
+
+## The checklist
+
+| # | Step | Canonical source |
+|---|---|---|
+| 1 | **Build the page** per design system + hero/nav rules | CLAUDE.md (Design System, Hero Sections), `memory/design-system.md`, `/design-example` |
+| 2 | **Nav decision** — root layout gives custom landers NO nav: either render `<Navigation/>` yourself, or intentionally go nav-less like the sanctioned `LandingPageTemplate` paid landers (do NOT "fix" those) | CLAUDE.md → Hero "SANCTIONED EXCEPTION"; memory: `landing_page_nav_and_age_gate_gotcha.md` |
+| 3 | **Age gate** — add the route to `AGE_GATE_EXEMPT_PATHS` if the global 21+ overlay would block the page's add-to-cart flow; otherwise confirm the overlay renders correctly over it | `src/components/AgeVerification.tsx` |
+| 4 | **Registry entry** — add/extend a `LandingPageDef` (key, canonicalPath, aliases, ctaSections). The registry is the single source of truth for the hub tab bar, per-page metrics, and A/B scoping — a lander missing here is invisible to all reporting | `src/lib/analytics/landing-pages.ts` |
+| 5 | **CTA instrumentation** — every CTA fires `trackCTAClick(...)` with a `CtaSection` that matches the registry's `ctaSections`, plus the first-party mirror `trackPodEvent('cta_click', ...)` (GA4 gets ad-blocked; the first-party `AnalyticsEvent` row does not) | `src/lib/analytics/ga4-events.ts`, `src/lib/analytics/client-tracker.ts` |
+| 6 | **A/B experiment (optional)** — use the DB-backed `Experiment`/`ExperimentVariant` system; do NOT touch Brian's code-driven variant registry (two systems coexist by design). Winners are picked with `computeSignificance()` — never eyeball | memory: `analytics_hub_state.md`; `src/lib/analytics/experiment-significance.ts` |
+| 7 | **Hub verification** — after deploy, the page's tab appears at `/admin/analytics` and CTA clicks register | `/admin/analytics` |
+| 8 | **Ship + schedule the re-measure** — merge via the `ship` skill, then create a scheduled task ≥7 days out that pulls the page's traffic/CTA/conversion numbers and reports a verdict | `ship` skill; verdict-task pattern |
+
+## Traps (each one shipped broken at least once)
+
+- **Tailwind arbitrary values with commas** (`text-[clamp(...)]`) silently generate NO CSS — the diff is clean, the page is broken. Use standard responsive classes; after deploy, fetch the served stylesheet and grep for the class if any `[...]` values were used.
+- **Verify add-to-cart in a real browser context, not SSR HTML** — the age-gate overlay only exists client-side (memory: `landing_page_nav_and_age_gate_gotcha.md`).
+- **Instrumentation accrues post-deploy only.** A lander that goes live before step 5 has a permanent data gap — that's why instrumentation precedes launch in the order above.
+- **If a paid campaign accompanies the lander**: geo exclusions and GA4 attribution gotchas are in memory — `delivery_footprint_exclusions.md` (never target Round Rock, Pflugerville, Leander, Dripping Springs, Buda, Kyle) and `google_ads_wedding_fails_gate_ga4_gotcha.md` (GA4 `sessionCampaignName` = the Ads DISPLAY name, never the utm slug; set a CPL kill gate up front).
+- **Canonical routes**: check the registry and CLAUDE.md's "Canonical marketing routes" before inventing a new path — several routes 301 (e.g. `/corporate`), and aliases belong in the registry entry, not as duplicate pages.
+
+## Done means
+
+Page live with nav + working add-to-cart, registry entry merged, at least one `cta_click` visible in the hub from a real click, experiment (if any) assigning variants, and the re-measure task scheduled. Report anything on this list you could not verify.

--- a/.claude/skills/reconcile/SKILL.md
+++ b/.claude/skills/reconcile/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: reconcile
+description: Investigate and fix production data inconsistencies — duplicate refunds, charge/order mismatches, inventory drift, doubled amendments, orphaned rows, webhook double-writes. Use when the user reports numbers not matching, suspected data corruption, or asks to "clean up", "reconcile", "audit", or "backfill" production data. Builds an operator-gated script (dry-run default, --apply flag, idempotent, refuses test keys) — NEVER mutate prod data ad hoc, and treat Stripe as the authoritative source for money.
+---
+
+# Reconcile — operator-gated production data fixes
+
+Production data fixes here follow one proven pattern: **measure first, propose a plan, apply only behind an explicit operator gate.** Ad-hoc `prisma.update()` runs against prod are forbidden — every past incident cleanup (duplicate refunds, doubled amendments, charge mismatches) went through a script, and the scripts are committed so the next investigation starts from prior art.
+
+## Phase 1 — investigate (read-only)
+
+1. Quantify the blast radius with read-only queries (`/db-query` skill / Postgres MCP). How many rows, how many dollars, which date range, still occurring or historical?
+2. **When money is involved, the DB is not the source of truth — Stripe is.** List the actual Stripe objects (refunds, charges, sessions) and diff against DB rows (memory: `refund_cap_stripe_authoritative.md`, `charge_snapshot_invariant.md`).
+3. Find the root cause before repairing data. If the writer bug is still live, fix and ship it first (via `ship`) — otherwise the repair re-corrupts.
+4. Read the closest prior-art script before writing a new one:
+
+| Script (`scripts/ops/`) | What it repaired |
+|---|---|
+| `reconcile-duplicate-refunds.mjs` | Webhook double-created Refund rows; merges/deletes only when DB↔Stripe reconcile 1:1 |
+| `fix-doubled-amendment-orders.mjs` | Amendment diff applied twice (submission + webhook) |
+| `audit-order-charge-mismatches.mjs` | OrderItems vs Stripe-charged lines (two-snapshot undercharge) |
+| `audit-affiliate-discounts.mjs` | Affiliate discount-redemption drift |
+
+`reconcile-duplicate-refunds.mjs` is the gold standard — copy its structure.
+
+## Phase 2 — write the script
+
+`scripts/ops/reconcile-<slug>.mjs`, with ALL of these properties (all lifted from the gold standard):
+
+- **Header comment** stating the bug, the repair semantics, and the safety invariant.
+- **Dry-run is the default.** Nothing writes without `--apply`. Support `--json` and a narrowing flag (e.g. `--order=N`) for spot checks.
+- **Fail loudly on bad env**: exit 1 if the needed keys are missing; **refuse `sk_test_`/`rk_test_` Stripe keys** (a test key silently returns empty lists and the script would "reconcile" against nothing).
+- **Safety invariant over reason-matching**: only apply a change when the post-change state provably matches the authoritative source (e.g. DB refund rows map 1:1 onto Stripe's live refunds, totals within a cent). Anything that doesn't reconcile cleanly → report `NEEDS-MANUAL`, touch nothing.
+- **Idempotent** — running twice is safe; re-running after a partial apply converges.
+- **Row locks where writers race**: inside a transaction, `SELECT ... FOR UPDATE ORDER BY id` before re-validating (single-writer principle, vault ADR-0006).
+- **Summary output**: counts per action (merge/delete/stamp/needs-manual) and dollar totals, both in dry-run and after apply.
+
+Env preamble for every run:
+```bash
+set -a && source .env.local && set +a
+node scripts/ops/reconcile-<slug>.mjs            # dry run
+node scripts/ops/reconcile-<slug>.mjs --apply    # only after operator approval
+```
+
+## Phase 3 — the operator gate
+
+1. Present the dry-run output to Allan: counts, dollars, the NEEDS-MANUAL list, and what `--apply` will change.
+2. **Wait for an explicit go.** "Apply it" means run `--apply` once and report the post-apply summary; anything less means stop at the dry run.
+3. After apply: re-run the dry run — it should now report zero planned changes. Paste that as proof of convergence.
+4. **Commit the script** (via `ship`). Uncommitted ops scripts have been lost to branch switches before (`reconcile-committed.mjs` was built in June and never committed — it's gone from the repo). The script *is* the documentation of what was repaired.
+
+## Never
+
+- Never mutate prod rows from an inline `node -e` / ad-hoc Prisma call.
+- Never delete rows on pattern-matching alone (reason strings, timestamps) — only on failed reconciliation against the authoritative source.
+- Never touch rows that other records point at (e.g. `OrderAmendment.refundId`) without handling the reference.
+- Never run `--apply` in the same turn you present the dry run. The gate is the point.

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: ship
+description: The only sanctioned way to get code onto main — branch/worktree setup, rebase on origin/main, quality gates (tsc, lint, vitest), PR creation, security review for high-stakes paths, merge, and MANDATORY post-merge verification that the code actually landed on origin/main and any manual migrations are applied. Use whenever creating a PR, merging, pushing a feature, or when the user says "ship it", "make a PR", "merge this". Also use to verify a past PR really merged. Prevents orphaned-branch merges (PR #125), unapplied migrations breaking prod (PR #130), stale-base branches, and skipped tests.
+---
+
+# Ship — branch → gates → PR → merge → PROVE it landed
+
+Getting code onto main has failed here in four distinct ways: a "merged" PR whose code lived on an orphaned commit (#125), code deployed against columns whose migration never ran (#130), branches cut from a stale local main, and red tests squeaking through before CI existed. Every section below exists because one of those happened.
+
+## 1. Pre-flight
+
+- **Verify where you are — never trust memory** (see memory: `shared_checkout_session_collisions.md`; multiple sessions share the main checkout):
+  ```bash
+  git branch --show-current && git status --short
+  ```
+- Prefer a worktree for anything non-trivial. If dev-server work is needed in it, `node_modules` must be **copied, not symlinked** (Turbopack can't resolve through symlinks — memory: `worktree_npm_run_dev.md`):
+  ```bash
+  git worktree add .claude/worktrees/<name> -b <branch> origin/main
+  cp -cR node_modules <worktree>/node_modules   # APFS clone, instant
+  ```
+- **Rebase on origin/main before starting AND again before opening the PR** (memory: `worktree_stale_base_rebase.md` — failing tests on a branch are often already fixed on main):
+  ```bash
+  git fetch origin && git rebase origin/main
+  ```
+  If `prisma/schema.prisma` moved in the rebase, run `npx prisma generate`.
+
+## 2. Gates — run locally, paste failures verbatim
+
+| Gate | Command |
+|---|---|
+| Typecheck | `npx tsc --noEmit` |
+| Lint | `npm run lint` |
+| Tests | `npm run test:run` |
+
+CI ("Test & Lint", a required check on main) runs all three on the PR, but run them locally first — a red gate found locally costs seconds; found in CI it costs a round-trip. A clean diff is not proof; these gates are the minimum bar, not the definition of done (see CLAUDE.md → Working Discipline).
+
+## 3. High-stakes routing
+
+If the diff touches **auth, Stripe/payments, refunds, webhooks, customer PII, or affiliate payouts**: run the `security-reviewer` agent on the diff and `/code-review` before merge. This is mandatory per CLAUDE.md; the security reviewer has caught races, wrong-row bugs, and timing attacks that self-review missed in four separate incidents.
+
+## 4. PR + merge
+
+```bash
+git push -u origin <branch>
+gh pr create --base main --title "<type>(<scope>): <summary>" --body "..."
+```
+- Wait for the required "Test & Lint" check to pass. Never merge around a red check.
+- Squash-merge is the house style (Changelog entries reference squash SHAs).
+
+## 5. Post-merge verification — non-negotiable
+
+A PR page saying "Merged" is a claim, not a fact (#125's code was reported merged while living on an unreachable commit). Prove it:
+
+```bash
+git fetch origin
+# 1. The merge commit is reachable from origin/main:
+git branch -r --contains <merge-sha> | grep -q "origin/main" && echo REACHABLE
+# 2. Spot-check one changed file's content on origin/main:
+git show origin/main:<path/to/changed/file> | grep -n "<distinctive line from your diff>"
+```
+
+Then, conditionally:
+
+- **Diff touched `prisma/migrations/manual/`** → confirm the migration pipeline sees it and prod schema matches (prevents #130):
+  ```bash
+  set -a && source .env.local && set +a
+  npm run db:migrate:check     # pending-migration count
+  npm run db:verify-schema     # declared columns vs information_schema
+  ```
+- **Diff touched Tailwind arbitrary values** (`[...]` classes, especially with commas/`clamp()`) → after deploy, fetch the served CSS and grep for the class. Tailwind's JIT silently emits nothing for values it can't classify — the page breaks with a clean diff.
+- **Diff added/changed a cron** → confirm the schedule is in `vercel.json` on origin/main.
+
+## 6. Report
+
+State: merged SHA, the reachability evidence, gate results, which conditional checks ran, and **anything not verified** (e.g. "deployed CSS not yet checked — Vercel build still running"). A faithful "not yet verified" beats a confident wrong "done".
+
+## Verify-mode
+
+Asked "did PR #N actually land?" — run section 5 against that PR's merge SHA (`gh pr view <N> --json mergeCommit,state`) and report the evidence.

--- a/claude.md
+++ b/claude.md
@@ -186,6 +186,7 @@ src/
 - **Draft Orders / Invoices**: Created in admin (`/ops/orders/create`) → customer pays via `/invoice/[token]` → Stripe
 - **Cart**: React Context + localStorage persistence
 - **Auth**: JWT tokens (`jose`) for customer + ops sessions; affiliate uses magic links
+- **Schema changes**: `db-migration` skill only — ADR-0008 manual additive SQL + `_manual_migrations` ledger (never `prisma db push`)
 
 ### Middleware (`src/middleware.ts`)
 - Canonical domain enforcement (www → non-www 301)
@@ -227,6 +228,8 @@ MDX-based blog stored in `content/blog/posts/` (134 posts). NOT database-backed.
 - Do not run `next build` to verify changes. Use `npx next lint` or `npx tsc --noEmit` for error checking.
 - Do not use Playwright or take screenshots to verify layouts.
 - Do not read or open image files. Reference images by path only.
+- Do not merge or declare a PR done outside the `ship` skill flow (post-merge verification is mandatory).
+- Do not run `prisma db push` or `prisma migrate dev` — schema changes go through the `db-migration` skill (a hook blocks these commands).
 
 ---
 
@@ -248,6 +251,9 @@ MDX-based blog stored in `content/blog/posts/` (134 posts). NOT database-backed.
 Skip all of this for trivial fixes (typos, renames, local one-liners — just do them).
 The bigger or riskier the change, the more of this is mandatory.
 
+- **Big tasks run on protocol.** For any multi-step/multi-file task, invoke the
+  `big-task` skill BEFORE starting; when continuing prior work at session start,
+  invoke `recall`. Merges go through the `ship` skill.
 - **Verify against the live code, not memory.** Re-read the actual file before
   claiming what it does. Claims like "mirrors X", "ported verbatim", "matches old
   behavior" assert equivalence — prove it by diffing/running both, or downgrade the


### PR DESCRIPTION
## What

Four new project skills + one guard hook + CLAUDE.md wiring, derived from a full read of the Obsidian memory vault (146 notes covering ~3 months of sessions, decisions, and runbooks). Companion global skills (`big-task`, `recall`) are installed at `~/.claude/skills/` outside this repo.

| Piece | Job |
|---|---|
| `.claude/skills/ship` | Branch→gates→PR→merge with **mandatory post-merge verification** — commit reachable from origin/main, migrations applied, served CSS spot-check. Prevents the #125 orphaned-merge and #130 unapplied-migration incidents. |
| `.claude/skills/db-migration` | Trigger surface for the ADR-0008 manual additive SQL pipeline; defers to `prisma/migrations/manual/README.md`. |
| `.claude/skills/reconcile` | Operator-gated prod-data-fix protocol: dry-run default, `--apply` gate, idempotent, refuses test keys, Stripe-authoritative. Modeled on `reconcile-duplicate-refunds.mjs`. |
| `.claude/skills/landing-page-launch` | Sequenced lander checklist: nav decision, age-gate exemption, registry entry, CTA instrumentation, A/B, hub check, re-measure task. |
| `.claude/settings.json` | New PreToolUse Bash hook blocking `prisma db push` / `prisma migrate dev` / `npm run db:push` / `npm run db:migrate` (allows `db:migrate:*`), with one-shot sentinel bypass `.claude/.allow-prisma-migrate` — mirrors the existing schema-edit hook. Hook logic tested against 8 command cases + sentinel consumption. |
| `claude.md` | 3 pointer lines wiring the skills into Working Discipline, Forbidden Actions, and Data Flow. |

## Why

The vault shows the same failures recurring: PRs reported merged that weren't on main, migrations that never ran, silent Tailwind CSS misses, ad-hoc prod data mutations. These skills encode the proven counter-patterns so weaker/other models follow them autonomously.

## Verification

- Hook: extracted the exact command string from settings.json and ran it against 8 inputs — 4 forbidden forms block (exit 2), `db:migrate:manual/check`, `db:verify-schema`, and normal commands pass, sentinel bypass consumes itself.
- `jq empty` passes on settings.json.
- Docs-only + settings change; no app code touched. CI (tsc/lint/vitest) should be a no-op pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)