### PR TITLE
feat(landing): footprint sweep + bachelorette/corporate content to bachelor standard

### DIFF
--- a/docs/AD-CAMPAIGN-UTM-CONVENTION.md
+++ b/docs/AD-CAMPAIGN-UTM-CONVENTION.md
@@ -37,6 +37,16 @@ Each campaign maps to one slug. Don't invent new ones — extend this table firs
 
 **Bachelor vs bachelorette gotcha:** `'bachelorette-party-delivery'.includes('bach')` returns true, so the segment classifier maps both campaigns to the `'bach'` segment. This is intentional — both are the bach-party business category. To split bachelor vs bachelorette in reporting, query `Order.utmCampaign`, NOT `Order.segment`.
 
+### 2026-07 update — live Search campaigns use date-stamped slugs
+
+The live Google Ads **Search** campaigns use `{vertical}-search-atx-YYYY-MM` (display name `{Vertical} · Search · ATX · YYYY-MM`), not the older un-dated slugs above. `classifySegment`'s UTM fallback substring-matches (`.includes('bach')` / `'corporate'` / `'wedding'`), so these still classify correctly — verified: `bachelorette-search-atx-2026-07` → `bach`, `corporate-search-atx-2026-07` → `corporate`, `bachelor-search-atx-2026-06` → `bach`. The un-dated slugs above remain valid for legacy / non-Search campaigns.
+
+| Live Search campaign | Canonical slug | Lands on |
+|---|---|---|
+| Bachelor · Search · ATX · 2026-06 | `bachelor-search-atx-2026-06` | `/austin-bachelor-party-delivery` |
+| Bachelorette · Search · ATX · 2026-07 | `bachelorette-search-atx-2026-07` | `/austin-bachelorette-party-delivery` |
+| Corporate · Search · ATX · 2026-07 | `corporate-search-atx-2026-07` | `/austin-corporate-event-delivery` |
+
 ## Example URLs
 
 **Wedding campaign #1 (first launch, calculator-targeted):**

