### PR TITLE
Allow iframe embedding of the customer-facing site (keep admin/ops locked)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -464,13 +464,16 @@ const nextConfig: NextConfig = {
     ];
 
     return [
-      // Security headers for all routes EXCEPT /partners/* (strict iframe policy).
-      // The negative lookahead keeps this rule from matching /partners so the
-      // partner-specific rule below can relax X-Frame-Options and frame-ancestors
-      // without conflicting (Next.js merges matching header rules, and duplicate
-      // X-Frame-Options headers cause browsers to block embedding).
+      // ─── STRICT iframe policy — internal tools only ────────────────
+      // /admin/* and /ops/* stay locked to SAMEORIGIN + frame-ancestors
+      // 'self' so an attacker can't UI-redress a logged-in operator's
+      // session (clickjacking). These are the only routes that carry
+      // ops auth cookies + admin capabilities, so opening them to
+      // arbitrary embedders is a real risk. Everything else on the site
+      // is safe to embed because it's either public or requires an
+      // explicit token/share-code in the URL.
       {
-        source: '/:path((?!partners).*)',
+        source: '/:path(admin|admin/.*|ops|ops/.*)',
         headers: [
           {
             key: 'X-Frame-Options',
@@ -483,13 +486,19 @@ const nextConfig: NextConfig = {
           },
         ],
       },
-      // Partner landing pages: allow any origin to iframe-embed them so
-      // affiliates can drop the POD store iframe into their own websites.
-      // X-Frame-Options is intentionally omitted (the header has no spec-
-      // compliant "allow all" value, and modern browsers honor CSP
-      // frame-ancestors instead).
+      // ─── OPEN iframe policy — every customer-facing surface ────────
+      // Homepage, landing pages, dashboard, invoice, products, blog,
+      // event invites, partner pages, order flow, etc. Partners
+      // (Premier Party Cruises, event hosts) can drop the POD site into
+      // an iframe on their own web pages so guests never leave the
+      // partner's brand experience.
+      //
+      // X-Frame-Options is intentionally omitted (the header has no
+      // spec-compliant "allow all" value, and duplicating it after the
+      // rule above would cause browsers to block embedding). Modern
+      // browsers honor CSP `frame-ancestors *` instead.
       {
-        source: '/partners/:path*',
+        source: '/:path((?!admin|ops).*)',
         headers: [
           ...commonSecurityHeaders,
           {


### PR DESCRIPTION
## Summary
- Rewrites the next.config.ts iframe policy so any origin can iframe the customer-facing surfaces of partyondelivery.com (homepage, landing pages, dashboard, invoice, products, blog, events, partners, order flow)
- Admin/ops stay strict (SAMEORIGIN + frame-ancestors 'self') — clickjacking protection for logged-in operators

## Why
Founder wants to embed the POD site inside a partner web page (e.g. Premier Party Cruises marina site). Previous config blocked it with X-Frame-Options: SAMEORIGIN across the whole site except a narrow /partners/* carve-out.

## Test plan
- [ ] After deploy: \`curl -I https://partyondelivery.com/\` → shows \`frame-ancestors *\`, no X-Frame-Options header
- [ ] \`curl -I https://partyondelivery.com/admin\` → shows \`X-Frame-Options: SAMEORIGIN\` + \`frame-ancestors 'self'\`
- [ ] Test embedding partyondelivery.com/ inside an iframe on a Premier Party Cruises staging page → loads cleanly
- [ ] Test embedding partyondelivery.com/admin → blocked by browser (as intended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)