### PR TITLE
fix(full-moon): center the Where pill under the datestamp

### DIFF
--- a/src/components/full-moon/Hero.tsx
+++ b/src/components/full-moon/Hero.tsx
@@ -38,26 +38,28 @@ export default function Hero({ onGetTicket }: HeroProps): ReactElement {
             </h1>
             <p className={styles.heroSub}>{HERO.sub}</p>
 
-            <div className={styles.datestamp}>
-              {DATESTAMP.map((cell) => (
-                <div key={cell.key} className={styles.dsCell}>
-                  <span className={styles.dsKey}>{cell.key}</span>
-                  <span className={styles.dsVal}>
-                    {cell.value}
-                    {cell.suffix ? <small>{cell.suffix}</small> : null}
-                  </span>
-                </div>
-              ))}
-            </div>
+            <div className={styles.heroStamps}>
+              <div className={styles.datestamp}>
+                {DATESTAMP.map((cell) => (
+                  <div key={cell.key} className={styles.dsCell}>
+                    <span className={styles.dsKey}>{cell.key}</span>
+                    <span className={styles.dsVal}>
+                      {cell.value}
+                      {cell.suffix ? <small>{cell.suffix}</small> : null}
+                    </span>
+                  </div>
+                ))}
+              </div>
 
-            <div className={styles.whereBox}>
-              <span className={styles.whereIcon} aria-hidden="true">
-                <Icon name="pin" strokeWidth={1.7} />
-              </span>
-              <div className={styles.dsCell}>
-                <span className={styles.dsKey}>Where</span>
-                <span className={styles.whereVal}>{LOCATION.name}</span>
-                <span className={styles.whereAddr}>{LOCATION.address}</span>
+              <div className={styles.whereBox}>
+                <span className={styles.whereIcon} aria-hidden="true">
+                  <Icon name="pin" strokeWidth={1.7} />
+                </span>
+                <div className={styles.dsCell}>
+                  <span className={styles.dsKey}>Where</span>
+                  <span className={styles.whereVal}>{LOCATION.name}</span>
+                  <span className={styles.whereAddr}>{LOCATION.address}</span>
+                </div>
               </div>
             </div>
 

--- a/src/components/full-moon/full-moon.module.css
+++ b/src/components/full-moon/full-moon.module.css
@@ -273,14 +273,24 @@
 }
 .heroGlow { color: inherit; }
 
+/* Datestamp + location pill stack — sized to the (wider) datestamp so the
+   location pill centers directly under the three timing tiles, left/desktop
+   and centered/mobile alike. */
+.heroStamps {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: fit-content;
+}
+
 /* Location pill — same glass box as the datestamp, sitting just below it. */
 .whereBox {
   display: flex;
   width: fit-content;
   align-items: center;
   gap: 10px;
-  /* Centered horizontally within the hero content column. */
-  margin: 16px auto 0;
+  /* Horizontal centering handled by .heroStamps (align-items: center). */
+  margin-top: 16px;
   padding: 6px 20px 6px 14px;
   border: 1px solid rgba(255, 255, 255, 0.28);
   border-radius: 14px;
@@ -1181,7 +1191,7 @@
   .ruleNeon, .ruleYellow { margin-left: auto; margin-right: auto; }
   .heroContent { text-align: center; }
   .heroCta { justify-content: center; }
-  .heroSub, .datestamp { margin-left: auto; margin-right: auto; }
+  .heroSub, .heroStamps { margin-left: auto; margin-right: auto; }
   .fact, .inc { align-items: center; text-align: center; }
   .drinksCard { text-align: center; }
   .drinksBody { margin-left: auto; margin-right: auto; }


### PR DESCRIPTION
Small layout fix: the hero "Where / Anderson Mill Marina" pill was centering within the whole hero column, so on desktop it sat off-axis to the right of the left-aligned datestamp.

Wraps the datestamp + location pill in a `fit-content` `.heroStamps` flex column (`align-items: center`) so the Where tile centers directly under the three timing tiles — consistent on mobile and desktop.

CSS-only + one wrapper div. tsc 0, lint 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)