--- a/src/components/landing/configs/bachelorette.ts
+++ b/src/components/landing/configs/bachelorette.ts
@@ -25,21 +25,35 @@ export const bacheloretteConfig: LandingConfig = {
   heroHeadline: 'Champagne Popped',
   heroHeadlineAccent: 'Before The Bride Lands.',
   heroSubhead:
-    "Bubbly, rosé, cocktail pitcher kits, and brunch mimosa bars — delivered to your Airbnb, hotel suite, or Lake Travis pontoon. You handle the sashes. We handle the rest.",
+    "Bubbly, rosé, cocktail pitcher kits, and brunch mimosa bars — delivered to your Airbnb, hotel suite, or Lake Travis pontoon. You handle the sashes; we handle the rest. Reschedule free up to 6 hours out.",
   heroBullets: [
-    'Champagne, rosé, seltzers & ready-to-pour pitcher kits',
-    'Group ordering & split pay — every girl picks her own',
-    'Airbnb, hotel suite, brunch venue, pontoon — wherever',
-    'Locally owned. 500+ Austin groups served. 5.0★ on Google.',
+    'Pre-stocked at the Airbnb before the bride even lands',
+    'One MOH link — every girl adds her own and pays her share',
+    'Dropped dockside to your Lake Travis pontoon, iced & ready',
+    'Brunch mimosa kits for the morning after — pour and go',
   ],
   heroImage: '/images/services/bach-parties/bachelorette-champagne-tower.webp',
+  heroImages: [
+    {
+      src: '/images/services/bach-parties/bachelorette-champagne-tower.webp',
+      alt: 'Champagne tower at an Austin bachelorette party stocked by Party On Delivery',
+    },
+    {
+      src: '/images/gallery/sunset-champagne-pontoon.webp',
+      alt: 'Bachelorette group toasting on a Lake Travis pontoon at sunset',
+    },
+    {
+      src: '/images/services/bach-parties/brunch-mimosa-bar.webp',
+      alt: 'Brunch mimosa bar delivered for an Austin bachelorette weekend',
+    },
+  ],
   heroTrustBadges: ['✓ TABC-licensed', '✓ 500+ Austin bach weekends', '★ 5.0 on Google', '✓ Split pay built-in'],
 
   trustStats: [
-    { stat: 'Group ordering', label: 'Girls add to one shared cart' },
-    { stat: 'Split pay', label: 'Each pays her share' },
-    { stat: 'Cocktail kits', label: 'Mimosa bars, espresso martinis, ready to pour' },
-    { stat: '500+', label: 'Groups served' },
+    { stat: '500+', label: 'Austin bach & bachelorette groups served' },
+    { stat: '5.0★', label: 'Google rating — see reviews below' },
+    { stat: '$0', label: 'Split-pay fees — every girl pays her share' },
+    { stat: '48-hr', label: 'Notice locks guaranteed pricing' },
   ],
 
   painHeadline: "You're the maid of honor — not the liquor runner.",
@@ -138,13 +152,15 @@ export const bacheloretteConfig: LandingConfig = {
 
   venuesEyebrow: 'EVERYWHERE THE GIRLS GO',
   venuesHeadline: 'Hotel suite. Lake pontoon. Brunch table. We deliver.',
+  // Footprint guard: only name the confirmed delivery footprint (Austin, Cedar
+  // Park, Westlake, Bee Cave, Lakeway, Lake Travis) in paid landing copy.
   venues: [
     { area: 'Downtown Hotel Suites', detail: 'Fairmont, JW Marriott, Line — discreet to your room' },
     { area: 'Rainey & East Austin Airbnbs', detail: 'Front door, kitchen-counter setup' },
     { area: 'Lake Travis Pontoons & Yachts', detail: 'Dockside loading, ice & coolers included' },
     { area: 'Brunch Spots', detail: 'Bring-your-own-bubbly venues — we time it to brunch' },
     { area: 'Spa & Pool Days', detail: 'Cabana drop-off at hotels with poolside service' },
-    { area: 'Wedding-Adjacent Houses', detail: 'Wimberley, Dripping Springs, Spicewood' },
+    { area: 'Wedding-Adjacent Houses', detail: 'Westlake, Bee Cave, Lakeway — straight to the big house' },
   ],
   venuesImage: '/images/hero/bach-hero-rainey.webp',
 
@@ -241,7 +257,7 @@ export const bacheloretteConfig: LandingConfig = {
   finalCtaHeadline: 'Lock it in.',
   finalCtaHeadlineAccent: 'Then enjoy the weekend you actually planned.',
   finalCtaSubhead:
-    "Most groups book 1–3 weeks out. Lake Travis weekends and Saturday brunches fill up fast.",
+    "Most groups book 1–3 weeks out, and Lake Travis weekends and Saturday brunches fill up fast. Reschedule free up to 6 hours before delivery — lock the date now and tweak later.",
   finalCtaImage: '/images/services/bach-parties/brunch-mimosa-bar.webp',
 
   planningCallUrl: 'https://123.partyondelivery.com/planning-call',

--- a/src/components/landing/configs/corporate.ts
+++ b/src/components/landing/configs/corporate.ts
@@ -33,13 +33,27 @@ export const corporateConfig: LandingConfig = {
     'White-glove delivery — coordinated with your venue',
   ],
   heroImage: '/images/products/premium-spirits-lifestyle.webp',
+  heroImages: [
+    {
+      src: '/images/hero/corporate-hero-conference.webp',
+      alt: 'Corporate conference reception bar stocked by Party On Delivery in Austin',
+    },
+    {
+      src: '/images/hero/corporate-hero-gala.webp',
+      alt: 'Austin corporate gala with premium wine and champagne service',
+    },
+    {
+      src: '/images/hero/corporate-hero-tech.webp',
+      alt: 'Austin tech company happy hour with craft beer and cocktails delivered',
+    },
+  ],
   heroTrustBadges: ['✓ TABC-licensed', '✓ $1M insured', '✓ COI available', '✓ Corporate cards / ACH / wire'],
 
   trustStats: [
-    { stat: 'TABC-licensed', label: 'Packaged-store license' },
-    { stat: '$1M insured', label: 'GL + liquor liability' },
-    { stat: 'Invoices', label: 'Available on request' },
-    { stat: 'Free returns', label: 'On unopened product' },
+    { stat: '500+', label: 'Austin events served' },
+    { stat: '5.0★', label: 'Google rating — see reviews below' },
+    { stat: '$1M', label: 'GL + liquor liability insured · COI on request' },
+    { stat: '72-hr', label: 'Standard lead time — faster when needed' },
   ],
 
   painHeadline:
@@ -102,7 +116,7 @@ export const corporateConfig: LandingConfig = {
   customLine:
     "Larger event or recurring need? Let's set up an account — call us.",
 
-  stepsHeadline: 'From PO to pour in three steps.',
+  stepsHeadline: 'From brief to pour in three steps.',
   steps: [
     {
       n: '1',
@@ -126,11 +140,13 @@ export const corporateConfig: LandingConfig = {
 
   venuesEyebrow: 'EVERYWHERE AUSTIN COMPANIES MEET',
   venuesHeadline: 'Office. Hotel ballroom. Lake ranch. We handle it.',
+  // Footprint guard: only name the confirmed delivery footprint (Austin, Cedar
+  // Park, Westlake, Bee Cave, Lakeway, Lake Travis) in paid landing copy.
   venues: [
     { area: 'Downtown Office Towers', detail: 'Loading dock or front desk — we know the buildings' },
     { area: 'Hotel Conference & Ballrooms', detail: 'Driskill, Fairmont, JW Marriott — coordinated with banquet teams' },
     { area: 'Lake Travis Event Venues', detail: 'Vintage Villas, Lakeway Resort, private estates' },
-    { area: 'Wine Country & Hill Country', detail: 'Driftwood, Wimberley, Dripping Springs ranches' },
+    { area: 'Westlake & Lakeway Venues', detail: 'Westlake, Bee Cave, Lakeway, Cedar Park offices & estates' },
     { area: 'SXSW & Conference Activations', detail: 'Brand activations, hospitality suites, panel sponsorships' },
     { area: 'Recurring Office Stocking', detail: 'Quarterly happy hours, kitchen restocks, client gifts' },
   ],
@@ -138,24 +154,30 @@ export const corporateConfig: LandingConfig = {
 
   reviewsEyebrow: '★★★★★ 5.0 ON GOOGLE',
   reviewsHeadline: 'The vendor your finance team approves of.',
+  // Real Google reviews (verbatim — harvested from the Business Profile reviews
+  // manager, same pool as bachelor.ts). The prior three entries were fabricated
+  // personas and were removed.
+  // TODO(operator): swap the two non-corporate reviews below for corporate-
+  // specific GBP quotes when harvested (approve verbatim — never paraphrase a
+  // real review), same flow as PR #121.
   reviews: [
     {
       quote:
-        "Booked them for a board dinner with 36 hours notice. Premium wine, perfect timing, paid invoice in our inbox same day. Now our default vendor for client events.",
-      author: 'Patricia L.',
-      detail: 'Chief of Staff, Austin SaaS company',
+        'Fast, fair and convenient. Very hard to get all 3 in any business. Will use again for our next visit to Austin!',
+      author: 'Tim Nappi',
+      detail: '★★★★★ via Google',
     },
     {
       quote:
-        'Stocked our SXSW activation across four days. Re-stocked twice on the fly. Invoice came through clean — finance loved it.',
-      author: 'Marcus D.',
-      detail: 'Head of Brand Marketing',
+        'Awesome delivery service! Drinks showed up cold and on time for stocking our rental for the weekend',
+      author: 'Bayne Pettinger',
+      detail: '★★★★★ via Google',
     },
     {
       quote:
-        "Holiday party for 80. They handled everything from the welcome champagne to the post-dinner whiskey flight. The CEO asked who they were.",
-      author: 'Andrea K.',
-      detail: 'VP People Ops',
+        'Used for a boat day on Lake Travis and it made it SO easy! Just showed up and our cooler was stocked with ice and all of the drinks we ordered ahead of time. 10/10 would recommend',
+      author: 'Rivajoy Giannitsis',
+      detail: '★★★★★ via Google · Lake Travis event',
     },
   ],
 
@@ -186,6 +208,42 @@ export const corporateConfig: LandingConfig = {
       a: 'Yes — free returns on any unopened product. If your event ends with full bottles untouched, send them back.',
     },
   ],
+
+  popularProducts: {
+    heading: 'Crowd-pleasers for Austin corporate events',
+    intro:
+      'The bottles and kits Austin companies add most for receptions, offsites, and office happy hours — invoiced and delivered cold to your venue.',
+    items: [
+      {
+        handle: 'veuve-clicquot-champagne-brut-750ml',
+        name: 'Veuve Clicquot Brut • 750ml',
+        blurb:
+          'The toast bottle for client dinners and milestones — the label your guests recognize.',
+        price: '$74.99',
+      },
+      {
+        handle: 'la-marca-prosecco-extra-dry-750ml-6-pack',
+        name: 'La Marca Prosecco • 6-Pack',
+        blurb:
+          'Six bottles of crowd-friendly Italian bubbly — the reception and mimosa-bar workhorse by the case.',
+        price: '$99.99',
+      },
+      {
+        handle: 'aperol-spritz-party-pitcher-kit-16-drinks',
+        name: 'Aperol Spritz Kit • Serves 16',
+        blurb:
+          'A ready-to-pour spritz bar for 16 — a polished welcome cocktail with zero bartender required.',
+        price: '$67.99',
+      },
+      {
+        handle: 'pinthouse-electric-jellyfish-16oz-4-pack-can',
+        name: 'Pinthouse Electric Jellyfish IPA',
+        blurb:
+          "Austin's cult hazy IPA in 16oz cans — the locally owned pick that makes an office happy hour feel like a brewery run.",
+        price: '$19.99',
+      },
+    ],
+  },
 
   finalCtaHeadline: 'Bring us the brief.',
   finalCtaHeadlineAccent: 'We deliver the rest.',

--- a/src/components/landing/configs/wedding.ts
+++ b/src/components/landing/configs/wedding.ts
@@ -125,11 +125,13 @@ export const weddingConfig: LandingConfig = {
 
   venuesEyebrow: 'EVERY AUSTIN WEDDING VENUE',
   venuesHeadline: 'Hill Country ranch. Downtown ballroom. Lakefront estate.',
+  // Footprint guard: only name the confirmed delivery footprint (Austin, Cedar
+  // Park, Westlake, Bee Cave, Lakeway, Lake Travis) in paid landing copy.
   venues: [
-    { area: 'Hill Country Ranches', detail: 'Wimberley, Dripping Springs, Driftwood, Spicewood' },
+    { area: 'Westlake & Hill Country Estates', detail: 'Westlake, Bee Cave, Lakeway estate venues' },
     { area: 'Downtown Hotel Ballrooms', detail: 'Driskill, Fairmont, JW Marriott, Line' },
     { area: 'Lakefront Estates', detail: 'Lake Travis, Lake Austin, private peninsulas' },
-    { area: 'Vineyard & Winery Venues', detail: 'Driftwood Estate, Duchman Family, William Chris' },
+    { area: 'Lakeside & Waterfront Venues', detail: 'Lakeway, Bee Cave, Lake Travis waterfront venues' },
     { area: 'Garden & Outdoor Venues', detail: 'Mercury Hall, Vista West Ranch, Barr Mansion' },
     { area: 'Welcome Houses & Airbnbs', detail: 'Stocked separately for guests on arrival' },
   ],


### PR DESCRIPTION
Config-only (no logic). Brings the bachelorette + corporate landers up to the bachelor standard and strips out-of-footprint venue copy ahead of launching the two new Google Ads campaigns.

## Footprint sweep
Venue/area copy on the wedding, bachelorette, and corporate landers now only names the confirmed delivery footprint (**Austin, Cedar Park, Westlake, Bee Cave, Lakeway, Lake Travis**). Removed Wimberley / Dripping Springs / Driftwood / Spicewood from visitor-facing copy; added positive-footprint guard comments. Grep gate passes (only residual is the pre-existing bachelor.ts guard comment, by design).

## bachelorette.ts → bachelor standard
- Hero image carousel (3 verified assets), numeric trust stats (500+ / 5.0★ / $0 split-pay / 48-hr)
- RSA-message-matched hero bullets (pre-stocked before the bride lands / MOH split-pay one-link / Lake Travis dockside / brunch mimosa kits)
- Free-reschedule risk-reversal in the hero subhead + final CTA

## corporate.ts → bachelor standard
- **Removed 3 fabricated persona reviews** ("Patricia L., Chief of Staff", etc.) → verbatim real Google reviews (Tim Nappi + two `TODO(operator)`-flagged for swap to corporate-specific GBP quotes; quotes must never be paraphrased)
- Hero carousel (3), numeric trust stats, verified `popularProducts` strip (Veuve Clicquot / La Marca Prosecco / Aperol Spritz kit / Pinthouse IPA — all confirmed ACTIVE + availableForSale in the DB)
- `From PO to pour` → `From brief to pour` — the only PO/net-terms phrase repo-wide in landing configs (per PR #196)

## docs
`AD-CAMPAIGN-UTM-CONVENTION.md` — documented the live date-stamped Search slugs (`bachelorette-search-atx-2026-07`, `corporate-search-atx-2026-07`) and verified the segment classifier substring-matches them.

## Operator follow-ups (flagged, non-blocking)
- Swap the 2 non-corporate reviews for corporate-specific GBP quotes (harvest per PR #121 flow)
- Confirm the `$1M GL + liquor liability` and `500+ Austin events` trust-stat claims (both already live on the page; now surfaced as stats)

## Test plan
- `npx tsc --noEmit` clean · `npx next lint` clean · `npm run test:run` **603 pass**
- Footprint grep gate clean · PR #196 compliance grep clean (no net-terms/PO/free-delivery/ship claims)

🤖 Generated with [Claude Code](https://claude.com/claude-code)