### PR TITLE
feat(backend): consolidate ops + admin nav (23 tabs → 13)

### DIFF
--- a/src/app/admin/affiliates/page.tsx
+++ b/src/app/admin/affiliates/page.tsx
@@ -4,6 +4,8 @@ import { useState, useEffect, useCallback, ReactElement } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import AddAffiliateModal from '@/components/ops/AddAffiliateModal';
+import SectionSubNav from '@/components/backend/SectionSubNav';
+import { PARTNERS_SUBNAV } from '@/components/backend/subnav-items';
 
 interface Application {
   id: string;
@@ -145,6 +147,9 @@ export default function AffiliatesPage(): ReactElement {
 
   return (
     <div className="max-w-7xl mx-auto px-4 py-6">
+      <div className="mb-4">
+        <SectionSubNav items={PARTNERS_SUBNAV} />
+      </div>
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-4">
         <h1 className="text-2xl font-bold text-gray-900">Affiliates</h1>
         <div className="flex gap-2">

--- a/src/app/admin/email-signups/page.tsx
+++ b/src/app/admin/email-signups/page.tsx
@@ -2,6 +2,8 @@ import Link from 'next/link';
 import { prisma } from '@/lib/database/client';
 import { getOpsSession } from '@/lib/auth/ops-session';
 import type { Prisma } from '@prisma/client';
+import SectionSubNav from '@/components/backend/SectionSubNav';
+import { EMAIL_SUBNAV } from '@/components/backend/subnav-items';
 
 /**
  * Admin → Emails → Signups.
@@ -94,7 +96,10 @@ export default async function EmailSignupsPage({
 
   return (
     <div className="p-4 md:p-8 bg-gray-50 min-h-screen">
-      {/* Header + sub-nav */}
+      <div className="mb-4">
+        <SectionSubNav items={EMAIL_SUBNAV} />
+      </div>
+      {/* Header */}
       <div className="mb-6">
         <div className="flex items-center gap-3 mb-1">
           <div className="w-11 h-11 rounded-xl bg-gradient-to-br from-pink-500 to-pink-600 flex items-center justify-center shadow">
@@ -106,10 +111,6 @@ export default async function EmailSignupsPage({
             <h1 className="text-3xl font-bold text-gray-900">Email Signups</h1>
             <p className="text-gray-500 mt-0.5">Every email address collected across the site (the leads store).</p>
           </div>
-        </div>
-        <div className="flex gap-2 mt-3">
-          <Link href="/admin/emails" className="px-3 py-1.5 text-sm font-semibold rounded-lg bg-gray-100 text-gray-600 hover:bg-gray-200">Email Preview</Link>
-          <span className="px-3 py-1.5 text-sm font-semibold rounded-lg bg-pink-600 text-white">Signups</span>
         </div>
       </div>
 

--- a/src/app/admin/emails/followups/page.tsx
+++ b/src/app/admin/emails/followups/page.tsx
@@ -9,8 +9,9 @@
  * this page calls also gates itself with requireOpsAuth.
  */
 
-import Link from 'next/link';
 import type { ReactElement } from 'react';
+import SectionSubNav from '@/components/backend/SectionSubNav';
+import { EMAIL_SUBNAV } from '@/components/backend/subnav-items';
 import CopyEditorPanel from '@/components/admin/followups/CopyEditorPanel';
 import FlagsPanel from '@/components/admin/followups/FlagsPanel';
 import QueuePanel from '@/components/admin/followups/QueuePanel';
@@ -21,7 +22,8 @@ import TestSendPanel from '@/components/admin/followups/TestSendPanel';
 
 export default function FollowupsAdminPage(): ReactElement {
   return (
-    <div className="space-y-6">
+    <div className="p-4 md:p-8 bg-gray-50 min-h-screen space-y-6">
+      <SectionSubNav items={EMAIL_SUBNAV} />
       <div className="flex items-center justify-between flex-wrap gap-2">
         <div>
           <h1 className="font-heading text-3xl tracking-[0.1em] text-gray-900">Follow-Ups</h1>
@@ -30,9 +32,6 @@ export default function FollowupsAdminPage(): ReactElement {
             Engine runs every 15 minutes.
           </p>
         </div>
-        <Link href="/admin/emails" className="btn-ghost">
-          ← Email Templates
-        </Link>
       </div>
 
       <FlagsPanel />

--- a/src/app/admin/emails/page.tsx
+++ b/src/app/admin/emails/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback, ReactElement } from 'react';
+import SectionSubNav from '@/components/backend/SectionSubNav';
+import { EMAIL_SUBNAV } from '@/components/backend/subnav-items';
 
 type EmailType = 'order-confirmation' | 'delivery-en-route' | 'delivery-completed' | 'payment-failed' | 'refund-processed' | 'order-cancelled' | 'invoice' | 'affiliate-welcome' | 'affiliate-prospect' | 'dashboard-link';
 
@@ -260,6 +262,9 @@ export default function EmailPreviewPage(): ReactElement {
 
   return (
     <div className="p-4 md:p-8 bg-gray-50 min-h-screen">
+      <div className="mb-4">
+        <SectionSubNav items={EMAIL_SUBNAV} />
+      </div>
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-8">
         <div className="flex items-center gap-3">
           <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-pink-500 to-pink-600 flex items-center justify-center shadow-lg">

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -165,21 +165,33 @@ export default function AdminLayout({ children }: AdminLayoutProps): ReactElemen
     );
   }
 
-  // Navigation items (admin-only strategic/management features)
-  const navItems = [
-    { href: '/admin/strategy', label: 'Game Plan' },
-    { href: '/admin/analytics', label: 'Analytics' },
-    { href: '/admin/customers', label: 'Customers' },
-    { href: '/admin/emails', label: 'Emails' },
-    { href: '/admin/emails/followups', label: 'Follow-Ups' },
-    { href: '/admin/email-signups', label: 'Email Signups' },
-    { href: '/admin/sync', label: 'Sync' },
-    { href: '/admin/reports', label: 'Reports' },
-    { href: '/admin/promotions', label: 'Promotions' },
-    { href: '/admin/affiliates', label: 'Affiliates' },
-    { href: '/admin/brians-stuff', label: "Brian's Stuff" },
-    { href: '/admin/settings', label: 'Settings' },
+  // Navigation items (admin-only strategic/management features).
+  // Consolidated 2026-07: Email groups templates + follow-ups + signups,
+  // Partners groups affiliates + promotions, Sync left the nav (page still
+  // reachable at /admin/sync), and Dashboard (the post-login landing page)
+  // finally got a nav entry.
+  const navItems: Array<{ href: string; label: string; match: string[] }> = [
+    { href: '/admin/dashboard', label: 'Dashboard', match: ['/admin/dashboard'] },
+    { href: '/admin/strategy', label: 'Game Plan', match: ['/admin/strategy'] },
+    { href: '/admin/analytics', label: 'Analytics', match: ['/admin/analytics'] },
+    { href: '/admin/customers', label: 'Customers', match: ['/admin/customers'] },
+    {
+      href: '/admin/emails',
+      label: 'Email',
+      match: ['/admin/emails', '/admin/email-signups'],
+    },
+    { href: '/admin/reports', label: 'Reports', match: ['/admin/reports'] },
+    {
+      href: '/admin/affiliates',
+      label: 'Partners',
+      match: ['/admin/affiliates', '/admin/promotions'],
+    },
+    { href: '/admin/brians-stuff', label: "Brian's Stuff", match: ['/admin/brians-stuff'] },
+    { href: '/admin/settings', label: 'Settings', match: ['/admin/settings'] },
   ];
+
+  const isActive = (item: { match: string[] }) =>
+    item.match.some((p) => pathname === p || pathname?.startsWith(`${p}/`));
 
   // Authenticated - render with navigation
   return (
@@ -197,8 +209,8 @@ export default function AdminLayout({ children }: AdminLayoutProps): ReactElemen
                   <Link
                     key={item.href}
                     href={item.href}
-                    className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
-                      pathname?.startsWith(item.href)
+                    className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                      isActive(item)
                         ? 'bg-gray-800 text-white'
                         : 'text-gray-300 hover:bg-gray-800 hover:text-white'
                     }`}
@@ -210,7 +222,7 @@ export default function AdminLayout({ children }: AdminLayoutProps): ReactElemen
             </div>
             <div className="hidden md:flex items-center gap-4">
               <Link
-                href="/ops/inventory"
+                href="/ops/orders"
                 className="text-sm text-gray-400 hover:text-white transition-colors"
               >
                 Ops Portal
@@ -248,7 +260,7 @@ export default function AdminLayout({ children }: AdminLayoutProps): ReactElemen
                 key={item.href}
                 href={item.href}
                 className={`block px-3 py-2 min-h-[44px] flex items-center rounded-md text-sm font-medium transition-colors ${
-                  pathname?.startsWith(item.href)
+                  isActive(item)
                     ? 'bg-gray-800 text-white'
                     : 'text-gray-300 hover:bg-gray-800 hover:text-white'
                 }`}
@@ -258,7 +270,7 @@ export default function AdminLayout({ children }: AdminLayoutProps): ReactElemen
             ))}
             <div className="border-t border-gray-800 pt-2 mt-2 space-y-1">
               <Link
-                href="/ops/inventory"
+                href="/ops/orders"
                 className="block px-3 py-2 min-h-[44px] flex items-center text-sm text-gray-400 hover:text-white transition-colors"
               >
                 Ops Portal

--- a/src/app/admin/promotions/page.tsx
+++ b/src/app/admin/promotions/page.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import SectionSubNav from '@/components/backend/SectionSubNav';
+import { PARTNERS_SUBNAV } from '@/components/backend/subnav-items';
 
 interface Discount {
   id: string;
@@ -136,12 +138,12 @@ export default function PromotionsPage() {
 
   return (
     <div className="p-4 md:p-8">
+      <div className="mb-4">
+        <SectionSubNav items={PARTNERS_SUBNAV} />
+      </div>
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">
         <div>
           <h1 className="text-2xl font-bold text-black">Promotions</h1>
-          <Link href="/admin/reports" className="text-blue-600 hover:text-blue-800 text-sm">
-            &larr; Back to Reports Dashboard
-          </Link>
         </div>
         <Link
           href="/admin/promotions/new"

--- a/src/app/ops/boat-schedule/page.tsx
+++ b/src/app/ops/boat-schedule/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import Link from 'next/link';
 import OrderDetailModal from './OrderDetailModal';
+import OrdersTabs from '@/components/ops/orders/OrdersTabs';
 
 type ViewTab = 'upcoming' | 'exceptions' | 'today' | 'weekly';
 
@@ -223,6 +224,9 @@ export default function BoatSchedulePage() {
 
   return (
     <div className="max-w-[1400px] mx-auto px-4 sm:px-6 lg:px-8 py-6">
+      <div className="mb-4">
+        <OrdersTabs active="boats" />
+      </div>
       {/* Header */}
       <div className="flex items-start justify-between mb-6 gap-4">
         <div>

--- a/src/app/ops/collections/page.tsx
+++ b/src/app/ops/collections/page.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect, useCallback, ReactElement } from 'react';
 import Link from 'next/link';
+import SectionSubNav from '@/components/backend/SectionSubNav';
+import { CATALOG_SUBNAV } from '@/components/backend/subnav-items';
 
 interface Collection {
   id: string;
@@ -91,6 +93,9 @@ export default function CollectionsPage(): ReactElement {
 
   return (
     <div className="p-4 md:p-8 bg-gray-50 min-h-screen">
+      <div className="mb-4">
+        <SectionSubNav items={CATALOG_SUBNAV} />
+      </div>
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-8">
         <div className="flex items-center gap-3">
@@ -114,15 +119,6 @@ export default function CollectionsPage(): ReactElement {
             </svg>
             New Collection
           </button>
-          <Link
-            href="/ops/products"
-            className="group px-4 py-2.5 bg-white border border-gray-200 text-gray-700 rounded-xl font-medium hover:bg-gray-50 hover:border-gray-300 transition-all duration-200 shadow-sm flex items-center gap-2"
-          >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-            </svg>
-            Products
-          </Link>
         </div>
       </div>
 

--- a/src/app/ops/inventory/page.tsx
+++ b/src/app/ops/inventory/page.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect, ReactElement, useCallback } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
+import SectionSubNav from '@/components/backend/SectionSubNav';
+import { CATALOG_SUBNAV } from '@/components/backend/subnav-items';
 
 interface InventoryItem {
   id: string;
@@ -683,6 +685,9 @@ export default function InventoryPage(): ReactElement {
 
   return (
     <div className="p-4 md:p-8 bg-gray-50 min-h-screen">
+      <div className="mb-4">
+        <SectionSubNav items={CATALOG_SUBNAV} />
+      </div>
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-8">
         <div>
@@ -731,24 +736,6 @@ export default function InventoryPage(): ReactElement {
             </svg>
             Refresh
           </button>
-          <Link
-            href="/ops/inventory/count"
-            className="px-4 py-2 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 transition-colors shadow-sm flex items-center gap-2"
-          >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
-            </svg>
-            AI Count
-          </Link>
-          <Link
-            href="/ops/inventory/predictions"
-            className="px-4 py-2 bg-purple-600 text-white rounded-lg font-medium hover:bg-purple-700 transition-colors shadow-sm flex items-center gap-2"
-          >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
-            </svg>
-            Predictions
-          </Link>
         </div>
       </div>
 

--- a/src/app/ops/layout.tsx
+++ b/src/app/ops/layout.tsx
@@ -145,25 +145,33 @@ export default function OpsLayout({ children }: OpsLayoutProps): ReactElement {
     );
   }
 
-  // Navigation items for ops (day-to-day operational tasks)
-  const navItems = [
-    { href: '/ops/inventory', label: 'Inventory' },
-    { href: '/ops/inventory/count', label: 'AI Count' },
-    { href: '/ops/inventory/predictions', label: 'Predictions' },
-    { href: '/ops/products', label: 'Products' },
-    { href: '/ops/orders', label: 'Orders' },
-    { href: '/ops/orders?view=carts', label: 'Unpaid Carts' },
-    { href: '/ops/boat-schedule', label: 'Boats' },
-    { href: '/ops/events', label: 'Events' },
-    { href: '/ops/orders?view=weekly', label: 'Weekly' },
-    { href: '/ops/collections', label: 'Collections' },
-    { href: '/ops/agent', label: 'Agent' },
+  // Navigation items for ops (day-to-day operational tasks).
+  // Consolidated 2026-07: Unpaid Carts + Weekly live inside Orders (in-page
+  // tabs), Boats is an Orders sub-view, Inventory + Collections live under
+  // Products, and AI Count / Predictions were retired from the nav.
+  const navItems: Array<{ href: string; label: string; match: string[] }> = [
+    {
+      href: '/ops/orders',
+      label: 'Orders',
+      match: ['/ops/orders', '/ops/boat-schedule', '/ops/group-orders'],
+    },
+    {
+      href: '/ops/products',
+      label: 'Products',
+      match: ['/ops/products', '/ops/inventory', '/ops/collections'],
+    },
+    {
+      href: '/ops/events',
+      label: 'Events',
+      match: ['/ops/events', '/ops/full-moon', '/ops/rsvps'],
+    },
+    { href: '/ops/agent', label: 'Agent', match: ['/ops/agent'] },
   ];
 
-  const isActive = (href: string) =>
-    pathname === href ||
-    (href === '/ops/inventory' && pathname === '/ops/inventory') ||
-    (href !== '/ops/inventory' && pathname?.startsWith(href));
+  const isActive = (item: { match: string[] }) =>
+    item.match.some(
+      (p) => pathname === p || pathname?.startsWith(`${p}/`) || pathname?.startsWith(`${p}?`),
+    );
 
   // Authenticated - render with navigation
   return (
@@ -173,7 +181,7 @@ export default function OpsLayout({ children }: OpsLayoutProps): ReactElement {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-14">
             <div className="flex items-center gap-8">
-              <Link href="/ops/inventory" className="font-semibold text-blue-200">
+              <Link href="/ops/orders" className="font-semibold text-blue-200">
                 Party On Ops
               </Link>
               <div className="hidden md:flex gap-1">
@@ -182,7 +190,7 @@ export default function OpsLayout({ children }: OpsLayoutProps): ReactElement {
                     key={item.href}
                     href={item.href}
                     className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
-                      isActive(item.href)
+                      isActive(item)
                         ? 'bg-blue-800 text-white'
                         : 'text-blue-200 hover:bg-blue-800 hover:text-white'
                     }`}
@@ -232,7 +240,7 @@ export default function OpsLayout({ children }: OpsLayoutProps): ReactElement {
                 key={item.href}
                 href={item.href}
                 className={`block px-3 py-2 min-h-[44px] flex items-center rounded-md text-sm font-medium transition-colors ${
-                  isActive(item.href)
+                  isActive(item)
                     ? 'bg-blue-800 text-white'
                     : 'text-blue-200 hover:bg-blue-800 hover:text-white'
                 }`}

--- a/src/app/ops/products/page.tsx
+++ b/src/app/ops/products/page.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect, useCallback, ReactElement } from 'react';
 import Link from 'next/link';
 import { PRODUCT_CATEGORIES, getCategoryByProductType, getCategoryColor } from '@/lib/product-categories';
+import SectionSubNav from '@/components/backend/SectionSubNav';
+import { CATALOG_SUBNAV } from '@/components/backend/subnav-items';
 
 interface ProductVariant {
   id: string;
@@ -212,6 +214,9 @@ export default function ProductsPage(): ReactElement {
 
   return (
     <div className="p-4 md:p-8 bg-gray-50 min-h-screen">
+      <div className="mb-4">
+        <SectionSubNav items={CATALOG_SUBNAV} />
+      </div>
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-8">
         <div>
@@ -231,15 +236,6 @@ export default function ProductsPage(): ReactElement {
         </div>
         <div className="flex flex-wrap gap-3 w-full sm:w-auto">
           <Link
-            href="/ops/collections"
-            className="group px-4 py-2.5 bg-gradient-to-r from-purple-600 to-purple-700 text-white rounded-xl font-medium hover:from-purple-700 hover:to-purple-800 transition-all duration-200 shadow-md shadow-purple-200 hover:shadow-lg hover:shadow-purple-300 flex items-center gap-2"
-          >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
-            </svg>
-            Collections
-          </Link>
-          <Link
             href="/ops/products/create"
             className="group px-4 py-2.5 bg-gradient-to-r from-green-600 to-green-700 text-white rounded-xl font-medium hover:from-green-700 hover:to-green-800 transition-all duration-200 shadow-md shadow-green-200 hover:shadow-lg hover:shadow-green-300 flex items-center gap-2"
           >
@@ -257,15 +253,6 @@ export default function ProductsPage(): ReactElement {
             </svg>
             Refresh
           </button>
-          <Link
-            href="/ops/sync"
-            className="group px-4 py-2.5 bg-gradient-to-r from-blue-600 to-blue-700 text-white rounded-xl font-medium hover:from-blue-700 hover:to-blue-800 transition-all duration-200 shadow-md shadow-blue-200 hover:shadow-lg hover:shadow-blue-300 flex items-center gap-2"
-          >
-            <svg className="w-4 h-4 group-hover:rotate-180 transition-transform duration-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-            </svg>
-            Sync from Shopify
-          </Link>
         </div>
       </div>
 

--- a/src/components/backend/SectionSubNav.tsx
+++ b/src/components/backend/SectionSubNav.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { ReactElement } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+export interface SectionSubNavItem {
+  /** Destination route */
+  href: string;
+  label: string;
+  /** Pathname prefixes that mark this item active (defaults to [href]) */
+  match?: string[];
+}
+
+/**
+ * Route-based sub-navigation pills shared by consolidated backend sections
+ * (Catalog: Products/Inventory/Collections, Email: Templates/Follow-Ups/Signups,
+ * Partners: Affiliates/Promotions). Renders a horizontally scrollable pill row
+ * with 44px touch targets; active state derives from the current pathname.
+ */
+export default function SectionSubNav({
+  items,
+}: {
+  items: SectionSubNavItem[];
+}): ReactElement {
+  const pathname = usePathname() || '';
+
+  // Longest-prefix wins so nested routes (/admin/emails/followups) light up
+  // their own pill instead of also matching the parent (/admin/emails).
+  const bestMatch = (item: SectionSubNavItem): number =>
+    Math.max(
+      -1,
+      ...(item.match ?? [item.href])
+        .filter((p) => pathname === p || pathname.startsWith(`${p}/`))
+        .map((p) => p.length),
+    );
+  const winner = items.reduce(
+    (best, item) => (bestMatch(item) > bestMatch(best) ? item : best),
+    items[0],
+  );
+  const isActive = (item: SectionSubNavItem): boolean =>
+    bestMatch(item) >= 0 && item === winner;
+
+  return (
+    <nav
+      aria-label="Section"
+      className="print:hidden flex gap-1.5 overflow-x-auto hide-scrollbar -mx-4 px-4 md:mx-0 md:px-0"
+    >
+      {items.map((item) => (
+        <Link
+          key={item.href}
+          href={item.href}
+          className={`min-h-[44px] px-4 inline-flex items-center text-sm font-semibold rounded-lg whitespace-nowrap transition-colors touch-manipulation ${
+            isActive(item)
+              ? 'bg-brand-blue text-white shadow-sm'
+              : 'bg-white border border-gray-200 text-gray-600 hover:bg-gray-50 hover:border-gray-300'
+          }`}
+        >
+          {item.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/src/components/backend/subnav-items.ts
+++ b/src/components/backend/subnav-items.ts
@@ -1,0 +1,21 @@
+import type { SectionSubNavItem } from './SectionSubNav';
+
+/** Ops Products group: catalog, stock levels, collections. */
+export const CATALOG_SUBNAV: SectionSubNavItem[] = [
+  { href: '/ops/products', label: 'Products' },
+  { href: '/ops/inventory', label: 'Inventory' },
+  { href: '/ops/collections', label: 'Collections' },
+];
+
+/** Admin Email group: template previews, follow-up engine, collected signups. */
+export const EMAIL_SUBNAV: SectionSubNavItem[] = [
+  { href: '/admin/emails', label: 'Templates' },
+  { href: '/admin/emails/followups', label: 'Follow-Ups' },
+  { href: '/admin/email-signups', label: 'Signups' },
+];
+
+/** Admin Partners group: affiliate program + discount codes. */
+export const PARTNERS_SUBNAV: SectionSubNavItem[] = [
+  { href: '/admin/affiliates', label: 'Affiliates' },
+  { href: '/admin/promotions', label: 'Promotions' },
+];

--- a/src/components/ops/orders/OrdersTabs.tsx
+++ b/src/components/ops/orders/OrdersTabs.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ReactElement } from 'react';
+import Link from 'next/link';
 
 export type OrdersTab = 'orders' | 'invoices' | 'carts';
 
@@ -10,30 +11,56 @@ const TABS: Array<{ key: OrdersTab; label: string; activeCls: string }> = [
   { key: 'carts', label: 'Unpaid Carts', activeCls: 'bg-orange-500 text-white shadow-sm' },
 ];
 
-/** Top-level tab bar: Orders / Invoices / Unpaid Carts. 44px touch targets. */
+const INACTIVE_CLS =
+  'bg-white border border-gray-200 text-gray-600 hover:bg-gray-50 hover:border-gray-300';
+const BASE_CLS =
+  'min-h-[44px] px-4 inline-flex items-center text-sm font-semibold rounded-lg whitespace-nowrap transition-colors touch-manipulation';
+
+/**
+ * Top-level tab bar for the Orders section: Orders / Invoices / Unpaid Carts
+ * (in-page views) + Boats (links to /ops/boat-schedule). 44px touch targets.
+ *
+ * On /ops/orders, pass `onChange` — the three order views switch in place and
+ * Boats renders as a link. On /ops/boat-schedule, pass `active="boats"` with
+ * no `onChange` — the order views render as links back to /ops/orders.
+ */
 export default function OrdersTabs({
   active,
   onChange,
 }: {
-  active: OrdersTab;
-  onChange: (tab: OrdersTab) => void;
+  active: OrdersTab | 'boats';
+  onChange?: (tab: OrdersTab) => void;
 }): ReactElement {
   return (
     <div className="print:hidden flex gap-1.5 overflow-x-auto hide-scrollbar -mx-4 px-4 md:mx-0 md:px-0">
-      {TABS.map((t) => (
-        <button
-          key={t.key}
-          type="button"
-          onClick={() => onChange(t.key)}
-          className={`min-h-[44px] px-4 text-sm font-semibold rounded-lg whitespace-nowrap transition-colors touch-manipulation ${
-            active === t.key
-              ? t.activeCls
-              : 'bg-white border border-gray-200 text-gray-600 hover:bg-gray-50 hover:border-gray-300'
-          }`}
-        >
-          {t.label}
-        </button>
-      ))}
+      {TABS.map((t) =>
+        onChange ? (
+          <button
+            key={t.key}
+            type="button"
+            onClick={() => onChange(t.key)}
+            className={`${BASE_CLS} ${active === t.key ? t.activeCls : INACTIVE_CLS}`}
+          >
+            {t.label}
+          </button>
+        ) : (
+          <Link
+            key={t.key}
+            href={`/ops/orders${t.key === 'orders' ? '' : `?view=${t.key}`}`}
+            className={`${BASE_CLS} ${active === t.key ? t.activeCls : INACTIVE_CLS}`}
+          >
+            {t.label}
+          </Link>
+        ),
+      )}
+      <Link
+        href="/ops/boat-schedule"
+        className={`${BASE_CLS} ${
+          active === 'boats' ? 'bg-brand-blue text-white shadow-sm' : INACTIVE_CLS
+        }`}
+      >
+        Boats
+      </Link>
     </div>
   );
 }


### PR DESCRIPTION
## What

Functional consolidation of both staff portals' navigation — first step of the backend facelift (the visual PWA redesign follows via Claude Design).

### Ops: 11 tabs → 4
| Tab | Absorbs |
|---|---|
| **Orders** | Unpaid Carts + Weekly (were already query-param views of the same page) + **Boats** (boat schedule is now a 4th tab in the Orders tab bar) |
| **Products** | Inventory + Collections (shared sub-nav pills on all three pages) |
| **Events** | unchanged (PR #212) |
| **Agent** | unchanged |

Also: AI Count + Predictions removed from nav **and** from the Inventory header buttons (routes stay reachable by URL); dead `/ops/sync` link removed from Products; brand link + cross-portal links now land on `/ops/orders`.

### Admin: 12 tabs → 9
| Tab | Absorbs |
|---|---|
| **Email** | Emails + Follow-Ups + Email Signups (sub-nav: Templates / Follow-Ups / Signups) |
| **Partners** | Affiliates + Promotions (sub-nav) |
| **Dashboard** | NEW nav entry — it's the post-login landing page but had no way back |
| *(removed)* | Sync — page still live at `/admin/sync` (linked from Features), just not a tab |

### How
- New `SectionSubNav` (route-aware pills, 44px touch targets, longest-prefix active matching) + `subnav-items.ts` groups.
- `OrdersTabs` extended: state-tab mode on `/ops/orders`, link mode on `/ops/boat-schedule` (Boats item).
- Both layouts' nav items now carry `match` prefixes so grouped routes highlight the right tab (e.g. `/admin/email-signups` lights up **Email**).
- No routes deleted or moved — every bookmark and deep link keeps working.

## Gates
- `npx tsc --noEmit` — 0 errors
- `npm run lint` — clean (pre-existing img warnings only)
- `npm run test:run` — 665/665

🤖 Generated with [Claude Code](https://claude.com/claude-code)