### PR TITLE
fix(leads): stop email keystroke fragments + harden follow-up link redirect

### DIFF
--- a/src/app/api/v1/landing/lead-event/route.ts
+++ b/src/app/api/v1/landing/lead-event/route.ts
@@ -24,6 +24,7 @@ import {
   markLeadStatus,
 } from '@/lib/leads/leadCapture';
 import { ensureVisitorCookie, COOKIE_NAME } from '@/lib/leads/cookie';
+import { normalizeEmail } from '@/lib/leads/email-validation';
 import { enqueueJourney } from '@/lib/followups/enqueue';
 import type {
   LeadEventType,
@@ -166,7 +167,10 @@ export async function POST(req: NextRequest) {
   // repeated field-blur events are no-ops; the engine re-checks lead status,
   // drafts, and orders with fresh reads before actually sending — and the
   // journey's feature flag stays off until Allan enables it.
-  const email = lead?.email ?? parsed.identify?.email ?? null;
+  // `lead.email` is already normalized server-side; the raw client fallback
+  // must be re-validated so a keystroke fragment (`an@`) can never anchor an
+  // abandoned-quote journey and hard-bounce.
+  const email = lead?.email ?? normalizeEmail(parsed.identify?.email);
   const promotedBeyondPartial = parsed.setStatus && parsed.setStatus !== 'PARTIAL';
   if (
     lead &&
@@ -188,7 +192,13 @@ export async function POST(req: NextRequest) {
         phone: lead.phone ?? parsed.identify?.phone ?? null,
         payload: {
           firstName: lead.firstName ?? parsed.identify?.firstName ?? null,
-          resumePath: parsed.page ?? '/order',
+          // Store only a clean site-relative pathname; anything else (absolute,
+          // protocol-relative, or backslash/tab tricks that WHATWG URL parsing
+          // would normalize into a foreign host) falls back to /order. This is
+          // defense-in-depth behind the engine's ctx.link() origin check, and
+          // keeps the queued payload clean for the pre-flip queue audit.
+          resumePath:
+            parsed.page && /^\/[\w\-/.]*$/.test(parsed.page) ? parsed.page : '/order',
           // Digits only — this value is quoted verbatim inside email copy.
           guestCount: /^\d{1,4}$/.test(rawGuestCount) ? rawGuestCount : null,
         },

--- a/src/components/landing/PackageBuilderModal.tsx
+++ b/src/components/landing/PackageBuilderModal.tsx
@@ -7,6 +7,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import Image from 'next/image';
 import { useLeadCapture } from '@/lib/leads/client';
+import { isCompleteEmail } from '@/lib/leads/email-validation';
 import { fireLeadConversionAndFlush } from '@/lib/leads/fireLeadConversion';
 import { getAttribution } from '@/lib/analytics/attribution';
 import { trackContactClick } from '@/lib/analytics/ga4-events';
@@ -169,7 +170,13 @@ export default function PackageBuilderModal({
       if (contactName && contactName !== prev.name) {
         lead.onBlurField('name', contactName, identify);
       }
-      if (contactEmail && contactEmail !== prev.email) {
+      // Only capture the email once it's a complete address — otherwise each
+      // debounce tick would fire a fresh fragment (`an@`, `anz@`, …).
+      if (
+        contactEmail &&
+        contactEmail !== prev.email &&
+        isCompleteEmail(contactEmail)
+      ) {
         lead.onBlurField('email', contactEmail, identify);
       }
       if (contactPhone && contactPhone !== prev.phone) {

--- a/src/components/leads/FormCaptureWatcher.tsx
+++ b/src/components/leads/FormCaptureWatcher.tsx
@@ -33,6 +33,7 @@
 import { useEffect } from 'react';
 import { usePathname } from 'next/navigation';
 import { sendLeadEvent, type LeadWidget } from '@/lib/leads/client';
+import { isCompleteEmail } from '@/lib/leads/email-validation';
 
 const SKIP_PATH_PATTERNS = [
   /^\/admin(\/|$)/,
@@ -147,8 +148,13 @@ export default function FormCaptureWatcher() {
       recentByField.set(dedupeKey, entry.value);
       pending.delete(dedupeKey);
 
+      // Keep the event + raw fieldValue for funnel analysis, but never let a
+      // mid-typing email fragment (`an@`) anchor a Lead — leave it out of
+      // identify so the upsert has nothing to key on.
       const identify: Record<string, string> = {};
-      identify[entry.fieldKind] = entry.value;
+      if (entry.fieldKind !== 'email' || isCompleteEmail(entry.value)) {
+        identify[entry.fieldKind] = entry.value;
+      }
 
       void sendLeadEvent({
         type: eventType,
@@ -206,8 +212,7 @@ export default function FormCaptureWatcher() {
         // see a fully-formed email so we don't lose it if they close the
         // tab mid-debounce.
         pending.set(fieldName, entry);
-        const looksLikeEmail =
-          fieldKind === 'email' && /.+@.+\..+/.test(value);
+        const looksLikeEmail = fieldKind === 'email' && isCompleteEmail(value);
         const looksLikePhone =
           fieldKind === 'phone' && value.replace(/\D/g, '').length >= 10;
         if (looksLikeEmail || looksLikePhone) {
@@ -232,7 +237,10 @@ export default function FormCaptureWatcher() {
         page: pathname,
         fieldName: entry.fieldName,
         fieldValue: entry.value,
-        identify: { [entry.fieldKind]: entry.value },
+        identify:
+          entry.fieldKind === 'email' && !isCompleteEmail(entry.value)
+            ? {}
+            : { [entry.fieldKind]: entry.value },
         metadata: { source: 'global-form-watcher', via: 'beacon' },
       }));
       try {

--- a/src/lib/followups/__tests__/link-safety.test.ts
+++ b/src/lib/followups/__tests__/link-safety.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+
+import { resolveSameOriginUrl } from '../links';
+
+const BASE = 'https://partyondelivery.com';
+
+describe('resolveSameOriginUrl — open-redirect guard (CWE-601)', () => {
+  it('keeps legitimate site-relative paths', () => {
+    expect(resolveSameOriginUrl('/wedding-drink-calculator', BASE).toString()).toBe(
+      'https://partyondelivery.com/wedding-drink-calculator',
+    );
+    expect(resolveSameOriginUrl('/order', BASE).pathname).toBe('/order');
+    expect(
+      resolveSameOriginUrl('/austin-bachelorette-party-delivery', BASE).origin,
+    ).toBe(BASE);
+  });
+
+  it('neutralizes every escape vector to the site root', () => {
+    for (const evil of [
+      '/\\evil.com', // backslash — WHATWG treats as `/`, becomes //evil.com
+      '//evil.com', // protocol-relative
+      '/\t/evil.com', // embedded tab stripped -> //evil.com
+      '/\n/evil.com', // embedded newline stripped
+      'https://evil.com', // absolute
+      'http://evil.com/phish', // absolute, different scheme
+      '\\\\evil.com', // double backslash
+      'javascript:alert(1)', // non-http scheme
+    ]) {
+      const url = resolveSameOriginUrl(evil, BASE);
+      expect(url.origin, `escape not neutralized: ${JSON.stringify(evil)}`).toBe(
+        BASE,
+      );
+    }
+  });
+
+  it('falls back to the site root on empty / unparseable input', () => {
+    expect(resolveSameOriginUrl('', BASE).origin).toBe(BASE);
+    expect(resolveSameOriginUrl('   ', BASE).origin).toBe(BASE);
+  });
+});

--- a/src/lib/followups/engine.ts
+++ b/src/lib/followups/engine.ts
@@ -31,6 +31,7 @@ import {
 } from './suppression';
 import type { EngineRunResult, FollowUpCopyOverrides, JourneyDef, JourneyKey } from './types';
 import { SITE_BASE_URL } from './types';
+import { resolveSameOriginUrl } from './links';
 
 const CLAIM_BATCH_SIZE = 50;
 const STUCK_PROCESSING_MINUTES = 30;
@@ -286,11 +287,10 @@ export async function processJob(
     job,
     payload: (job.payload as Record<string, unknown> | null) ?? {},
     link: (path: string) => {
-      // Open-redirect guard (CWE-601): payload paths may echo public route
-      // input, and new URL(path, base) IGNORES the base for absolute and
-      // protocol-relative paths. Only site-relative paths survive.
-      const safePath = path.startsWith('/') && !path.startsWith('//') ? path : '/';
-      const url = new URL(safePath, SITE_BASE_URL);
+      // Open-redirect guard (CWE-601): resolveSameOriginUrl rejects any path
+      // that escapes our origin — the payload path echoes public,
+      // unauthenticated route input. See links.ts + link-safety.test.ts.
+      const url = resolveSameOriginUrl(path, SITE_BASE_URL);
       url.searchParams.set('utm_source', 'email');
       url.searchParams.set('utm_medium', 'followup');
       url.searchParams.set('utm_campaign', journey.key);

--- a/src/lib/followups/enqueue.ts
+++ b/src/lib/followups/enqueue.ts
@@ -14,6 +14,7 @@ import { Prisma, type FollowUpJob } from '@prisma/client';
 import { prisma } from '@/lib/database/client';
 import { getJourney } from './journeys';
 import { normalizeEmail } from './suppression';
+import { isCompleteEmail } from '@/lib/leads/email-validation';
 import { entityIdFromDedupeKey, type JourneyKey } from './types';
 
 const MAX_JITTER_MS = 45 * 60 * 1000;
@@ -102,7 +103,12 @@ export async function enqueueJourney(
   if (!stepDef) return { enqueued: false, reason: 'no-such-step' };
 
   const email = normalizeEmail(opts.email);
-  if (!email || !email.includes('@')) return { enqueued: false, reason: 'invalid-email' };
+  // Completeness backstop: only a full address may anchor an email-sending
+  // journey, regardless of caller. Stops keystroke fragments / garbage from
+  // being queued (they'd hard-bounce) even if a future caller skips the
+  // route-level pre-check. `normalizeEmail` here (from ./suppression) only
+  // trims + lowercases + checks for '@'; isCompleteEmail is the strict gate.
+  if (!email || !isCompleteEmail(email)) return { enqueued: false, reason: 'invalid-email' };
 
   const scheduledFor = computeSendAt(opts.baseTime ?? new Date(), stepDef.delayHours);
 

--- a/src/lib/followups/links.ts
+++ b/src/lib/followups/links.ts
@@ -1,0 +1,35 @@
+/**
+ * Follow-up email link safety.
+ *
+ * Every link in a follow-up email is built from a payload path that may echo
+ * public, unauthenticated route input (e.g. abandoned-quote's `resumePath` =
+ * the landing page's `page` field, POSTed to /api/v1/landing/lead-event with
+ * no auth). If an attacker can steer that path to a foreign host, they get a
+ * legitimate, info@partyondelivery.com-signed email whose CTA points at their
+ * domain — phishing on our sending reputation (CWE-601, Open Redirect).
+ *
+ * A string-prefix check is NOT sufficient. WHATWG URL parsing (what `new URL`
+ * uses) treats `\` as `/` for http(s) and strips embedded tab/newline, so
+ * `"/\evil.com"` and `"/\t/evil.com"` both normalize to `https://evil.com`.
+ * The only robust guard is to resolve the path and compare the *resulting*
+ * origin to ours.
+ */
+
+/**
+ * Resolve `path` against `baseUrl` and return the resulting URL only if it
+ * stays on the same origin; otherwise return the site root. Never throws.
+ *
+ * Kept as a pure, exported function (no side effects, no env reads) so the
+ * open-redirect guard is unit-testable in isolation — see
+ * `__tests__/link-safety.test.ts`.
+ */
+export function resolveSameOriginUrl(path: string, baseUrl: string): URL {
+  const base = new URL(baseUrl);
+  let resolved: URL;
+  try {
+    resolved = new URL(path, base);
+  } catch {
+    return new URL('/', base);
+  }
+  return resolved.origin === base.origin ? resolved : new URL('/', base);
+}

--- a/src/lib/leads/__tests__/email-validation.test.ts
+++ b/src/lib/leads/__tests__/email-validation.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+
+import { isCompleteEmail, normalizeEmail } from '../email-validation';
+
+describe('normalizeEmail', () => {
+  it('accepts a complete address and trims + lowercases it', () => {
+    expect(normalizeEmail('  A@B.CO ')).toBe('a@b.co');
+    expect(normalizeEmail('anzola.hathorne@gmail.com')).toBe(
+      'anzola.hathorne@gmail.com',
+    );
+    expect(normalizeEmail('Name+tag@Sub.Example.com')).toBe(
+      'name+tag@sub.example.com',
+    );
+  });
+
+  it('rejects mid-typing keystroke fragments', () => {
+    for (const fragment of [
+      'an@',
+      'anz@',
+      'anzo@',
+      '@gmail.com',
+      'a@gmail',
+      'a@b',
+      'a@b.',
+      'a@b.c', // single-char TLD — still typing
+      'plainaddress',
+    ]) {
+      expect(normalizeEmail(fragment)).toBeNull();
+    }
+  });
+
+  it('rejects addresses containing internal whitespace', () => {
+    expect(normalizeEmail('a b@c.com')).toBeNull();
+    expect(normalizeEmail('a@b c.com')).toBeNull();
+  });
+
+  it('returns null for empty / missing input', () => {
+    expect(normalizeEmail('')).toBeNull();
+    expect(normalizeEmail('   ')).toBeNull();
+    expect(normalizeEmail(null)).toBeNull();
+    expect(normalizeEmail(undefined)).toBeNull();
+  });
+});
+
+describe('isCompleteEmail', () => {
+  it('is true only for complete addresses', () => {
+    expect(isCompleteEmail('a@b.co')).toBe(true);
+    expect(isCompleteEmail('anzola.hathorne@gmail.com')).toBe(true);
+  });
+
+  it('is false for fragments and empties', () => {
+    expect(isCompleteEmail('an@')).toBe(false);
+    expect(isCompleteEmail('@gmail.com')).toBe(false);
+    expect(isCompleteEmail('a@b.c')).toBe(false);
+    expect(isCompleteEmail(null)).toBe(false);
+    expect(isCompleteEmail(undefined)).toBe(false);
+  });
+});

--- a/src/lib/leads/client.ts
+++ b/src/lib/leads/client.ts
@@ -14,6 +14,7 @@
 import { useCallback, useMemo } from 'react';
 
 import { getAttribution } from '@/lib/analytics/attribution';
+import { isCompleteEmail } from './email-validation';
 
 const LEAD_EVENT_URL = '/api/v1/landing/lead-event';
 const PIXEL_URL = '/api/v1/landing/visitor-pixel';
@@ -169,6 +170,22 @@ export async function fireVisitorPixel(page: string) {
 }
 
 /**
+ * Drop `identify.email` when it is still a mid-typing fragment (`an@`,
+ * `@gmail.com`). The field-blur event + its raw `fieldValue` still fire so
+ * funnel/drop-off analysis is unchanged — we only refuse to let an
+ * incomplete address anchor a Lead row (and, downstream, an abandoned-quote
+ * follow-up that would hard-bounce).
+ */
+function stripIncompleteEmail(identify?: Identify): Identify | undefined {
+  if (!identify || identify.email == null || isCompleteEmail(identify.email)) {
+    return identify;
+  }
+  const rest: Identify = { ...identify };
+  delete rest.email;
+  return rest;
+}
+
+/**
  * React hook bound to a widget + page slug. Returns convenience functions
  * for the most common form-instrumentation patterns.
  */
@@ -184,7 +201,7 @@ export function useLeadCapture(opts: { widget: LeadWidget; page?: string }) {
         page,
         fieldName,
         fieldValue: value,
-        identify,
+        identify: stripIncompleteEmail(identify),
       });
     },
     [widget, page],

--- a/src/lib/leads/email-validation.ts
+++ b/src/lib/leads/email-validation.ts
@@ -1,0 +1,48 @@
+/**
+ * Email completeness validation — shared by server lead-capture and the
+ * browser-side capture widgets.
+ *
+ * WHY THIS EXISTS (and why it is its own module, not part of leadCapture.ts):
+ * the lead widgets fire a capture on every typing pause, so a visitor typing
+ * `anzolahathorne@gmail.com` used to persist a fresh Lead row for `an@`,
+ * `anz@`, `anzo@`, … — ~10–21 undeliverable fragments per real person. Those
+ * fragments also fed the abandoned-quote follow-up enqueue, which would
+ * hard-bounce and torch info@partyondelivery.com deliverability.
+ *
+ * The guard: only treat a string as an email once it is a *syntactically
+ * complete* address (local@domain.tld). This module is intentionally pure —
+ * no Prisma, no React, no 'use client' — so both server routes and client
+ * components can import it without dragging the database client into the
+ * browser bundle. leadCapture.ts imports Prisma, so the helper cannot live
+ * there.
+ */
+
+/**
+ * Matches `local@domain.tld` after trim/lowercase: a local part with no
+ * spaces or `@`, an `@`, a domain with no spaces or `@`, a dot, and a TLD of
+ * at least two non-space/non-@ characters. Deliberately conservative — it
+ * rejects mid-typing fragments (`an@`, `@gmail.com`, `a@b`, `a@b.c`) while
+ * accepting real addresses. It is a completeness gate, not a full RFC 5322
+ * validator (delivery is the real test of validity).
+ */
+const COMPLETE_EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+
+/**
+ * Normalize a candidate email to a trimmed, lowercased address, or return
+ * null if it is missing or not a complete address. Use this anywhere a Lead
+ * row is keyed/created on email so fragments never anchor a lead.
+ */
+export function normalizeEmail(value?: string | null): string | null {
+  if (!value) return null;
+  const trimmed = value.trim().toLowerCase();
+  return COMPLETE_EMAIL_RE.test(trimmed) ? trimmed : null;
+}
+
+/**
+ * True when `value` is a syntactically complete email. Client-safe gate for
+ * the capture widgets — use before attaching `identify.email` or firing an
+ * email-specific capture so partial keystrokes stay funnel-only.
+ */
+export function isCompleteEmail(value?: string | null): boolean {
+  return normalizeEmail(value) !== null;
+}

--- a/src/lib/leads/leadCapture.ts
+++ b/src/lib/leads/leadCapture.ts
@@ -19,6 +19,7 @@ import type {
   LeadStatus,
   VisitorSession,
 } from '@prisma/client';
+import { normalizeEmail } from './email-validation';
 
 export type IdentifyInput = {
   email?: string | null;
@@ -81,11 +82,10 @@ function mergeAttributionMetadata(
 
 const MAX_FIELD_VALUE_LEN = 1000;
 
-function normEmail(v?: string | null) {
-  if (!v) return null;
-  const trimmed = v.trim().toLowerCase();
-  return trimmed && trimmed.includes('@') ? trimmed : null;
-}
+// Email completeness lives in ./email-validation (a Prisma-free module so the
+// browser capture widgets can share the same rule). `normalizeEmail` rejects
+// mid-typing fragments like `an@` / `@gmail.com`, so a Lead is only ever
+// keyed/created on a syntactically complete address.
 
 function normPhone(v?: string | null) {
   if (!v) return null;
@@ -151,7 +151,7 @@ export async function getOrCreateSession(opts: {
  * creating a new lead from a partial submit.
  */
 export async function findLead(input: IdentifyInput): Promise<Lead | null> {
-  const email = normEmail(input.email);
+  const email = normalizeEmail(input.email);
   const phone = normPhone(input.phone);
   if (!email && !phone) return null;
   return prisma.lead.findFirst({
@@ -178,7 +178,7 @@ export async function upsertLead(
   ctx: LeadContext,
   session?: VisitorSession | null,
 ): Promise<Lead | null> {
-  const email = normEmail(identify.email);
+  const email = normalizeEmail(identify.email);
   const phone = normPhone(identify.phone);
   const firstName = nonEmpty(identify.firstName);
   const lastName = nonEmpty(identify.lastName);


### PR DESCRIPTION
## Why
The lead-capture widgets persisted a **Lead row per keystroke** of the email field (`an@` → `anz@` → …) — ~10–21 undeliverable fragment rows per real visitor. Those fragments also fed the **abandoned-quote follow-up enqueue**, so once that journey's flag flips on they'd hard-bounce and torch `info@partyondelivery.com` deliverability. This PR is the prerequisite for enabling the abandoned-quote nurture path.

## What
- **New `src/lib/leads/email-validation.ts`** — Prisma-free `normalizeEmail` / `isCompleteEmail`, shared by server + client (kept separate from `leadCapture.ts` so client components don't pull Prisma into the browser bundle).
- A **complete** address is now required before an email can:
  - key/create a `Lead` (`leadCapture.ts` `findLead`/`upsertLead` — the universal server backstop)
  - anchor an abandoned-quote journey (`lead-event/route.ts` enqueue fallback)
  - attach to `identify` from a blur/typing capture (`client.ts` `onBlurField`, `FormCaptureWatcher` capture+beacon, `PackageBuilderModal` debounce)
- Funnel events + raw `fieldValue` are **unchanged** — only `identify.email` is withheld while incomplete.

## Security hardening (from this PR's security review)
The review surfaced a **pre-existing HIGH open-redirect (CWE-601)** in the follow-up engine's `ctx.link()`: the abandoned-quote `resumePath` echoes unauthenticated route input, and `enqueueJourney` writes job rows **regardless of the feature flag**, so a `/\evil.com` path could be planted now and fire an `info@partyondelivery.com`-signed phishing link the moment the flag is enabled. Fixed here because PR-1 gates that flip:
- **`links.ts` `resolveSameOriginUrl()`** — resolve-then-compare-origin guard (string-prefix checks miss backslash/tab/newline WHATWG normalization) + `link-safety.test.ts` regression tests covering every escape vector.
- **`enqueue.ts`** — `isCompleteEmail()` completeness backstop for any caller (it was importing the weak `normalizeEmail`).
- **`route.ts`** — `resumePath` sanitized to a clean site-relative pathname (defense-in-depth + keeps the queue clean for the pre-flip audit).

Deferred (tracked): dead `/api/leads/drink-calculator` route PII-logs (separate task — external callers unknown); rate-limiting the public `lead-event` endpoint (operationally mitigated by auditing the queue before flipping the flag).

## Test plan
- `npx tsc --noEmit` — clean
- `npx next lint` — clean (one pre-existing unrelated `PackageBuilderModal` warning)
- `npm run test:run` — **603 pass**, incl. new `email-validation` (6) + `link-safety` (3) suites; followups' 53 stay green

🤖 Generated with [Claude Code](https://claude.com/claude-code)