### PR TITLE
feat(full-moon): backend money-tracking, refunds, capacity guard

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -196,6 +196,16 @@ const nextConfig: NextConfig = {
         permanent: true,
       },
 
+      // 2026-07-08 Full Moon Party moved to a date-specific URL so each
+      // month's cruise gets its own page (/full-moon → /full-moon-aug1).
+      // Keeps the already-live/indexed URL, shared links, and OG preview
+      // working, and preserves the Stripe return URL for anyone mid-checkout.
+      {
+        source: '/full-moon',
+        destination: '/full-moon-aug1',
+        permanent: true,
+      },
+
       // 2026-07-02 orphaned design-exploration demo pages deleted (zombie
       // catalog pattern — no inbound links, not in sitemap, no metadata,
       // linked to a 404ing /heritage). GSC + GA4 confirmed zero

--- a/scripts/full-moon/batch-refund.ts
+++ b/scripts/full-moon/batch-refund.ts
@@ -1,0 +1,128 @@
+/**
+ * Operator-gated BATCH REFUND for the Lake Travis Full Moon Party.
+ *
+ * Refunds EVERY paying PAID ticket order in full — used when the cruise is
+ * postponed for not reaching the 32-guest minimum ("<32 → refund everyone").
+ *
+ * Usage:
+ *   npx tsx scripts/full-moon/batch-refund.ts             # DRY RUN (default)
+ *   npx tsx scripts/full-moon/batch-refund.ts --apply     # execute refunds + email buyers
+ *   npx tsx scripts/full-moon/batch-refund.ts --apply --no-email
+ *
+ * Safety:
+ *   - Dry-run by default; only --apply moves money.
+ *   - Refuses a non-live Stripe key under --apply (this event runs on LIVE keys).
+ *   - Idempotent: reuses getMaxRefundable + a deterministic idempotency key, so a
+ *     re-run never double-refunds (already-refunded orders are skipped).
+ *   - Skips $0 comps. Marks orders REFUNDED. Emails each buyer the roll-forward
+ *     notice (unless --no-email).
+ *
+ * Env: source .env.local first (DATABASE_URL + STRIPE_SECRET_KEY + RESEND_API_KEY).
+ *
+ * NOTE: dotenv is loaded BEFORE the app modules are dynamically imported so the
+ * Stripe/Prisma singletons initialize with the sourced env.
+ */
+import { config } from 'dotenv';
+
+config({ path: '.env.local' });
+config();
+
+const APPLY = process.argv.includes('--apply');
+const NO_EMAIL = process.argv.includes('--no-email');
+
+function money(n: number): string {
+  return `$${n.toFixed(2)}`;
+}
+
+async function main(): Promise<void> {
+  if (!process.env.DATABASE_URL) {
+    console.error('DATABASE_URL not set. Source .env.local first.');
+    process.exit(1);
+  }
+
+  const stripeKey = process.env.STRIPE_SECRET_KEY || '';
+  const isLiveKey = stripeKey.startsWith('sk_live_');
+  if (!stripeKey) {
+    console.error('STRIPE_SECRET_KEY not set. Source .env.local first.');
+    process.exit(1);
+  }
+  if (APPLY && !isLiveKey) {
+    console.error(
+      `Refusing --apply: STRIPE_SECRET_KEY is not a live key (starts with "${stripeKey.slice(0, 8)}…"). ` +
+        'This event runs on live Stripe keys.',
+    );
+    process.exit(1);
+  }
+  if (!isLiveKey) {
+    console.warn('⚠️  STRIPE_SECRET_KEY is not a live key — dry-run figures reflect TEST-mode Stripe data.\n');
+  }
+
+  const tag = APPLY ? '[APPLY]' : '[DRY RUN]';
+
+  const { getFullMoonRoster } = await import('../../src/lib/full-moon/roster');
+  const { refundFullMoonOrder } = await import('../../src/lib/full-moon/refund');
+  const { prisma } = await import('../../src/lib/database/client');
+
+  try {
+    const roster = await getFullMoonRoster();
+    if (!roster.productFound) {
+      console.error('Ticket product not found — nothing to refund.');
+      process.exit(1);
+    }
+
+    const paying = roster.orders.filter((o) => !o.isComp);
+    console.log(`${tag} Full Moon Party — batch refund`);
+    console.log(`  Tickets sold (incl comps): ${roster.totals.ticketsSold}`);
+    console.log(
+      `  Paying orders: ${paying.length} · Comps skipped: ${roster.totals.compOrders} · Collected: ${money(roster.totals.collected)}`,
+    );
+    console.log(`  Email buyers: ${APPLY && !NO_EMAIL ? 'yes' : 'no'}\n`);
+
+    const counts: Record<string, number> = {};
+    let plannedOrMoved = 0;
+
+    for (const o of paying) {
+      const outcome = await refundFullMoonOrder(o.orderId, {
+        apply: APPLY,
+        sendEmail: APPLY && !NO_EMAIL,
+      });
+      counts[outcome.status] = (counts[outcome.status] ?? 0) + 1;
+      if (outcome.status === 'refunded' || outcome.status === 'would-refund') {
+        plannedOrMoved += outcome.amount;
+      }
+
+      const parts = [
+        `  ${tag} #${outcome.orderNumber} ${outcome.name} <${outcome.email}> — ${outcome.status}`,
+      ];
+      if (outcome.amount) parts.push(money(outcome.amount));
+      if (outcome.stripeRefundId) parts.push(`(${outcome.stripeRefundId})`);
+      if (outcome.emailSent) parts.push('✉');
+      if (outcome.error) parts.push(`ERROR: ${outcome.error}`);
+      console.log(parts.join(' '));
+    }
+
+    console.log('\nSummary:');
+    for (const [status, n] of Object.entries(counts).sort()) {
+      console.log(`  ${status}: ${n}`);
+    }
+    console.log(`\n${APPLY ? 'Total refunded' : 'Total that WOULD be refunded'}: ${money(plannedOrMoved)}`);
+
+    const errors = counts['error'] ?? 0;
+    if (!APPLY) {
+      console.log('\nDRY RUN — re-run with --apply to move money. This refunds EVERY paying ticket in full.');
+    } else if (errors > 0) {
+      console.log(`\n⚠️  ${errors} order(s) errored — re-run --apply to retry (idempotent; already-refunded orders are skipped).`);
+    } else {
+      console.log('\n✅ Done.');
+    }
+
+    process.exitCode = errors > 0 ? 1 : 0;
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((err) => {
+  console.error('Failed:', err);
+  process.exit(1);
+});

--- a/src/app/api/admin/full-moon/roster/route.ts
+++ b/src/app/api/admin/full-moon/roster/route.ts
@@ -1,0 +1,29 @@
+/**
+ * GET /api/admin/full-moon/roster
+ *
+ * Ops-only sales roster for the Lake Travis Full Moon Party: every PAID ticket
+ * order (buyer name/email/phone, amount, quantity, Stripe payment-intent id,
+ * date) plus totals ($ collected, tickets sold, N of the minimum, advertised
+ * cap, hard cap). Exposes buyer PII, so it is gated by requireOpsAuth.
+ *
+ * NOTE: /api/admin/** is NOT covered by the middleware auth matcher (only
+ * /api/v1/admin/** is), so this handler MUST guard itself.
+ */
+import { NextResponse } from 'next/server';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
+import { getFullMoonRoster } from '@/lib/full-moon/roster';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(): Promise<NextResponse> {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  try {
+    const roster = await getFullMoonRoster();
+    return NextResponse.json({ success: true, ...roster });
+  } catch (error) {
+    console.error('[FullMoon Roster] failed:', error instanceof Error ? error.message : error);
+    return NextResponse.json({ success: false, error: 'Failed to load roster' }, { status: 500 });
+  }
+}

--- a/src/app/api/cron/full-moon-deadline/route.ts
+++ b/src/app/api/cron/full-moon-deadline/route.ts
@@ -1,0 +1,108 @@
+/**
+ * GET /api/cron/full-moon-deadline
+ *
+ * Vercel cron. Runs daily. At event−`deadlineDays` (Aug 1 → ~Jul 25), if fewer
+ * than the minimum tickets are sold, it:
+ *   1. Flips the public threshold widget to "postponed" (sets the
+ *      `full_moon_postponed` flag), and
+ *   2. Emails the operator an alert with the count + the exact batch-refund
+ *      command to run.
+ *
+ * DELIBERATELY does NOT move money or email buyers. Refunds + buyer comms are
+ * an operator action: `npx tsx scripts/full-moon/batch-refund.ts --apply`.
+ * Idempotent — once postponed, subsequent runs no-op (no repeat alerts).
+ *
+ * Auth: requires CRON_SECRET in the Authorization header (Vercel sets this for
+ * scheduled jobs).
+ */
+import { NextResponse, type NextRequest } from 'next/server';
+import { EVENT } from '@/components/full-moon/event';
+import { getFullMoonRoster } from '@/lib/full-moon/roster';
+import { isFullMoonPostponed, setFullMoonPostponed, deadlineWindow } from '@/lib/full-moon/event-state';
+import { sendEmail } from '@/lib/email/resend-client';
+import { EmailType } from '@prisma/client';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const CRON_SECRET = process.env.CRON_SECRET;
+const OPS_ALERT_EMAIL = process.env.OPS_ALERT_EMAIL || 'allan@partyondelivery.com';
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  // Fail CLOSED: if CRON_SECRET is unset/misconfigured, reject rather than run
+  // unauthenticated (this flips a public state + alerts the operator).
+  const auth = req.headers.get('authorization');
+  if (!CRON_SECRET || auth !== `Bearer ${CRON_SECRET}`) {
+    return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 });
+  }
+
+  const window = deadlineWindow(Date.now(), EVENT.isoDate, EVENT.deadlineDays);
+  if (window !== 'in-window') {
+    return NextResponse.json({ ok: true, action: window === 'not-yet' ? 'before-deadline' : 'past-event' });
+  }
+
+  // Already postponed → nothing to do (don't re-alert).
+  if (await isFullMoonPostponed()) {
+    return NextResponse.json({ ok: true, action: 'already-postponed' });
+  }
+
+  const roster = await getFullMoonRoster();
+  const sold = roster.totals.ticketsSold;
+
+  // Minimum met — the cruise is a go. No-op.
+  if (sold >= EVENT.minimum) {
+    return NextResponse.json({ ok: true, action: 'minimum-met', sold, minimum: EVENT.minimum });
+  }
+
+  // Short at the deadline → postpone + alert the operator (no money moved here).
+  await setFullMoonPostponed(true, 'deadline-cron');
+
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://partyondelivery.com';
+  let alerted = false;
+  try {
+    const subject = `[Full Moon] Postponed — ${sold}/${EVENT.minimum} sold. Run the batch refund.`;
+    const bodyLines = [
+      `The Lake Travis Full Moon Party (${EVENT.dateLabel}) is short of its ${EVENT.minimum}-guest minimum at the deadline.`,
+      ``,
+      `Tickets sold (incl. comps): ${sold}`,
+      `Paying orders: ${roster.totals.payingOrders}`,
+      `Collected: $${roster.totals.collected.toFixed(2)}`,
+      ``,
+      `The public page now shows "Postponed". Money has NOT been touched.`,
+      ``,
+      `Next step — refund everyone (dry-run first, then apply):`,
+      `  npx tsx scripts/full-moon/batch-refund.ts`,
+      `  npx tsx scripts/full-moon/batch-refund.ts --apply`,
+      ``,
+      `Roster: ${baseUrl}/ops/full-moon`,
+    ];
+    const html = `<pre style="font-family:ui-monospace,Menlo,monospace;font-size:14px;line-height:1.5">${bodyLines
+      .join('\n')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')}</pre>`;
+
+    const resendId = await sendEmail({
+      to: OPS_ALERT_EMAIL,
+      subject,
+      html,
+      text: bodyLines.join('\n'),
+      type: EmailType.WELCOME, // reuse — internal ops alert, no dedicated type
+      metadata: { flow: 'full-moon-deadline-alert', sold, minimum: EVENT.minimum },
+      tags: [{ name: 'flow', value: 'full_moon_deadline_alert' }],
+    });
+    alerted = Boolean(resendId);
+  } catch (error) {
+    console.error('[FullMoon Deadline] alert email failed:', error instanceof Error ? error.message : error);
+  }
+
+  return NextResponse.json({
+    ok: true,
+    action: 'postponed',
+    sold,
+    minimum: EVENT.minimum,
+    collected: roster.totals.collected,
+    payingOrders: roster.totals.payingOrders,
+    operatorAlerted: alerted,
+    at: new Date().toISOString(),
+  });
+}

