### PR TITLE
fix(inventory): skip committedQuantity increment for untracked variants

### DIFF
--- a/src/__tests__/commit-inventory-untracked.test.ts
+++ b/src/__tests__/commit-inventory-untracked.test.ts
@@ -1,0 +1,139 @@
+/**
+ * commitInventoryForOrderItem — untracked variants must not accumulate committed stock.
+ *
+ * Commit fires at payment; release only fires at fulfillment, and
+ * fulfillVariantInventory skips trackInventory=false variants. If commit did NOT
+ * apply the same skip, evergreen items (cocktail kits, mixers, fresh produce)
+ * would build up phantom committed units forever and instantly block checkout
+ * the moment trackInventory is flipped back on (the 2026-06-24 cocktail-kit
+ * incident). These tests prove commit mirrors fulfillment's skip.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/database/client', () => ({
+  prisma: {},
+}));
+
+import { commitInventoryForOrderItem } from '@/lib/inventory/services/order-service';
+
+const mockVariantUpdate = vi.fn().mockResolvedValue({});
+const mockMovementCreate = vi.fn().mockResolvedValue({});
+
+/** Fake transaction client: one product, one variant, controllable trackInventory. */
+function fakeTx(args: {
+  isBundle?: boolean;
+  bundleComponents?: { componentProductId: string; componentVariantId: string | null; quantity: number }[];
+  variant: { id: string; committedQuantity: number; trackInventory: boolean } | null;
+}): Parameters<typeof commitInventoryForOrderItem>[0] {
+  return {
+    product: {
+      findUnique: vi.fn().mockResolvedValue({
+        isBundle: args.isBundle ?? false,
+        bundleComponents: args.bundleComponents ?? [],
+      }),
+    },
+    productVariant: {
+      findUnique: vi.fn().mockResolvedValue(args.variant),
+      findFirst: vi.fn().mockResolvedValue(args.variant),
+      update: mockVariantUpdate,
+    },
+    inventoryMovement: {
+      create: mockMovementCreate,
+    },
+  } as unknown as Parameters<typeof commitInventoryForOrderItem>[0];
+}
+
+describe('commitInventoryForOrderItem — trackInventory guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('commits a tracked variant: increments committedQuantity and writes a COMMITTED movement', async () => {
+    const tx = fakeTx({ variant: { id: 'v1', committedQuantity: 3, trackInventory: true } });
+
+    await commitInventoryForOrderItem(tx, 'p1', 'v1', 2, 1001, 'order-1');
+
+    expect(mockVariantUpdate).toHaveBeenCalledWith({
+      where: { id: 'v1' },
+      data: { committedQuantity: { increment: 2 } },
+    });
+    expect(mockMovementCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        variantId: 'v1',
+        type: 'COMMITTED',
+        quantity: 2,
+        previousQuantity: 3,
+        newQuantity: 5,
+      }),
+    });
+  });
+
+  it('skips an untracked variant entirely: no increment, no movement row', async () => {
+    const tx = fakeTx({ variant: { id: 'v-evergreen', committedQuantity: 94, trackInventory: false } });
+
+    await commitInventoryForOrderItem(tx, 'p1', 'v-evergreen', 5, 1002, 'order-2');
+
+    expect(mockVariantUpdate).not.toHaveBeenCalled();
+    expect(mockMovementCreate).not.toHaveBeenCalled();
+  });
+
+  it('skips untracked bundle components too (explicit componentVariantId branch)', async () => {
+    const tx = fakeTx({
+      isBundle: true,
+      bundleComponents: [{ componentProductId: 'cp1', componentVariantId: 'cv1', quantity: 3 }],
+      variant: { id: 'cv1', committedQuantity: 10, trackInventory: false },
+    });
+
+    await commitInventoryForOrderItem(tx, 'bundle-1', 'unused', 2, 1003, 'order-3');
+
+    expect(mockVariantUpdate).not.toHaveBeenCalled();
+    expect(mockMovementCreate).not.toHaveBeenCalled();
+  });
+
+  it('skips untracked bundle components resolved via findFirst (no componentVariantId)', async () => {
+    const tx = fakeTx({
+      isBundle: true,
+      bundleComponents: [{ componentProductId: 'cp1', componentVariantId: null, quantity: 1 }],
+      variant: { id: 'cv1', committedQuantity: 0, trackInventory: false },
+    });
+
+    await commitInventoryForOrderItem(tx, 'bundle-1', 'unused', 4, 1004, 'order-4');
+
+    expect(mockVariantUpdate).not.toHaveBeenCalled();
+    expect(mockMovementCreate).not.toHaveBeenCalled();
+  });
+
+  it('still commits tracked bundle components (multiplied by component quantity)', async () => {
+    const tx = fakeTx({
+      isBundle: true,
+      bundleComponents: [{ componentProductId: 'cp1', componentVariantId: 'cv1', quantity: 3 }],
+      variant: { id: 'cv1', committedQuantity: 1, trackInventory: true },
+    });
+
+    await commitInventoryForOrderItem(tx, 'bundle-1', 'unused', 2, 1005, 'order-5');
+
+    expect(mockVariantUpdate).toHaveBeenCalledWith({
+      where: { id: 'cv1' },
+      data: { committedQuantity: { increment: 6 } },
+    });
+    expect(mockMovementCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        variantId: 'cv1',
+        type: 'COMMITTED',
+        quantity: 6,
+        previousQuantity: 1,
+        newQuantity: 7,
+      }),
+    });
+  });
+
+  it('does nothing when the variant does not exist', async () => {
+    const tx = fakeTx({ variant: null });
+
+    await commitInventoryForOrderItem(tx, 'p1', 'v-missing', 1, 1006, 'order-6');
+
+    expect(mockVariantUpdate).not.toHaveBeenCalled();
+    expect(mockMovementCreate).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/inventory/services/order-service.ts
+++ b/src/lib/inventory/services/order-service.ts
@@ -68,6 +68,9 @@ export interface OrderItemWithProduct {
  * Increments committedQuantity on ProductVariant (does NOT decrement inventoryQuantity).
  * Physical stock is only decremented when the order is fulfilled/delivered.
  * If the product is a bundle, commits each component's inventory instead.
+ * Untracked variants (trackInventory=false) are skipped entirely — fulfillment
+ * never releases their committed units, so committing them would accumulate
+ * phantom committed stock that blocks checkout if tracking is ever re-enabled.
  */
 type TransactionClient = Omit<typeof prisma, '$connect' | '$disconnect' | '$on' | '$transaction' | '$use' | '$extends'>;
 
@@ -103,16 +106,16 @@ export async function commitInventoryForOrderItem(
       if (component.componentVariantId) {
         componentVariant = await tx.productVariant.findUnique({
           where: { id: component.componentVariantId },
-          select: { id: true, committedQuantity: true },
+          select: { id: true, committedQuantity: true, trackInventory: true },
         });
       } else {
         componentVariant = await tx.productVariant.findFirst({
           where: { productId: component.componentProductId },
-          select: { id: true, committedQuantity: true },
+          select: { id: true, committedQuantity: true, trackInventory: true },
         });
       }
 
-      if (componentVariant) {
+      if (componentVariant && componentVariant.trackInventory) {
         await tx.productVariant.update({
           where: { id: componentVariant.id },
           data: { committedQuantity: { increment: commitQty } },
@@ -136,10 +139,10 @@ export async function commitInventoryForOrderItem(
     // Regular product: commit variant directly
     const variant = await tx.productVariant.findUnique({
       where: { id: variantId },
-      select: { id: true, committedQuantity: true },
+      select: { id: true, committedQuantity: true, trackInventory: true },
     });
 
-    if (variant) {
+    if (variant && variant.trackInventory) {
       await tx.productVariant.update({
         where: { id: variant.id },
         data: { committedQuantity: { increment: orderQuantity } },


### PR DESCRIPTION
## Problem

`commitInventoryForOrderItem` in `src/lib/inventory/services/order-service.ts` incremented `committedQuantity` unconditionally, but `fulfillVariantInventory` (same file) skips variants with `trackInventory=false`. So evergreen items (cocktail kits, Fresh Victor mixers, fresh produce) accumulate committed units forever: commit fires at payment, release never fires at fulfillment.

**Prod evidence** (2026-07-04 reconciliation dry run): 10 untracked variants carry 200 phantom committed units (Fresh Victor Mexican Lime & Agave alone has 94).

Harmless while untracked, but instantly blocks checkout if anyone flips `trackInventory` back on — the exact failure mode of the 2026-06-24 cocktail-kit incident.

## Fix

In `commitInventoryForOrderItem`, select `trackInventory` on both variant lookups (the bundle-component branch and the direct-variant branch) and skip the increment + `COMMITTED` movement row when `trackInventory=false`, mirroring `fulfillVariantInventory`.

## Test

New `src/__tests__/commit-inventory-untracked.test.ts` (6 cases): tracked variant commits normally, untracked variant is skipped entirely, untracked bundle components skipped on both lookup branches, tracked bundle components still commit with the quantity multiplier, missing variant is a no-op.

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — only pre-existing `<img>` warnings
- `npm run test:run` — 422 passed (44 files), incl. the 6 new cases

## Not in this PR

The existing 200 phantom units in prod are cleaned separately via `scripts/ops/reconcile-committed.mjs --zero-untracked` (operator-gated, dry-run default). This code fix only stops new phantom units from accumulating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)