### PR TITLE
fix(copy): real zone minimums on /faqs + delivery utils delegate to rates.ts

### DIFF
--- a/src/app/faqs/page.tsx
+++ b/src/app/faqs/page.tsx
@@ -21,7 +21,7 @@ export default function FAQsPage() {
         },
         {
           q: "What is your minimum order requirement?",
-          a: "TESTING MODE: Currently no minimum order requirements. Normally $100 for central Austin, $150 for outer areas."
+          a: "Minimum orders depend on your delivery zone: $100 for central Austin, $125 for greater Austin, and $150 for extended areas like Cedar Park and Georgetown. Enter your zip at checkout to see your exact minimum — and orders over $250, $300, or $400 (by zone) get free standard delivery."
         },
         {
           q: "What are your delivery hours?",

--- a/src/lib/utils/delivery.ts
+++ b/src/lib/utils/delivery.ts
@@ -1,5 +1,7 @@
 /** Delivery utility functions */
 
+import { isInDeliveryArea, getMinimumOrder } from '@/lib/delivery/rates';
+
 /**
  * Normalize a delivery date to noon UTC to prevent timezone display issues.
  * Dates stored as midnight UTC (00:00) display as the previous day in US timezones.
@@ -11,8 +13,9 @@ export function normalizeDeliveryDate(date: Date | string): Date {
 }
 
 export function getEarliestDeliveryDate(): Date {
+  // 48-hour standard ordering window (matches /faqs, terms, and landing copy).
   const date = new Date();
-  date.setHours(date.getHours() + 72);
+  date.setHours(date.getHours() + 48);
   return date;
 }
 
@@ -26,25 +29,13 @@ export function formatDeliveryDate(date: Date): string {
   }).format(date);
 }
 
+// Zone data lives in src/lib/delivery/rates.ts (the source of truth per
+// ADR-0002) — these wrappers exist for legacy callers and must not carry
+// their own zip lists or amounts.
 export function isValidDeliveryArea(zipCode: string): boolean {
-  const austinZipCodes = [
-    '78701', '78702', '78703', '78704', '78705',
-    '78712', '78721', '78722', '78723', '78724',
-    '78725', '78726', '78727', '78728', '78729',
-    '78730', '78731', '78732', '78733', '78734',
-    '78735', '78736', '78737', '78738', '78739',
-    '78741', '78742', '78744', '78745', '78746',
-    '78747', '78748', '78749', '78750', '78751',
-    '78752', '78753', '78754', '78756', '78757',
-    '78758', '78759',
-  ];
-  return austinZipCodes.includes(zipCode);
+  return isInDeliveryArea(zipCode);
 }
 
 export function getOrderMinimum(zipCode: string): number {
-  const premiumZipCodes = ['78746', '78733', '78738', '78732'];
-  if (premiumZipCodes.includes(zipCode)) {
-    return 150;
-  }
-  return 100;
+  return getMinimumOrder(zipCode);
 }


### PR DESCRIPTION
## What

- **/faqs still told customers "TESTING MODE: Currently no minimum order requirements"** — replaced with the real zone minimums from `src/lib/delivery/rates.ts` ($100 central / $125 greater / $150 extended, free-delivery thresholds $250/$300/$400).
- `src/lib/utils/delivery.ts` carried a stale zip list + premium-zip minimums contradicting rates.ts (ADR-0002 source of truth): `isValidDeliveryArea`/`getOrderMinimum` now delegate to rates.ts, and `getEarliestDeliveryDate` matches the published 48-hour window (was 72h). No current importers outside the legacy shopify utils barrel (verified via grep), so this is copy-level risk only.

Found during the Communication Playbook facts audit (playbook PR incoming from `claude/peaceful-neumann-703c07`).

## Gates (run locally in the PR worktree)

- `npx tsc --noEmit` ✓
- `npm run lint` ✓ (0 errors)
- `npm run test:run` ✓ 422/422

## Not touched on purpose

The /faqs delivery-areas answer still names Round Rock — checkout does accept Round Rock zips; whether we *advertise* there is an open marketing-footprint question tracked in `content/playbook/open-questions.md` (playbook PR), not resolved silently here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)