### PR TITLE
feat(followups): live copy editor in the admin (DB overrides, no deploy)

### DIFF
--- a/src/app/admin/emails/followups/page.tsx
+++ b/src/app/admin/emails/followups/page.tsx
@@ -11,6 +11,7 @@
 
 import Link from 'next/link';
 import type { ReactElement } from 'react';
+import CopyEditorPanel from '@/components/admin/followups/CopyEditorPanel';
 import FlagsPanel from '@/components/admin/followups/FlagsPanel';
 import QueuePanel from '@/components/admin/followups/QueuePanel';
 import SentLogPanel from '@/components/admin/followups/SentLogPanel';
@@ -35,6 +36,7 @@ export default function FollowupsAdminPage(): ReactElement {
       </div>
 
       <FlagsPanel />
+      <CopyEditorPanel />
       <TestSendPanel />
       <StatsPanel />
       <QueuePanel />

--- a/src/app/api/ops/followups/copy/route.ts
+++ b/src/app/api/ops/followups/copy/route.ts
@@ -1,0 +1,79 @@
+/**
+ * GET /api/ops/followups/copy — defaults + saved overrides + token docs for
+ *                               the admin copy editor.
+ * PUT /api/ops/followups/copy — save one step's override
+ *                               { journeyKey, step, subject?, body? }.
+ *                               Empty subject AND body resets to default.
+ *
+ * Ops-auth only.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
+import { DEFAULT_COPY, TOKEN_REFERENCE } from '@/lib/followups/copy';
+import {
+  getFollowUpCopyOverrides,
+  saveFollowUpCopyOverride,
+} from '@/lib/followups/copy-overrides';
+import { JOURNEY_KEYS } from '@/lib/followups/journeys';
+import type { JourneyKey } from '@/lib/followups/types';
+
+const saveSchema = z.object({
+  journeyKey: z.enum(JOURNEY_KEYS as [string, ...string[]]),
+  step: z.number().int().min(1).max(2),
+  subject: z.string().max(200).optional().default(''),
+  body: z.string().max(8000).optional().default(''),
+});
+
+export async function GET() {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  try {
+    const overrides = await getFollowUpCopyOverrides();
+    return NextResponse.json({
+      success: true,
+      defaults: DEFAULT_COPY,
+      tokens: TOKEN_REFERENCE,
+      overrides,
+    });
+  } catch (error) {
+    console.error('[ops/followups/copy GET] Error:', error);
+    return NextResponse.json({ success: false, error: 'Failed to load copy' }, { status: 500 });
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  try {
+    const parsed = saveSchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return NextResponse.json({ success: false, error: 'Invalid body' }, { status: 400 });
+    }
+    const { journeyKey, step, subject, body } = parsed.data;
+
+    // A step must actually exist to be overridden (e.g. no step 2 on
+    // newsletter-welcome; event-quiz step 1 is intentionally empty).
+    const defaults = DEFAULT_COPY[journeyKey as JourneyKey]?.[step - 1];
+    if (!defaults || (!defaults.subject && !defaults.body)) {
+      return NextResponse.json(
+        { success: false, error: 'That journey step has no editable copy' },
+        { status: 400 }
+      );
+    }
+
+    const overrides = await saveFollowUpCopyOverride(
+      journeyKey as JourneyKey,
+      step,
+      { subject, body },
+      'admin'
+    );
+    return NextResponse.json({ success: true, overrides });
+  } catch (error) {
+    console.error('[ops/followups/copy PUT] Error:', error);
+    return NextResponse.json({ success: false, error: 'Failed to save copy' }, { status: 500 });
+  }
+}

--- a/src/app/api/ops/followups/test-send/route.ts
+++ b/src/app/api/ops/followups/test-send/route.ts
@@ -13,6 +13,7 @@ import { EmailType, type FollowUpJob } from '@prisma/client';
 import { requireOpsAuth } from '@/lib/auth/ops-session';
 import { sendEmailDetailed } from '@/lib/email/resend-client';
 import { getJourney, JOURNEY_KEYS } from '@/lib/followups/journeys';
+import { getFollowUpCopyOverrides } from '@/lib/followups/copy-overrides';
 import { buildPreferencesUrl, normalizeEmail } from '@/lib/followups/suppression';
 import { SITE_BASE_URL } from '@/lib/followups/types';
 
@@ -77,6 +78,8 @@ export async function POST(request: NextRequest) {
         return url.toString();
       },
       unsubscribeUrl: buildPreferencesUrl(to),
+      // Test sends render with saved overrides — what you see is what ships.
+      copyOverrides: await getFollowUpCopyOverrides(),
     });
     if (!rendered) {
       return NextResponse.json(

--- a/src/components/admin/followups/CopyEditorPanel.tsx
+++ b/src/components/admin/followups/CopyEditorPanel.tsx
@@ -1,0 +1,254 @@
+'use client';
+
+/**
+ * Live copy editor for follow-up emails: pick a journey step, edit subject +
+ * body, save. Overrides persist in the DB and take effect on the engine's
+ * next tick — no deploy. Empty fields fall back to the code defaults.
+ * Data: GET/PUT /api/ops/followups/copy.
+ */
+
+import { useEffect, useMemo, useState, type ReactElement } from 'react';
+import { renderTemplate } from '@/lib/followups/copy';
+
+interface StepCopy {
+  subject: string;
+  body: string;
+}
+interface TokenDoc {
+  token: string;
+  description: string;
+}
+interface CopyResponse {
+  success: boolean;
+  defaults: Record<string, StepCopy[]>;
+  tokens: Record<string, TokenDoc[]>;
+  overrides: Record<string, Record<number, { subject?: string; body?: string }>>;
+}
+
+/** Sample values for the live preview (mirrors the test-send payload). */
+const PREVIEW_TOKENS: Record<string, string> = {
+  firstName: 'Sarah',
+  guestCount: '25',
+  resumeLink: 'https://partyondelivery.com/order',
+  deliveryDate: 'Saturday, July 18',
+  invoiceLink: 'https://partyondelivery.com/invoice/sample',
+  businessName: 'Sample Rentals LLC',
+  reviewLink: 'https://123.partyondelivery.com/reviews',
+};
+
+export default function CopyEditorPanel(): ReactElement {
+  const [data, setData] = useState<CopyResponse | null>(null);
+  const [journeyKey, setJourneyKey] = useState('abandoned-quote');
+  const [step, setStep] = useState(1);
+  const [subject, setSubject] = useState('');
+  const [body, setBody] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState('');
+
+  const load = async (): Promise<CopyResponse | null> => {
+    try {
+      const res = await fetch('/api/ops/followups/copy');
+      const json = (await res.json()) as CopyResponse;
+      if (json.success) {
+        setData(json);
+        return json;
+      }
+    } catch {
+      setStatus('Failed to load copy');
+    }
+    return null;
+  };
+
+  useEffect(() => {
+    void load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Journey steps that actually have copy (skips event-quiz's empty step 1).
+  const editableSteps = useMemo(() => {
+    if (!data) return [];
+    return (data.defaults[journeyKey] ?? [])
+      .map((copy, i) => ({ step: i + 1, hasCopy: Boolean(copy.subject && copy.body) }))
+      .filter((s) => s.hasCopy)
+      .map((s) => s.step);
+  }, [data, journeyKey]);
+
+  // Sync the form whenever the selection (or data) changes.
+  useEffect(() => {
+    if (!data) return;
+    const effectiveStep = editableSteps.includes(step) ? step : (editableSteps[0] ?? 1);
+    if (effectiveStep !== step) {
+      setStep(effectiveStep);
+      return;
+    }
+    const override = data.overrides[journeyKey]?.[effectiveStep];
+    const defaults = data.defaults[journeyKey]?.[effectiveStep - 1];
+    setSubject(override?.subject ?? defaults?.subject ?? '');
+    setBody(override?.body ?? defaults?.body ?? '');
+    setStatus('');
+  }, [data, journeyKey, step, editableSteps]);
+
+  const isOverridden = Boolean(data?.overrides[journeyKey]?.[step]);
+  const defaults = data?.defaults[journeyKey]?.[step - 1];
+
+  const save = async (reset = false): Promise<void> => {
+    setBusy(true);
+    setStatus('');
+    try {
+      const res = await fetch('/api/ops/followups/copy', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          journeyKey,
+          step,
+          subject: reset ? '' : subject,
+          body: reset ? '' : body,
+        }),
+      });
+      const json = await res.json();
+      if (json.success) {
+        setStatus(reset ? 'Reset to default.' : 'Saved — live on the next engine run (≤15 min).');
+        await load();
+      } else {
+        setStatus(`Save failed: ${json.error}`);
+      }
+    } catch {
+      setStatus('Save failed: network error');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!data) {
+    return <div className="card text-sm text-gray-500">Loading copy editor…</div>;
+  }
+
+  const previewBody = renderTemplate(body, PREVIEW_TOKENS);
+  const previewSubject = subject.replace(/\{([a-zA-Z0-9_]+)\}/g, (_, n) => PREVIEW_TOKENS[n] ?? '');
+
+  return (
+    <div className="card">
+      <h2 className="text-lg font-bold tracking-[0.08em] text-gray-900 mb-1">Edit Email Copy</h2>
+      <p className="text-sm text-gray-500 mb-4">
+        Changes save to the database and apply to the next send — no deploy. Curly-brace tokens
+        fill in per customer; a line whose token has no value is dropped from the email.
+      </p>
+
+      <div className="grid gap-3 md:grid-cols-3 mb-4">
+        <select
+          value={journeyKey}
+          onChange={(e) => setJourneyKey(e.target.value)}
+          className="input-premium"
+        >
+          {Object.keys(data.defaults).map((key) => (
+            <option key={key} value={key}>
+              {key}
+            </option>
+          ))}
+        </select>
+        <select
+          value={step}
+          onChange={(e) => setStep(Number(e.target.value))}
+          className="input-premium"
+        >
+          {editableSteps.map((n) => (
+            <option key={n} value={n}>
+              Touch {n}
+            </option>
+          ))}
+        </select>
+        <div className="flex items-center">
+          {isOverridden ? (
+            <span className="text-xs bg-amber-50 text-amber-800 border border-amber-200 rounded px-2 py-1">
+              customized — default is preserved underneath
+            </span>
+          ) : (
+            <span className="text-xs bg-gray-100 text-gray-600 rounded px-2 py-1">
+              using default copy
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="mb-3">
+        <label className="block text-base font-semibold text-gray-700 mb-1">Subject</label>
+        <input
+          type="text"
+          value={subject}
+          onChange={(e) => setSubject(e.target.value)}
+          className="input-premium w-full"
+          maxLength={200}
+        />
+      </div>
+
+      <div className="mb-3">
+        <label className="block text-base font-semibold text-gray-700 mb-1">Body</label>
+        <textarea
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          rows={12}
+          className="input-premium w-full font-mono text-sm"
+          maxLength={8000}
+        />
+      </div>
+
+      <div className="mb-4 text-sm text-gray-500">
+        <span className="font-semibold text-gray-700">Tokens for this journey: </span>
+        {(data.tokens[journeyKey] ?? []).map((t) => (
+          <span key={t.token} className="inline-block mr-3" title={t.description}>
+            <code className="bg-gray-100 rounded px-1">{`{${t.token}}`}</code>
+          </span>
+        ))}
+      </div>
+
+      <div className="flex gap-2 flex-wrap mb-4">
+        <button
+          type="button"
+          onClick={() => void save(false)}
+          disabled={busy || !subject.trim() || !body.trim()}
+          className="btn-primary disabled:opacity-50"
+        >
+          {busy ? 'Saving…' : 'Save Copy'}
+        </button>
+        <button
+          type="button"
+          onClick={() => void save(true)}
+          disabled={busy || !isOverridden}
+          className="btn-secondary disabled:opacity-50"
+        >
+          Reset to Default
+        </button>
+        {defaults && (
+          <button
+            type="button"
+            onClick={() => {
+              setSubject(defaults.subject);
+              setBody(defaults.body);
+            }}
+            disabled={busy}
+            className="btn-ghost"
+          >
+            Load Default Into Editor
+          </button>
+        )}
+      </div>
+      {status && (
+        <p className={`text-sm mb-4 ${status.startsWith('Save failed') ? 'text-red-600' : 'text-green-700'}`}>
+          {status}
+        </p>
+      )}
+
+      <div className="border border-gray-200 rounded-lg p-4 bg-gray-50">
+        <p className="text-xs text-gray-500 mb-2">
+          Preview with sample data (Sarah, 25 guests) — use Test Send below to see the real email.
+        </p>
+        <p className="text-sm font-semibold text-gray-900 mb-2">Subject: {previewSubject}</p>
+        <pre className="text-sm text-gray-800 whitespace-pre-wrap font-sans">{previewBody}</pre>
+        <p className="text-sm text-gray-800 mt-4 whitespace-pre-wrap">{'Allan\nParty On Delivery'}</p>
+        <p className="text-xs text-gray-500 mt-3">
+          Party On Delivery · 7600 N Lamar #A2, Austin, TX 78752 · Unsubscribe
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/followups/__tests__/copy.test.ts
+++ b/src/lib/followups/__tests__/copy.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Template semantics for the editable follow-up copy: token substitution,
+ * the line-drop rule for missing values, and admin-override precedence.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { FollowUpJob } from '@prisma/client';
+import {
+  renderTemplate,
+  buildStepEmail,
+  POSTAL_ADDRESS,
+  GOOGLE_REVIEW_URL,
+} from '../copy';
+import type { JourneyEmailContext } from '../types';
+
+function makeCtx(
+  payload: Record<string, unknown> = {},
+  copyOverrides?: JourneyEmailContext['copyOverrides']
+): JourneyEmailContext {
+  return {
+    job: { id: 'job-1', step: 1 } as unknown as FollowUpJob,
+    payload,
+    link: (path: string) => `https://partyondelivery.com${path}`,
+    unsubscribeUrl: 'https://partyondelivery.com/email/preferences?email=x&token=y',
+    copyOverrides,
+  };
+}
+
+describe('renderTemplate', () => {
+  it('substitutes tokens', () => {
+    expect(renderTemplate('Hey {firstName}, party for {guestCount}?', { firstName: 'Sam', guestCount: '25' }))
+      .toBe('Hey Sam, party for 25?');
+  });
+
+  it('drops the whole line when a token has no value', () => {
+    const out = renderTemplate(
+      'Hey {firstName},\n\nLine one stays.\nPlanning for {guestCount} people.\n\nLine two stays.',
+      { firstName: 'Sam', guestCount: null }
+    );
+    expect(out).not.toContain('Planning for');
+    expect(out).toContain('Line one stays.');
+    expect(out).toContain('Line two stays.');
+  });
+
+  it('treats unknown tokens as missing (line drops) and collapses blank runs', () => {
+    const out = renderTemplate('A\n\n{mystery}\n\nB', { firstName: 'x' });
+    expect(out).toBe('A\n\nB');
+  });
+});
+
+describe('buildStepEmail', () => {
+  it('renders default copy with payload tokens and the CAN-SPAM footer', () => {
+    const email = buildStepEmail('abandoned-quote', 1, makeCtx({ firstName: 'Sam', guestCount: '25', resumePath: '/order' }));
+    expect(email).not.toBeNull();
+    expect(email!.subject).toBe('your drink numbers from Party On Delivery');
+    expect(email!.text).toContain('Hey Sam,');
+    expect(email!.text).toContain('about 25 people');
+    expect(email!.text).toContain('https://partyondelivery.com/order');
+    expect(email!.text).toContain(POSTAL_ADDRESS);
+    expect(email!.text).toContain('Unsubscribe:');
+    expect(email!.html).toContain(POSTAL_ADDRESS.replace(/&/g, '&amp;'));
+  });
+
+  it('drops the guest-count line when unknown but keeps the rest', () => {
+    const email = buildStepEmail('abandoned-quote', 1, makeCtx({}));
+    expect(email!.text).toContain('Hey there,');
+    expect(email!.text).not.toContain('people');
+    expect(email!.text).toContain('Pick it back up here');
+  });
+
+  it('admin overrides win over defaults', () => {
+    const email = buildStepEmail(
+      'contact-form',
+      1,
+      makeCtx(
+        { firstName: 'Sam' },
+        { 'contact-form': { 1: { subject: 'we got it, {firstName}', body: 'Custom body for {firstName}.' } } }
+      )
+    );
+    expect(email!.subject).toBe('we got it, Sam');
+    expect(email!.text).toContain('Custom body for Sam.');
+    expect(email!.text).toContain(POSTAL_ADDRESS); // footer always appended
+  });
+
+  it('partial override keeps the default for the other field', () => {
+    const email = buildStepEmail(
+      'contact-form',
+      1,
+      makeCtx({ firstName: 'Sam' }, { 'contact-form': { 1: { subject: 'custom subject' } } })
+    );
+    expect(email!.subject).toBe('custom subject');
+    expect(email!.text).toContain('I read these personally');
+  });
+
+  it('event-quiz step 1 has no copy and returns null', () => {
+    expect(buildStepEmail('event-quiz', 1, makeCtx({}))).toBeNull();
+  });
+
+  it('post-purchase-review uses the review link verbatim', () => {
+    const email = buildStepEmail('post-purchase-review', 1, makeCtx({ firstName: 'Sam' }));
+    expect(email!.text).toContain(GOOGLE_REVIEW_URL);
+  });
+});

--- a/src/lib/followups/copy-overrides.ts
+++ b/src/lib/followups/copy-overrides.ts
@@ -1,0 +1,68 @@
+/**
+ * Follow-up email system — DB-backed copy overrides.
+ *
+ * Same storage the invoice-template editor uses (EmailTemplateContent, one
+ * JSON row per templateType). The engine reads this once per tick, so a save
+ * in /admin/emails/followups affects the very next send — no deploy.
+ */
+
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/database/client';
+import type { FollowUpCopyOverrides, JourneyKey, StepCopyOverride } from './types';
+
+const TEMPLATE_TYPE = 'followups';
+
+/** All saved overrides ({} when none). Never throws — copy must not block sends. */
+export async function getFollowUpCopyOverrides(): Promise<FollowUpCopyOverrides> {
+  try {
+    const record = await prisma.emailTemplateContent.findUnique({
+      where: { templateType: TEMPLATE_TYPE },
+    });
+    if (!record) return {};
+    return (record.content as FollowUpCopyOverrides) ?? {};
+  } catch (error) {
+    console.error('[followups] failed to load copy overrides — using defaults:', error);
+    return {};
+  }
+}
+
+/**
+ * Save one step's override. Empty subject AND body clears the override
+ * (falls back to the code default).
+ */
+export async function saveFollowUpCopyOverride(
+  journeyKey: JourneyKey,
+  step: number,
+  override: StepCopyOverride,
+  updatedBy?: string
+): Promise<FollowUpCopyOverrides> {
+  const current = await getFollowUpCopyOverrides();
+  const journey = { ...(current[journeyKey] ?? {}) };
+
+  const subject = override.subject?.trim() || undefined;
+  const body = override.body?.trim() || undefined;
+  if (!subject && !body) {
+    delete journey[step];
+  } else {
+    journey[step] = { ...(subject ? { subject } : {}), ...(body ? { body } : {}) };
+  }
+
+  const next: FollowUpCopyOverrides = { ...current, [journeyKey]: journey };
+  if (Object.keys(journey).length === 0) {
+    delete next[journeyKey];
+  }
+
+  await prisma.emailTemplateContent.upsert({
+    where: { templateType: TEMPLATE_TYPE },
+    create: {
+      templateType: TEMPLATE_TYPE,
+      content: next as unknown as Prisma.InputJsonValue,
+      updatedBy,
+    },
+    update: {
+      content: next as unknown as Prisma.InputJsonValue,
+      updatedBy,
+    },
+  });
+  return next;
+}

--- a/src/lib/followups/copy.ts
+++ b/src/lib/followups/copy.ts
@@ -1,17 +1,22 @@
 /**
  * Follow-up email system — copy.
  *
- * DRAFT STUBS in Allan's voice — plain text, personal, no branded HTML.
- * Allan does a copy pass on this file before journeys are enabled (open item
- * #2 in the build plan). Copy is written to survive edge cases: it never
- * asserts the reader hasn't ordered (they may have paid with another email)
- * and step-2 contact copy tolerates Allan having already replied by hand.
+ * Copy lives as plain-text TEMPLATES with {tokens}. The defaults below ship
+ * in code; Allan can override any subject/body per journey step from
+ * /admin/emails/followups (stored in EmailTemplateContent, read by the
+ * engine every tick — edits go live without a deploy).
+ *
+ * Template semantics (keep simple, documented in the editor UI):
+ *   - {token} is replaced with its value (see TOKEN_REFERENCE per journey)
+ *   - if a token has NO value for a given customer, the whole LINE containing
+ *     it is dropped — write optional info on its own line
+ *   - subjects never drop; unresolved tokens are removed instead
  *
  * Every email gets the CAN-SPAM footer: sender identity + physical mailing
  * address + unsubscribe link.
  */
 
-import type { JourneyEmailContext, RenderedEmail } from './types';
+import type { JourneyEmailContext, JourneyKey, RenderedEmail } from './types';
 
 /**
  * CAN-SPAM physical mailing address — appears in the footer of every
@@ -20,13 +25,187 @@ import type { JourneyEmailContext, RenderedEmail } from './types';
 export const POSTAL_ADDRESS = '7600 N Lamar #A2, Austin, TX 78752';
 
 /**
- * Google review link for the post-purchase ask.
- * TODO(Allan): confirm the canonical review URL before Phase 3 goes live
- * (same target the GHL review.request flow uses today).
+ * Review page for the post-purchase ask (GHL-managed subdomain, same target
+ * the planning-call links use). Confirmed by Allan 2026-07-06.
  */
-export const GOOGLE_REVIEW_URL = 'https://g.page/party-on-delivery/review';
+export const GOOGLE_REVIEW_URL = 'https://123.partyondelivery.com/reviews';
 
 const SIGNATURE = 'Allan\nParty On Delivery';
+
+/** One journey step's copy: a subject and a plain-text body template. */
+export interface StepCopy {
+  subject: string;
+  body: string;
+}
+
+/**
+ * Default copy for every journey step (index 0 = step 1). Drafted in Allan's
+ * voice; the admin editor overrides these per step without code changes.
+ */
+export const DEFAULT_COPY: Record<JourneyKey, StepCopy[]> = {
+  'abandoned-quote': [
+    {
+      subject: 'your drink numbers from Party On Delivery',
+      body: `Hey {firstName},
+
+You were running drink numbers on our site — I saved where you left off so you don't have to start over.
+Looks like you were planning for about {guestCount} people.
+
+Pick it back up here: {resumeLink}
+
+Or skip the clicking entirely — reply with your event date and headcount and I'll price it out for you personally.`,
+    },
+    {
+      subject: 'want me to price it out for you?',
+      body: `Hey {firstName},
+
+Still planning? No pressure either way — but if a drink order is still on your list, reply with your date and I'll put a quote together myself. Takes me about ten minutes and you'll get real delivery pricing, not a guess.`,
+    },
+  ],
+  'unpaid-invoice': [
+    {
+      subject: 'holding your date?',
+      body: `Hey {firstName},
+
+I sent over your quote for {deliveryDate} — just checking it landed. Want me to keep holding things on my end?
+
+Your quote is here whenever you're ready: {invoiceLink}
+
+If the date, headcount, or items changed, reply and I'll update it — takes two minutes.`,
+    },
+    {
+      subject: 'should I close this out?',
+      body: `Hey {firstName},
+
+Should I close this one out? If plans changed, no worries at all — happens all the time.
+
+If you still want delivery, grab it before I release the slot.
+
+Quote's still here: {invoiceLink}
+
+Either way, a one-line reply helps me keep the calendar straight.`,
+    },
+  ],
+  'partner-inquiry': [
+    {
+      subject: 'got your partnership inquiry',
+      body: `Hey {firstName},
+
+Thanks for reaching out about partnering — this lands directly with me, not a bot. I'll take a proper look at {businessName} and get back to you within a day or two.
+
+In the meantime, if you have questions about how the program works (commissions, delivery zones, how guests order), just reply here.`,
+    },
+    {
+      subject: 'still interested in partnering?',
+      body: `Hey {firstName},
+
+Following up on your partnership inquiry — still interested? If it's easier to talk it through, reply with a couple of times that work and I'll call you.
+
+If the timing's just not right, tell me and I'll check back down the road instead of nudging you.`,
+    },
+  ],
+  'contact-form': [
+    {
+      subject: 'got your message',
+      body: `Hey {firstName},
+
+Just confirming your message made it to me — I read these personally and I'll get back to you shortly.
+
+If it's time-sensitive (event this week, delivery question for an existing order), reply with "urgent" in the subject and I'll jump on it first.`,
+    },
+    {
+      subject: 'did my reply reach you?',
+      body: `Hey {firstName},
+
+Quick check — did my reply reach you? Email filters eat things sometimes.
+
+If you didn't see anything from me, check spam or just reply here and I'll resend. If we already connected, ignore this one.`,
+    },
+  ],
+  'newsletter-welcome': [
+    {
+      subject: "welcome — here's how this works",
+      body: `Hey {firstName},
+
+Thanks for confirming — you're on the list. Here's how this works: about once or twice a month I send party-planning ideas, seasonal picks, and early access to deals. No daily blasts, ever.
+
+Planning something right now? Reply and tell me about it — date, headcount, vibe — and I'll point you at the right setup.`,
+    },
+  ],
+  'affiliate-apply': [
+    {
+      subject: 'got your application',
+      body: `Hey {firstName},
+
+Got your partner program application — thanks for the interest. I review every application myself, so expect to hear from me within a couple of days.
+
+If you want to add anything (audience size, how you'd promote us, past partnerships), just reply to this email and it goes straight into your file.`,
+    },
+    {
+      subject: 'your application — quick check-in',
+      body: `Hey {firstName},
+
+Quick check-in on your partner application — it's still in my queue, not lost. If anything's changed on your end (or you have questions about commission structure), reply here.`,
+    },
+  ],
+  'event-quiz': [
+    // Step 1 is the instant welcome sent by /api/v1/event-quiz/submit —
+    // this journey only ever sends step 2. Slot kept for shape consistency.
+    { subject: '', body: '' },
+    {
+      subject: 'did the plan land?',
+      body: `Hey {firstName},
+
+You grabbed a drink plan from our event quiz a few days back — how's it looking?
+
+If you want a second set of eyes on quantities, or real delivery pricing for your date, reply with the date and headcount and I'll sort it out personally.`,
+    },
+  ],
+  'post-purchase-review': [
+    {
+      subject: "how'd we do?",
+      body: `Hey {firstName},
+
+Delivery's done — hope the party was a good one.
+
+If we earned it, a quick review genuinely helps us more than any ad: {reviewLink}
+
+And if anything was off — late, wrong item, anything — reply and tell me first. I'll make it right.`,
+    },
+  ],
+};
+
+/** Tokens available per journey, shown in the admin editor. */
+export const TOKEN_REFERENCE: Record<JourneyKey, Array<{ token: string; description: string }>> = {
+  'abandoned-quote': [
+    { token: 'firstName', description: 'Customer first name ("there" when unknown)' },
+    { token: 'guestCount', description: 'Headcount from the calculator — line drops when unknown' },
+    { token: 'resumeLink', description: 'Link back to where they left off' },
+  ],
+  'unpaid-invoice': [
+    { token: 'firstName', description: 'Customer first name ("there" when unknown)' },
+    { token: 'deliveryDate', description: 'Delivery date on the quote — line drops when unknown' },
+    { token: 'invoiceLink', description: 'Pay/view link for the quote — line drops when unknown' },
+  ],
+  'partner-inquiry': [
+    { token: 'firstName', description: 'Contact first name ("there" when unknown)' },
+    { token: 'businessName', description: 'Their business ("your business" when unknown)' },
+  ],
+  'contact-form': [{ token: 'firstName', description: 'First name ("there" when unknown)' }],
+  'newsletter-welcome': [{ token: 'firstName', description: 'First name ("there" when unknown)' }],
+  'affiliate-apply': [
+    { token: 'firstName', description: 'Applicant first name ("there" when unknown)' },
+    { token: 'businessName', description: 'Their business ("your business" when unknown)' },
+  ],
+  'event-quiz': [
+    { token: 'firstName', description: 'First name ("there" when unknown)' },
+    { token: 'resumeLink', description: 'Link to their recommended landing page' },
+  ],
+  'post-purchase-review': [
+    { token: 'firstName', description: 'Customer first name ("there" when unknown)' },
+    { token: 'reviewLink', description: 'The review page (123.partyondelivery.com/reviews)' },
+  ],
+};
 
 function escapeHtml(s: string): string {
   return s
@@ -44,9 +223,45 @@ function linkify(escaped: string): string {
   );
 }
 
+const TOKEN_RE = /\{([a-zA-Z0-9_]+)\}/g;
+
 /**
- * Wrap plain-text body copy into the minimal HTML + text pair every follow-up
- * uses: paragraphs only, no branding, CAN-SPAM footer at the bottom.
+ * Substitute {tokens} into a body template. Lines referencing a token with
+ * no value are dropped entirely; leftover blank runs collapse. Exported for
+ * tests and the editor's live preview.
+ */
+export function renderTemplate(
+  template: string,
+  tokens: Record<string, string | null | undefined>
+): string {
+  const kept = template.split('\n').filter((line) => {
+    const refs = [...line.matchAll(TOKEN_RE)].map((m) => m[1]);
+    return refs.every((name) => {
+      const value = tokens[name];
+      return value !== null && value !== undefined && value !== '';
+    });
+  });
+  return kept
+    .map((line) => line.replace(TOKEN_RE, (_, name) => String(tokens[name] ?? '')))
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+/** Subjects never drop — unresolved tokens are removed and spaces tidied. */
+function renderSubject(
+  template: string,
+  tokens: Record<string, string | null | undefined>
+): string {
+  return template
+    .replace(TOKEN_RE, (_, name) => String(tokens[name] ?? ''))
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+}
+
+/**
+ * Wrap rendered plain-text body copy into the minimal HTML + text pair every
+ * follow-up uses: paragraphs only, no branding, CAN-SPAM footer at the bottom.
  */
 export function renderFollowUpEmail(
   subject: string,
@@ -75,215 +290,61 @@ function str(payload: Record<string, unknown>, key: string): string | null {
   return typeof v === 'string' && v.trim() ? v.trim() : null;
 }
 
-function firstName(ctx: JourneyEmailContext): string {
-  return str(ctx.payload, 'firstName') ?? 'there';
+/** Token values for a journey step, built from the job payload at send time. */
+export function buildTokens(
+  journeyKey: JourneyKey,
+  ctx: JourneyEmailContext
+): Record<string, string | null> {
+  const tokens: Record<string, string | null> = {
+    firstName: str(ctx.payload, 'firstName') ?? 'there',
+  };
+  switch (journeyKey) {
+    case 'abandoned-quote':
+      tokens.guestCount = str(ctx.payload, 'guestCount');
+      tokens.resumeLink = ctx.link(str(ctx.payload, 'resumePath') ?? '/order');
+      break;
+    case 'unpaid-invoice': {
+      const invoicePath = str(ctx.payload, 'invoicePath');
+      tokens.invoiceLink = invoicePath ? ctx.link(invoicePath) : null;
+      tokens.deliveryDate = str(ctx.payload, 'deliveryDate');
+      break;
+    }
+    case 'partner-inquiry':
+    case 'affiliate-apply':
+      tokens.businessName = str(ctx.payload, 'businessName') ?? 'your business';
+      break;
+    case 'event-quiz':
+      tokens.resumeLink = ctx.link(str(ctx.payload, 'resumePath') ?? '/order');
+      break;
+    case 'post-purchase-review':
+      // External subdomain (GHL-managed) — used verbatim, no UTM appending.
+      tokens.reviewLink = GOOGLE_REVIEW_URL;
+      break;
+    default:
+      break;
+  }
+  return tokens;
 }
 
-// ---------------------------------------------------------------------------
-// abandoned-quote — calculator/package-builder email captured, no order
-// ---------------------------------------------------------------------------
-
-export function abandonedQuoteStep1(ctx: JourneyEmailContext): RenderedEmail {
-  const name = firstName(ctx);
-  const resumePath = str(ctx.payload, 'resumePath') ?? '/order';
-  const guestCount = str(ctx.payload, 'guestCount');
-  const numbersLine = guestCount
-    ? `You were running drink numbers for about ${guestCount} people — I saved where you left off so you don't have to start over.`
-    : `You were running drink numbers on our site — I saved where you left off so you don't have to start over.`;
-
-  const body = `Hey ${name},
-
-${numbersLine}
-
-Pick it back up here: ${ctx.link(resumePath)}
-
-Or skip the clicking entirely — reply with your event date and headcount and I'll price it out for you personally.`;
-
-  return renderFollowUpEmail(
-    'your drink numbers from Party On Delivery',
-    body,
-    ctx.unsubscribeUrl
-  );
-}
-
-export function abandonedQuoteStep2(ctx: JourneyEmailContext): RenderedEmail {
-  const name = firstName(ctx);
-  const body = `Hey ${name},
-
-Still planning? No pressure either way — but if a drink order is still on your list, reply with your date and I'll put a quote together myself. Takes me about ten minutes and you'll get real delivery pricing, not a guess.`;
-
-  return renderFollowUpEmail(
-    'want me to price it out for you?',
-    body,
-    ctx.unsubscribeUrl
-  );
-}
-
-// ---------------------------------------------------------------------------
-// unpaid-invoice — quote/invoice sent, not paid
-// ---------------------------------------------------------------------------
-
-export function unpaidInvoiceStep1(ctx: JourneyEmailContext): RenderedEmail {
-  const name = firstName(ctx);
-  const invoicePath = str(ctx.payload, 'invoicePath');
-  const eventLine = str(ctx.payload, 'deliveryDate')
-    ? ` for ${str(ctx.payload, 'deliveryDate')}`
-    : '';
-  const payLine = invoicePath
-    ? `Your quote is here whenever you're ready: ${ctx.link(invoicePath)}`
-    : `Reply here and I'll resend your quote.`;
-
-  const body = `Hey ${name},
-
-I sent over your quote${eventLine} — just checking it landed. Want me to keep holding things on my end?
-
-${payLine}
-
-If the date, headcount, or items changed, reply and I'll update it — takes two minutes.`;
-
-  return renderFollowUpEmail('holding your date?', body, ctx.unsubscribeUrl);
-}
-
-export function unpaidInvoiceStep2(ctx: JourneyEmailContext): RenderedEmail {
-  const name = firstName(ctx);
-  const invoicePath = str(ctx.payload, 'invoicePath');
-  const payLine = invoicePath ? `\n\nQuote's still here: ${ctx.link(invoicePath)}` : '';
-
-  const body = `Hey ${name},
-
-Should I close this one out? If plans changed, no worries at all — happens all the time.
-
-If you still want delivery, grab it before I release the slot.${payLine}
-
-Either way, a one-line reply helps me keep the calendar straight.`;
-
-  return renderFollowUpEmail('should I close this out?', body, ctx.unsubscribeUrl);
-}
-
-// ---------------------------------------------------------------------------
-// partner-inquiry — B2B partnership form
-// ---------------------------------------------------------------------------
-
-export function partnerInquiryStep1(ctx: JourneyEmailContext): RenderedEmail {
-  const name = firstName(ctx);
-  const businessName = str(ctx.payload, 'businessName');
-  const aboutLine = businessName
-    ? `I'll take a proper look at ${businessName} and get back to you within a day or two.`
-    : `I'll take a proper look and get back to you within a day or two.`;
-
-  const body = `Hey ${name},
-
-Thanks for reaching out about partnering — this lands directly with me, not a bot. ${aboutLine}
-
-In the meantime, if you have questions about how the program works (commissions, delivery zones, how guests order), just reply here.`;
-
-  return renderFollowUpEmail('got your partnership inquiry', body, ctx.unsubscribeUrl);
-}
-
-export function partnerInquiryStep2(ctx: JourneyEmailContext): RenderedEmail {
-  const name = firstName(ctx);
-  const body = `Hey ${name},
-
-Following up on your partnership inquiry — still interested? If it's easier to talk it through, reply with a couple of times that work and I'll call you.
-
-If the timing's just not right, tell me and I'll check back down the road instead of nudging you.`;
-
-  return renderFollowUpEmail('still interested in partnering?', body, ctx.unsubscribeUrl);
-}
-
-// ---------------------------------------------------------------------------
-// contact-form — general contact form ack + reply-check
-// ---------------------------------------------------------------------------
-
-export function contactFormStep1(ctx: JourneyEmailContext): RenderedEmail {
-  const name = firstName(ctx);
-  const body = `Hey ${name},
-
-Just confirming your message made it to me — I read these personally and I'll get back to you shortly.
-
-If it's time-sensitive (event this week, delivery question for an existing order), reply with "urgent" in the subject and I'll jump on it first.`;
-
-  return renderFollowUpEmail('got your message', body, ctx.unsubscribeUrl);
-}
-
-export function contactFormStep2(ctx: JourneyEmailContext): RenderedEmail {
-  const name = firstName(ctx);
-  const body = `Hey ${name},
-
-Quick check — did my reply reach you? Email filters eat things sometimes.
-
-If you didn't see anything from me, check spam or just reply here and I'll resend. If we already connected, ignore this one.`;
-
-  return renderFollowUpEmail('did my reply reach you?', body, ctx.unsubscribeUrl);
-}
-
-// ---------------------------------------------------------------------------
-// newsletter-welcome — post-double-opt-in welcome
-// ---------------------------------------------------------------------------
-
-export function newsletterWelcomeStep1(ctx: JourneyEmailContext): RenderedEmail {
-  const name = firstName(ctx);
-  const body = `Hey ${name},
-
-Thanks for confirming — you're on the list. Here's how this works: about once or twice a month I send party-planning ideas, seasonal picks, and early access to deals. No daily blasts, ever.
-
-Planning something right now? Reply and tell me about it — date, headcount, vibe — and I'll point you at the right setup.`;
-
-  return renderFollowUpEmail('welcome — here\'s how this works', body, ctx.unsubscribeUrl);
-}
-
-// ---------------------------------------------------------------------------
-// affiliate-apply — partner program application ack + check-in
-// ---------------------------------------------------------------------------
-
-export function affiliateApplyStep1(ctx: JourneyEmailContext): RenderedEmail {
-  const name = firstName(ctx);
-  const body = `Hey ${name},
-
-Got your partner program application — thanks for the interest. I review every application myself, so expect to hear from me within a couple of days.
-
-If you want to add anything (audience size, how you'd promote us, past partnerships), just reply to this email and it goes straight into your file.`;
-
-  return renderFollowUpEmail('got your application', body, ctx.unsubscribeUrl);
-}
-
-export function affiliateApplyStep2(ctx: JourneyEmailContext): RenderedEmail {
-  const name = firstName(ctx);
-  const body = `Hey ${name},
-
-Quick check-in on your partner application — it's still in my queue, not lost. If anything's changed on your end (or you have questions about commission structure), reply here.`;
-
-  return renderFollowUpEmail('your application — quick check-in', body, ctx.unsubscribeUrl);
-}
-
-// ---------------------------------------------------------------------------
-// event-quiz — quiz completed (instant welcome already exists; step 2 only)
-// ---------------------------------------------------------------------------
-
-export function eventQuizStep2(ctx: JourneyEmailContext): RenderedEmail {
-  const name = firstName(ctx);
-  const body = `Hey ${name},
-
-You grabbed a drink plan from our event quiz a few days back — how's it looking?
-
-If you want a second set of eyes on quantities, or real delivery pricing for your date, reply with the date and headcount and I'll sort it out personally.`;
-
-  return renderFollowUpEmail('did the plan land?', body, ctx.unsubscribeUrl);
-}
-
-// ---------------------------------------------------------------------------
-// post-purchase-review — delivered order, single review ask
-// ---------------------------------------------------------------------------
-
-export function postPurchaseReviewStep1(ctx: JourneyEmailContext): RenderedEmail {
-  const name = firstName(ctx);
-  const body = `Hey ${name},
-
-Delivery's done — hope the party was a good one.
-
-If we earned it, a quick Google review genuinely helps us more than any ad: ${GOOGLE_REVIEW_URL}
-
-And if anything was off — late, wrong item, anything — reply and tell me first. I'll make it right.`;
-
-  return renderFollowUpEmail('how\'d we do?', body, ctx.unsubscribeUrl);
+/**
+ * Render one journey step: admin override (ctx.copyOverrides) wins over the
+ * code default; token substitution + line-drop; CAN-SPAM footer. Returns
+ * null when the step has no copy (e.g. event-quiz step 1).
+ */
+export function buildStepEmail(
+  journeyKey: JourneyKey,
+  step: number,
+  ctx: JourneyEmailContext
+): RenderedEmail | null {
+  const defaults = DEFAULT_COPY[journeyKey]?.[step - 1];
+  const override = ctx.copyOverrides?.[journeyKey]?.[step];
+  const subjectTpl = override?.subject?.trim() || defaults?.subject || '';
+  const bodyTpl = override?.body?.trim() || defaults?.body || '';
+  if (!subjectTpl || !bodyTpl) return null;
+
+  const tokens = buildTokens(journeyKey, ctx);
+  const body = renderTemplate(bodyTpl, tokens);
+  const subject = renderSubject(subjectTpl, tokens);
+  if (!body || !subject) return null;
+  return renderFollowUpEmail(subject, body, ctx.unsubscribeUrl);
 }

--- a/src/lib/followups/engine.ts
+++ b/src/lib/followups/engine.ts
@@ -23,12 +23,13 @@ import { sendEmailDetailed } from '@/lib/email/resend-client';
 import { FEATURE_FLAGS, isFeatureEnabled } from '@/lib/features/feature-flags';
 import { enqueueJourney, enqueueNextStep } from './enqueue';
 import { JOURNEYS } from './journeys';
+import { getFollowUpCopyOverrides } from './copy-overrides';
 import {
   buildOneClickUnsubscribeUrl,
   buildPreferencesUrl,
   isSuppressed,
 } from './suppression';
-import type { EngineRunResult, JourneyDef, JourneyKey } from './types';
+import type { EngineRunResult, FollowUpCopyOverrides, JourneyDef, JourneyKey } from './types';
 import { SITE_BASE_URL } from './types';
 
 const CLAIM_BATCH_SIZE = 50;
@@ -229,7 +230,11 @@ async function markCanceled(job: FollowUpJob, reason: string, status = 'canceled
 }
 
 /** Process one claimed job through the full pre-send pipeline. Exported for tests. */
-export async function processJob(job: FollowUpJob, journey: JourneyDef): Promise<JobOutcome> {
+export async function processJob(
+  job: FollowUpJob,
+  journey: JourneyDef,
+  copyOverrides?: FollowUpCopyOverrides
+): Promise<JobOutcome> {
   // 1. Suppression list (unsubscribe/bounce/complaint).
   if (await isSuppressed(job.email)) {
     await markCanceled(job, 'suppressed', 'suppressed');
@@ -293,6 +298,7 @@ export async function processJob(job: FollowUpJob, journey: JourneyDef): Promise
       return url.toString();
     },
     unsubscribeUrl: buildPreferencesUrl(job.email),
+    copyOverrides,
   });
   if (!rendered) {
     await markCanceled(job, 'no-content');
@@ -424,6 +430,10 @@ export async function runFollowUpEngine(opts: { now?: Date } = {}): Promise<Engi
   const jobs = await claimDueJobs(enabled.map((j) => j.key));
   result.claimed = jobs.length;
 
+  // Admin copy overrides — one read per tick, so a save in the dashboard
+  // affects the very next send.
+  const copyOverrides = jobs.length > 0 ? await getFollowUpCopyOverrides() : undefined;
+
   const journeyByKey = new Map(enabled.map((j) => [j.key as string, j]));
   for (const job of jobs) {
     const journey = journeyByKey.get(job.journeyKey);
@@ -436,7 +446,7 @@ export async function runFollowUpEngine(opts: { now?: Date } = {}): Promise<Engi
       continue;
     }
     try {
-      const outcome = await processJob(job, journey);
+      const outcome = await processJob(job, journey, copyOverrides);
       if (outcome === 'sent') result.sent++;
       else if (outcome === 'canceled') result.canceled++;
       else if (outcome === 'suppressed') result.suppressed++;

--- a/src/lib/followups/journeys.ts
+++ b/src/lib/followups/journeys.ts
@@ -15,21 +15,14 @@ import type { FollowUpJob } from '@prisma/client';
 import { prisma } from '@/lib/database/client';
 import { FEATURE_FLAGS } from '@/lib/features/feature-flags';
 import { entityIdFromDedupeKey, type JourneyDef, type JourneyKey } from './types';
-import {
-  abandonedQuoteStep1,
-  abandonedQuoteStep2,
-  unpaidInvoiceStep1,
-  unpaidInvoiceStep2,
-  partnerInquiryStep1,
-  partnerInquiryStep2,
-  contactFormStep1,
-  contactFormStep2,
-  newsletterWelcomeStep1,
-  affiliateApplyStep1,
-  affiliateApplyStep2,
-  eventQuizStep2,
-  postPurchaseReviewStep1,
-} from './copy';
+import { buildStepEmail } from './copy';
+
+/**
+ * Step renderer: default copy lives in copy.ts (DEFAULT_COPY); admin
+ * overrides arrive via ctx.copyOverrides (fetched once per engine tick).
+ */
+const step = (journeyKey: JourneyKey, n: number) => (ctx: Parameters<typeof buildStepEmail>[2]) =>
+  buildStepEmail(journeyKey, n, ctx);
 
 /** Draft statuses that mean "this email is already in an active sales motion". */
 const ACTIVE_DRAFT_STATUSES = ['SENT', 'VIEWED', 'PAID', 'CONVERTED'] as const;
@@ -64,8 +57,8 @@ export const JOURNEYS: JourneyDef[] = [
     featureFlag: FEATURE_FLAGS.FOLLOWUPS_ABANDONED_QUOTE,
     phase: 1,
     steps: [
-      { delayHours: 24, buildEmail: abandonedQuoteStep1 },
-      { delayHours: 96, buildEmail: abandonedQuoteStep2 },
+      { delayHours: 24, buildEmail: step('abandoned-quote', 1) },
+      { delayHours: 96, buildEmail: step('abandoned-quote', 2) },
     ],
     shouldCancel: async (job: FollowUpJob) => {
       if (job.leadId) {
@@ -100,8 +93,8 @@ export const JOURNEYS: JourneyDef[] = [
     featureFlag: FEATURE_FLAGS.FOLLOWUPS_UNPAID_INVOICE,
     phase: 1,
     steps: [
-      { delayHours: 24, buildEmail: unpaidInvoiceStep1 },
-      { delayHours: 120, buildEmail: unpaidInvoiceStep2 },
+      { delayHours: 24, buildEmail: step('unpaid-invoice', 1) },
+      { delayHours: 120, buildEmail: step('unpaid-invoice', 2) },
     ],
     shouldCancel: async (job: FollowUpJob) => {
       if (!job.draftOrderId) return 'missing-draft-ref';
@@ -127,8 +120,8 @@ export const JOURNEYS: JourneyDef[] = [
     // kill the partnership conversation.
     skipGlobalPaidGuard: true,
     steps: [
-      { delayHours: 0, buildEmail: partnerInquiryStep1 },
-      { delayHours: 96, buildEmail: partnerInquiryStep2 },
+      { delayHours: 0, buildEmail: step('partner-inquiry', 1) },
+      { delayHours: 96, buildEmail: step('partner-inquiry', 2) },
     ],
     shouldCancel: async (job: FollowUpJob) => {
       if (!job.partnerInquiryId) return 'missing-inquiry-ref';
@@ -149,8 +142,8 @@ export const JOURNEYS: JourneyDef[] = [
     featureFlag: FEATURE_FLAGS.FOLLOWUPS_CONTACT_FORM,
     phase: 2,
     steps: [
-      { delayHours: 0, buildEmail: contactFormStep1 },
-      { delayHours: 72, buildEmail: contactFormStep2 },
+      { delayHours: 0, buildEmail: step('contact-form', 1) },
+      { delayHours: 72, buildEmail: step('contact-form', 2) },
     ],
     shouldCancel: async (job: FollowUpJob) => {
       if (job.leadId) {
@@ -172,7 +165,7 @@ export const JOURNEYS: JourneyDef[] = [
       'Single welcome ~1h after double-opt-in confirmation. Cancels only on suppression.',
     featureFlag: FEATURE_FLAGS.FOLLOWUPS_NEWSLETTER_WELCOME,
     phase: 2,
-    steps: [{ delayHours: 1, buildEmail: newsletterWelcomeStep1 }],
+    steps: [{ delayHours: 1, buildEmail: step('newsletter-welcome', 1) }],
     shouldCancel: async () => null,
   },
   {
@@ -185,8 +178,8 @@ export const JOURNEYS: JourneyDef[] = [
     // B2B thread, same rationale as partner-inquiry.
     skipGlobalPaidGuard: true,
     steps: [
-      { delayHours: 0, buildEmail: affiliateApplyStep1 },
-      { delayHours: 120, buildEmail: affiliateApplyStep2 },
+      { delayHours: 0, buildEmail: step('affiliate-apply', 1) },
+      { delayHours: 120, buildEmail: step('affiliate-apply', 2) },
     ],
     shouldCancel: async (job: FollowUpJob) => {
       const applicationId = entityIdFromDedupeKey(job.dedupeKey);
@@ -211,7 +204,7 @@ export const JOURNEYS: JourneyDef[] = [
       // Step 1 slot exists for shape consistency but is never enqueued —
       // the instant welcome in /api/v1/event-quiz/submit is touch #1.
       { delayHours: 0, buildEmail: () => null },
-      { delayHours: 96, buildEmail: eventQuizStep2 },
+      { delayHours: 96, buildEmail: step('event-quiz', 2) },
     ],
     shouldCancel: async (job: FollowUpJob) => {
       if (job.leadId) {
@@ -230,7 +223,7 @@ export const JOURNEYS: JourneyDef[] = [
     phase: 3,
     // The trigger IS a paid order — the global paid guard would cancel every job.
     skipGlobalPaidGuard: true,
-    steps: [{ delayHours: 48, buildEmail: postPurchaseReviewStep1 }],
+    steps: [{ delayHours: 48, buildEmail: step('post-purchase-review', 1) }],
     shouldCancel: async (job: FollowUpJob) => {
       if (!job.orderId) return 'missing-order-ref';
       const order = await prisma.order.findUnique({ where: { id: job.orderId } });

--- a/src/lib/followups/types.ts
+++ b/src/lib/followups/types.ts
@@ -48,6 +48,21 @@ export interface RenderedEmail {
   text: string;
 }
 
+/** Admin override for one journey step's copy (empty/missing = use default). */
+export interface StepCopyOverride {
+  subject?: string;
+  body?: string;
+}
+
+/**
+ * All copy overrides, keyed by journey then step number (1-based).
+ * Stored in EmailTemplateContent under templateType 'followups' and edited
+ * at /admin/emails/followups.
+ */
+export type FollowUpCopyOverrides = Partial<
+  Record<JourneyKey, Record<number, StepCopyOverride>>
+>;
+
 /** Context handed to a journey step's buildEmail at send time. */
 export interface JourneyEmailContext {
   job: FollowUpJob;
@@ -57,6 +72,8 @@ export interface JourneyEmailContext {
   link: (path: string) => string;
   /** Token-signed /email/preferences URL for the job's email (CAN-SPAM footer). */
   unsubscribeUrl: string;
+  /** Admin copy overrides, fetched once per engine tick. Absent = defaults. */
+  copyOverrides?: FollowUpCopyOverrides;
 }
 
 /** One touch in a journey (2-touch max per Allan's locked decision). */


### PR DESCRIPTION
## What this adds

A copy editor on /admin/emails/followups (top of the page, under the flags): pick any journey touch, edit the subject and body, hit Save. Overrides live in the database (EmailTemplateContent, same mechanism as the invoice-text editor) and the engine re-reads them every tick — **edits are live on the next send, no deploy**.

- Tokens like `{firstName}` fill in per customer; the editor lists which tokens each journey supports
- A line whose token has no value for that customer is dropped from the email (write optional info on its own line)
- Empty save = reset to the code default; "Load Default Into Editor" to start from the original
- Live preview with sample data + the real footer; Test Send renders with saved overrides so what you test is what ships
- Review link for the post-purchase ask set to https://123.partyondelivery.com/reviews

Stacked on #191 (postal address), which is stacked on #190 (Phases 1–4). Merge order: #190 → #191 → this.

Gates: tsc clean, lint clean, 431 tests green (9 new tests for template semantics + override precedence). New ops route double-gated with requireOpsAuth + Zod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)