--- a/src/app/api/v1/full-moon/count/route.ts
+++ b/src/app/api/v1/full-moon/count/route.ts
@@ -2,22 +2,30 @@
  * GET /api/v1/full-moon/count
  *
  * Public live ticket count for the threshold widget: the sum of ticket
- * quantities across PAID orders for the Full Moon Party ticket product.
- * Returns 0 gracefully if the product doesn't exist yet or on any error, so
- * the widget always renders.
+ * quantities across PAID orders for the Full Moon Party ticket product, plus
+ * the widget `state` ('working' | 'met' | 'cancelled', where 'cancelled' ===
+ * postponed). Returns 0 / 'working' gracefully if the product doesn't exist yet
+ * or on any error, so the widget always renders.
+ *
+ * `capacity` intentionally stays the ADVERTISED capacity (50). The real hard
+ * cap (60) is enforced server-side in the ticket route and never surfaced here.
  */
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/database/client';
 import { EVENT, TICKET_PRODUCT_HANDLE } from '@/components/full-moon/event';
+import { isFullMoonPostponed, deriveFullMoonState } from '@/lib/full-moon/event-state';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(): Promise<NextResponse> {
   try {
-    const product = await prisma.product.findUnique({
-      where: { handle: TICKET_PRODUCT_HANDLE },
-      select: { id: true },
-    });
+    const [product, postponed] = await Promise.all([
+      prisma.product.findUnique({
+        where: { handle: TICKET_PRODUCT_HANDLE },
+        select: { id: true },
+      }),
+      isFullMoonPostponed(),
+    ]);
 
     let sold = 0;
     if (product) {
@@ -28,12 +36,14 @@ export async function GET(): Promise<NextResponse> {
       sold = agg._sum.quantity ?? 0;
     }
 
+    const state = deriveFullMoonState(sold, EVENT.minimum, postponed);
+
     return NextResponse.json(
-      { sold, minimum: EVENT.minimum, capacity: EVENT.capacity },
+      { sold, minimum: EVENT.minimum, capacity: EVENT.capacity, state },
       { headers: { 'Cache-Control': 'public, max-age=15, s-maxage=15' } },
     );
   } catch (error) {
     console.error('[FullMoon Count] failed:', error instanceof Error ? error.message : error);
-    return NextResponse.json({ sold: 0, minimum: EVENT.minimum, capacity: EVENT.capacity });
+    return NextResponse.json({ sold: 0, minimum: EVENT.minimum, capacity: EVENT.capacity, state: 'working' });
   }
 }

--- a/src/app/api/v1/full-moon/ticket/route.ts
+++ b/src/app/api/v1/full-moon/ticket/route.ts
@@ -22,6 +22,8 @@ import { checkRateLimit } from '@/lib/security/rate-limit';
 import {
   computeTicketAmounts,
   ticketIdempotencyKey,
+  wouldExceedHardCap,
+  remainingUnderHardCap,
   TicketPurchaseSchema,
   EVENT_TICKET_METADATA_FLAG,
 } from '@/lib/full-moon/ticket';
@@ -70,6 +72,31 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
 
     const { quantity, subtotal, unitAmountCents } = computeTicketAmounts(Number(variant.price), body.quantity);
+
+    // Hard-cap guard. The public page advertises capacity 50, but the real boat
+    // limit is EVENT.hardCap (60). Reject any purchase that would push total
+    // PAID sales past it — server-side, so the displayed number never changes.
+    // NOTE: this counts PAID orders at session-creation time; an in-flight
+    // unpaid checkout isn't counted, so a burst could momentarily overshoot by
+    // a few. That slop is absorbed by the 50→60 buffer (we never advertise 60).
+    const soldAgg = await prisma.orderItem.aggregate({
+      _sum: { quantity: true },
+      where: { productId: product.id, order: { financialStatus: 'PAID' } },
+    });
+    const sold = soldAgg._sum.quantity ?? 0;
+    if (wouldExceedHardCap(sold, quantity, EVENT.hardCap)) {
+      const remaining = remainingUnderHardCap(sold, EVENT.hardCap);
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            remaining > 0
+              ? `Only ${remaining} spot${remaining === 1 ? '' : 's'} left — please lower your quantity and try again.`
+              : 'This cruise is fully booked.',
+        },
+        { status: 409 },
+      );
+    }
 
     const item: DraftOrderItem = {
       productId: product.id,

--- a/src/app/api/v1/full-moon/ticket/route.ts
+++ b/src/app/api/v1/full-moon/ticket/route.ts
@@ -156,8 +156,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
           ...(body.attribution?.utmSource ? { utmSource: body.attribution.utmSource } : {}),
           ...(body.attribution?.utmCampaign ? { utmCampaign: body.attribution.utmCampaign } : {}),
         },
-        success_url: `${baseUrl}/full-moon?ticket=success`,
-        cancel_url: `${baseUrl}/full-moon?ticket=cancelled`,
+        success_url: `${baseUrl}/full-moon-aug1?ticket=success`,
+        cancel_url: `${baseUrl}/full-moon-aug1?ticket=cancelled`,
       },
       // Same email + quantity within ~5 min resolves to one session → one charge.
       { idempotencyKey: ticketIdempotencyKey(body.email, quantity, Date.now()) },

