### PR TITLE
chore(home): remove expired 4th of July CTA from homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -56,22 +56,6 @@ export default function HomePage() {
       {/* Hero Section - Client Component with A/B Testing */}
       <HeroSectionExperimental />
 
-      {/* Seasonal: 4th of July landing-page CTA (sits directly under the hero) */}
-      <section className="bg-white py-8 border-b border-gray-100">
-        <div className="container-custom flex flex-col items-center justify-center gap-4 text-center sm:flex-row">
-          <span aria-hidden="true" className="hidden h-8 w-1.5 rounded-full bg-gradient-to-b from-red-600 via-white to-blue-600 sm:block" />
-          <p className="text-sm font-semibold tracking-[0.08em] text-gray-700">HOSTING FOR THE FOURTH?</p>
-          <TrackedLink href="/austin-4th-of-july-delivery" section="choose_path" buttonText="4th of July Drinks">
-            <button className="inline-flex items-center gap-2 rounded-lg bg-brand-blue px-8 py-4 text-sm font-semibold tracking-[0.08em] text-white transition-colors hover:bg-blue-700">
-              4th of July Drinks
-              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14 5l7 7m0 0l-7 7m7-7H3" />
-              </svg>
-            </button>
-          </TrackedLink>
-        </div>
-      </section>
-
       {/* Start Order CTA */}
       <section className="py-16 bg-gray-50">
         <div className="max-w-4xl mx-auto px-8 text-center">


### PR DESCRIPTION
Follow-up to #202. That PR merged while GitHub's PR head was stuck on the first commit, so the squash captured only the exit-intent popup fix — this homepage change was left behind and **"HOSTING FOR THE FOURTH?" is still live on main**. This PR lands it cleanly.

## Change
July 4th has passed, so the "HOSTING FOR THE FOURTH? / 4th of July Drinks" banner under the hero is stale. Removes that seasonal section from `src/app/page.tsx`.

**Scope: homepage only** (per operator decision). The `/austin-4th-of-july-delivery` landing page and the `/cocktail-kits` "July 4th Cocktails!" section stay live (seasonal SEO, reused next year).

## Verification
- `npx tsc --noEmit` — clean
- `npx next lint` — no errors (one pre-existing `<img>` warning, unrelated)
- `npm run test:run` — 603 tests passing
- Cherry-pick of the original commit `5eb3683f`, re-based cleanly on the post-#202 main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)