### PR TITLE
fix(cart): Add to Cart silently reloads instead of adding (age-verify value mismatch)

### DIFF
--- a/src/contexts/CartContext.tsx
+++ b/src/contexts/CartContext.tsx
@@ -72,7 +72,10 @@ export function CartProvider({ children }: { children: React.ReactNode }): React
 
   const checkAgeVerification = (): boolean => {
     const ageVerified = localStorage.getItem('age_verified') || localStorage.getItem('ageVerified');
-    return ageVerified === 'true';
+    // Accept both stamps: the main age gate (AgeVerification.tsx) writes '1',
+    // while product/quick-buy modals write 'true'. Requiring only 'true' made
+    // Add to Cart silently reload for anyone verified via the main gate.
+    return ageVerified === 'true' || ageVerified === '1';
   };
 
   const openCart = (): void => {


### PR DESCRIPTION
## The bug
Customers reported that clicking **Add to Cart** on product pages did nothing — the page just reloaded and no item was added.

## Root cause
An age-verification value mismatch:
- The main age gate (`AgeVerification.tsx`) stamps `localStorage.age_verified = '1'`
- `CartContext.checkAgeVerification()` required `=== 'true'`

So for anyone who cleared the 21+ gate the normal way, the cart treated them as **not** age-verified and took the failure path — which **wipes the age keys and `window.location.reload()`s** — so the item was never added. It was intermittent (and orders still flowed) only because several product/quick-buy modals happen to write `'true'`.

## Reproduction (live, via Playwright)
- `age_verified='true'` → click Add → `POST /api/v1/cart` **success**, item added ✅
- `age_verified='1'` (what the main gate writes) → click Add → **page reloads, zero cart calls, nothing added** ❌

## Fix
Reader accepts both `'1'` and `'true'`. Fixes every affected session immediately, including ones that already have `'1'` stored. Also covers `openCart`/`toggleCart`, which use the same check.

## Verification
`npx eslint` clean, `npx tsc --noEmit` clean. One-line logic change; no schema/API changes.

**Note:** touches the age-verification (compliance) path — recommend a quick /code-review + security-reviewer pass before merge. It only *widens* acceptance to the legitimate value the app itself writes; it does not accept empty/arbitrary values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)