--- a/src/app/full-moon-aug1/page.tsx
+++ b/src/app/full-moon-aug1/page.tsx
@@ -5,7 +5,7 @@ import { EVENT, OG_IMAGE, SHARE } from '@/components/full-moon/event';
 export const metadata: Metadata = {
   title: 'Lake Travis Full Moon Party · Party On Delivery',
   description: `A sunset cruise that becomes a moonrise dance party on Lake Travis — a three-and-a-half-hour BYOB cruise with a DJ, water, ice & cups. $${EVENT.price} a ticket; drinks ordered ahead through Party On Delivery.`,
-  alternates: { canonical: '/full-moon' },
+  alternates: { canonical: '/full-moon-aug1' },
   openGraph: {
     title: SHARE.title,
     description: `Sunset cruise + moonrise dance party on Lake Travis. $${EVENT.price}, BYOB via Party On Delivery.`,
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
   robots: { index: true, follow: true },
 };
 
-/** /full-moon — Lake Travis Full Moon Party landing page (preview). */
+/** /full-moon-aug1 — Lake Travis Full Moon Party landing page (Aug 1 event). */
 export default function FullMoonPage(): React.ReactElement {
   return <FullMoonParty />;
 }

--- a/src/app/ops/full-moon/page.tsx
+++ b/src/app/ops/full-moon/page.tsx
@@ -124,7 +124,7 @@ export default function FullMoonRosterPage(): ReactElement {
         </div>
         <div className="flex items-center gap-3">
           <a
-            href="/full-moon"
+            href="/full-moon-aug1"
             target="_blank"
             rel="noopener noreferrer"
             className="text-sm font-medium text-blue-600 hover:underline"

--- a/src/app/ops/full-moon/page.tsx
+++ b/src/app/ops/full-moon/page.tsx
@@ -1,0 +1,268 @@
+'use client';
+
+import { useState, useEffect, useCallback, type ReactElement } from 'react';
+
+interface RosterOrder {
+  orderId: string;
+  orderNumber: number;
+  name: string;
+  email: string;
+  phone: string;
+  amount: number;
+  quantity: number;
+  paymentIntentId: string | null;
+  createdAt: string;
+  financialStatus: string;
+  isComp: boolean;
+}
+
+interface RosterTotals {
+  ticketsSold: number;
+  payingOrders: number;
+  compOrders: number;
+  collected: number;
+  minimum: number;
+  advertisedCapacity: number;
+  hardCap: number;
+  overMinimum: boolean;
+}
+
+interface RosterResponse {
+  success: boolean;
+  productFound: boolean;
+  orders: RosterOrder[];
+  totals: RosterTotals;
+  error?: string;
+}
+
+function formatWhen(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function formatMoney(n: number): string {
+  return `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function StatTile({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+}): ReactElement {
+  return (
+    <div className="rounded-xl border border-gray-100 bg-white px-5 py-4 shadow-sm">
+      <div className="text-3xl font-bold text-gray-900">{value}</div>
+      <div className="mt-0.5 text-xs font-bold uppercase tracking-wider text-gray-500">{label}</div>
+      {sub ? <div className="mt-1 text-sm text-gray-500">{sub}</div> : null}
+    </div>
+  );
+}
+
+/**
+ * Ops sales roster for the Lake Travis Full Moon Party. Read-only: lists every
+ * PAID ticket order with buyer contact info, amount, quantity, and the Stripe
+ * payment-intent id, plus rolled-up totals ($ collected, tickets sold vs. the
+ * 32 minimum, advertised cap 50, hard cap 60). Auto-gated by the /ops password.
+ */
+export default function FullMoonRosterPage(): ReactElement {
+  const [data, setData] = useState<RosterResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const fetchRoster = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const res = await fetch('/api/admin/full-moon/roster');
+      const json = (await res.json()) as RosterResponse;
+      if (!res.ok || !json.success) {
+        setError(json.error || 'Failed to load roster.');
+        return;
+      }
+      setData(json);
+    } catch {
+      setError('Network error — try refreshing.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchRoster();
+  }, [fetchRoster]);
+
+  const totals = data?.totals;
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-4 md:p-8">
+      {/* Header */}
+      <div className="mb-8 flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
+        <div className="flex items-center gap-3">
+          <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-purple-600 shadow-lg">
+            <svg className="h-6 w-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
+              />
+            </svg>
+          </div>
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900">Full Moon Party — Sales</h1>
+            <p className="mt-0.5 text-gray-500">Lake Travis Full Moon Party ticket roster</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          <a
+            href="/full-moon"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm font-medium text-blue-600 hover:underline"
+          >
+            View page ↗
+          </a>
+          <button
+            onClick={fetchRoster}
+            disabled={loading}
+            className="flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2.5 font-medium text-gray-700 shadow-sm transition-all duration-200 hover:border-gray-300 hover:bg-gray-50 disabled:opacity-50"
+          >
+            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+              />
+            </svg>
+            {loading ? 'Refreshing…' : 'Refresh'}
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mb-6 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="space-y-4">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-16 animate-pulse rounded-xl bg-white shadow-sm" />
+          ))}
+        </div>
+      ) : !data?.productFound ? (
+        <div className="rounded-xl border border-gray-100 bg-white p-16 text-center shadow-sm">
+          <p className="text-xl font-semibold text-gray-700">Ticket product not found</p>
+          <p className="mt-2 text-gray-500">
+            Run <code className="rounded bg-gray-100 px-1.5 py-0.5">scripts/full-moon/upsert-ticket-product.mjs --apply</code> first.
+          </p>
+        </div>
+      ) : (
+        <>
+          {/* Totals */}
+          {totals && (
+            <div className="mb-8 grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <StatTile
+                label="Tickets Sold"
+                value={String(totals.ticketsSold)}
+                sub={`${totals.ticketsSold} of ${totals.minimum} min · ${totals.overMinimum ? 'sailing ✓' : `${Math.max(0, totals.minimum - totals.ticketsSold)} to go`}`}
+              />
+              <StatTile label="Collected" value={formatMoney(totals.collected)} sub={`${totals.payingOrders} paying orders`} />
+              <StatTile label="Comps" value={String(totals.compOrders)} sub="counted, not charged" />
+              <StatTile
+                label="Capacity"
+                value={`${totals.ticketsSold}/${totals.advertisedCapacity}`}
+                sub={`advertised ${totals.advertisedCapacity} · hard cap ${totals.hardCap}`}
+              />
+            </div>
+          )}
+
+          {data.orders.length === 0 ? (
+            <div className="rounded-xl border border-gray-100 bg-white p-16 text-center shadow-sm">
+              <p className="text-xl font-semibold text-gray-700">No tickets sold yet</p>
+              <p className="mt-2 text-gray-500">Paid orders will appear here as they come in.</p>
+            </div>
+          ) : (
+            <div className="overflow-hidden rounded-xl border border-gray-100 bg-white shadow-sm">
+              <div className="overflow-x-auto">
+                <table className="w-full">
+                  <thead className="border-b border-gray-200 bg-gradient-to-r from-gray-50 to-gray-100/50">
+                    <tr>
+                      <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-gray-600">
+                        Order
+                      </th>
+                      <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-gray-600">
+                        Name
+                      </th>
+                      <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-gray-600">
+                        Contact
+                      </th>
+                      <th className="px-4 py-3 text-center text-xs font-bold uppercase tracking-wider text-gray-600">
+                        Qty
+                      </th>
+                      <th className="px-4 py-3 text-right text-xs font-bold uppercase tracking-wider text-gray-600">
+                        Amount
+                      </th>
+                      <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-gray-600">
+                        Payment Intent
+                      </th>
+                      <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-gray-600">
+                        Paid
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100">
+                    {data.orders.map((o) => (
+                      <tr key={o.orderId} className="hover:bg-gray-50">
+                        <td className="whitespace-nowrap px-4 py-3 font-medium text-gray-900">
+                          #{o.orderNumber}
+                        </td>
+                        <td className="px-4 py-3 text-gray-900">
+                          <span className="font-medium">{o.name}</span>
+                          {o.isComp && (
+                            <span className="ml-2 rounded bg-amber-100 px-1.5 py-0.5 text-xs font-bold uppercase tracking-wide text-amber-800">
+                              Comp
+                            </span>
+                          )}
+                        </td>
+                        <td className="px-4 py-3 text-sm text-gray-700">
+                          <div>{o.email}</div>
+                          {o.phone && <div className="text-gray-500">{o.phone}</div>}
+                        </td>
+                        <td className="px-4 py-3 text-center font-semibold text-gray-900">{o.quantity}</td>
+                        <td className="whitespace-nowrap px-4 py-3 text-right font-medium text-gray-900">
+                          {formatMoney(o.amount)}
+                        </td>
+                        <td className="px-4 py-3">
+                          {o.paymentIntentId ? (
+                            <code className="text-sm text-gray-600">{o.paymentIntentId}</code>
+                          ) : (
+                            <span className="text-sm text-gray-400">— (no charge)</span>
+                          )}
+                        </td>
+                        <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">
+                          {formatWhen(o.createdAt)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/ops/layout.tsx
+++ b/src/app/ops/layout.tsx
@@ -155,6 +155,7 @@ export default function OpsLayout({ children }: OpsLayoutProps): ReactElement {
     { href: '/ops/orders?view=carts', label: 'Unpaid Carts' },
     { href: '/ops/boat-schedule', label: 'Boats' },
     { href: '/ops/rsvps', label: 'RSVPs' },
+    { href: '/ops/full-moon', label: 'Full Moon' },
     { href: '/ops/orders?view=weekly', label: 'Weekly' },
     { href: '/ops/collections', label: 'Collections' },
     { href: '/ops/agent', label: 'Agent' },

--- a/src/components/chat/PartyChatMount.tsx
+++ b/src/components/chat/PartyChatMount.tsx
@@ -36,7 +36,7 @@ const HIDE_PATTERNS: RegExp[] = [
   // own dedicated flow.
   /^\/events(\/|$)/,
   // Full Moon Party lander — has its own share FAB; keep it distraction-free.
-  /^\/full-moon(\/|$)/,
+  /^\/full-moon-aug1(\/|$)/,
 ];
 
 export default function PartyChatMount() {

--- a/src/components/full-moon/FullMoonParty.tsx
+++ b/src/components/full-moon/FullMoonParty.tsx
@@ -29,7 +29,7 @@ function Experience(): ReactElement {
   // The Get-a-Ticket CTA opens the purchase form (→ Stripe Checkout).
   const onGetTicket = openTicket;
 
-  // Returning from Stripe: /full-moon?ticket=success|cancelled.
+  // Returning from Stripe: /full-moon-aug1?ticket=success|cancelled.
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const status = params.get('ticket');

--- a/src/components/full-moon/ThresholdWidget.tsx
+++ b/src/components/full-moon/ThresholdWidget.tsx
@@ -24,6 +24,8 @@ type TicketState = 'working' | 'met' | 'cancelled';
 export default function ThresholdWidget({ onGetTicket }: ThresholdWidgetProps): ReactElement {
   const { capacity, minimum } = EVENT;
   const [sold, setSold] = useState(THRESHOLD.sold);
+  // Authoritative widget state from the live count endpoint (null until loaded).
+  const [serverState, setServerState] = useState<TicketState | null>(null);
   const [inView, setInView] = useState(false);
   const [fillPct, setFillPct] = useState(0);
   const [guestsOpen, setGuestsOpen] = useState(false);
@@ -32,8 +34,10 @@ export default function ThresholdWidget({ onGetTicket }: ThresholdWidgetProps): 
   const confettiFired = useRef(false);
   const reduced = useReducedMotion();
 
-  const forcedCancelled = THRESHOLD.state === 'cancelled';
-  const state: TicketState = forcedCancelled ? 'cancelled' : sold >= minimum ? 'met' : 'working';
+  // Prefer the live server state (which already folds in the postponed flag);
+  // fall back to the static snapshot / local derivation before it loads.
+  const state: TicketState =
+    serverState ?? (THRESHOLD.state === 'cancelled' ? 'cancelled' : sold >= minimum ? 'met' : 'working');
   const pct = Math.min(100, Math.round((sold / capacity) * 100));
   const markerPct = Math.round((minimum / capacity) * 100);
   const toGo = Math.max(0, minimum - sold);
@@ -43,7 +47,11 @@ export default function ThresholdWidget({ onGetTicket }: ThresholdWidgetProps): 
     fetch('/api/v1/full-moon/count')
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
-        if (active && data && typeof data.sold === 'number') setSold(data.sold);
+        if (!active || !data) return;
+        if (typeof data.sold === 'number') setSold(data.sold);
+        if (data.state === 'working' || data.state === 'met' || data.state === 'cancelled') {
+          setServerState(data.state);
+        }
       })
       .catch(() => undefined);
     return () => {

--- a/src/components/full-moon/event.ts
+++ b/src/components/full-moon/event.ts
@@ -88,7 +88,14 @@ export interface FullMoonEvent {
   backAtDock: string;
   sunset: string;
   price: number;
+  /** Advertised capacity — what the public page shows ("/50", "Boat capacity: 50"). */
   capacity: number;
+  /**
+   * Real hard cap enforced server-side in the ticket route. Higher than the
+   * advertised `capacity` so we keep a small safety buffer without changing the
+   * number guests see. Never surfaced publicly.
+   */
+  hardCap: number;
   minimum: number;
   /** Days before the event the minimum must be met. */
   deadlineDays: number;
@@ -112,6 +119,7 @@ export const EVENT: FullMoonEvent = {
   sunset: '8:26 PM',
   price: 59,
   capacity: 50,
+  hardCap: 60,
   minimum: 32,
   deadlineDays: 7,
   shareUrl: 'https://partyondelivery.com/full-moon',

--- a/src/components/full-moon/event.ts
+++ b/src/components/full-moon/event.ts
@@ -122,7 +122,7 @@ export const EVENT: FullMoonEvent = {
   hardCap: 60,
   minimum: 32,
   deadlineDays: 7,
-  shareUrl: 'https://partyondelivery.com/full-moon',
+  shareUrl: 'https://partyondelivery.com/full-moon-aug1',
   ordersUrl: '/order',
 };
 

--- a/src/lib/email/email-service.ts
+++ b/src/lib/email/email-service.ts
@@ -579,6 +579,115 @@ Premium Alcohol Delivery
 }
 
 /**
+ * Send the Lake Travis Full Moon Party roll-forward refund email.
+ *
+ * Used when the event is postponed for not hitting its minimum: the cruise
+ * rolls to the next full moon and every ticket is refunded in full. Framed as
+ * a postponement (not a generic order refund) so buyers understand why their
+ * ticket was refunded and that no action is needed.
+ */
+export async function sendFullMoonRefundEmail(
+  customerEmail: string,
+  customerName: string,
+  orderNumber: number,
+  refundAmount: number | string,
+): Promise<string | null> {
+  const { formatCurrency } = await import('./resend-client');
+  const rawFirstName = (customerName || 'there').trim().split(/\s+/)[0] || 'there';
+  // Escape before interpolating into the HTML body (buyer-controlled name).
+  const firstNameHtml = rawFirstName
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+
+  const html = `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Full Moon Party — Postponed &amp; Refunded</title>
+</head>
+<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #f9fafb;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #f9fafb; padding: 40px 20px;">
+    <tr>
+      <td align="center">
+        <table width="600" cellpadding="0" cellspacing="0" style="background-color: #ffffff; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1);">
+          <tr>
+            <td style="background-color: #1a1a1a; padding: 32px; text-align: center;">
+              <img src="https://partyondelivery.com/images/pod-logo-2025.png" alt="Party On Delivery" width="180" style="width: 180px; max-width: 100%; height: auto; margin-bottom: 12px;" />
+              <p style="color: #ffffff; margin: 0; font-size: 14px; letter-spacing: 0.05em;">LAKE TRAVIS FULL MOON PARTY</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 24px;">
+              <p style="margin: 0 0 16px; font-size: 16px; color: #1a1a1a;">Hi ${firstNameHtml},</p>
+              <p style="margin: 0 0 16px; font-size: 16px; color: #666;">
+                This full moon cruise didn't reach the guest minimum we need to safely cast off, so we're
+                <strong>rolling it forward to the next full moon</strong>. There's nothing you need to do.
+              </p>
+              <p style="margin: 0 0 16px; font-size: 16px; color: #666;">
+                We've <strong>refunded your ticket (order #${orderNumber}) in full</strong>.
+              </p>
+              <div style="background-color: #f0fdf4; border-radius: 8px; padding: 16px; margin-bottom: 16px; text-align: center;">
+                <p style="margin: 0; color: #166534; font-size: 14px;">Refund Amount</p>
+                <p style="margin: 4px 0 0; font-size: 24px; font-weight: 600; color: #1a1a1a;">${formatCurrency(refundAmount)}</p>
+              </div>
+              <p style="margin: 16px 0; font-size: 14px; color: #666;">
+                Please allow 5-10 business days for the refund to appear on your original payment method.
+                We'll send the next date your way soon — we'd love to have you aboard.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td style="background-color: #1a1a1a; padding: 24px; text-align: center;">
+              <p style="margin: 0; color: #D4AF37; font-size: 14px;">Questions?</p>
+              <p style="margin: 8px 0 0; color: #ffffff; font-size: 14px;">Reply to this email or contact us at support@partyondelivery.com</p>
+              <p style="margin: 16px 0 0; color: #666; font-size: 12px;">&copy; ${new Date().getFullYear()} Party On Delivery. All rights reserved.</p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>
+  `.trim();
+
+  const text = `
+LAKE TRAVIS FULL MOON PARTY
+
+Hi ${rawFirstName},
+
+This full moon cruise didn't reach the guest minimum we need to safely cast off, so we're rolling it forward to the next full moon. There's nothing you need to do.
+
+We've refunded your ticket (order #${orderNumber}) in full.
+
+Refund Amount: ${formatCurrency(refundAmount)}
+
+Please allow 5-10 business days for the refund to appear on your original payment method. We'll send the next date your way soon — we'd love to have you aboard.
+
+Questions? Reply to this email or contact support@partyondelivery.com
+
+Party On Delivery
+  `.trim();
+
+  return sendEmail({
+    to: customerEmail,
+    subject: `Full Moon Party postponed — your ticket is refunded (Order #${orderNumber})`,
+    html,
+    text,
+    type: EmailType.REFUND_PROCESSED,
+    metadata: {
+      orderNumber,
+      refundAmount,
+      flow: 'full-moon-roll-forward',
+    },
+  });
+}
+
+/**
  * Send order cancellation notification
  */
 export async function sendOrderCancellationEmail(

--- a/src/lib/features/feature-flags.ts
+++ b/src/lib/features/feature-flags.ts
@@ -41,6 +41,12 @@ export const FEATURE_FLAGS = {
   FOLLOWUPS_AFFILIATE_APPLY: 'followups_affiliate_apply',
   FOLLOWUPS_EVENT_QUIZ: 'followups_event_quiz',
   FOLLOWUPS_POST_PURCHASE_REVIEW: 'followups_post_purchase_review',
+
+  // Full Moon Party — set true when the event is postponed/cancelled (short of
+  // the minimum at the deadline). Flips the public threshold widget to its
+  // "postponed" state. Set by the deadline cron or the operator; reset to
+  // resume selling. See src/lib/full-moon/event-state.ts.
+  FULL_MOON_POSTPONED: 'full_moon_postponed',
 } as const;
 
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS];

--- a/src/lib/full-moon/__tests__/event-state.test.ts
+++ b/src/lib/full-moon/__tests__/event-state.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { deriveFullMoonState, deadlineWindow, deadlineTimestamp } from '../event-state';
+
+describe('deriveFullMoonState', () => {
+  const MIN = 32;
+
+  it('is "working" below the minimum when not postponed', () => {
+    expect(deriveFullMoonState(0, MIN, false)).toBe('working');
+    expect(deriveFullMoonState(31, MIN, false)).toBe('working');
+  });
+
+  it('is "met" at or above the minimum when not postponed', () => {
+    expect(deriveFullMoonState(32, MIN, false)).toBe('met');
+    expect(deriveFullMoonState(50, MIN, false)).toBe('met');
+  });
+
+  it('postponed wins regardless of the sold count', () => {
+    expect(deriveFullMoonState(0, MIN, true)).toBe('cancelled');
+    expect(deriveFullMoonState(31, MIN, true)).toBe('cancelled');
+    expect(deriveFullMoonState(45, MIN, true)).toBe('cancelled');
+  });
+});
+
+describe('deadlineWindow (event 2026-08-01, deadline 7 days)', () => {
+  const ISO = '2026-08-01';
+  const DAYS = 7;
+
+  it('deadline is 2026-07-25 00:00 UTC', () => {
+    expect(deadlineTimestamp(ISO, DAYS)).toBe(Date.parse('2026-07-25T00:00:00Z'));
+  });
+
+  it('is "not-yet" before the deadline', () => {
+    expect(deadlineWindow(Date.parse('2026-07-24T23:59:00Z'), ISO, DAYS)).toBe('not-yet');
+  });
+
+  it('is "in-window" from the deadline through the event day', () => {
+    expect(deadlineWindow(Date.parse('2026-07-25T00:00:01Z'), ISO, DAYS)).toBe('in-window');
+    expect(deadlineWindow(Date.parse('2026-07-28T12:00:00Z'), ISO, DAYS)).toBe('in-window');
+    expect(deadlineWindow(Date.parse('2026-08-01T20:00:00Z'), ISO, DAYS)).toBe('in-window');
+  });
+
+  it('is "past-event" after the event day', () => {
+    expect(deadlineWindow(Date.parse('2026-08-02T00:00:01Z'), ISO, DAYS)).toBe('past-event');
+  });
+});

--- a/src/lib/full-moon/__tests__/refund.test.ts
+++ b/src/lib/full-moon/__tests__/refund.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for refundFullMoonOrder — the money-safety branches:
+ *  - mixed (non-ticket) orders are NEVER blind-refunded
+ *  - $0 comps and no-payment orders are skipped
+ *  - already-refunded orders (cap ≤ 0) are skipped (idempotent re-run)
+ *  - dry-run computes but never writes; apply refunds + stamps + emails
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const prismaMock = vi.hoisted(() => ({
+  order: { findUnique: vi.fn() },
+  product: { findUnique: vi.fn() },
+  refund: { update: vi.fn() },
+}));
+const stripeMock = vi.hoisted(() => ({ refunds: { create: vi.fn() } }));
+const getMaxRefundableMock = vi.hoisted(() => vi.fn());
+const createRefundMock = vi.hoisted(() => vi.fn());
+const sendFullMoonRefundEmailMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/database/client', () => ({ prisma: prismaMock }));
+vi.mock('@/lib/stripe/client', () => ({ stripe: stripeMock }));
+vi.mock('@/lib/stripe/refund-utils', () => ({ getMaxRefundable: getMaxRefundableMock }));
+vi.mock('@/lib/inventory/services/order-service', () => ({ createRefund: createRefundMock }));
+vi.mock('@/lib/email/email-service', () => ({ sendFullMoonRefundEmail: sendFullMoonRefundEmailMock }));
+
+import { refundFullMoonOrder } from '../refund';
+
+const TICKET = { id: 'prod_ticket' };
+
+function buildOrder(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'o1',
+    orderNumber: 401,
+    customerName: 'Jane Doe',
+    customerEmail: 'jane@example.com',
+    total: 59,
+    stripePaymentIntentId: 'pi_1',
+    internalNote: null,
+    refunds: [] as Array<{ amount: number }>,
+    items: [{ productId: 'prod_ticket', totalPrice: 59 }],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  prismaMock.product.findUnique.mockResolvedValue(TICKET);
+});
+
+describe('refundFullMoonOrder — skip branches (no Stripe call)', () => {
+  it('skips a mixed order (non-ticket line item)', async () => {
+    prismaMock.order.findUnique.mockResolvedValue(
+      buildOrder({ items: [{ productId: 'prod_ticket', totalPrice: 59 }, { productId: 'other', totalPrice: 20 }] }),
+    );
+    const r = await refundFullMoonOrder('o1', { apply: true });
+    expect(r.status).toBe('skipped-mixed-order');
+    expect(stripeMock.refunds.create).not.toHaveBeenCalled();
+    expect(getMaxRefundableMock).not.toHaveBeenCalled();
+  });
+
+  it('skips a $0 comp (ticket-only, total 0)', async () => {
+    prismaMock.order.findUnique.mockResolvedValue(
+      buildOrder({ total: 0, stripePaymentIntentId: null, internalNote: 'full-moon-comp', items: [{ productId: 'prod_ticket', totalPrice: 0 }] }),
+    );
+    const r = await refundFullMoonOrder('o1', { apply: true });
+    expect(r.status).toBe('skipped-comp');
+    expect(stripeMock.refunds.create).not.toHaveBeenCalled();
+  });
+
+  it('skips an order with no payment intent', async () => {
+    prismaMock.order.findUnique.mockResolvedValue(buildOrder({ stripePaymentIntentId: null }));
+    const r = await refundFullMoonOrder('o1', { apply: true });
+    expect(r.status).toBe('skipped-no-payment');
+  });
+
+  it('skips an already fully-refunded order (cap ≤ 0) — idempotent re-run', async () => {
+    prismaMock.order.findUnique.mockResolvedValue(buildOrder());
+    getMaxRefundableMock.mockResolvedValue(0);
+    const r = await refundFullMoonOrder('o1', { apply: true });
+    expect(r.status).toBe('skipped-already-refunded');
+    expect(stripeMock.refunds.create).not.toHaveBeenCalled();
+  });
+});
+
+describe('refundFullMoonOrder — dry-run vs apply', () => {
+  it('dry-run computes the amount but never writes or emails', async () => {
+    prismaMock.order.findUnique.mockResolvedValue(buildOrder());
+    getMaxRefundableMock.mockResolvedValue(59);
+    const r = await refundFullMoonOrder('o1', { apply: false });
+    expect(r.status).toBe('would-refund');
+    expect(r.amount).toBe(59);
+    expect(stripeMock.refunds.create).not.toHaveBeenCalled();
+    expect(createRefundMock).not.toHaveBeenCalled();
+    expect(sendFullMoonRefundEmailMock).not.toHaveBeenCalled();
+  });
+
+  it('apply refunds the full remaining amount, stamps the row, and emails the buyer', async () => {
+    prismaMock.order.findUnique.mockResolvedValue(buildOrder());
+    getMaxRefundableMock.mockResolvedValue(59);
+    stripeMock.refunds.create.mockResolvedValue({ id: 're_1', status: 'succeeded' });
+    createRefundMock.mockResolvedValue('refund_row_1');
+    sendFullMoonRefundEmailMock.mockResolvedValue('email_1');
+
+    const r = await refundFullMoonOrder('o1', { apply: true });
+
+    expect(r.status).toBe('refunded');
+    expect(r.amount).toBe(59);
+    expect(r.stripeRefundId).toBe('re_1');
+    expect(r.emailSent).toBe(true);
+
+    // Idempotency key is scoped to (order, amountCents).
+    expect(stripeMock.refunds.create).toHaveBeenCalledWith(
+      expect.objectContaining({ payment_intent: 'pi_1', amount: 5900 }),
+      { idempotencyKey: 'fm-batch-refund-o1-5900' },
+    );
+    expect(createRefundMock).toHaveBeenCalledWith('o1', 59, expect.any(String));
+    expect(prismaMock.refund.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'refund_row_1' } }),
+    );
+    expect(sendFullMoonRefundEmailMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('apply with sendEmail:false refunds but does not email', async () => {
+    prismaMock.order.findUnique.mockResolvedValue(buildOrder());
+    getMaxRefundableMock.mockResolvedValue(59);
+    stripeMock.refunds.create.mockResolvedValue({ id: 're_2', status: 'succeeded' });
+    createRefundMock.mockResolvedValue('refund_row_2');
+
+    const r = await refundFullMoonOrder('o1', { apply: true, sendEmail: false });
+    expect(r.status).toBe('refunded');
+    expect(sendFullMoonRefundEmailMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/full-moon/__tests__/roster.test.ts
+++ b/src/lib/full-moon/__tests__/roster.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for getFullMoonRoster — the load-bearing guarantee is that MONEY is
+ * scoped to ticket line items and $0 comps are excluded from "$ collected"
+ * while still counting toward the headcount.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const prismaMock = vi.hoisted(() => ({
+  product: { findUnique: vi.fn() },
+  order: { findMany: vi.fn() },
+}));
+
+vi.mock('@/lib/database/client', () => ({ prisma: prismaMock }));
+
+import { getFullMoonRoster } from '../roster';
+
+const D = new Date('2026-07-08T12:00:00Z');
+
+function order(
+  overrides: Partial<{
+    id: string;
+    orderNumber: number;
+    customerName: string;
+    customerEmail: string;
+    customerPhone: string | null;
+    deliveryPhone: string;
+    stripePaymentIntentId: string | null;
+    internalNote: string | null;
+    financialStatus: string;
+    items: Array<{ quantity: number; totalPrice: number }>;
+  }>,
+) {
+  return {
+    id: 'o1',
+    orderNumber: 1,
+    customerName: 'Jane Doe',
+    customerEmail: 'jane@example.com',
+    customerPhone: '5125551234',
+    deliveryPhone: 'n/a',
+    createdAt: D,
+    stripePaymentIntentId: 'pi_1',
+    internalNote: null,
+    financialStatus: 'PAID',
+    items: [{ quantity: 1, totalPrice: 59 }],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getFullMoonRoster', () => {
+  it('returns an empty roster when the product does not exist', async () => {
+    prismaMock.product.findUnique.mockResolvedValue(null);
+    const r = await getFullMoonRoster();
+    expect(r.productFound).toBe(false);
+    expect(r.orders).toEqual([]);
+    expect(r.totals.ticketsSold).toBe(0);
+    expect(r.totals.collected).toBe(0);
+  });
+
+  it('counts comps in headcount but excludes them from money; money is ticket-scoped', async () => {
+    prismaMock.product.findUnique.mockResolvedValue({ id: 'prod_ticket' });
+    prismaMock.order.findMany.mockResolvedValue([
+      order({ id: 'comp', orderNumber: 390, customerName: 'Allan', internalNote: 'full-moon-comp', stripePaymentIntentId: null, items: [{ quantity: 1, totalPrice: 0 }] }),
+      order({ id: 'a', orderNumber: 401, stripePaymentIntentId: 'pi_a', items: [{ quantity: 2, totalPrice: 118 }] }),
+      order({ id: 'b', orderNumber: 402, stripePaymentIntentId: 'pi_b', items: [{ quantity: 1, totalPrice: 59 }] }),
+    ]);
+
+    const r = await getFullMoonRoster();
+
+    expect(r.productFound).toBe(true);
+    expect(r.totals.ticketsSold).toBe(4); // 1 comp + 2 + 1
+    expect(r.totals.payingOrders).toBe(2);
+    expect(r.totals.compOrders).toBe(1);
+    expect(r.totals.collected).toBe(177); // 118 + 59, comp's $0 excluded
+    expect(r.totals.advertisedCapacity).toBe(50);
+    expect(r.totals.hardCap).toBe(60);
+    expect(r.totals.overMinimum).toBe(false);
+
+    const comp = r.orders.find((o) => o.orderId === 'comp')!;
+    expect(comp.isComp).toBe(true);
+    expect(comp.amount).toBe(0);
+    const a = r.orders.find((o) => o.orderId === 'a')!;
+    expect(a.isComp).toBe(false);
+    expect(a.amount).toBe(118);
+    expect(a.quantity).toBe(2);
+  });
+
+  it('marks overMinimum once the headcount reaches the minimum (32)', async () => {
+    prismaMock.product.findUnique.mockResolvedValue({ id: 'prod_ticket' });
+    prismaMock.order.findMany.mockResolvedValue([
+      order({ id: 'big', items: [{ quantity: 32, totalPrice: 1888 }] }),
+    ]);
+    const r = await getFullMoonRoster();
+    expect(r.totals.ticketsSold).toBe(32);
+    expect(r.totals.overMinimum).toBe(true);
+  });
+});

--- a/src/lib/full-moon/__tests__/ticket.test.ts
+++ b/src/lib/full-moon/__tests__/ticket.test.ts
@@ -3,6 +3,8 @@ import {
   computeTicketAmounts,
   isEventTicketSession,
   ticketIdempotencyKey,
+  wouldExceedHardCap,
+  remainingUnderHardCap,
   TicketPurchaseSchema,
 } from '../ticket';
 
@@ -62,6 +64,34 @@ describe('ticketIdempotencyKey', () => {
     expect(ticketIdempotencyKey('a@b.com', 2, t)).not.toBe(ticketIdempotencyKey('a@b.com', 2, t + 6 * 60_000));
     expect(ticketIdempotencyKey('a@b.com', 2, t)).not.toBe(ticketIdempotencyKey('a@b.com', 3, t));
     expect(ticketIdempotencyKey('A@B.com', 2, t)).toBe(ticketIdempotencyKey('a@b.com', 2, t));
+  });
+});
+
+describe('wouldExceedHardCap', () => {
+  const CAP = 60;
+
+  it('allows a purchase that lands exactly on the cap', () => {
+    expect(wouldExceedHardCap(58, 2, CAP)).toBe(false);
+    expect(wouldExceedHardCap(0, 60, CAP)).toBe(false);
+  });
+
+  it('rejects a purchase that would cross the cap', () => {
+    expect(wouldExceedHardCap(59, 2, CAP)).toBe(true);
+    expect(wouldExceedHardCap(60, 1, CAP)).toBe(true);
+  });
+
+  it('advertised capacity (50) is NOT the ceiling — selling above 50 is allowed up to 60', () => {
+    expect(wouldExceedHardCap(50, 8, CAP)).toBe(false); // 58 ≤ 60
+    expect(wouldExceedHardCap(55, 5, CAP)).toBe(false); // 60 ≤ 60
+    expect(wouldExceedHardCap(55, 6, CAP)).toBe(true); // 61 > 60
+  });
+});
+
+describe('remainingUnderHardCap', () => {
+  it('reports spots left, never negative', () => {
+    expect(remainingUnderHardCap(55, 60)).toBe(5);
+    expect(remainingUnderHardCap(60, 60)).toBe(0);
+    expect(remainingUnderHardCap(65, 60)).toBe(0);
   });
 });
 

--- a/src/lib/full-moon/event-state.ts
+++ b/src/lib/full-moon/event-state.ts
@@ -1,0 +1,95 @@
+/**
+ * Full Moon Party event state — the "postponed" toggle behind the public
+ * threshold widget.
+ *
+ * Stored as a boolean row in the existing `feature_flags` table (key
+ * `full_moon_postponed`) so no schema change is needed. When true, the event
+ * has been rolled forward (short of the minimum at the deadline) and the widget
+ * shows its "Postponed" state. Set by the deadline cron or an operator; reset to
+ * resume selling.
+ *
+ * The widget's own state vocabulary is 'working' | 'met' | 'cancelled', where
+ * 'cancelled' renders as "Postponed" (rolled forward, tickets refunded). We keep
+ * that vocabulary here so the count endpoint can hand the widget a state string
+ * it already understands.
+ */
+import { prisma } from '@/lib/database/client';
+import { FEATURE_FLAGS } from '@/lib/features/feature-flags';
+
+/** Public threshold-widget state. 'cancelled' === postponed / rolled forward. */
+export type FullMoonState = 'working' | 'met' | 'cancelled';
+
+/**
+ * Whether the event is currently marked postponed/cancelled. Reads the flag
+ * directly (bypassing the rollout-percentage feature-flag evaluation and its
+ * cache) so a flip is reflected immediately. Fails open to `false` (keep
+ * selling) so a DB hiccup never falsely tells buyers the event is off.
+ */
+export async function isFullMoonPostponed(): Promise<boolean> {
+  try {
+    const flag = await prisma.featureFlag.findUnique({
+      where: { key: FEATURE_FLAGS.FULL_MOON_POSTPONED },
+      select: { enabled: true },
+    });
+    return flag?.enabled === true;
+  } catch (error) {
+    console.error('[FullMoon State] read failed:', error instanceof Error ? error.message : error);
+    return false;
+  }
+}
+
+/**
+ * Set (or clear) the postponed flag. Idempotent — safe to call repeatedly.
+ * @param postponed true to postpone/cancel, false to resume selling.
+ * @param by short actor label for the audit description (e.g. 'deadline-cron').
+ */
+export async function setFullMoonPostponed(postponed: boolean, by = 'system'): Promise<void> {
+  await prisma.featureFlag.upsert({
+    where: { key: FEATURE_FLAGS.FULL_MOON_POSTPONED },
+    update: {
+      enabled: postponed,
+      rolloutPercentage: postponed ? 100 : 0,
+      description: `Full Moon ${postponed ? 'postponed' : 'selling'} — set by ${by}`,
+    },
+    create: {
+      key: FEATURE_FLAGS.FULL_MOON_POSTPONED,
+      enabled: postponed,
+      rolloutPercentage: postponed ? 100 : 0,
+      description: `Full Moon ${postponed ? 'postponed' : 'selling'} — set by ${by}`,
+    },
+  });
+}
+
+/**
+ * Derive the public widget state from the sold count and the postponed flag.
+ * Pure so it can be unit-tested. Postponed wins; otherwise the minimum being
+ * met flips 'working' → 'met'.
+ */
+export function deriveFullMoonState(sold: number, minimum: number, postponed: boolean): FullMoonState {
+  if (postponed) return 'cancelled';
+  return sold >= minimum ? 'met' : 'working';
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** UTC ms of the deadline: `deadlineDays` before the event date. */
+export function deadlineTimestamp(isoDate: string, deadlineDays: number): number {
+  return Date.parse(`${isoDate}T00:00:00Z`) - deadlineDays * DAY_MS;
+}
+
+/** UTC ms of the end of the event day. */
+export function eventEndTimestamp(isoDate: string): number {
+  return Date.parse(`${isoDate}T23:59:59Z`);
+}
+
+export type DeadlineWindow = 'not-yet' | 'in-window' | 'past-event';
+
+/**
+ * Where `nowMs` falls relative to the deadline window. The deadline cron only
+ * acts while 'in-window' (past the deadline, on or before the event day). Pure.
+ */
+export function deadlineWindow(nowMs: number, isoDate: string, deadlineDays: number): DeadlineWindow {
+  if (nowMs < deadlineTimestamp(isoDate, deadlineDays)) return 'not-yet';
+  if (nowMs > eventEndTimestamp(isoDate)) return 'past-event';
+  return 'in-window';
+}

--- a/src/lib/full-moon/refund.ts
+++ b/src/lib/full-moon/refund.ts
@@ -1,0 +1,174 @@
+/**
+ * Full Moon Party — full-refund helper for one ticket order.
+ *
+ * Reuses the same Stripe-authoritative plumbing as the admin refund route so
+ * retries can never double-refund:
+ *  - getMaxRefundable() caps the refund at (Stripe-captured − prior refunds),
+ *    taking the LARGER of the DB sum and Stripe's actual refunded total.
+ *  - A deterministic idempotency key means a replayed request returns the same
+ *    Stripe refund instead of issuing new money.
+ *  - createRefund() writes the DB Refund row and recomputes financialStatus
+ *    (→ REFUNDED once fully refunded).
+ *
+ * Money-safety notes:
+ *  - $0 comps (host/VIP) are skipped — nothing was charged.
+ *  - An order already fully refunded returns 'skipped-already-refunded' (cap ≤ 0),
+ *    so re-running the batch is safe.
+ *  - Stripe is the source of truth; this never trusts Order.total for the cap.
+ */
+import { prisma } from '@/lib/database/client';
+import { stripe } from '@/lib/stripe/client';
+import { getMaxRefundable } from '@/lib/stripe/refund-utils';
+import { createRefund } from '@/lib/inventory/services/order-service';
+import { sendFullMoonRefundEmail } from '@/lib/email/email-service';
+import { TICKET_PRODUCT_HANDLE } from '@/components/full-moon/event';
+
+export type FullMoonRefundStatus =
+  | 'refunded'
+  | 'would-refund'
+  | 'skipped-already-refunded'
+  | 'skipped-no-payment'
+  | 'skipped-comp'
+  | 'skipped-mixed-order'
+  | 'error';
+
+export interface FullMoonRefundOutcome {
+  orderId: string;
+  orderNumber: number;
+  name: string;
+  email: string;
+  status: FullMoonRefundStatus;
+  /** Amount still refundable per Stripe, in dollars. */
+  maxRefundable: number;
+  /** Amount actually refunded (apply) or that would be refunded (dry-run). */
+  amount: number;
+  stripeRefundId?: string;
+  emailSent?: boolean;
+  error?: string;
+}
+
+export const DEFAULT_FULL_MOON_REFUND_REASON = 'Full Moon Party postponed — minimum not met';
+
+export interface RefundFullMoonOptions {
+  /** false = dry-run (no Stripe/DB writes, no email); true = execute. */
+  apply: boolean;
+  /** Refund reason stamped on Stripe + the DB Refund row. */
+  reason?: string;
+  /** Send the buyer the roll-forward email on a successful refund (default true). */
+  sendEmail?: boolean;
+}
+
+/**
+ * Refund one Full Moon ticket order in full (its entire remaining refundable
+ * amount). Idempotent and dry-run-safe. Loads the order fresh so a mid-run
+ * re-read always reflects the latest DB state.
+ */
+export async function refundFullMoonOrder(
+  orderId: string,
+  opts: RefundFullMoonOptions,
+): Promise<FullMoonRefundOutcome> {
+  const reason = opts.reason ?? DEFAULT_FULL_MOON_REFUND_REASON;
+
+  const [order, ticketProduct] = await Promise.all([
+    prisma.order.findUnique({
+      where: { id: orderId },
+      include: { refunds: true, items: { select: { productId: true, totalPrice: true } } },
+    }),
+    prisma.product.findUnique({ where: { handle: TICKET_PRODUCT_HANDLE }, select: { id: true } }),
+  ]);
+  if (!order) {
+    return {
+      orderId,
+      orderNumber: 0,
+      name: '',
+      email: '',
+      status: 'error',
+      maxRefundable: 0,
+      amount: 0,
+      error: 'Order not found',
+    };
+  }
+
+  const base = {
+    orderId,
+    orderNumber: order.orderNumber,
+    name: order.customerName,
+    email: order.customerEmail,
+  };
+
+  // Refuse to refund an order that bundles anything other than the ticket
+  // product — refunding the whole PaymentIntent would over-refund non-ticket
+  // dollars. Ticket orders are ticket-only by construction; a mixed order is
+  // unexpected and must be handled by hand, never blind-refunded.
+  const hasNonTicketItem = !ticketProduct || order.items.some((it) => it.productId !== ticketProduct.id);
+  if (hasNonTicketItem) {
+    return { ...base, status: 'skipped-mixed-order', maxRefundable: 0, amount: 0 };
+  }
+
+  // Nothing charged — a $0 comp / host row (defined by $0, not the note, so a
+  // genuinely-paid order can never be silently skipped over a stray tag).
+  if (Number(order.total) === 0) {
+    return { ...base, status: 'skipped-comp', maxRefundable: 0, amount: 0 };
+  }
+  if (!order.stripePaymentIntentId) {
+    return { ...base, status: 'skipped-no-payment', maxRefundable: 0, amount: 0 };
+  }
+
+  try {
+    const priorRefunds = order.refunds.reduce((sum, r) => sum + Number(r.amount), 0);
+    const maxRefundable = await getMaxRefundable(order.stripePaymentIntentId, priorRefunds);
+
+    // Already fully refunded — safe to re-run.
+    if (maxRefundable <= 0) {
+      return { ...base, status: 'skipped-already-refunded', maxRefundable: 0, amount: 0 };
+    }
+
+    if (!opts.apply) {
+      return { ...base, status: 'would-refund', maxRefundable, amount: maxRefundable };
+    }
+
+    const amountCents = Math.round(maxRefundable * 100);
+    const refund = await stripe.refunds.create(
+      {
+        payment_intent: order.stripePaymentIntentId,
+        amount: amountCents,
+        reason: 'requested_by_customer',
+        metadata: { orderId, orderNumber: String(order.orderNumber), reason },
+      },
+      // Scoped to (order, amount) so a retried run replays the SAME refund
+      // instead of issuing new money.
+      { idempotencyKey: `fm-batch-refund-${orderId}-${amountCents}` },
+    );
+
+    // Write + stamp the DB Refund row; createRefund recomputes financialStatus
+    // (→ REFUNDED once the full captured amount is refunded).
+    const refundRowId = await createRefund(orderId, maxRefundable, reason);
+    await prisma.refund.update({
+      where: { id: refundRowId },
+      data: { stripeRefundId: refund.id, processedBy: 'batch-refund', processedAt: new Date() },
+    });
+
+    let emailSent = false;
+    if (opts.sendEmail !== false) {
+      try {
+        await sendFullMoonRefundEmail(order.customerEmail, order.customerName, order.orderNumber, maxRefundable);
+        emailSent = true;
+      } catch (emailError) {
+        console.error(
+          `[FullMoon Refund] email failed for order #${order.orderNumber}:`,
+          emailError instanceof Error ? emailError.message : emailError,
+        );
+      }
+    }
+
+    return { ...base, status: 'refunded', maxRefundable, amount: maxRefundable, stripeRefundId: refund.id, emailSent };
+  } catch (error) {
+    return {
+      ...base,
+      status: 'error',
+      maxRefundable: 0,
+      amount: 0,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/src/lib/full-moon/roster.ts
+++ b/src/lib/full-moon/roster.ts
@@ -1,0 +1,146 @@
+/**
+ * Full Moon Party sales roster (server-side, ops-only data).
+ *
+ * Resolves every PAID order for the DRAFT ticket product into a roster row
+ * (buyer name/email/phone, amount, ticket quantity, Stripe payment-intent id,
+ * date) plus rolled-up totals. Shared by the ops roster endpoint, the deadline
+ * cron, and the operator batch-refund script so they all agree on what "sold"
+ * and "collected" mean.
+ *
+ * Money vs. headcount: a $0 comp (internalNote === 'full-moon-comp', e.g. the
+ * host) COUNTS toward the headcount/minimum but is EXCLUDED from dollars
+ * collected — matching how the count/guest-list endpoints treat it.
+ */
+import { prisma } from '@/lib/database/client';
+import { EVENT, TICKET_PRODUCT_HANDLE } from '@/components/full-moon/event';
+
+/** internalNote marker written by scripts/full-moon/comp-guest.mjs. */
+export const FULL_MOON_COMP_NOTE = 'full-moon-comp';
+
+/** One PAID Full Moon order. */
+export interface RosterOrder {
+  orderId: string;
+  orderNumber: number;
+  name: string;
+  email: string;
+  phone: string;
+  /** Ticket-only revenue for this order, in dollars (0 for comps). */
+  amount: number;
+  /** Number of tickets on this order (sum of the ticket line-item quantities). */
+  quantity: number;
+  /** Stripe PaymentIntent id — null for $0 comps (no charge). */
+  paymentIntentId: string | null;
+  createdAt: string;
+  financialStatus: string;
+  /** True for a $0 comp / host row — counts toward headcount, not money. */
+  isComp: boolean;
+}
+
+/** Rolled-up roster totals. */
+export interface RosterTotals {
+  /** Sum of ticket quantities across PAID orders, comps included. */
+  ticketsSold: number;
+  /** Count of paying (non-comp) orders. */
+  payingOrders: number;
+  /** Count of $0 comp orders. */
+  compOrders: number;
+  /** Dollars collected — paying orders only, comps excluded. */
+  collected: number;
+  minimum: number;
+  /** Advertised capacity shown publicly (50). */
+  advertisedCapacity: number;
+  /** Real hard cap enforced server-side (60) — internal only. */
+  hardCap: number;
+  /** True once the headcount reaches the minimum. */
+  overMinimum: boolean;
+}
+
+export interface FullMoonRoster {
+  /** False if the ticket product doesn't exist yet. */
+  productFound: boolean;
+  orders: RosterOrder[];
+  totals: RosterTotals;
+}
+
+/**
+ * Build the full sales roster + totals for the Full Moon Party ticket product.
+ * Returns an empty roster (productFound=false) if the product is missing.
+ */
+export async function getFullMoonRoster(): Promise<FullMoonRoster> {
+  const emptyTotals: RosterTotals = {
+    ticketsSold: 0,
+    payingOrders: 0,
+    compOrders: 0,
+    collected: 0,
+    minimum: EVENT.minimum,
+    advertisedCapacity: EVENT.capacity,
+    hardCap: EVENT.hardCap,
+    overMinimum: false,
+  };
+
+  const product = await prisma.product.findUnique({
+    where: { handle: TICKET_PRODUCT_HANDLE },
+    select: { id: true },
+  });
+  if (!product) {
+    return { productFound: false, orders: [], totals: emptyTotals };
+  }
+
+  const orders = await prisma.order.findMany({
+    where: {
+      financialStatus: 'PAID',
+      items: { some: { productId: product.id } },
+    },
+    select: {
+      id: true,
+      orderNumber: true,
+      customerName: true,
+      customerEmail: true,
+      customerPhone: true,
+      deliveryPhone: true,
+      createdAt: true,
+      stripePaymentIntentId: true,
+      internalNote: true,
+      financialStatus: true,
+      // Scope BOTH quantity and money to the ticket line items, so a bundled /
+      // mixed order can never inflate the Full Moon headcount or "$ collected".
+      items: { where: { productId: product.id }, select: { quantity: true, totalPrice: true } },
+    },
+    orderBy: { createdAt: 'desc' },
+  });
+
+  const rosterOrders: RosterOrder[] = orders.map((o) => {
+    const quantity = o.items.reduce((sum, it) => sum + it.quantity, 0);
+    // Ticket-only revenue (never order.total, which could include other items).
+    const amount = Math.round(o.items.reduce((sum, it) => sum + Number(it.totalPrice), 0) * 100) / 100;
+    const isComp = o.internalNote === FULL_MOON_COMP_NOTE || amount === 0;
+    return {
+      orderId: o.id,
+      orderNumber: o.orderNumber,
+      name: o.customerName,
+      email: o.customerEmail,
+      phone: o.customerPhone || o.deliveryPhone || '',
+      amount,
+      quantity,
+      paymentIntentId: o.stripePaymentIntentId,
+      createdAt: o.createdAt.toISOString(),
+      financialStatus: String(o.financialStatus),
+      isComp,
+    };
+  });
+
+  const totals: RosterTotals = { ...emptyTotals };
+  for (const row of rosterOrders) {
+    totals.ticketsSold += row.quantity;
+    if (row.isComp) {
+      totals.compOrders += 1;
+    } else {
+      totals.payingOrders += 1;
+      totals.collected += row.amount;
+    }
+  }
+  totals.collected = Math.round(totals.collected * 100) / 100;
+  totals.overMinimum = totals.ticketsSold >= EVENT.minimum;
+
+  return { productFound: true, orders: rosterOrders, totals };
+}

--- a/src/lib/full-moon/ticket.ts
+++ b/src/lib/full-moon/ticket.ts
@@ -63,6 +63,22 @@ export function isEventTicketSession(metadata: Record<string, string> | null | u
 }
 
 /**
+ * Whether selling `requested` more tickets would push total PAID sales past the
+ * real hard cap. The public page advertises a lower capacity (50); this guards
+ * the true physical limit (60) server-side so we never oversell the boat.
+ *
+ * Pure so it can be unit-tested. `sold` is the current PAID ticket count.
+ */
+export function wouldExceedHardCap(sold: number, requested: number, hardCap: number): boolean {
+  return sold + requested > hardCap;
+}
+
+/** How many tickets can still be sold before hitting the hard cap (never negative). */
+export function remainingUnderHardCap(sold: number, hardCap: number): number {
+  return Math.max(0, hardCap - sold);
+}
+
+/**
  * Deterministic idempotency key for the Stripe session so rapid duplicate
  * submits (double-click, retry, second tab) resolve to the SAME session — and
  * therefore a single charge — within a short window. Buckets by ~5 minutes.

--- a/vercel.json
+++ b/vercel.json
@@ -95,6 +95,10 @@
     {
       "path": "/api/cron/finance-weekly-briefing",
       "schedule": "0 14 * * 1"
+    },
+    {
+      "path": "/api/cron/full-moon-deadline",
+      "schedule": "0 15 * * *"
     }
   ]
 }


### PR DESCRIPTION
Backend money-tracking + refund/capacity safety net for the **LIVE** Lake Travis Full Moon Party ticketing. High-stakes: moves real customer money on live Stripe keys.

## What's in it
1. **Sales roster (read-only)** — `getFullMoonRoster()` + ops-gated `GET /api/admin/full-moon/roster` (`requireOpsAuth`, since `/api/admin/**` isn't middleware-gated) + `/ops/full-moon` page (nav entry added). Shows every PAID order (name, email, phone, amount, qty, payment-intent id, date) + totals ($ collected, tickets sold, N of 32 min, cap 50, hard cap 60). Money is **ticket-line-scoped**; $0 comps count toward headcount but are excluded from money.
2. **Operator-gated batch refund** — `scripts/full-moon/batch-refund.ts` (`npx tsx`): dry-run default, `--apply`, **refuses non-live Stripe keys**, idempotent via `getMaxRefundable` + a deterministic idempotency key, skips comps + mixed orders, marks orders REFUNDED, emails each buyer a roll-forward notice. Reuses the existing refund plumbing.
3. **Deadline cron** — `GET /api/cron/full-moon-deadline` (CRON_SECRET, **fail-closed**, registered daily in `vercel.json`). At event−7d, if short of the 32 minimum: flips the widget to "Postponed" (via a `feature_flags` row — no migration) and **emails the operator**. Deliberately **NEVER moves money or emails buyers** — refunds stay a manual operator run.
4. **Capacity guard** — `EVENT.hardCap=60` enforced **server-side** in `POST /api/v1/full-moon/ticket`; advertised capacity stays 50 (page still shows "/50"). `wouldExceedHardCap` helper + tests.

## Design decisions (operator-confirmed)
- Cron is **detect + alert only** (respects "never auto-fire bulk refunds").
- Postponed state is a **DB-backed boolean** reusing the existing `feature_flags` table (no schema change).
- Roster surfaced as **ops page + API**.
- Batch refund **auto-emails each buyer** a roll-forward notice.

## Review
- `security-reviewer` agent: 0 critical/high; 3 medium + 2 low — **all fixed** (mixed-order over-refund guard, cron fail-closed, roster/refund tests, HTML-escape buyer name, comp-skip keyed on $0).
- `/code-review`: approve, no correctness issues beyond the acknowledged pre-payment cap race (bounded by the 50→60 buffer).

## Gates
`npx tsc --noEmit` 0 · `npm run lint` clean · `npm run test:run` **656/656** (+43 new). Batch-refund **dry-run verified against prod** (read-only: 1 sold = comp, 0 paying, \$0) — no live refund executed (operator-run).

## Not in scope
No Vercel env changes, no `FULL_MOON_TICKETS_LIVE` flip, no live refund executed. Admin "hide from guest list" toggle still deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)