### PR TITLE
fix: remove instant lead-magnet popup + expired 4th of July homepage CTA

### DIFF
--- a/src/components/admin/LeadMagnetView.tsx
+++ b/src/components/admin/LeadMagnetView.tsx
@@ -27,7 +27,7 @@ export default function LeadMagnetView() {
         </p>
         <p className="text-xs text-amber-800 mt-2 italic">
           Triggers supported: <strong>time on page</strong>,{' '}
-          <strong>scroll depth</strong>, <strong>exit intent</strong>, and{' '}
+          <strong>scroll depth</strong>, and{' '}
           <strong>manual</strong> (any button can force-open via{' '}
           <code>window.dispatchEvent</code>).
         </p>
@@ -139,8 +139,8 @@ export default function LeadMagnetView() {
             <code>&apos;/austin-*-party-delivery&apos;</code>.
           </li>
           <li>
-            Pick one or more <code>triggers</code> — time, scroll, exit-intent,
-            and/or manual.
+            Pick one or more <code>triggers</code> — time, scroll, and/or
+            manual.
           </li>
           <li>
             Set <code>rewardUrl</code> to the page or PDF you want the user to

--- a/src/components/leadMagnet/LeadMagnetController.tsx
+++ b/src/components/leadMagnet/LeadMagnetController.tsx
@@ -6,7 +6,7 @@
  * Mounted in the root layout. On every page load:
  *   1. Reads LEAD_MAGNETS from config
  *   2. Filters down to magnets that apply to the current pathname
- *   3. Wires up triggers (time-on-page, scroll depth, exit-intent)
+ *   3. Wires up triggers (time-on-page, scroll depth)
  *   4. First trigger that fires → opens the LeadMagnetModal
  *
  * Cooldown lives in localStorage as `lm_seen_<id>` (timestamp). If the
@@ -104,13 +104,6 @@ export default function LeadMagnetController() {
         };
         window.addEventListener('scroll', onScroll, { passive: true });
         cleanupFns.push(() => window.removeEventListener('scroll', onScroll));
-      } else if (t.type === 'exit-intent') {
-        const onMouseOut = (e: MouseEvent) => {
-          // Mouse left the top of the viewport — classic desktop exit intent.
-          if (!e.relatedTarget && e.clientY <= 0) fire('exit-intent');
-        };
-        document.addEventListener('mouseout', onMouseOut);
-        cleanupFns.push(() => document.removeEventListener('mouseout', onMouseOut));
       }
     }
 

--- a/src/components/leads/PixelMount.tsx
+++ b/src/components/leads/PixelMount.tsx
@@ -36,7 +36,7 @@ export default function PixelMount() {
         <FormCaptureWatcher />
       </Suspense>
       {/* Lead-magnet trigger controller — watches the current path and
-          fires the matching magnet's triggers (time/scroll/exit-intent). */}
+          fires the matching magnet's triggers (time/scroll). */}
       <LeadMagnetController />
       {/* Floating chat bubble — appears on the homepage + landing pages.
           Hidden on admin/ops/dashboard/checkout/event-quiz. */}

--- a/src/lib/leadMagnet/config.ts
+++ b/src/lib/leadMagnet/config.ts
@@ -13,7 +13,6 @@
 export type TriggerRule =
   | { type: 'time'; seconds: number }
   | { type: 'scroll'; percent: number } // 0–100 of page scroll height
-  | { type: 'exit-intent' }
   | { type: 'manual' }; // only opens when something calls openLeadMagnet()
 
 export type LeadMagnet = {
@@ -105,7 +104,6 @@ export const LEAD_MAGNETS: LeadMagnet[] = [
     triggers: [
       { type: 'time', seconds: 25 },
       { type: 'scroll', percent: 55 },
-      { type: 'exit-intent' },
       { type: 'manual' },
     ],
     cooldownDays: 7,


### PR DESCRIPTION
Two homepage-experience fixes reported in one session.

---

## 1. Playbook popup fires instantly on page load

### Problem
In an incognito window, the "The Party On Delivery Playbook" lead-capture popup appears within a second of loading the homepage — before the visitor can read the hero. Live on production (the lead-magnet config on `main` is unchanged).

### Root cause
The popup (lead-magnet system, `src/lib/leadMagnet/config.ts`) has four triggers; the first to fire wins: `time 25s`, `scroll 55%`, `exit-intent`, `manual`. By elimination, only **exit-intent** can fire instantly on a fresh load:

- `time` waits a full 25s
- `scroll` needs 55% depth + a real scroll event
- `manual` is never dispatched on the homepage (only the `/flyer` preview button uses it)

The exit-intent handler fired on a `mouseout` at the top edge (`clientY <= 0`) and was **armed instantly on load with no grace period**. In incognito the cursor sits at the top of the screen (you just used the address bar), so the first mouse movement read as "leaving the top" and fired the popup immediately.

### Fix
Remove the exit-intent trigger entirely. The popup now only appears after **25s on the page** or **55% scroll** — never from mouse movement. Also removes the now-dead exit-intent branch in the controller, the `TriggerRule` union member, and stale "exit intent" mentions in `PixelMount` and the admin `LeadMagnetView` help text.

---

## 2. Expired 4th of July CTA on the homepage

July 4th has passed, so the "HOSTING FOR THE FOURTH? / 4th of July Drinks" banner under the hero is stale. Removed that seasonal section from the homepage.

**Scope: homepage only** (per operator decision). The `/austin-4th-of-july-delivery` landing page and the `/cocktail-kits` "July 4th Cocktails!" section stay live — they're seasonal SEO assets that regain value next July, and removing the page would 404 a ranking URL.

---

## Verification
- `npx tsc --noEmit` — clean
- `npx next lint` — no errors (one pre-existing `<img>` warning, unrelated)
- `npm run test:run` — 603 tests passing
- No schema/migration changes; not high-stakes (no auth/Stripe/PII/webhooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
