### PR TITLE
docs(seo): YouTube strategy — bach-first Q&A video brief + keyword research (all 3 segments)

### DIFF
--- a/data/seo/gsc/2026-07-09-segments.json
+++ b/data/seo/gsc/2026-07-09-segments.json
@@ -1,0 +1,3775 @@
+{
+  "window": {
+    "start": "2026-04-09",
+    "end": "2026-07-06"
+  },
+  "site": "sc-domain:partyondelivery.com",
+  "segments": {
+    "bach": [
+      {
+        "query": "bachelor party alcohol delivery austin",
+        "clicks": 0,
+        "impressions": 121,
+        "position": 18.8,
+        "page": "/",
+        "video_moveable": true
+      },
+      {
+        "query": "bachelorette party alcohol delivery austin",
+        "clicks": 0,
+        "impressions": 91,
+        "position": 22.9,
+        "page": "/",
+        "video_moveable": true
+      },
+      {
+        "query": "best brunch in austin for bachelorette party",
+        "clicks": 1,
+        "impressions": 63,
+        "position": 10.1,
+        "page": "/blog/top-brunch-spots-for-an-austin-bachelorette-crew",
+        "video_moveable": true
+      },
+      {
+        "query": "best brunch in austin bachelorette party",
+        "clicks": 0,
+        "impressions": 61,
+        "position": 9.2,
+        "page": "/blog/top-brunch-spots-for-an-austin-bachelorette-crew",
+        "video_moveable": true
+      },
+      {
+        "query": "austin bachelorette party brunch",
+        "clicks": 0,
+        "impressions": 52,
+        "position": 8.9,
+        "page": "/blog/top-brunch-spots-for-an-austin-bachelorette-crew",
+        "video_moveable": true
+      },
+      {
+        "query": "austin texas bachelor party",
+        "clicks": 0,
+        "impressions": 43,
+        "position": 63.8,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "austin bachelorette party",
+        "clicks": 0,
+        "impressions": 25,
+        "position": 49.4,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "austin bachelor party bbq",
+        "clicks": 0,
+        "impressions": 23,
+        "position": 22.7,
+        "page": "/blog/best-bbq-spots-for-a-bachelor-party-lunch-in-austin",
+        "video_moveable": true
+      },
+      {
+        "query": "bachelorette brunch",
+        "clicks": 0,
+        "impressions": 22,
+        "position": 26,
+        "page": "/blog/top-brunch-spots-for-an-austin-bachelorette-crew",
+        "video_moveable": false
+      },
+      {
+        "query": "austin bachelor party",
+        "clicks": 0,
+        "impressions": 20,
+        "position": 44.9,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelor party austin",
+        "clicks": 0,
+        "impressions": 16,
+        "position": 24.2,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": true
+      },
+      {
+        "query": "metallic tattoo temporary bachelorette",
+        "clicks": 0,
+        "impressions": 15,
+        "position": 34.7,
+        "page": "/products/metallic-temporary-tattoos-perfect-for-bachelorette-parties",
+        "video_moveable": false
+      },
+      {
+        "query": "austin bachelor party packages",
+        "clicks": 0,
+        "impressions": 12,
+        "position": 27,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette party retreat",
+        "clicks": 0,
+        "impressions": 12,
+        "position": 27.8,
+        "page": "/blog/spa-and-wellness-retreat-ideas-for-a-relaxing-bachelorette",
+        "video_moveable": false
+      },
+      {
+        "query": "austin bachelor party budget",
+        "clicks": 0,
+        "impressions": 10,
+        "position": 22.4,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": true
+      },
+      {
+        "query": "large bachelorette party austin",
+        "clicks": 0,
+        "impressions": 9,
+        "position": 31.2,
+        "page": "/blog/unique-airbnbs-for-large-bachelorette-groups-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "austin texas bachelorette party",
+        "clicks": 0,
+        "impressions": 8,
+        "position": 65.4,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "brunch bachelorette party",
+        "clicks": 0,
+        "impressions": 8,
+        "position": 25.1,
+        "page": "/blog/top-brunch-spots-for-an-austin-bachelorette-crew",
+        "video_moveable": false
+      },
+      {
+        "query": "where to order premixed spritz drinks for bachelorette party",
+        "clicks": 0,
+        "impressions": 8,
+        "position": 15.4,
+        "page": "/products/aperol-spritz-party-pitcher-kit-16-drinks",
+        "video_moveable": true
+      },
+      {
+        "query": "austin bachelor party ideas",
+        "clicks": 0,
+        "impressions": 7,
+        "position": 45,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "austin bachelor party summer",
+        "clicks": 0,
+        "impressions": 6,
+        "position": 27,
+        "page": "/blog/ultimate-guide-austin-bachelor-parties",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelor parties near me",
+        "clicks": 0,
+        "impressions": 6,
+        "position": 14.3,
+        "page": "https://www.partyondelivery.com/",
+        "video_moveable": true
+      },
+      {
+        "query": "bachelorette party austin",
+        "clicks": 0,
+        "impressions": 6,
+        "position": 62,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette party brunch",
+        "clicks": 0,
+        "impressions": 6,
+        "position": 17.7,
+        "page": "/blog/top-brunch-spots-for-an-austin-bachelorette-crew",
+        "video_moveable": true
+      },
+      {
+        "query": "bachelorette wellness retreat",
+        "clicks": 0,
+        "impressions": 6,
+        "position": 12.5,
+        "page": "/blog/spa-and-wellness-retreat-ideas-for-a-relaxing-bachelorette",
+        "video_moveable": true
+      },
+      {
+        "query": "best places in austin for bachelorette party",
+        "clicks": 0,
+        "impressions": 6,
+        "position": 41.2,
+        "page": "/blog/top-brunch-spots-for-an-austin-bachelorette-crew",
+        "video_moveable": false
+      },
+      {
+        "query": "wellness retreat bachelorette",
+        "clicks": 0,
+        "impressions": 6,
+        "position": 16.7,
+        "page": "/blog/spa-and-wellness-retreat-ideas-for-a-relaxing-bachelorette",
+        "video_moveable": true
+      },
+      {
+        "query": "where to eat austin bachelorette party",
+        "clicks": 0,
+        "impressions": 6,
+        "position": 30.2,
+        "page": "/blog/top-brunch-spots-for-an-austin-bachelorette-crew",
+        "video_moveable": false
+      },
+      {
+        "query": "austin bachelor party outdoor",
+        "clicks": 0,
+        "impressions": 5,
+        "position": 20.6,
+        "page": "/blog/ultimate-guide-austin-bachelor-parties",
+        "video_moveable": true
+      },
+      {
+        "query": "i'm planning a bachelorette party in austin and want a rooftop venue with an all-inclusive event package (catering, decor, entertainment). what are the top options?",
+        "clicks": 0,
+        "impressions": 5,
+        "position": 18.8,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": true
+      },
+      {
+        "query": "planning a wellness bachelorette party spirituswellness",
+        "clicks": 0,
+        "impressions": 5,
+        "position": 12.8,
+        "page": "/blog/spa-and-wellness-retreat-ideas-for-a-relaxing-bachelorette",
+        "video_moveable": true
+      },
+      {
+        "query": "austin texas restaurants bachelorette party",
+        "clicks": 0,
+        "impressions": 4,
+        "position": 41,
+        "page": "/blog/top-brunch-spots-for-an-austin-bachelorette-crew",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelor party activities in austin tx",
+        "clicks": 0,
+        "impressions": 4,
+        "position": 46.8,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette spa retreat",
+        "clicks": 0,
+        "impressions": 4,
+        "position": 22.5,
+        "page": "/blog/spa-and-wellness-retreat-ideas-for-a-relaxing-bachelorette",
+        "video_moveable": true
+      },
+      {
+        "query": "bachelorette wellness weekend",
+        "clicks": 0,
+        "impressions": 4,
+        "position": 28.5,
+        "page": "/blog/spa-and-wellness-retreat-ideas-for-a-relaxing-bachelorette",
+        "video_moveable": false
+      },
+      {
+        "query": "things to do in austin for bachelorette party",
+        "clicks": 0,
+        "impressions": 4,
+        "position": 74.3,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "austin bachelorette party bars",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 35.7,
+        "page": "/blog/top-brunch-spots-for-an-austin-bachelorette-crew",
+        "video_moveable": false
+      },
+      {
+        "query": "austin bachelorette party hashtag",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 21.7,
+        "page": "/blog/diy-austin-bachelorette-scavenger-hunt-ideas",
+        "video_moveable": true
+      },
+      {
+        "query": "austin bachelorette party packing list",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 33.3,
+        "page": "/blogs/news/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "austin bachelorette party restaurants",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 35.7,
+        "page": "/blog/top-brunch-spots-for-an-austin-bachelorette-crew",
+        "video_moveable": false
+      },
+      {
+        "query": "austin texas bachelor party ideas",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 68.3,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelor parties in austin",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 50,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelor party austin tx",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 61.7,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelor party ideas austin",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 46.3,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette austin texas",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 61.3,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette party retreat getaways",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 38.3,
+        "page": "/blog/spa-and-wellness-retreat-ideas-for-a-relaxing-bachelorette",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette party spa getaway",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 47.3,
+        "page": "/blog/spa-and-wellness-retreat-ideas-for-a-relaxing-bachelorette",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette weekend austin",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 75.3,
+        "page": "/blogs/news/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette weekend austin tx",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 80,
+        "page": "/blogs/news/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "spa bachelorette party",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 49,
+        "page": "/blog/spa-and-wellness-retreat-ideas-for-a-relaxing-bachelorette",
+        "video_moveable": false
+      },
+      {
+        "query": "spa bachelorette weekend",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 39,
+        "page": "/blog/spa-and-wellness-retreat-ideas-for-a-relaxing-bachelorette",
+        "video_moveable": false
+      },
+      {
+        "query": "things to do in austin for a bachelor party",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 50.7,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "things to do in austin for bachelor party",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 35.3,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "wellness retreat bachelorette party",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 19.7,
+        "page": "/blog/spa-and-wellness-retreat-ideas-for-a-relaxing-bachelorette",
+        "video_moveable": true
+      },
+      {
+        "query": "bachelorette decorations near me",
+        "clicks": 1,
+        "impressions": 2,
+        "position": 4.5,
+        "page": "https://www.partyondelivery.com/",
+        "video_moveable": false
+      },
+      {
+        "query": "austin bachelor parties",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 48.5,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "austin bachelor party brewery",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 18.5,
+        "page": "/austin-bachelor-party-delivery",
+        "video_moveable": true
+      },
+      {
+        "query": "austin bachelor party nightlife",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 16.5,
+        "page": "/blog/ultimate-guide-austin-bachelor-parties",
+        "video_moveable": true
+      },
+      {
+        "query": "austin bachelorette parties",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 41,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "austin bachelorette party summer",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 59.5,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "austin bachelorette party where to stay",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 39,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "austin bachelorette weekend",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 49,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "austin tx bachelor party ideas",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 33.5,
+        "page": "/",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelor box",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 49.5,
+        "page": "/austin-bachelor-party-delivery",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelor parties austin",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 50,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelor party activities austin",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 47.5,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelor party austin tx ideas",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 57,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelor party confidential",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 42,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelor party ideas austin tx",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 57.5,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelor party in austin texas",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 76.5,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette austin tx",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 61,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette in austin tx",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 60,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette party supplies nearby",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 5.5,
+        "page": "https://www.partyondelivery.com/",
+        "video_moveable": true
+      },
+      {
+        "query": "bachelorette yoga austin tx",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 6.5,
+        "page": "/blogs/news/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": true
+      },
+      {
+        "query": "best places to stay in austin for a bachelorette party",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 19.5,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": true
+      },
+      {
+        "query": "best restaurants austin bachelorette party",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 25,
+        "page": "/blog/top-brunch-spots-for-an-austin-bachelorette-crew",
+        "video_moveable": true
+      },
+      {
+        "query": "brunch for bachelorette party",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 10.5,
+        "page": "/blog/top-brunch-spots-for-an-austin-bachelorette-crew",
+        "video_moveable": true
+      },
+      {
+        "query": "how long are bachelor parties",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 53,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "spa retreat bachelorette party",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 24,
+        "page": "/blog/spa-and-wellness-retreat-ideas-for-a-relaxing-bachelorette",
+        "video_moveable": true
+      },
+      {
+        "query": "things to do in austin texas for a bachelor party",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 32,
+        "page": "/",
+        "video_moveable": false
+      },
+      {
+        "query": "what to do in austin texas for bachelorette party",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 90,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "what's the best destination for a bachelor party rental in austin",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 17.5,
+        "page": "/blogs/news/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": true
+      },
+      {
+        "query": "where to stay for bachelorette party in austin",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 38.5,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "where to stay in austin for bachelorette party",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 43,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "where to stay in austin texas for a bachelorette party",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 62.5,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "amazon bachelorette decorations",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 13,
+        "page": "https://www.partyondelivery.com/",
+        "video_moveable": true
+      },
+      {
+        "query": "austin bachelor party activities",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 1,
+        "page": "/",
+        "video_moveable": false
+      },
+      {
+        "query": "austin bachelor party downtown",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 39,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "austin bachelor party itinerary",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 41,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "austin bachelorette",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 58,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "austin bachelorette activities",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 27,
+        "page": "/blog/top-brunch-spots-for-an-austin-bachelorette-crew",
+        "video_moveable": false
+      },
+      {
+        "query": "austin bachelorette party guide",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 54,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "austin bachelorette party hashtags",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 29,
+        "page": "/blog/diy-austin-bachelorette-scavenger-hunt-ideas",
+        "video_moveable": false
+      },
+      {
+        "query": "austin bachelorette party hotel",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 32,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "austin bachelorette party hotels",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 28,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "austin bachelorette party itin",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 2,
+        "page": "/",
+        "video_moveable": false
+      },
+      {
+        "query": "austin bachelorette party packages",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 39,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "austin bachelorette party planner",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 40,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "austin bachelorette party texas",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 68,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "austin for bachelorette party",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 56,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "austin hotels for bachelorette party",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 34,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "austin texas bachelor party activities",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 1,
+        "page": "/",
+        "video_moveable": false
+      },
+      {
+        "query": "austin tx bachelor party",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 71,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "austin tx bachelorette",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 65,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "austin tx bachelorette party",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 63,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "austin tx bachelorette party ideas",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 74,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelor parties",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 21,
+        "page": "https://www.partyondelivery.com/",
+        "video_moveable": true
+      },
+      {
+        "query": "bachelor party activities in austin",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 57,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelor party austin texas ideas",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 58,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelor party decorations",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 5,
+        "page": "https://www.partyondelivery.com/",
+        "video_moveable": true
+      },
+      {
+        "query": "bachelor party ideas austin texas",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 64,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelor party in austin",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 20,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": true
+      },
+      {
+        "query": "bachelor planning",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 53,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette parties austin",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 42,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette parties in austin",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 40,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette parties in austin texas",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 64,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette parties in austin tx",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 62,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette parties texas",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 60,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette party austin texas",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 62,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette party austin texas ideas",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 73,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette party austin tx",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 61,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette party decorations",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 4,
+        "page": "https://www.partyondelivery.com/",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette party favors",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 13,
+        "page": "https://www.partyondelivery.com/",
+        "video_moveable": true
+      },
+      {
+        "query": "bachelorette party ideas austin",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 52,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette party ideas in austin tx",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 77,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette party lake travis",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 68,
+        "page": "/blogs/news/austin-party-houses-bachelor-party-alcohol-delivery-complete-coordination-guide-for-boat-parties",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette party packages austin tx",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 55,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette party spa",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 18,
+        "page": "/blog/spa-and-wellness-retreat-ideas-for-a-relaxing-bachelorette",
+        "video_moveable": true
+      },
+      {
+        "query": "bachelorette party store",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 1,
+        "page": "https://www.partyondelivery.com/",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette party suggestions austin",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 61,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette spa party",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 75,
+        "page": "/blog/spa-and-wellness-retreat-ideas-for-a-relaxing-bachelorette",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette spa weekend",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 40,
+        "page": "/blog/spa-and-wellness-retreat-ideas-for-a-relaxing-bachelorette",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelorette weekend in austin",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 51,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "bachelors of austin",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 73,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "best austin bachelorette party itinerary",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 6,
+        "page": "/blog/top-brunch-spots-for-an-austin-bachelorette-crew",
+        "video_moveable": true
+      },
+      {
+        "query": "best bars for bachelorette parties in austin",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 27,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "best places to eat in austin for bachelorette party",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 22,
+        "page": "/blog/top-brunch-spots-for-an-austin-bachelorette-crew",
+        "video_moveable": true
+      },
+      {
+        "query": "best places to stay in austin for bachelorette party",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 25,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": true
+      },
+      {
+        "query": "best restaurants in austin for bachelorette party",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 42,
+        "page": "/blog/top-brunch-spots-for-an-austin-bachelorette-crew",
+        "video_moveable": false
+      },
+      {
+        "query": "best spirits to gift for bachelorette party",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 64,
+        "page": "/blog/austin-gift-guide-party-lovers-home-bartenders",
+        "video_moveable": false
+      },
+      {
+        "query": "best things to do in austin for a bachelorette party",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 57,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "best things to do in austin texas for bachelorette party",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 54,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "brunch bachelorette",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 10,
+        "page": "/blog/top-brunch-spots-for-an-austin-bachelorette-crew",
+        "video_moveable": true
+      },
+      {
+        "query": "fun places to have a bachelorette party",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 1,
+        "page": "/blog/diy-austin-bachelorette-scavenger-hunt-ideas",
+        "video_moveable": false
+      },
+      {
+        "query": "how far ahead should i book for a bachelorette trip in austin",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 1,
+        "page": "/",
+        "video_moveable": false
+      },
+      {
+        "query": "lake travis bachelorette party",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 1,
+        "page": "/",
+        "video_moveable": false
+      },
+      {
+        "query": "places to stay in austin tx for bachelorette party",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 52,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "spa getaway bachelorette party",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 17,
+        "page": "/blog/spa-and-wellness-retreat-ideas-for-a-relaxing-bachelorette",
+        "video_moveable": true
+      },
+      {
+        "query": "spa weekend bachelorette party",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 65,
+        "page": "/blog/spa-and-wellness-retreat-ideas-for-a-relaxing-bachelorette",
+        "video_moveable": false
+      },
+      {
+        "query": "things to do austin bachelorette party",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 77,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "things to do for a bachelorette party in austin tx",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 84,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "things to do in austin bachelor party",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 53,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "things to do in austin texas bachelor party",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 67,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "things to do in austin texas bachelorette party",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 85,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "things to do in austin texas for a bachelorette party",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 88,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "unique austin bachelorette party",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 48,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "what to do in austin for bachelorette party",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 82,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "what to do in austin texas for a bachelorette party",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 94,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "when is a bachelor party",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 73,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "when should bachelor party be",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 54,
+        "page": "/blog/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners",
+        "video_moveable": false
+      },
+      {
+        "query": "where to stay in austin bachelorette party",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 44,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "where to stay in austin for a bachelorette party",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 39,
+        "page": "/blog/austin-bachelorette-parties-best-ways-to-spend-a-weekend-in-austin",
+        "video_moveable": false
+      }
+    ],
+    "wedding": [
+      {
+        "query": "team bride sunglasses",
+        "clicks": 1,
+        "impressions": 305,
+        "position": 9.9,
+        "page": "/products/team-bride-sunglasses",
+        "video_moveable": true
+      },
+      {
+        "query": "all inclusive wedding packages austin texas",
+        "clicks": 0,
+        "impressions": 134,
+        "position": 53.9,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "all inclusive wedding venues",
+        "clicks": 0,
+        "impressions": 129,
+        "position": 53,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding packages austin tx",
+        "clicks": 0,
+        "impressions": 104,
+        "position": 63.2,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding drink delivery",
+        "clicks": 0,
+        "impressions": 96,
+        "position": 15,
+        "page": "/",
+        "video_moveable": true
+      },
+      {
+        "query": "small wedding venues austin",
+        "clicks": 0,
+        "impressions": 94,
+        "position": 28.1,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding folding chairs austin, tx",
+        "clicks": 0,
+        "impressions": 93,
+        "position": 24.1,
+        "page": "/rentals/chair-rentals-austin",
+        "video_moveable": true
+      },
+      {
+        "query": "wedding bar",
+        "clicks": 0,
+        "impressions": 88,
+        "position": 49.3,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "bar packages for weddings",
+        "clicks": 0,
+        "impressions": 78,
+        "position": 69.2,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "all inclusive wedding packages austin",
+        "clicks": 0,
+        "impressions": 77,
+        "position": 39.5,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "all inclusive wedding venue",
+        "clicks": 0,
+        "impressions": 77,
+        "position": 51.5,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "all inclusive wedding venues austin",
+        "clicks": 0,
+        "impressions": 73,
+        "position": 43,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "all inclusive wedding venues in austin tx",
+        "clicks": 0,
+        "impressions": 62,
+        "position": 68.4,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "all inclusive wedding venues austin tx",
+        "clicks": 0,
+        "impressions": 55,
+        "position": 47.5,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding venue packages",
+        "clicks": 0,
+        "impressions": 52,
+        "position": 66,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "austin wedding packages",
+        "clicks": 0,
+        "impressions": 49,
+        "position": 65.6,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "all inclusive wedding packages in austin tx",
+        "clicks": 0,
+        "impressions": 47,
+        "position": 66.4,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "team bride glasses",
+        "clicks": 0,
+        "impressions": 47,
+        "position": 10.9,
+        "page": "/products/team-bride-sunglasses",
+        "video_moveable": true
+      },
+      {
+        "query": "wedding packages austin",
+        "clicks": 0,
+        "impressions": 39,
+        "position": 57.3,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding venue package",
+        "clicks": 0,
+        "impressions": 34,
+        "position": 62.7,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "indoor wedding locations",
+        "clicks": 0,
+        "impressions": 30,
+        "position": 66.2,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "bar for weddings",
+        "clicks": 0,
+        "impressions": 27,
+        "position": 49.3,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "team bride sash",
+        "clicks": 0,
+        "impressions": 27,
+        "position": 13.3,
+        "page": "/products/team-bride-sash",
+        "video_moveable": true
+      },
+      {
+        "query": "team bride sashes",
+        "clicks": 0,
+        "impressions": 23,
+        "position": 14,
+        "page": "/products/team-bride-sash",
+        "video_moveable": true
+      },
+      {
+        "query": "wedding alcohol delivery",
+        "clicks": 0,
+        "impressions": 23,
+        "position": 12.8,
+        "page": "/",
+        "video_moveable": true
+      },
+      {
+        "query": "full service wedding venues",
+        "clicks": 0,
+        "impressions": 20,
+        "position": 75.5,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "venues for a small wedding",
+        "clicks": 0,
+        "impressions": 20,
+        "position": 32.3,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "alcohol catering for wedding",
+        "clicks": 0,
+        "impressions": 17,
+        "position": 78.5,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "bride squad glasses",
+        "clicks": 0,
+        "impressions": 16,
+        "position": 10.3,
+        "page": "/products/team-bride-sunglasses",
+        "video_moveable": true
+      },
+      {
+        "query": "small intimate wedding venues near me",
+        "clicks": 0,
+        "impressions": 16,
+        "position": 51.3,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "small wedding ideas near me",
+        "clicks": 0,
+        "impressions": 16,
+        "position": 43.1,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "venue wedding packages",
+        "clicks": 0,
+        "impressions": 16,
+        "position": 53.9,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "are friday and sunday weddings discounted",
+        "clicks": 0,
+        "impressions": 14,
+        "position": 20.3,
+        "page": "/blog/friday-sunday-wedding-save-money",
+        "video_moveable": true
+      },
+      {
+        "query": "austin small wedding venues",
+        "clicks": 0,
+        "impressions": 14,
+        "position": 28.6,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "inclusive wedding venue",
+        "clicks": 0,
+        "impressions": 14,
+        "position": 62,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "intimate wedding locations",
+        "clicks": 0,
+        "impressions": 14,
+        "position": 45.1,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "small wedding venues in austin",
+        "clicks": 0,
+        "impressions": 14,
+        "position": 28,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "all-inclusive wedding venue",
+        "clicks": 0,
+        "impressions": 13,
+        "position": 66.3,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding event packages",
+        "clicks": 0,
+        "impressions": 13,
+        "position": 90,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "austin all inclusive wedding venues",
+        "clicks": 0,
+        "impressions": 12,
+        "position": 49.3,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "small wedding locations",
+        "clicks": 0,
+        "impressions": 12,
+        "position": 37.4,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "unique wedding venues near me",
+        "clicks": 0,
+        "impressions": 12,
+        "position": 62.4,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding venue all inclusive",
+        "clicks": 0,
+        "impressions": 12,
+        "position": 68.5,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding venues all inclusive",
+        "clicks": 0,
+        "impressions": 12,
+        "position": 55.2,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "bride squad sunglasses",
+        "clicks": 0,
+        "impressions": 11,
+        "position": 10,
+        "page": "/products/team-bride-sunglasses",
+        "video_moveable": true
+      },
+      {
+        "query": "austin destination wedding",
+        "clicks": 0,
+        "impressions": 10,
+        "position": 73.1,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding venue online ordering website austin",
+        "clicks": 0,
+        "impressions": 10,
+        "position": 66.1,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "austin all inclusive wedding packages",
+        "clicks": 0,
+        "impressions": 9,
+        "position": 41.6,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "bride balloons near me",
+        "clicks": 0,
+        "impressions": 9,
+        "position": 12.6,
+        "page": "/products/bride-balloons",
+        "video_moveable": true
+      },
+      {
+        "query": "cozy wedding venues",
+        "clicks": 0,
+        "impressions": 9,
+        "position": 33.2,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "unique small wedding venues",
+        "clicks": 0,
+        "impressions": 9,
+        "position": 46,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding bar packages",
+        "clicks": 0,
+        "impressions": 9,
+        "position": 68.4,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "all inclusive venues for weddings",
+        "clicks": 0,
+        "impressions": 8,
+        "position": 60.6,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "all-inclusive micro wedding packages austin",
+        "clicks": 0,
+        "impressions": 8,
+        "position": 59.6,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "all-inclusive wedding packages austin",
+        "clicks": 0,
+        "impressions": 8,
+        "position": 31.4,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "all-inclusive wedding venues",
+        "clicks": 0,
+        "impressions": 8,
+        "position": 61.8,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "intimate wedding venues austin",
+        "clicks": 0,
+        "impressions": 8,
+        "position": 31.4,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "small town wedding venue",
+        "clicks": 0,
+        "impressions": 8,
+        "position": 54.1,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "small venues for weddings",
+        "clicks": 0,
+        "impressions": 8,
+        "position": 20.9,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": true
+      },
+      {
+        "query": "small venues for weddings near me",
+        "clicks": 0,
+        "impressions": 8,
+        "position": 28.1,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "full-service wedding venues",
+        "clicks": 0,
+        "impressions": 7,
+        "position": 54.7,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "inclusive wedding venues",
+        "clicks": 0,
+        "impressions": 7,
+        "position": 45,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "intimate wedding gathering austin",
+        "clicks": 0,
+        "impressions": 7,
+        "position": 42.3,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding venue and reception packages",
+        "clicks": 0,
+        "impressions": 7,
+        "position": 57.6,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "all-inclusive wedding packages austin tx",
+        "clicks": 0,
+        "impressions": 6,
+        "position": 47.5,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "best small wedding venues near me",
+        "clicks": 0,
+        "impressions": 6,
+        "position": 62,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "bulk spritz ingredients for wedding reception buy online",
+        "clicks": 0,
+        "impressions": 6,
+        "position": 6.5,
+        "page": "/products/aperol-spritz-party-pitcher-kit-16-drinks",
+        "video_moveable": true
+      },
+      {
+        "query": "four seasons austin wedding cost",
+        "clicks": 0,
+        "impressions": 6,
+        "position": 24.2,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": true
+      },
+      {
+        "query": "small venues for small weddings",
+        "clicks": 0,
+        "impressions": 6,
+        "position": 37.8,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding event package",
+        "clicks": 0,
+        "impressions": 6,
+        "position": 80.5,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding ring toss game",
+        "clicks": 0,
+        "impressions": 6,
+        "position": 33.3,
+        "page": "/products/ring-toss-game",
+        "video_moveable": false
+      },
+      {
+        "query": "weddings parties",
+        "clicks": 0,
+        "impressions": 6,
+        "position": 55.3,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "commodore perry estate wedding cost",
+        "clicks": 0,
+        "impressions": 5,
+        "position": 60.2,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "intimate wedding ceremony locations",
+        "clicks": 0,
+        "impressions": 5,
+        "position": 46.2,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "omni barton creek wedding cost",
+        "clicks": 0,
+        "impressions": 5,
+        "position": 59.4,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "relaxed wedding venues",
+        "clicks": 0,
+        "impressions": 5,
+        "position": 36.6,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "small outdoor wedding venues near me",
+        "clicks": 0,
+        "impressions": 5,
+        "position": 42,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "all in one wedding venues",
+        "clicks": 0,
+        "impressions": 4,
+        "position": 76,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "bar for wedding",
+        "clicks": 0,
+        "impressions": 4,
+        "position": 67.3,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "best micro wedding venues near me",
+        "clicks": 0,
+        "impressions": 4,
+        "position": 69,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "cosy wedding venues",
+        "clicks": 0,
+        "impressions": 4,
+        "position": 35.8,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "cute wedding venues",
+        "clicks": 0,
+        "impressions": 4,
+        "position": 44.5,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "full service weddings",
+        "clicks": 0,
+        "impressions": 4,
+        "position": 58.5,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "intimate wedding venue near me",
+        "clicks": 0,
+        "impressions": 4,
+        "position": 28.8,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "places for small weddings",
+        "clicks": 0,
+        "impressions": 4,
+        "position": 39.8,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "small wedding reception spaces near me",
+        "clicks": 0,
+        "impressions": 4,
+        "position": 67.8,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "small wedding space near me",
+        "clicks": 0,
+        "impressions": 4,
+        "position": 78.5,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding drink vendor",
+        "clicks": 0,
+        "impressions": 4,
+        "position": 36.8,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding packages in austin",
+        "clicks": 0,
+        "impressions": 4,
+        "position": 63.8,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding venues ideas",
+        "clicks": 0,
+        "impressions": 4,
+        "position": 46.8,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding venues open house",
+        "clicks": 0,
+        "impressions": 4,
+        "position": 59.8,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "alcohol packages for weddings",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 57,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "bar services for weddings",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 26.7,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "barr mansion wedding cost",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 46.7,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "best indoor wedding venues",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 80.3,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "best wedding packages",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 58,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "bride squad sash",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 18,
+        "page": "/products/team-bride-sash",
+        "video_moveable": true
+      },
+      {
+        "query": "bride squad sashes",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 28,
+        "page": "/products/team-bride-sash",
+        "video_moveable": false
+      },
+      {
+        "query": "bride team glasses",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 10,
+        "page": "/products/team-bride-sunglasses",
+        "video_moveable": true
+      },
+      {
+        "query": "bride team sash",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 17,
+        "page": "/products/team-bride-sash",
+        "video_moveable": true
+      },
+      {
+        "query": "byob wedding venues",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 5.7,
+        "page": "/austin-byob-venues",
+        "video_moveable": true
+      },
+      {
+        "query": "classic wedding packages",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 92.7,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "commodore perry wedding cost",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 54.7,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "lady bird johnson wildflower center wedding cost",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 68.7,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "low key wedding venues",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 36.3,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "package wedding venues",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 68,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "places for small weddings near me",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 40.7,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "sash team bride",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 16,
+        "page": "/products/team-bride-sash",
+        "video_moveable": true
+      },
+      {
+        "query": "self service wedding bar",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 40,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "small intimate wedding venue near me",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 61.7,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "small places to have a wedding",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 51,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "small wedding party venues",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 17.7,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": true
+      },
+      {
+        "query": "small wedding venue austin",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 30,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "small wedding venue in austin",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 22.7,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": true
+      },
+      {
+        "query": "team bride goggles",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 8.7,
+        "page": "/products/team-bride-sunglasses",
+        "video_moveable": true
+      },
+      {
+        "query": "team bride sunglass",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 9.3,
+        "page": "/products/team-bride-sunglasses",
+        "video_moveable": true
+      },
+      {
+        "query": "wedding alcohol packages",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 71,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding bar rental",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 26.3,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding bar service",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 52.7,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding bar vendor",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 31.3,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding limited",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 31.3,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding venue with bar package",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 94.3,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding venues small near me",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 57,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "alcohol vendors for weddings",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 6,
+        "page": "/weddings",
+        "video_moveable": true
+      },
+      {
+        "query": "all inclusive wedding reception venues",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 50.5,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "austin wedding favors",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 11.5,
+        "page": "https://www.partyondelivery.com/",
+        "video_moveable": true
+      },
+      {
+        "query": "bar for a wedding",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 61,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "bar for wedding reception",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 58,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "bar services for weddings near me",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 81,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "bars for weddings",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 34.5,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "best chair delivery and setup services for weddings",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 8.5,
+        "page": "/rentals/chair-rentals-austin",
+        "video_moveable": true
+      },
+      {
+        "query": "best wedding venues for small weddings",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 77.5,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "bulk aperol spritz ingredients suppliers for events wedding",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 15,
+        "page": "/products/aperol-spritz-party-pitcher-kit-16-drinks",
+        "video_moveable": true
+      },
+      {
+        "query": "bulk spritz ingredients for wedding buy online",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 9,
+        "page": "/products/aperol-spritz-party-pitcher-kit-16-drinks",
+        "video_moveable": true
+      },
+      {
+        "query": "buy the bride a drink",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 2,
+        "page": "https://www.partyondelivery.com/",
+        "video_moveable": false
+      },
+      {
+        "query": "casual wedding venues",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 22.5,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": true
+      },
+      {
+        "query": "cultural wedding packages",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 94.5,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "event space for small wedding",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 65,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "everything included wedding venues",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 63,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "hidden gem wedding venues near me",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 35.5,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "inclusive wedding",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 29,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "inclusive weddings",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 69,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "intimate wedding venue",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 23,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": true
+      },
+      {
+        "query": "intimate wedding venues near me",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 40.5,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "location wedding packages",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 88.5,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "night wedding venues",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 50,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "places to have a small wedding near me",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 68,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "places to have small weddings",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 66.5,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "places to have small weddings near me",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 48,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "small venue for wedding ceremony",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 36,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "small wedding location",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 28.5,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "small wedding places",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 26,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "small wedding venues in austin texas",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 48.5,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "small wedding venues in austin tx",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 44.5,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "team groom goggles",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 10,
+        "page": "/products/team-bride-sunglasses",
+        "video_moveable": true
+      },
+      {
+        "query": "the knot austin wedding cost average 2025",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 12,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": true
+      },
+      {
+        "query": "unique places to have a wedding near me",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 57.5,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "venue rental vs all inclusive wedding",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 64,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding bundle package",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 32,
+        "page": "/blog/all-inclusive-austin-wedding-venues",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding favors",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 1,
+        "page": "https://www.partyondelivery.com/",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding location ideas",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 55,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding packages list",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 75.5,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding reception package",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 80,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding reception walk-in coolers for rent",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 21,
+        "page": "/rentals/cooler-rentals-austin",
+        "video_moveable": true
+      },
+      {
+        "query": "wedding venues packages",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 69,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "where to buy discount kegs for weddings",
+        "clicks": 0,
+        "impressions": 2,
+        "position": 16.5,
+        "page": "/kegs",
+        "video_moveable": true
+      },
+      {
+        "query": "all inclusive micro wedding packages austin",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 65,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "all inclusive small wedding venues near austin",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 3,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "all inclusive wedding locations",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 48,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "all inclusive wedding venues near me",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 23,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": true
+      },
+      {
+        "query": "all-inclusive wedding services",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 47,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "austin wedding venues all inclusive",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 47,
+        "page": "/blog/all-inclusive-austin-wedding-venues",
+        "video_moveable": false
+      },
+      {
+        "query": "average wedding cost austin texas 2025",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 9,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": true
+      },
+      {
+        "query": "bar at a wedding",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 89,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "bar at wedding",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 71,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "bar in wedding",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 61,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "bar service wedding",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 33,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "bar weddings",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 37,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "best place to buy bulk alcohol for wedding",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 8,
+        "page": "/",
+        "video_moveable": true
+      },
+      {
+        "query": "best places for wedding receptions near me",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 18,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": true
+      },
+      {
+        "query": "best weekend wedding venues",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 36,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "bridal sash near me",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 2,
+        "page": "https://www.partyondelivery.com/",
+        "video_moveable": false
+      },
+      {
+        "query": "bride balloons nearby",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 13,
+        "page": "/products/bride-balloons",
+        "video_moveable": true
+      },
+      {
+        "query": "bride crew sash",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 20,
+        "page": "/products/team-bride-sash",
+        "video_moveable": true
+      },
+      {
+        "query": "bride decorations",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 15,
+        "page": "https://www.partyondelivery.com/",
+        "video_moveable": true
+      },
+      {
+        "query": "bride helium balloons",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 15,
+        "page": "/products/bride-balloons",
+        "video_moveable": true
+      },
+      {
+        "query": "bride sash near me",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 1,
+        "page": "https://www.partyondelivery.com/",
+        "video_moveable": false
+      },
+      {
+        "query": "bride shades",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 9,
+        "page": "/products/team-bride-sunglasses",
+        "video_moveable": true
+      },
+      {
+        "query": "bride team sunglasses",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 9,
+        "page": "/products/team-bride-sunglasses",
+        "video_moveable": true
+      },
+      {
+        "query": "bring your own alcohol wedding venues",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 10,
+        "page": "/austin-byob-venues",
+        "video_moveable": true
+      },
+      {
+        "query": "byob wedding venue",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 9,
+        "page": "/austin-byob-venues",
+        "video_moveable": true
+      },
+      {
+        "query": "camp merrie-woode wedding alcohol bartender",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 10,
+        "page": "/weddings",
+        "video_moveable": true
+      },
+      {
+        "query": "casual wedding venue",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 25,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": true
+      },
+      {
+        "query": "cool places to have a wedding",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 95,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "cost of liquor for wedding",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 77,
+        "page": "/blog/friday-sunday-wedding-save-money",
+        "video_moveable": false
+      },
+      {
+        "query": "cute places to have a wedding",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 79,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "drink catering for weddings",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 90,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "eco friendly disposable cups wedding",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 38,
+        "page": "/products/disposable-eco-friendly-cocktail-cups-10-pack-12oz",
+        "video_moveable": false
+      },
+      {
+        "query": "fresh off the market bridal shower theme",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 2,
+        "page": "https://www.partyondelivery.com/",
+        "video_moveable": false
+      },
+      {
+        "query": "full service wedding venue",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 52,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "getaway weddings",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 26,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "hidden wedding venues near me",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 63,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "hotel wedding packages",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 28,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "how much does alcohol cost for a wedding",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 77,
+        "page": "/blog/friday-sunday-wedding-save-money",
+        "video_moveable": false
+      },
+      {
+        "query": "how much will alcohol cost for a wedding",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 86,
+        "page": "/blog/friday-sunday-wedding-save-money",
+        "video_moveable": false
+      },
+      {
+        "query": "inclusive wedding packages",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 93,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "intimate wedding location",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 35,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "intimate wedding places",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 44,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "intimate wedding venues",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 49,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "intimate weddings near me",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 32,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "justine's secret house wedding cost",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 64,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "kegs for wedding",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 56,
+        "page": "/kegs",
+        "video_moveable": false
+      },
+      {
+        "query": "last minute wedding locations",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 53,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "light up the dance floor wedding sign",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 52,
+        "page": "/products/neon-light-up-dance-floor",
+        "video_moveable": false
+      },
+      {
+        "query": "low key wedding venues near me",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 62,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "lowkey wedding venues",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 38,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "outdoor games for weddings",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 3,
+        "page": "/products/giant-yard-pong-game",
+        "video_moveable": false
+      },
+      {
+        "query": "outdoor small wedding venues near me",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 64,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "parties for weddings",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 69,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "places for a small wedding near me",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 73,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "places to have a small wedding",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 88,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "places to have a small wedding ceremony",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 39,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "places to have a small wedding reception near me",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 23,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": true
+      },
+      {
+        "query": "pretty places to have a wedding",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 67,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "quaint wedding venues",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 30,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "relaxed weddings",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 31,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "rent white chairs for wedding near me",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 4,
+        "page": "/rentals/chair-rentals-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "romantic intimate wedding venues",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 59,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "romantic small wedding venues",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 54,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "sekrit theater wedding cost",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 74,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "self serve wedding bar",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 37,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "simple wedding locations",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 44,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "small beautiful wedding venues",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 43,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "small place for wedding",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 58,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "small places to have a wedding near me",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 15,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": true
+      },
+      {
+        "query": "small romantic wedding venues",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 48,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "small unique wedding venues",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 45,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "small unique wedding venues near me",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 29,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "small venue for wedding near me",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 17,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": true
+      },
+      {
+        "query": "small venue wedding near me",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 25,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": true
+      },
+      {
+        "query": "small venues for wedding",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 17,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": true
+      },
+      {
+        "query": "small venues for wedding reception",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 27,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "small wedding ceremony locations near me",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 26,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "small wedding parties",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 45,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "small wedding venues austin texas",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 57,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "small wedding venues austin tx",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 64,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "team bride shades",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 7,
+        "page": "/products/team-bride-sunglasses",
+        "video_moveable": true
+      },
+      {
+        "query": "team bride specs",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 11,
+        "page": "/products/team-bride-sunglasses",
+        "video_moveable": true
+      },
+      {
+        "query": "team bride team groom sunglasses",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 20,
+        "page": "/products/team-bride-sunglasses",
+        "video_moveable": true
+      },
+      {
+        "query": "team.bride sash",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 12,
+        "page": "/products/team-bride-sash",
+        "video_moveable": true
+      },
+      {
+        "query": "the wedding bar",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 69,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "traditional wedding packages",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 99,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "unique small wedding venues near me",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 28,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "universal weddings",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 73,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "unknown wedding venues near me",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 40,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "venues for intimate weddings",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 32,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "venues for small weddings near me",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 64,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "vintage villas wedding cost",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 89,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding alcohol catering",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 54,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding balloons delivered",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 23,
+        "page": "/products/bride-balloons",
+        "video_moveable": true
+      },
+      {
+        "query": "wedding bar catering",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 59,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding chair rental austin",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 45,
+        "page": "/rentals/chair-rentals-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding chair rentals austin tx",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 53,
+        "page": "/rentals/chair-rentals-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding cocktail bar",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 66,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding couple chairs for rent",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 10,
+        "page": "/rentals/chair-rentals-austin",
+        "video_moveable": true
+      },
+      {
+        "query": "wedding drink bar",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 53,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding event space packages",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 96,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding favors for guests",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 1,
+        "page": "https://www.partyondelivery.com/",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding helium balloons delivered",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 38,
+        "page": "/products/bride-balloons",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding inclusive packages",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 71,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding kegs",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 68,
+        "page": "/kegs",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding lawn games",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 4,
+        "page": "/products/giant-yard-pong-game",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding liquor packages",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 1,
+        "page": "/",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding on memorial day weekend",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 2,
+        "page": "/blog/friday-sunday-wedding-save-money",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding only venues",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 39,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding open bar packages",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 90,
+        "page": "/weddings",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding package venue",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 59,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding packages in austin texas",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 73,
+        "page": "/blog/all-inclusive-austin-wedding-venues",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding packages in austin tx",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 60,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding party packages",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 67,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding small venues",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 44,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding table and chair rental",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 43,
+        "page": "/rentals/chair-rentals-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding venue ideas near me",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 20,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": true
+      },
+      {
+        "query": "wedding venue intimate",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 60,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding venues byob",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 11,
+        "page": "/austin-byob-venues",
+        "video_moveable": true
+      },
+      {
+        "query": "wedding venues near me for small wedding",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 23,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": true
+      },
+      {
+        "query": "wedding venues that include food",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 99,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding venues that provide everything",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 96,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding venues with catering included",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 75,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding venues with everything included",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 71,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding venues with package deals",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 71,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "wedding venues with packages",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 49,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      },
+      {
+        "query": "what is an all inclusive wedding venue",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 91,
+        "page": "/blog/all-inclusive-austin-wedding-venues",
+        "video_moveable": false
+      },
+      {
+        "query": "what is an all-inclusive wedding venue",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 96,
+        "page": "/blog/all-inclusive-austin-wedding-venues",
+        "video_moveable": false
+      },
+      {
+        "query": "where can i buy discount kegs for weddings in my area",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 34,
+        "page": "/kegs",
+        "video_moveable": false
+      },
+      {
+        "query": "where to have a small wedding",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 37,
+        "page": "/blog/best-small-wedding-venues-near-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "white rental chairs for weddings",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 99,
+        "page": "/rentals/chair-rentals-austin",
+        "video_moveable": false
+      },
+      {
+        "query": "who pays for alcohol at wedding reception",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 70,
+        "page": "/blog/friday-sunday-wedding-save-money",
+        "video_moveable": false
+      },
+      {
+        "query": "zilker clubhouse wedding",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 73,
+        "page": "/blog/all-inclusive-austin-wedding-venues-with-packages",
+        "video_moveable": false
+      }
+    ],
+    "corporate": [
+      {
+        "query": "where to get soft drinks delivered for corporate events?",
+        "clicks": 0,
+        "impressions": 49,
+        "position": 7.9,
+        "page": "/",
+        "video_moveable": true
+      },
+      {
+        "query": "soft drinks delivery for corporate events",
+        "clicks": 0,
+        "impressions": 33,
+        "position": 11.9,
+        "page": "/",
+        "video_moveable": true
+      },
+      {
+        "query": "austin corporate event table rentals",
+        "clicks": 0,
+        "impressions": 8,
+        "position": 17.9,
+        "page": "/rentals/cocktail-table-rentals-austin",
+        "video_moveable": true
+      },
+      {
+        "query": "best beer keg delivery service for corporate events",
+        "clicks": 0,
+        "impressions": 4,
+        "position": 3.3,
+        "page": "/kegs",
+        "video_moveable": false
+      },
+      {
+        "query": "last-minute corporate catering with drink service delivery",
+        "clicks": 0,
+        "impressions": 4,
+        "position": 10.3,
+        "page": "/corporate",
+        "video_moveable": true
+      },
+      {
+        "query": "corporate alcohol",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 50.7,
+        "page": "/corporate",
+        "video_moveable": false
+      },
+      {
+        "query": "corporate alcohol delivery",
+        "clicks": 0,
+        "impressions": 3,
+        "position": 51.3,
+        "page": "/",
+        "video_moveable": false
+      },
+      {
+        "query": "premium beer delivery to office corporate",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 8,
+        "page": "/",
+        "video_moveable": true
+      },
+      {
+        "query": "where can i order non alcoholic beer kegs for corporate events",
+        "clicks": 0,
+        "impressions": 1,
+        "position": 49,
+        "page": "/kegs",
+        "video_moveable": false
+      }
+    ]
+  }
+}

--- a/data/seo/internal-data-bach-2026-07-10.md
+++ b/data/seo/internal-data-bach-2026-07-10.md
@@ -1,0 +1,23 @@
+# Internal bach-party data pull (2026-07-10, read-only)
+
+Source: prod Postgres via read-only aggregates. Bach = `group_orders_v2` where `party_type IN (BACH, BACHELOR, BACHELORETTE)` OR name matches `bach`. All GroupOrderV2 data is 2026-only (system launched this year).
+
+| Metric | Value |
+|---|---|
+| Bach dashboards created (Jan–Jul 2026) | **532** (of which 66 are BOAT-typed with bach names) |
+| Paid orders linked to bach dashboards | 57 |
+| Revenue on those orders | $18,755 |
+| Avg / median order | $329 / $253 |
+| Avg / median spend per group | $368 / $286 |
+| Lead time (order → delivery) | **median 2 days**, avg 5.5 days |
+| Avg sub-orders per dashboard | 1.1 |
+
+Top products at bach parties (units): High Noon Variety 12pk **52**, Surfside Starter 8pk **38**, High Noon Tequila Seltzer 8pk **24**, Bottled Water 32pk **22**, Ice 20lb **21**, Wycliff Brut **21**, Michelob Ultra 24pk **20**, Solo Cups **18**, Miller Lite 16, Tito's 1.75L 15, White Claw 24pk 13, Surfside Lemonade 13, Topo Chico 12, Coors Light 11, Modelo 10, prosecco (Amor Di Amanti 10 + La Marca 9), Espolon 1.75L 9, Mom Water 8.
+
+Reads:
+- **Seltzers won the bach party**: High Noon + Surfside + White Claw + Mom Water ≈ 148 units vs ~57 for all beer — >2:1.
+- Hydration is a real category: water + Topo + Rambler in the top 20; ice top-5.
+- Bubbly culture confirmed: Wycliff + proseccos ≈ 40 bottles (mimosas/towers).
+- Groups order LAST-MINUTE: half within ~48h of delivery.
+
+Caveats for public claims: "532" counts dashboards *created* (not all converted to paid orders — 57 paid orders attached); per-group spend covers what they order through us, not their total alcohol budget. Claims in the script that use these numbers are flagged for Allan's approval.

--- a/data/seo/internal-data-wedding-corporate-2026-07-14.md
+++ b/data/seo/internal-data-wedding-corporate-2026-07-14.md
@@ -1,0 +1,27 @@
+# Internal wedding + corporate data pull (2026-07-14, read-only)
+
+Same method as the bach pull: `group_orders_v2` by `party_type` (or name match), paid orders only. GroupOrderV2 data is 2026-only. **Small samples — treat as directional; all public claims need Allan sign-off.**
+
+## Wedding (party_type WEDDING or name ~ wedding|bridal|bride)
+| Metric | Value |
+|---|---|
+| Dashboards | 109 |
+| Paid orders | 15 |
+| Avg / median order | **$1,058 / $1,019** (≈3× bach) |
+| Median lead time | **10 days** |
+
+Top products: Amor Di Amanti Prosecco 25 · Dos Equis 12pk 24 · Bogle Pinot Noir 22 · Espolon 1.75L 21 · Chandon Brut 20 · Oyster Bay Sauv Blanc 18 · Chateau St. Michelle Sauv Blanc 18 · 14 Hands Cab 18 · Tito's 1.75L 18 · Michelob Ultra 17.
+**Read: weddings are wine-and-bubbly-first** (whites + sparkling lead), matching the calculator's 40% wine split — the opposite of bach (seltzer-first).
+
+## Corporate (party_type CORPORATE or name ~ corporate|office|company)
+| Metric | Value |
+|---|---|
+| Dashboards | 51 |
+| Paid orders | 11 |
+| Avg / median order | **$815 / $782** |
+| Median lead time | **7 days** |
+
+Top products: Josh Cellars Pinot Grigio 14 · **Lalo Blanco Tequila** 10 · **Austin Beerworks Pearl Snap** 9 · Whitehaven Sauv Blanc 8 · Chateau St. Michelle 8 · Willamette Valley Pinot Noir 8 · Daou Cab 8 · Miller Lite 8 · Modelo 7 · Bogle Cab 7.
+**Read: corporate buys premium + local** (Lalo, Daou, Willamette, Austin Beerworks) — "your team notices the good bottles" is data-backed.
+
+Lander-attributed orders (orders.landing_page ~ wedding|corporate): 0 — attribution column too young to use for claims.

--- a/data/seo/semrush/2026-07-09/keyword-magic-bachelor-party-drinks.txt
+++ b/data/seo/semrush/2026-07-09/keyword-magic-bachelor-party-drinks.txt
@@ -1,0 +1,12 @@
+SEMrush Keyword Magic Tool — seed: "bachelor party drinks" — db=us — captured 2026-07-09
+Cluster totals: All keywords: 70 | Total Volume: 710 | Average KD: 5%
+Columns: keyword | intent | volume | KD% | CPC | SERP-feature-count
+
+bachelor party drinking games | I | 170 | 3 | 0.18 | 7
+bachelor party drinks | C | 140 | 12 | 0.32 | 8   <- commercial intent
+drinks for bachelor party | I/C | 90 | 4 | 0.00 | 6
+drinking games bachelor party | I | 40 | 3 | 0.00 | 7
+drinking games for bachelor party | n/a | 30 | pending
+non drinking bachelor party ideas | n/a | 30 | pending
+bachelor party drink ideas | n/a | 20 | pending
+(long tail 0-20/mo: game/rules/team variants; modifier groups: game 22, ideas 17, best 6)

--- a/data/seo/semrush/2026-07-09/keyword-magic-bachelorette-party-alcohol.txt
+++ b/data/seo/semrush/2026-07-09/keyword-magic-bachelorette-party-alcohol.txt
@@ -1,0 +1,16 @@
+SEMrush Keyword Magic Tool — seed: "bachelorette party alcohol" — db=us — captured 2026-07-09
+Cluster totals: All keywords: 53 | Total Volume: 420 | Average KD: n/a (most rows pending refresh)
+KEY FINDING: cluster is tiny and dominated by NON-alcoholic / alcohol-free intent (10 of 53 kws "non", 7 "without").
+
+Top rows (keyword | volume):
+non alcoholic bachelorette party ideas | 30
+alcohol for bachelorette party | 20
+alcohol free bachelorette party ideas | 20
+bachelorette party alcohol ideas | 20
+bachelorette party drinks alcoholic | 20
+how much alcohol to buy for bachelorette party | 20
+best alcohol for bachelorette party | 20
+bachelorette party alcohol delivery austin | 10
+how much alcohol for a bachelorette party | 10
+bachelorette party austin alcohol delivery | 0
+(rest of cluster: 0-20/mo, mostly no-alcohol variants)

--- a/data/seo/semrush/2026-07-09/keyword-magic-bachelorette-party-drinks.txt
+++ b/data/seo/semrush/2026-07-09/keyword-magic-bachelorette-party-drinks.txt
@@ -1,0 +1,19 @@
+SEMrush Keyword Magic Tool — seed: "bachelorette party drinks" — db=us — captured 2026-07-09
+Cluster totals: All keywords: 197 | Total Volume: 1,970 | Average KD: 8%
+Columns: keyword | intent | volume | KD% | CPC | SERP-feature-count
+
+bachelorette party drinking games | I | 260 | 16 | 0.21 | 7
+bachelorette party drinks | I | 210 | 4 | 0.32 | 7
+bachelorette party drink recipes | I | 140 | 6 | 0.37 | 5
+drink if bachelorette party game | C | 90 | 18 | 0.00 | 5
+bachelorette party drink if game | C | 70 | 8 | 0.00 | 5
+drinks for bachelorette party | I | 70 | 5 | 0.37 | 8
+non drinking bachelorette party ideas | I | 70 | 4 | 0.03 | 6
+bachelorette party drink ideas | I | 50 | 2 | 0.55 | 7
+bachelorette party drink markers | C | 40 | 19 | 0.34 | 5
+bachelorette party drinking game | n/a | 40 | pending
+drinking games for bachelorette party | C | 40 | 6 | 0.21 | 5
+bachelorette party signature drink | n/a | 20 | pending
+best bachelorette party drinks | n/a | 20 | pending
+where to order premixed spritz drinks for bachelorette party | n/a | 10 | pending
+(long tail: 10-30/mo recipe/game/name variants; notable modifier groups: game 54, ideas 21, fun 15, non 11, name 10, alcohol 8, signature 6, recipe 4)

--- a/data/seo/semrush/2026-07-09/keyword-magic-corporate-event-drinks.txt
+++ b/data/seo/semrush/2026-07-09/keyword-magic-corporate-event-drinks.txt
@@ -1,0 +1,13 @@
+SEMrush Keyword Magic Tool — seed: "corporate event drinks" — db=us — captured 2026-07-09
+Cluster totals: All keywords: 12 | Total Volume: 110 | Average KD: 6%
+
+corporate event space houston with food and drink | C | 40 | 6 | 0.00 | 3
+best corporate event space houston with food and drink | n/a | 20 | pending
+best corporate event spaces houston with food and drink | n/a | 10
+corporate event drink station | n/a | 10
+corporate event drink toppers | n/a | 10
+soft drinks bulk delivery for corporate events | n/a | 10
+soft drinks delivery for corporate events | n/a | 10   <- we rank pos 11.9 for this (GSC)
+(rest: 0/mo)
+
+FINDING: corporate event drink searches are effectively nonexistent on Google — 110/mo total and half of it is Houston venue-space intent, not drinks.

--- a/data/seo/semrush/2026-07-09/keyword-magic-corporate-event-ideas.txt
+++ b/data/seo/semrush/2026-07-09/keyword-magic-corporate-event-ideas.txt
@@ -1,0 +1,22 @@
+SEMrush Keyword Magic Tool — seed: "corporate event ideas" — db=us — captured 2026-07-09
+Cluster totals: All keywords: 1,285 | Total Volume: 13,450 | Average KD: 11%
+Columns: keyword | intent | volume | KD% | CPC | SERP-feature-count
+
+corporate event ideas | I | 1,900 | 20 | 3.95 | 10
+corporate team building event ideas | I | 1,000 | 44 | 3.13 | 8
+fun corporate event ideas | I | 480 | 28 | 3.88 | 6
+entertainment ideas for corporate events | I | 320 | 21 | 3.28 | 5
+ideas for corporate events | I | 320 | 9 | 3.95 | 6
+corporate event entertainment ideas | I | 260 | 16 | 3.28 | 5
+corporate event ideas for large groups | I | 260 | 13 | 4.51 | 6
+corporate events ideas | I | 260 | 11 | 3.00 | 7
+corporate networking event ideas | I | 210 | 12 | 0.00 | 7
+best corporate event ideas | C | 170 | 24 | 3.33 | 7
+corporate christmas event ideas | I | 140 | 15 | 1.94 | 6
+corporate social event ideas | I | 110 | 4 | 3.78 | 8
+corporate holiday event ideas | I | 50 | 14 | 4.60 | 6
+corporate holiday party event ideas | I | 40 | 16 | 2.89 | 7
+summer corporate event ideas | I | 70 | 2 | 4.51 | 5
+(1,285 kws total; city-modified variants 30-110/mo each — nyc, chicago, atlanta etc.; no Austin variant visible on page 1)
+
+FINDING: this is the real corporate cluster — 13.4k/mo, KD ~11 avg, CPC $3-5 (advertisers value it). Matches 2026-06 vidIQ finding that "corporate event ideas" wins on YouTube. Corporate video should target this broad term with a drinks/bar angle, not "corporate event drinks" (dead).

--- a/data/seo/semrush/2026-07-09/keyword-magic-how-much-alcohol-for-party.txt
+++ b/data/seo/semrush/2026-07-09/keyword-magic-how-much-alcohol-for-party.txt
@@ -1,0 +1,11 @@
+SEMrush Keyword Magic Tool — seed: "how much alcohol for party" — db=us — captured 2026-07-09
+Cluster totals: All keywords: 108 | Total Volume: 730 | Average KD: 15%
+Columns: keyword | intent | volume | KD% | CPC | SERP-feature-count
+
+how much alcohol to buy for a party | I | 140 | 19 | 0.58 | 4
+how much alcohol for a party | I | 50 | 23 | 0.64 | 5
+how much alcohol to buy for party | I | 40 | 5 | 0.66 | 7
+how much alcohol for a party of 50 | I | 30 | 14 | 1.60 | 7
+(long tail 10-20/mo: guest-count + calculator variants)
+
+CORPORATE NOTE: "office" appears in exactly 1 keyword ("how much alcohol should i get for an office party") at 0 volume. "christmas party" variant also 0. Corporate/office alcohol-quantity searches are effectively nonexistent on Google.

--- a/data/seo/semrush/2026-07-09/keyword-magic-how-much-alcohol-for-wedding.txt
+++ b/data/seo/semrush/2026-07-09/keyword-magic-how-much-alcohol-for-wedding.txt
@@ -1,0 +1,26 @@
+SEMrush Keyword Magic Tool — seed: "how much alcohol for wedding" — db=us — captured 2026-07-09
+Cluster totals: All keywords: 264 | Total Volume: 3,580 | Average KD: 10%
+Columns: keyword | intent | volume | KD% | CPC | SERP-feature-count | freshness
+
+how much alcohol to buy for a wedding | I | 390 | 7 | 0.37 | 5 | 1 month
+how much alcohol to buy for wedding | I | 210 | 7 | 0.60 | 6 | 1 month
+how much alcohol for wedding | I | 170 | 5 | 0.47 | 6 | 2 weeks
+how much alcohol to order for a wedding | I | 110 | 12 | 0.37 | 4 | 1 month
+how much is alcohol for a wedding | I | 110 | 10 | 0.47 | 7 | 3 weeks
+how much alcohol for a wedding of 100 | I | 90 | 5 | 0.40 | 5 | 1 month
+how much alcohol for a wedding | I | 70 | 17 | 0.54 | 6 | 1 month
+how much does alcohol cost for a wedding | I | 70 | 12 | 0.72 | 6 | 3 weeks
+how much does alcohol cost for wedding | I | 70 | 17 | 0.80 | 6 | 1 month
+how much will alcohol cost for a wedding | I | 70 | 22 | 0.80 | 7 | 1 month
+how much alcohol do i need for my wedding | I | 50 | 5 | 0.00 | 5 | 1 month
+how much alcohol for wedding calculator | I | 50 | 9 | 0.00 | 5 | 1 month
+how much alcohol should you buy for a wedding | I | 50 | 3 | 0.00 | 5 | 1 month
+how much alcohol for a wedding calculator | I | 40 | 10 | 0.00 | 5 | 1 month
+how much alcohol for a wedding of 150 | n/a | 40 | n/a | 0.15 | needs refresh
+calculating how much alcohol to buy for a wedding | I | 30 | 14 | 1.05 | 6 | 1 month
+how much alcohol for my wedding | n/a | 30 | n/a | 0.00 | needs refresh
+how much alcohol for wedding of 100 | n/a | 30 | n/a | 0.18 | needs refresh
+how much alcohol should i buy for my wedding | n/a | 30 | n/a | 0.00 | needs refresh
+(long tail continues at 20/mo each: ~80 guest-count and phrasing variants, all n/a KD pending refresh)
+
+Notable modifier groups (keyword count): buy 53, person 42, cost 27, need 27, "100" 26, "150" 24, guest 21, "200" 16, calculator 16, spend 12, reception 10, budget 7

--- a/data/seo/semrush/2026-07-09/keyword-magic-wedding-bar.txt
+++ b/data/seo/semrush/2026-07-09/keyword-magic-wedding-bar.txt
@@ -1,0 +1,33 @@
+SEMrush Keyword Magic Tool — seed: "wedding bar" — db=us — captured 2026-07-09
+Cluster totals: All keywords: 8,761 | Total Volume: 85,820 | Average KD: 14%
+Columns: keyword | intent | volume | KD% | CPC | SERP-feature-count
+(page 1 of 88 captured; drink/bar-service relevant rows extracted)
+
+wedding bar menu | I | 1600 | 15 | 1.10 | 8
+wedding bar | I/C | 880 | 15 | 1.51 | 8
+how much is an open bar at a wedding | I | 720 | 18 | 1.42 | 5
+open bar wedding cost | I | 590 | 10 | 1.52 | 6
+bar for weddings | C | 480 | 15 | 1.85 | 7
+bar services for weddings | C | 390 | 12 | 2.01 | 5
+how much does an open bar cost at a wedding | I | 390 | 18 | 1.50 | 5
+price for open bar at wedding | I | 390 | 3 | 1.64 | 5
+how much for open bar wedding | I | 320 | 10 | 1.50 | 5
+wedding bar services | T | 320 | 29 | 1.97 | 4
+cash bar wedding | I | 260 | 28 | 1.87 | 7
+open bar wedding | I | 260 | 20 | 1.57 | 6
+how much do open bars cost at weddings | I | 210 | 16 | 1.60 | 4
+how much does an open bar for a wedding cost | I | 210 | 14 | 1.60 | 5
+how much does open bar cost for wedding | I | 210 | 10 | 1.60 | 5
+mobile bar for weddings | C | 210 | 17 | 1.31 | 4
+rent a bar for a wedding near me | I/T | 210 | 6 | 0.00 | 3
+wedding open bar | I | 210 | 3 | 1.85 | 5
+bar service for wedding | C | 170 | 24 | 2.01 | 5
+diy wedding bar | I | 170 | 6 | 0.73 | 8
+how much is an open bar for a wedding | I | 170 | 7 | 1.42 | 5
+open bar cost wedding | I | 170 | 8 | 1.64 | 5
+stock the bar party for wedding | I | 170 | 12 | 0.59 | 6
+what is a cash bar at a wedding | I | 170 | 28 | 0.00 | 6
+bar packages for weddings | I | 140 | 8 | 1.64 | 7
+diy wedding bar (dupe entry above) — see also "wedding bars for rent" 170 KD4
+
+NOTE: bulk of the 85k cluster is non-drink intent (candy bar 673 kws, dessert bar, coffee bar, taco bar, signs/decor). The OPEN BAR COST sub-cluster (~2,500/mo combined, KD 3-18) is the money angle for a video: DIY/delivery vs venue open bar cost comparison.

--- a/data/seo/semrush/2026-07-09/organic-positions-partyondelivery.txt
+++ b/data/seo/semrush/2026-07-09/organic-positions-partyondelivery.txt
@@ -1,0 +1,19 @@
+SEMrush Organic Rankings — partyondelivery.com — db=us — Jul 8 2026 data — captured 2026-07-09
+Totals: 1,490 US keywords | est. traffic 469/mo | traffic cost $661
+Columns: keyword | intent | position | volume | KD% | URL
+(page 1 of 15; segment/relevant rows)
+
+adult birthday party ideas | I | 7 | 3.6K | 24 | /blog/15-unique-birthday-party-ideas-in-austin-for-adults   <- top traffic driver (18%)
+alcohol delivery | C | 24 | 27.1K | 51 | /
+booze delivery austin | C | 2 | 140 | 20 | /
+alcohol delivery austin | C | 6 | 260 | 11 | /
+team bride sunglasses | I | 5 | 90 | 11 | /products/team-bride-sunglasses
+small venues for weddings | C | 20 | 720 | 17 | /blog/best-small-wedding-venues-near-austin
+small wedding locations | T | 33 | 1.9K | 21 | /blog/best-small-wedding-venues-near-austin
+things to do in austin for a bachelor party | I | 51 | 70 | 4 | /blog/austin-bachelor-party-do-s-and-don-ts...
+all inclusive wedding venues in austin tx | C | 68 | 90 | 7 | /blog/all-inclusive-austin-wedding-venues...
+cooler rentals | C | 15 | 390 | 8 | /rentals/cooler-rentals-austin
+drink dispenser for party | C | 33 | 1.9K | 31 | /products/glass-beverage-dispenser
+who delivers alcohol | I | 29 | 2.4K | 48 | /
+
+NOTE: SEMrush sees no meaningful segment-keyword rankings that GSC didn't already show (GSC first-party data is richer for segments). Domain's biggest organic asset is the adult-birthday blog post + branded/delivery terms.

--- a/data/seo/semrush/2026-07-10/keyword-magic-QUESTIONS-bachelor-party.txt
+++ b/data/seo/semrush/2026-07-10/keyword-magic-QUESTIONS-bachelor-party.txt
@@ -1,0 +1,43 @@
+SEMrush Keyword Magic Tool — QUESTIONS tab — seed: "bachelor party" — db=us — captured 2026-07-10
+Cluster totals: 2,158 question keywords | Total Volume: 21,080/mo | Average KD: 16%
+Columns: keyword | intent | volume | KD% | CPC
+(page 1 of 22, sorted by volume)
+
+what is a bachelor party (+4 spelling variants) | I | 1900+1000+720+480+480 | 28-37 | 0.00  <- definition cluster ~4,600/mo
+who pays for bachelor party | I | 590 | 17 | 0.00
+who pays for a bachelor party | I | 390 | 17 | 0.00
+who pays bachelor party | I | 320 | 17 | 0.00
+who pays for the bachelor party | I | 320 | 19 | 0.00   <- who-pays cluster ~1,620/mo KD17-19
+how to organize bachelor party | I | 260 | 15 | 1.28
+how to throw a bachelor party | I | 260 | 26 | 1.30
+how do you plan a bachelor party | I | 210 | 14 | 1.28
+how to plan a bachelor party | I | 210 | 19 | 1.28
+who plans the bachelor party | I | 210 | 22 | 1.44   <- planning cluster ~1,150/mo
+what happens at a bachelor party | I | 170 | 9 | 0.00
+what to do for a bachelor party | I | 170 | 33 | 0.90
+what are bachelor parties for | I | 140 | 11 | 0.00
+what goes on at bachelor parties | I | 140 | 12 | 0.00
+when should bachelor party be | I | 140 | 15 | 0.00
+does the best man pay for the bachelor party | C | 110 | 20 | 0.00
+what is the point of a bachelor party | I | 110 | 21 | 0.00
+does the best man plan the bachelor party | C | 90 | 10 | 0.00
+what happens at bachelor parties | I | 90 | 7 | 0.00
+do you bring a gift to a bachelor party | I | 70 | 7 | 0.00
+does the groom pay for the bachelor party | I | 70 | 7 | 0.00
+what do guys do at a bachelor party | I | 70 | 11 | 0.00
+what to bring to a bachelor party | I | 70 | 3 | 0.00
+when do bachelor parties happen | I | 70 | 18 | 0.00
+how long are bachelor parties | I | 50 | 8 | 0.00
+what to pack for a bachelor party | n/a | 40 | pending
+what do you call a bachelor and bachelorette party together | n/a | 30 | pending
+what is a combined bachelor and bachelorette party called | n/a | 30 | pending
+(long tail: timing/gift/who-goes variants 30-70/mo)
+
+Modifier groups (kw count): stay 104, pay 99, plan 91, vegas 76, guy 62, much 51, long 40, austin 17
+
+QUESTION THEMES BY COMBINED VOLUME:
+1. definition (~4,600/mo, KD 28-37) — "what is a bachelor party" — top-funnel, high KD
+2. who-pays (~2,200/mo incl best-man/groom variants, KD 7-20)
+3. planning/how-to (~1,150/mo, KD 10-26)
+4. what-happens/what-do-guys-do (~800/mo, KD 7-18)
+5. timing/duration (~600/mo, KD 8-23)

--- a/data/seo/semrush/2026-07-10/keyword-magic-QUESTIONS-bachelorette-party.txt
+++ b/data/seo/semrush/2026-07-10/keyword-magic-QUESTIONS-bachelorette-party.txt
@@ -1,0 +1,54 @@
+SEMrush Keyword Magic Tool — QUESTIONS tab — seed: "bachelorette party" — db=us — captured 2026-07-10
+Cluster totals: 2,877 question keywords | Total Volume: 38,630/mo | Average KD: 13%
+Columns: keyword | intent | volume | KD% | CPC
+(page 1 of 29, sorted by volume — top ~100 rows)
+
+what is a bachelorette party | I | 2400 | 28 | 0.00
+is ybor city safe bachelorette party | n/a | 1900 | n/a | (tampa-specific, ignore)
+who pays for bachelorette party | I | 880 | 11 | 0.00
+how to plan a bachelorette party | I | 480 | 11 | 1.28
+who plans the bachelorette party | I | 390 | 16 | 1.64
+do you bring a gift to a bachelorette party | I | 320 | 12 | 0.15
+what to put in bachelorette party bags | I | 320 | 23 | 0.42
+what to wear to a bachelorette party | I | 320 | 18 | 0.40
+what's a bachelorette party | I | 320 | 12 | 0.00
+what happens at bachelorette parties | I | 260 | 12 | 0.00
+what to do for a bachelorette party | I | 260 | 21 | 0.41
+when is a bachelorette party | I | 260 | 14 | 0.00
+what to wear on a bachelorette party | I | 210 | 23 | 0.40
+when do you have a bachelorette party | I | 210 | 13 | 0.00
+when to have bachelorette party | I | 210 | 15 | 0.00
+who pays for the bachelorette party | I | 210 | 12 | 0.00
+how to organize a bachelorette party | I | 170 | 14 | 1.28
+what to do bachelorette party | I | 170 | 26 | 0.41
+when to have bridal shower and bachelorette party | I | 170 | 10 | 0.42
+what to bring to a bachelorette party | I | 140 | 6 | 0.18
+what's the difference between a bridal shower and bachelorette party | I | 140 | 16 | 0.01
+when should a/the bachelorette party be (4 variants) | I | 140 each | 7-13 | 0.00
+where to go for bachelorette party | I | 140 | 23 | 0.36
+who is invited to bachelorette party | I | 140 | 28 | 0.00
+who to invite to bachelorette party | I | 140 | 15 | 0.00
+does the bride pay for bachelorette party | I | 110 | 8 | 0.00
+what do you do at a bachelorette party | I | 110 | 11 | 0.06
+what to do for/in bachelorette party (variants) | I | 110 each | 18-19 | 0.41
+when to do bachelorette party | I | 110 | 6 | 0.00
+who pays for a bachelorette party | I | 110 | 12 | 0.00
+how to plan bachelorette party | I | 90 | 16 | 1.28
+must haves for a bachelorette party | I | 90 | 13 | 0.45
+what to get bride for bachelorette party | C | 90 | 18 | 0.52
+how long are bachelorette parties | I | 70 | 23 | 0.00
+how long is a bachelorette party | I | 70 | 23 | 0.00
+how long before the wedding is the bachelorette party | I | 70 | 7 | 0.00
+how much does a bachelorette party cost | I | 70 | 25 | 0.00
+does the maid of honor pay for the bachelorette party | I | 70 | 10 | 0.00
+where to have a bachelorette party | I/C | 70 | 17 | 0.86
+(+ long tail: gift/invite/supplies/timing variants 70-140/mo each)
+
+Modifier groups (kw count): plan 178, bride 177, gift 175, pay 140, wear 129, go 128, invitation 127, stay 107, much 77, throw 74, far 59, cost 35, book 29, austin 25
+
+QUESTION THEMES BY COMBINED VOLUME:
+1. definition/what-happens (~4,500/mo) — "what is", "what happens at" — top-funnel
+2. who-pays/cost (~1,700/mo, KD 8-25) — who pays, does bride pay, MOH pay, how much cost
+3. planning/how-to (~1,400/mo, KD 11-16) — how to plan/organize, who plans
+4. timing (~1,600/mo, KD 6-26) — when to have, how long before wedding, how long is
+5. etiquette: gifts/invites/wear (~2,500/mo) — bring a gift?, who to invite, what to wear

--- a/data/seo/semrush/2026-07-14/keyword-magic-QUESTIONS-holiday-party.txt
+++ b/data/seo/semrush/2026-07-14/keyword-magic-QUESTIONS-holiday-party.txt
@@ -1,0 +1,17 @@
+SEMrush Keyword Magic Tool — QUESTIONS tab — seed: "holiday party" — db=us — captured 2026-07-14
+Cluster totals: 1,154 question keywords | Total Volume: 6,440/mo | Average KD: 19%
+What-to-wear dominates (~2,500/mo, not our topic). Corporate-planning signal:
+
+how to plan a corporate holiday party | I | 70 | KD 0 (!) | 0.00   <- best corporate question found anywhere
+how to host a holiday cocktail party | I | 70 | 9 | 0.00
+how to host a holiday party | I | 50 | 21 | 0.00
+how to plan a holiday party | I | 40 | 12 | 0.17
+what to bring to a holiday party | I | 170 | 15 | 0.00 (guest intent, adjacent)
+how long should a holiday party be | n/a | 20
+how to choose drinks for holiday open house party | n/a | 20
+how to plan a company/work/office holiday party (3 variants) | n/a | 20 each
+tax-deductible cluster: are holiday parties tax deductible 20 + company 2024 20 + meals-100%-deductible 20 + is-a-holiday-party 20 ≈ 80/mo combined
+how to have/host a virtual holiday party | n/a | 40 combined
+should i go to my company holiday party | n/a | 20
+
+FINDING: pairs with corporate-event-ideas cluster (corporate christmas event ideas 140 KD15 + corporate holiday event ideas 50 KD14 + corporate holiday party event ideas 40 KD16, from 2026-07-09 pull). Fall corporate video = holiday-party planning angle: "how to plan a corporate holiday party" (KD 0) as the question spine, ideas-listicle as the body, tax-deductibility as the differentiator chapter.

--- a/data/seo/semrush/2026-07-14/keyword-magic-QUESTIONS-office-party.txt
+++ b/data/seo/semrush/2026-07-14/keyword-magic-QUESTIONS-office-party.txt
@@ -1,0 +1,19 @@
+SEMrush Keyword Magic Tool — QUESTIONS tab — seed: "office party" — db=us — captured 2026-07-14
+Cluster totals: 1,205 question keywords | Total Volume: 8,870/mo | Average KD: 30%
+NOTE: heavily polluted — most volume is the "Office Christmas Party" MOVIE (where to watch/stream ~2,300/mo), The Office TV episodes, and political party-switching questions. Clean signal below.
+
+Relevant rows (keyword | volume | KD):
+what to wear to office christmas/holiday party (cluster) | ~800/mo combined | 8-23   <- big but outfit intent, not ours
+what happens at office dinner parties | 480 | n/a
+how to plan an office christmas party | 20 | n/a
+how to plan an office holiday party | 20 | n/a
+how to plan an office party | 20 | n/a
+how to make an office party fun | 20 | n/a
+how to make office christmas party fun | 20 | n/a
+are office parties tax deductible | 20 | n/a
+how to categorize office party expense quickbooks | 30 | n/a
+how to categorize office party expense | 20 | n/a
+how to include remote employees in office parties | 20 | n/a (CPC 2.69!)
+how to hire a police officer for a party | 20 | n/a
+
+FINDING: corporate/office PLANNING questions are ~20/mo each on Google — confirms the 2026-07-09 verdict that the corporate video must target "corporate event ideas" (idea-browsing intent, 13.4k/mo cluster) rather than question-answering. The tax-deductible + expense-categorization questions are the only distinctly *corporate* questions with any pulse — usable as a differentiating chapter (nobody making event content answers the finance question).

--- a/data/seo/semrush/2026-07-14/keyword-magic-QUESTIONS-wedding-alcohol.txt
+++ b/data/seo/semrush/2026-07-14/keyword-magic-QUESTIONS-wedding-alcohol.txt
@@ -1,0 +1,31 @@
+SEMrush Keyword Magic Tool — QUESTIONS tab — seed: "wedding alcohol" — db=us — captured 2026-07-14
+Cluster totals: 656 question keywords | Total Volume: 6,180/mo | Average KD: 11%
+Columns: keyword | intent | volume | KD% | CPC
+
+how much alcohol to buy for a wedding | I | 390 | 7 | 0.37
+how much alcohol to buy for wedding | I | 210 | 7 | 0.60
+how much alcohol for wedding | I | 170 | 5 | 0.47
+how much alcohol to order for a wedding | I | 110 | 12 | 0.37
+how much is alcohol for a wedding | I | 110 | 10 | 0.47
+where to buy alcohol in bulk for wedding | I | 110 | 16 | 0.76
+where to buy bulk alcohol for wedding | I | 110 | 19 | 1.25   <- transactional pair, 220/mo combined
+how much alcohol for a wedding of 100 | I | 90 | 5 | 0.40
+how to calculate alcohol for a wedding | I | 90 | 5 | 0.76
+how to calculate alcohol for wedding | I | 90 | 12 | 0.39
+how much does alcohol cost for a wedding | I | 70 | 12 | 0.72
+how to estimate alcohol for wedding | I | 70 | 4 | 0.76
+who pays for alcohol at wedding | I | 70 | 15 | 0.00
+who pays for alcohol at a wedding | I | 50 | 14 | 0.00
+who pays for the alcohol at a wedding | I | 50 | 14 | 0.00   <- who-pays-for-alcohol ~170/mo
+how much alcohol for wedding calculator (+4 calculator variants) | I | 40-50 each | 5-10
+where to buy alcohol for wedding | I | 50 | 18 | 1.48
+how much alcohol for a wedding of 150 | n/a | 40
+do you need an alcohol license for a wedding | n/a | 20
+do you need insurance to serve alcohol at a wedding | n/a | 20
+do wedding venues water down alcohol | n/a | 20   <- fun contrarian hook
+can i serve alcohol at my wedding | n/a | 20
+how many bottles of alcohol for a wedding | n/a | 20
+how many non alcoholic drinks per person at a wedding | n/a | 20
+(guest-count long tail 50-200 guests, 20/mo each; modifier groups: much 318, buy 97, person 54, cost 47, calculator 33, 100 27, 150 25)
+
+QUESTION THEMES: quantity/calculator (~2,500/mo, KD 3-12) · where-to-buy-bulk (~330/mo, transactional) · cost (~400/mo) · who-pays-for-alcohol (~170/mo) · rules/license/insurance (~100/mo) · per-person servings (~150/mo)

--- a/data/seo/serp-paa/2026-07-10.md
+++ b/data/seo/serp-paa/2026-07-10.md
@@ -1,0 +1,40 @@
+# Google SERP harvest — bach PAA + video features (2026-07-10)
+
+Live desktop SERPs, Austin IP, logged-in account (geo/personalization caveat applies).
+
+## Q1: "how to plan a bachelorette party"
+- **VIDEO PACK PRESENT** (3 videos): WedEverything "Ten Tips For Planning Your The Bachelor/Bachelorette Party" (10:27, Jan 2026); Wedding Planning Podcast "Bachelorette Party Planning Tips + Sample Itineraries" (24:02, Apr 2026); The Unveiled Bride "Maid of Honor Workshop Part 2" (27:26, 2021). All small channels, all LONG videos — a tight 3–5 min listicle is differentiated.
+- Organic: Reddit r/weddingplanning #2 ("How do I plan a Bachelorette Party?"), The Knot checklist/timeline #3.
+- Related: "how to plan a bachelorette party as the maid of honor", "…on a budget", "planning a bachelorette party in 30 days", "bachelorette party planning template/pdf".
+
+## Q2: "who pays for bachelorette party"
+- PAA: "Who is supposed to pay for The Bachelorette party?", "Does the groom's mom go to The Bachelorette party?", "Does the maid of honor pay for The Bachelorette Goodie bags?"
+- **SHORT VIDEOS CAROUSEL PRESENT** — Instagram/TikTok/YouTube shorts rank (Kiki Astor IG 1:29 "Who actually throws the bachelorette party? Who pays…", Fortune 0:58, ABC7 1:48). A Tamron Hall YouTube video ranks organically with only 2.6K views.
+- Consensus answer in SERP: guests pay own way + split the bride's share; MOH coordinates.
+- Related: "does MOH pay for bachelorette party", "does bride pay for bachelorette trip", "destination bachelorette party etiquette".
+
+## Q3: "how much does a bachelorette party cost"
+- PAA: "Who typically pays for a bachelorette party?", "How much is too much to ask for a bachelorette party?", "How much does the average bridesmaid spend on the bachelorette party?"
+- Stats in SERP: The Knot avg $1,300/person (1–2 days) 2025; letsbatch $400–1,000; hellobachparty $537 avg.
+- **Local competitor alert**: fly-rides.com published "How Much Does a Bachelorette Party Cost in Austin?" ($300–1500/person) 7 DAYS AGO — someone local is moving on this exact content space.
+
+## Q4: "how to plan a bachelor party"
+- PAA: "What are the rules of a bachelor party?", "Who is supposed to plan a bachelor party?", "What are you supposed to do for a bachelor party?", "Who typically pays for a bachelor party?"
+- **VIDEO PACK PRESENT**: WedEverything (same 10:27 video ranks both genders); Tailored Fit 2:34 **from 2014** still ranking; Abby Lee 14:28 (2019). Space is starved of fresh video.
+- Related: "how to plan a bachelor party at home", "who plans the bachelor party", "is a bachelor party cheating".
+
+## Q5: "austin bachelorette party itinerary"
+- **MASSIVE AI OVERVIEW** (~24 citations): full 3-day itinerary — SoCo/Paperboy/murals day 1, **"The quintessential Austin bachelorette activity—a boat day!" on Lake Travis day 2** ("Pack a cooler, your bride tribe swimsuits"), spa/pool day 3. Cites Stag & Hen, TikTok creators, WakeLine Boat Rentals, Lake Travis Yacht Rentals, Visit Austin, The Knot.
+- **KEY GAP: no alcohol-delivery service is cited anywhere in the AI Overview** despite "pack a cooler" being in the canonical answer. The "who fills the cooler" slot is unclaimed — that's the LLM-search opening.
+- TikTok videos rank inline (whatwouldfallonwear 1:18; Stag & Hen 1:29, 7.9K views).
+- Related: "…itinerary 3 days", "where to stay in Austin for bachelorette party", "bachelorette bars austin", "best restaurants for bachelorette party austin".
+
+## Q6 (from 2026-07-09 session): "austin bachelorette party"
+- No video pack; Stag & Hen guide #1, Do512, Reddit, ClassBento, CNT, The Knot. Instagram profile result (bookchicktrips).
+- Related: itinerary, Airbnb, venues, packages, outfits.
+
+## Cross-SERP takeaways
+1. Planning-question SERPs (both genders) have VIDEO PACKS owned by small/stale channels → winnable with fresh, short, well-chaptered video.
+2. Etiquette/cost SERPs surface SHORTS carousels → the chop-into-shorts plan has a direct Google surface, not just social reach.
+3. Austin itinerary queries are answered by an AI Overview that already scripts a boat day + cooler — PartyOn's delivery angle is the missing citation. Structure blog content to be the quotable "how the cooler gets filled" source.
+4. Reddit threads rank top-3 on nearly every question — phrasing answers in first-person practical language (like Reddit answers) matches what Google rewards here.

--- a/data/seo/serp-paa/2026-07-14-wedding-corporate.md
+++ b/data/seo/serp-paa/2026-07-14-wedding-corporate.md
@@ -1,0 +1,28 @@
+# SERP + YouTube harvest — wedding & corporate (2026-07-14)
+
+Live desktop SERPs + YouTube searches, Austin IP, logged-in (geo/personalization caveat).
+
+## "how much does an open bar cost at a wedding" (Google)
+- PAA: "How much is an open bar for a 150 person wedding?", "Is open bar worth it for a wedding?", "How much does alcohol cost for a wedding of 150 people?", "What is the 50/20/30 rule for weddings?"
+- Cost benchmarks in SERP: **$15–90/pp** (Zola, EventWorks, Postmark); **$25–45/pp typical** (Swan Lake, Curated: limited $20–25, full $35–45); WeddingWire anecdotes $30–40/pp. The Knot: liquor adds $10–15/pp over beer+wine.
+- No video pack, no shorts carousel. Reddit + Facebook budget threads rank high; a top Facebook answer literally says "Buy your own" — DIY sentiment is mainstream.
+- Related: per-guest-count variants (50/100/150/200/300), "open bar wedding cost calculator".
+- **Strategic note:** our published wedding tiers run **$13–26/pp** — the top of our range sits at the BOTTOM of the venue open-bar range. That comparison is the video's money moment.
+
+## "how to plan a corporate holiday party" (Google)
+- PAA: "What are the 5 C's of event planning?", "How to make a corporate Christmas party fun?", "How to Christmas party corporate style?", "How to plan a company holiday party?"
+- No video pack. Venue-blog listicles (Vault 634, Kruse Plaza, Paperless Post) + Reddit r/humanresources threads own it. Heavy sponsored presence (Cvent, corporate planners, a TX Hill Country retreat venue).
+- SERP advice consensus: budget first, book 6–12 mo ahead, Thursday/Friday mid-December, consider lunch/November to save.
+- Related: "…template", "…example", "…on a budget", "inexpensive office holiday party ideas".
+
+## YouTube: "how much alcohol for wedding"
+- **Near-zero competition.** Top result: "How to Calculate Alcohol Cost for Your Wedding" (Event Planning channel, 10K views, 5 YEARS old, 7 chapters). Topical shorts at 232–1.7K views. One irrelevant viral short (7.5M, destination-wedding entertainment). Sponsored: Destify wedding planning.
+- The calculator/how-much slot on YouTube is effectively vacant.
+
+## YouTube: "corporate holiday party ideas"
+- Also weak: "Office Holiday Party Ideas: 3 ways" (Elevate Experiences, 27K views, **7 years old**), "6 Ideas for Corporate Holiday Parties in 2022" (11K, 3y). Sponsored corporate-event planners (BoomPop) buying the query.
+
+## Cross-check with 2026-07-09/10 data
+- "how much alcohol for wedding" Google SERP: AI Overview + The Knot #1, our Wedding ad serving, NO video pack (2026-07-09).
+- "corporate event ideas": 1,900/mo KD20 head, 13,450/mo cluster; top live YouTube autocomplete; Reddit r/Austin "isn't lame" #1 locally.
+- Both fall videos face stale-or-absent video incumbents on both engines.

--- a/data/seo/youtube-autocomplete/2026-07-09.json
+++ b/data/seo/youtube-autocomplete/2026-07-09.json
@@ -1,0 +1,1086 @@
+{
+  "how much alcohol for bachelorette party": [
+    "best places for bachelorette party",
+    "what to do in bachelorette party"
+  ],
+  "bachelorette party alcohol checklist": [],
+  "alcohol delivery lake travis boat party": [],
+  "bachelor party bar setup": [
+    "how to plan bachelor party",
+    "bachelor party home ideas"
+  ],
+  "bachelor party alcohol delivery austin": [
+    "bachelor party drinking scene",
+    "bachelor party locations"
+  ],
+  "bachelorette party austin": [
+    "austin bachelorette party",
+    "bachelorette austin"
+  ],
+  "bachelor party austin": [
+    "bachelor party austin tx"
+  ],
+  "how much alcohol for wedding 100 guests": [],
+  "wedding bar shopping list": [
+    "shopping list for wedding",
+    "wedding bar menu",
+    "wedding bar ideas"
+  ],
+  "stock the bar wedding": [
+    "starting a barn wedding venue",
+    "bar setup for wedding",
+    "starting a wedding venue"
+  ],
+  "wedding alcohol calculator": [
+    "wedding alcohol",
+    "wedding beer guy"
+  ],
+  "byob wedding venue austin": [
+    "bay area wedding venues",
+    "wedding venues in austin tx",
+    "austin wedding venues"
+  ],
+  "wedding drink delivery": [
+    "wedding drink"
+  ],
+  "how much alcohol for wedding": [],
+  "office party bar setup": [
+    "office party planning",
+    "office party hosting",
+    "office disco cafe",
+    "office parties"
+  ],
+  "how much alcohol for corporate event": [],
+  "company party drink calculator": [
+    "company party",
+    "company party ideas"
+  ],
+  "corporate event bartending austin": [
+    "corporate event aftermovie",
+    "corporate event party",
+    "corporate event mc",
+    "corporate event hosting"
+  ],
+  "corporate event drinks": [
+    "corporate event",
+    "corporate event party",
+    "corporate event mc",
+    "corporate event recap"
+  ],
+  "how much alcohol for": [
+    "how much alcohol in beer",
+    "how much alcohol in wine",
+    "how much alcohol in whisky",
+    "how much alcohol in breezer",
+    "how much alcohol in vodka",
+    "how much alcohol in red bull",
+    "how much alcohol in magic moment",
+    "how many alcohol in beer",
+    "how many alcohol in red bull",
+    "how much alcohol is in kombucha"
+  ],
+  "bachelorette party alcohol": [],
+  "bachelor party alcohol": [
+    "bachelor party drinking scene",
+    "bachelor party drinking whatsapp status",
+    "bachelor party drinking games",
+    "bachelor party hanks",
+    "bachelor party plan"
+  ],
+  "wedding bar": [
+    "wedding barbie",
+    "wedding barn",
+    "wedding bartender",
+    "wedding bar",
+    "wedding barat song",
+    "wedding bar menu",
+    "wedding baraat songs",
+    "wedding baraat",
+    "wedding barat",
+    "wedding baraat dance"
+  ],
+  "wedding alcohol": [
+    "wedding alcohol",
+    "wedding alcohol party",
+    "alcohol wedding card",
+    "indian wedding alcohol",
+    "punjabi wedding alcohol",
+    "rajput wedding alcohol",
+    "ambani wedding alcohol",
+    "no alcohol wedding",
+    "wedding cake without alcohol",
+    "wedding liquor"
+  ],
+  "stock the bar": [
+    "stock the bar party",
+    "the stock barbie",
+    "the stock bar",
+    "the stock market barometer",
+    "the bar stock exchange mumbai",
+    "the bar stock exchange lucknow",
+    "the bar stock exchange belapur",
+    "the bar stock exchange",
+    "the bar stock exchange bandra",
+    "the bar stock exchange club lucknow"
+  ],
+  "corporate party drinks": [
+    "corporate cocktail party",
+    "corporate cocktail party music"
+  ],
+  "office party drinks": [
+    "office cocktail party outfits",
+    "office cocktail party",
+    "office drinks",
+    "office party ideas"
+  ],
+  "how much alcohol for a": [
+    "how much does alcohol affect muscle growth",
+    "how many alcohol city academy",
+    "how much alcohol is allowed for driving",
+    "how much alcohol do you drink"
+  ],
+  "how much alcohol for b": [
+    "how much alcohol in beer",
+    "how much alcohol in breezer",
+    "how much alcohol is bad",
+    "how much alcohol has brian drunk",
+    "how much alcohol in red bull",
+    "how many alcohol in beer"
+  ],
+  "how much alcohol for c": [
+    "how much alcohol can you take on a plane",
+    "how much alcohol causes cirrhosis",
+    "how much alcohol can you drink",
+    "how much alcohol consumption is safe",
+    "how much alcohol causes fatty liver",
+    "how much liquor can i carry in domestic flight",
+    "how much liquor can i carry in international flight",
+    "how much liquor can i carry in flight from goa",
+    "how much liquor can i carry in train from goa",
+    "how much liquor can i carry in train"
+  ],
+  "how much alcohol for d": [
+    "how much alcohol do you drink skit",
+    "how much alcohol do you drink",
+    "how much alcohol per day",
+    "how much alcohol has peter drunk",
+    "how much alcohol can you drink",
+    "how much alcohol has brian drunk",
+    "how many alcohol se dekha nahi hai",
+    "how much alcohol is allowed for driving",
+    "how much alcohol has homer drunk"
+  ],
+  "how much alcohol for e": [
+    "how much alcohol do you drink",
+    "how much alcohol in beer"
+  ],
+  "how much alcohol for f": [
+    "how much alcohol causes fatty liver",
+    "how much alcohol in beer"
+  ],
+  "how much alcohol for g": [
+    "how much alcohol is good",
+    "how much alcohol has peter griffin drunk",
+    "how much gsm paper for alcohol markers",
+    "how much alcohol do you drink"
+  ],
+  "how much alcohol for h": [
+    "how much alcohol has peter drunk",
+    "how much alcohol has brian drunk",
+    "how much alcohol is healthy",
+    "how much alcohol is halal",
+    "how much alcohol is harmful",
+    "how much alcohol is haram",
+    "how much alcohol has homer drunk",
+    "how much alcohol do you drink",
+    "how much alcohol in beer"
+  ],
+  "how much alcohol for i": [
+    "how much alcohol is safe",
+    "how much alcohol is safe to drink and drive",
+    "how much alcohol is safe to drink",
+    "how much alcohol in beer",
+    "how much alcohol in wine",
+    "how much alcohol in whisky",
+    "how much alcohol in breezer",
+    "how much alcohol in vodka",
+    "how much alcohol is good",
+    "how much alcohol is bad"
+  ],
+  "how much alcohol for j": [
+    "how much alcohol do you drink"
+  ],
+  "how much alcohol for k": [
+    "how much alcohol is in kombucha"
+  ],
+  "how much alcohol for l": [
+    "how much alcohol causes fatty liver"
+  ],
+  "how much alcohol for m": [
+    "how much alcohol in magic moment",
+    "how much gsm paper for alcohol markers",
+    "how much do alcohol markers cost",
+    "how much is alcohol markers"
+  ],
+  "how much alcohol for n": [],
+  "how much alcohol for o": [
+    "how much alcohol is ok"
+  ],
+  "how much alcohol for p": [
+    "how much alcohol per day",
+    "how much alcohol has peter drunk",
+    "how much alcohol is permissible in islam",
+    "how much alcohol is safe per week",
+    "how much gsm paper for alcohol markers"
+  ],
+  "how much alcohol for q": [],
+  "how much alcohol for r": [
+    "how much alcohol in red wine",
+    "how much alcohol in red bull",
+    "how many alcohol in red bull"
+  ],
+  "how much alcohol for s": [
+    "how much alcohol is safe",
+    "how much alcohol is safe to drink and drive",
+    "how much alcohol is safe to drink",
+    "how much alcohol is safe per week",
+    "how many alcohol se dekha nahi hai",
+    "how much drink alcohol safe per day",
+    "how much alcohol in whisky",
+    "how much alcohol in beer",
+    "how much alcohol do you drink",
+    "how much alcohol can you drink"
+  ],
+  "how much alcohol for t": [
+    "how much alcohol is safe to drink daily",
+    "how much alcohol can you take on a plane",
+    "how much alcohol is safe to drink and drive",
+    "how much alcohol is safe to drink"
+  ],
+  "how much alcohol for u": [],
+  "how much alcohol for v": [
+    "how much alcohol in vodka",
+    "how much alcohol is in vanilla extract"
+  ],
+  "how much alcohol for w": [
+    "how much alcohol in wine",
+    "how much alcohol in whisky",
+    "how much alcohol in beer",
+    "how much alcohol do you drink"
+  ],
+  "how much alcohol for x": [],
+  "how much alcohol for y": [
+    "how much alcohol can you take on a plane",
+    "how much alcohol can you drink",
+    "how much alcohol do you drink skit",
+    "how much alcohol do you drink"
+  ],
+  "how much alcohol for z": [
+    "how much alcohol do you drink"
+  ],
+  "wedding bar a": [
+    "wedding bar",
+    "wedding bar setup",
+    "wedding bar mala song",
+    "wedding bar diy",
+    "wedding bar decoration ideas",
+    "wedding bar ideas",
+    "wedding bar menu",
+    "wedding bar mala",
+    "wedding bar sign",
+    "bridal bar"
+  ],
+  "wedding bar b": [
+    "wedding bells bar",
+    "wedding boba bar",
+    "red wedding burlington bar",
+    "wedding bar",
+    "wedding bar diy",
+    "wedding bar setup",
+    "wedding bar ideas",
+    "wedding bar counter"
+  ],
+  "wedding bar c": [
+    "wedding bar counter",
+    "wedding coffee bar",
+    "wedding candy bar",
+    "wedding crashers bar mitzvah",
+    "wedding cash bar",
+    "wedding ice cream bar",
+    "wedding house char bar",
+    "wedding hot chocolate bar",
+    "wedding bar",
+    "wedding bar ideas"
+  ],
+  "wedding bar d": [
+    "wedding bar diy",
+    "wedding bar decoration ideas",
+    "wedding date bar scene",
+    "wedding dessert bar",
+    "hookah bar wedding dance",
+    "wedding bells dhanbad bar",
+    "american wedding gay bar dance off",
+    "wedding bar",
+    "wedding bar ideas",
+    "wedding bar counter"
+  ],
+  "wedding bar e": [
+    "wedding bar",
+    "wedding bar setup",
+    "wedding bar mala song",
+    "wedding bar diy",
+    "wedding bar decoration ideas",
+    "wedding bar ideas",
+    "wedding bar menu",
+    "wedding bar mala",
+    "wedding bar sign",
+    "bridal bar"
+  ],
+  "wedding bar f": [
+    "wedding flower bar",
+    "wedding singer bar fight",
+    "wedding bar",
+    "wedding bar ideas",
+    "wedding bar counter",
+    "wedding bar setup",
+    "wedding bar diy"
+  ],
+  "wedding bar g": [
+    "american wedding gay bar",
+    "american wedding gay bar dance off",
+    "wedding bar",
+    "wedding bar counter",
+    "wedding bar ideas",
+    "wedding bar diy",
+    "wedding bar setup"
+  ],
+  "wedding bar h": [
+    "wedding dance hookah bar",
+    "happy wedding bar scene",
+    "wedding bar",
+    "wedding bar ideas",
+    "wedding bar setup",
+    "wedding bar diy"
+  ],
+  "wedding bar i": [
+    "wedding bar ideas",
+    "wedding bar decoration ideas",
+    "bar in wedding",
+    "indian wedding bar",
+    "wedding bar setup",
+    "wedding bar counter",
+    "wedding bar diy"
+  ],
+  "wedding bar j": [
+    "wedding bar",
+    "wedding bar setup",
+    "wedding bar diy",
+    "wedding bar ideas",
+    "wedding bar menu"
+  ],
+  "wedding bar k": [
+    "wedding bar",
+    "wedding bar ideas",
+    "wedding bar diy",
+    "wedding bar setup"
+  ],
+  "wedding bar l": [
+    "wedding bar",
+    "wedding bar ideas",
+    "wedding bar diy",
+    "wedding bar setup"
+  ],
+  "wedding bar m": [
+    "wedding bar menu",
+    "wedding bar mala song",
+    "wedding bar mala",
+    "wedding singer bar mitzvah scene",
+    "wedding crashers bar mitzvah",
+    "wedding open bar math",
+    "happy wedding movie bar scene",
+    "muriel's wedding bar scene",
+    "wedding mini bar",
+    "wedding bar"
+  ],
+  "wedding bar n": [
+    "wedding bar",
+    "wedding bar setup",
+    "wedding bar mala song",
+    "wedding bar diy",
+    "wedding bar decoration ideas",
+    "wedding bar ideas",
+    "wedding bar menu",
+    "wedding bar mala",
+    "wedding bar sign",
+    "wedding barn"
+  ],
+  "wedding bar o": [
+    "wedding open bar",
+    "wedding open bar math",
+    "wedding bar",
+    "wedding bar ideas",
+    "wedding bar setup",
+    "wedding bar diy",
+    "wedding bar counter"
+  ],
+  "wedding bar p": [
+    "wedding pasta bar",
+    "wedding perfume bar",
+    "wedding pizza bar",
+    "wedding bar ideas",
+    "wedding bar",
+    "wedding bar counter",
+    "wedding bar diy"
+  ],
+  "wedding bar q": [
+    "wedding bar diy",
+    "wedding bar ideas",
+    "wedding bar",
+    "wedding bar counter"
+  ],
+  "wedding bar r": [
+    "wedding ramen bar",
+    "bridal bar recipe",
+    "bridal bar recipe in tamil",
+    "pub wedding reception",
+    "red wedding reaction bar",
+    "diy taco bar wedding reception",
+    "red wedding bar",
+    "wedding bar counter",
+    "wedding bar ideas",
+    "wedding bar"
+  ],
+  "wedding bar s": [
+    "wedding bar sign",
+    "wedding bar setup",
+    "wedding singer bar scene",
+    "wedding singer bar mitzvah scene",
+    "wedding singer bar fight",
+    "wedding salad bar",
+    "happy wedding bar scene",
+    "american wedding bar scene",
+    "wedding date bar scene",
+    "wedding bar mala song"
+  ],
+  "wedding bar t": [
+    "wedding taco bar",
+    "wedding bar",
+    "wedding bar setup",
+    "wedding bar ideas",
+    "wedding bar diy",
+    "wedding bar counter"
+  ],
+  "wedding bar u": [
+    "wedding bar",
+    "wedding bar ideas",
+    "wedding bar diy",
+    "wedding bar counter",
+    "wedding bar setup"
+  ],
+  "wedding bar v": [
+    "wedding bar",
+    "wedding bar ideas",
+    "wedding bar setup",
+    "wedding bar diy"
+  ],
+  "wedding bar w": [
+    "white wedding bar scene",
+    "wedding bar",
+    "wedding bar ideas",
+    "wedding bar diy",
+    "wedding bar counter"
+  ],
+  "wedding bar x": [
+    "wedding bar",
+    "wedding bar ideas",
+    "wedding bar diy",
+    "wedding bar decoration ideas"
+  ],
+  "wedding bar y": [
+    "wedding bar",
+    "wedding bar setup",
+    "wedding bar mala song",
+    "wedding bar diy",
+    "wedding bar decoration ideas",
+    "wedding bar ideas",
+    "wedding bar menu",
+    "wedding bar mala",
+    "wedding bar sign",
+    "bridal bar"
+  ],
+  "wedding bar z": [
+    "wedding bar diy",
+    "wedding bar",
+    "wedding bar setup",
+    "wedding bar ideas"
+  ],
+  "bachelorette party a": [
+    "bachelorette party at home",
+    "bachelorette party activities",
+    "bachelorette party at home ideas",
+    "hen party accessories",
+    "bachelorette party the summer i turned pretty",
+    "angela's bachelorette party the office",
+    "bachelorette party on a budget",
+    "bachelorette party south africa",
+    "bachelorette party decoration ideas at home",
+    "bachelorette party crazy rich asians"
+  ],
+  "bachelorette party b": [
+    "bachelorette party bar",
+    "bachelorette party background",
+    "bachelorette party bus",
+    "bachelorette party black people",
+    "bachelorette party betrayal",
+    "bachelorette party boys",
+    "bachelorette party bags",
+    "bachelorette party bikini",
+    "bachelorette party beach",
+    "bachelorette party bride"
+  ],
+  "bachelorette party c": [
+    "bachelorette party cheating",
+    "bachelorette party cheating stories",
+    "bachelorette party cruise",
+    "bachelorette party charleston sc",
+    "bachelorette party confessions",
+    "bachelorette party crazy",
+    "bachelorette party club",
+    "bachelorette party choices",
+    "bachelorette party comedy",
+    "bachelorette party cake"
+  ],
+  "bachelorette party d": [
+    "bachelorette party decorations",
+    "bachelorette party dhar mann",
+    "bachelorette party dresses",
+    "bachelorette party dance",
+    "bachelorette party drama",
+    "bachelorette party dancer",
+    "bachelorette party destinations",
+    "bachelorette party disaster",
+    "bachelorette party diy",
+    "bachelorette party decoration ideas"
+  ],
+  "bachelorette party e": [
+    "bachelorette party entry song",
+    "hen party everybody",
+    "hen party ebribari",
+    "bachelorette party songs english",
+    "snl bachelorette party espresso",
+    "bachelorette party sound effect",
+    "expensive bachelorette party",
+    "epcot bachelorette party",
+    "bachelorette party",
+    "bachelorette party videos"
+  ],
+  "bachelorette party f": [
+    "bachelorette party favors",
+    "bachelorette party fight",
+    "bachelorette party from hell",
+    "bachelorette party fails",
+    "bachelorette party favors ideas",
+    "bachelorette party florida",
+    "bachelorette party for bride",
+    "bachelorette party funny",
+    "bachelorette party for groom",
+    "bachelorette party food"
+  ],
+  "bachelorette party g": [
+    "bachelorette party games",
+    "bachelorette party gone wrong",
+    "bachelorette party gift",
+    "bachelorette party gift bags",
+    "bachelorette party gone too far",
+    "bachelorette party games for bride",
+    "bachelorette party game ideas",
+    "bachelorette party goes wrong",
+    "bachelorette party girls",
+    "bachelorette party gifts for bridesmaids"
+  ],
+  "bachelorette party h": [
+    "bachelorette party hayley williams",
+    "bachelorette party hairstyles",
+    "bachelorette party horror stories",
+    "bachelorette party songs hindi",
+    "bachelorette party at home",
+    "bachelorette party dress haul",
+    "lily bachelorette party himym",
+    "bachelorette party at home ideas",
+    "bachelorette party from hell",
+    "bachelorette party in hotel room"
+  ],
+  "bachelorette party i": [
+    "bachelorette party ideas",
+    "bachelorette party in miami",
+    "bachelorette party in nashville",
+    "bachelorette party in vegas",
+    "bachelorette party india",
+    "bachelorette party ideas for bride",
+    "bachelorette party ideas games",
+    "bachelorette party ideas at home",
+    "bachelorette party indian",
+    "bachelorette party ideas for groom"
+  ],
+  "bachelorette party j": [
+    "snl bachelorette party josh o'connor",
+    "bachelorette party payal jain",
+    "jasmine bachelorette party 90 day fiance",
+    "jo bachelorette party tvd",
+    "bachelorette party",
+    "bachelorette party videos",
+    "bachelorette party at home",
+    "bachelorette party scene"
+  ],
+  "bachelorette party k": [
+    "bachelorette party kiss",
+    "bachelorette party kelsey",
+    "bachelorette party kannada",
+    "bachelorette party kya hota hai",
+    "bachelorette party kerala",
+    "hen party karaoke songs",
+    "bachelorette party in kolkata",
+    "klailea bachelorette party",
+    "bachelorette party",
+    "bachelorette party videos"
+  ],
+  "bachelorette party l": [
+    "bachelorette party las vegas",
+    "bachelorette party lorax",
+    "hen party life drawing",
+    "hen party london",
+    "hen party liverpool",
+    "lorelai bachelorette party",
+    "laurdiy bachelorette party",
+    "lily bachelorette party himym",
+    "amy's bachelorette party 1000-lb sisters",
+    "lucifer bachelorette party"
+  ],
+  "bachelorette party m": [
+    "bachelorette party movie",
+    "bachelorette party music",
+    "bachelorette party mix",
+    "bachelorette party music playlist",
+    "bachelorette party movie scene",
+    "bachelorette party miami",
+    "bachelorette party magician",
+    "bachelorette party mamma mia",
+    "bachelorette party makeup",
+    "bachelorette party men"
+  ],
+  "bachelorette party n": [
+    "bachelorette party nashville",
+    "bachelorette party new orleans",
+    "bachelorette party nyc",
+    "angelina bachelorette party new orleans",
+    "hen night party",
+    "bachelorette parties will never be the same snl",
+    "bachelorette parties will never be the same",
+    "nashville bachelorette party playlist",
+    "napa bachelorette party",
+    "nola bachelorette party"
+  ],
+  "bachelorette party o": [
+    "bachelorette party outfit ideas",
+    "bachelorette party on a budget",
+    "bachelorette party outfits",
+    "hen party outfits",
+    "bride bachelorette party outfits",
+    "brooke's bachelorette party one tree hill",
+    "bachelorette party new orleans",
+    "nashville bachelorette party outfits",
+    "angela's bachelorette party the office",
+    "snl bachelorette party josh o'connor"
+  ],
+  "bachelorette party p": [
+    "bachelorette party playlist",
+    "bachelorette party planning",
+    "bachelorette party photo",
+    "bachelorette party prep",
+    "bachelorette party philippines",
+    "bachelorette party photoshoot",
+    "bachelorette party playlist 2024",
+    "bachelorette party pronunciation",
+    "bachelorette party places in bangalore",
+    "bachelorette party payal jain"
+  ],
+  "bachelorette party q": [
+    "bachelorette party questions",
+    "bachelorette party at home",
+    "bachelorette party",
+    "bachelorette party diy"
+  ],
+  "bachelorette party r": [
+    "bachelorette party reddit",
+    "bachelorette party reels",
+    "bachelorette party return gift ideas",
+    "bachelorette party ruined wedding",
+    "bachelorette party reels songs",
+    "bachelorette party cheating reddit",
+    "bachelorette party crazy rich asians",
+    "bachelorette party in hotel room",
+    "rosa bachelorette party",
+    "rayleen bachelorette party"
+  ],
+  "bachelorette party s": [
+    "bachelorette party songs",
+    "bachelorette party snl",
+    "bachelorette party stories",
+    "bachelorette party supplies",
+    "bachelorette party scene",
+    "bachelorette party san diego",
+    "bachelorette party songs bollywood",
+    "bachelorette party songs 2025",
+    "bachelorette party setup",
+    "bachelorette party storytime"
+  ],
+  "bachelorette party t": [
+    "bachelorette party themes",
+    "bachelorette party tom hanks",
+    "bachelorette party tsitp",
+    "bachelorette party tiktok",
+    "bachelorette party trip",
+    "bachelorette party theme ideas",
+    "bachelorette party the summer i turned pretty",
+    "bachelorette party trailer",
+    "bachelorette party telugu",
+    "bachelorette party tupperware"
+  ],
+  "bachelorette party u": [
+    "bachelorette party uce gang",
+    "hen party uk",
+    "bachelorette party stand up comedy",
+    "unique bachelorette party ideas",
+    "bachelorette party at home",
+    "bachelorette party",
+    "bachelorette party scene",
+    "bachelorette party crazy",
+    "bachelorette party videos"
+  ],
+  "bachelorette party v": [
+    "bachelorette party vlog",
+    "bachelorette party vegas",
+    "bachelorette party videos",
+    "bachelorette party video ideas",
+    "hen party vlog",
+    "hen party video",
+    "hen party violin",
+    "hen party vlog uk",
+    "shrenu bachelorette party vlog",
+    "bachelorette party"
+  ],
+  "bachelorette party w": [],
+  "bachelorette party x": [],
+  "bachelorette party y": [
+    "yacht bachelorette party",
+    "bachelorette party",
+    "bachelorette party at home",
+    "bachelorette party confessions",
+    "bachelorette party videos"
+  ],
+  "bachelorette party z": [
+    "bachelorette party scene",
+    "bachelorette party",
+    "bachelorette party crazy"
+  ],
+  "bachelor party a": [
+    "bachelor party austin tx",
+    "bachelor party arrow scene",
+    "bachelor party activities",
+    "bachelor party airbnb",
+    "bachelor party adrian zmed",
+    "bachelor party and then some",
+    "bachelor party amsterdam",
+    "bachelor party achara kirk",
+    "bachelor party asif ali intro",
+    "bachelor party ayyappa"
+  ],
+  "bachelor party b": [
+    "bachelor party bathroom scene",
+    "bachelor party brad",
+    "bachelor party belly dance",
+    "bachelor party balloon",
+    "bachelor party bus scene",
+    "bachelor party bachelor party",
+    "bachelor party best scenes",
+    "bachelor party background music",
+    "bachelor party brad laugh",
+    "bachelor party bangla natok"
+  ],
+  "bachelor party c": [
+    "bachelor party comedian",
+    "bachelor party cheating",
+    "bachelor party cole",
+    "bachelor party car scene",
+    "bachelor party cruise",
+    "bachelor party comedy",
+    "bachelor party cooking scene",
+    "bachelor party crazy rich asian",
+    "bachelor party code",
+    "bachelor party cancun"
+  ],
+  "bachelor party d": [
+    "bachelor party donkey scene",
+    "bachelor party donkey",
+    "bachelor party destinations",
+    "bachelor party donkey dance",
+    "bachelor party dance",
+    "bachelor party dexter",
+    "bachelor party dance scene",
+    "bachelor party dance performance",
+    "bachelor party dance hall days",
+    "bachelor party drugs to the left"
+  ],
+  "bachelor party e": [
+    "bachelor party ending",
+    "bachelor party elevator",
+    "bachelor party episode",
+    "bachelor party edit",
+    "bachelor party ep-06",
+    "bachelor party english song",
+    "bachelor party entry song",
+    "bachelor party episode 15",
+    "bachelor party europe",
+    "bachelor party episode 30"
+  ],
+  "bachelor party f": [
+    "bachelor party full movie",
+    "bachelor party foot long",
+    "bachelor party full moon",
+    "bachelor party full movie 1984",
+    "bachelor party funny scenes",
+    "bachelor party fire trucks",
+    "bachelor party fight scene",
+    "bachelor party for",
+    "bachelor party foot long scene",
+    "bachelor party fantastic four"
+  ],
+  "bachelor party g": [
+    "bachelor party games",
+    "bachelor party girl",
+    "bachelor party gary",
+    "bachelor party gone wrong",
+    "bachelor party games ideas",
+    "bachelor party golf trip",
+    "bachelor party gifts",
+    "bachelor party games for groom",
+    "bachelor party gift ideas for groom",
+    "bachelor party golf"
+  ],
+  "bachelor party h": [
+    "bachelor party hot dog scene",
+    "bachelor party hot dog",
+    "bachelor party hotel scene",
+    "bachelor party horse",
+    "bachelor party hanks",
+    "bachelor party house md",
+    "bachelor party how i met your mother",
+    "bachelor party hangover",
+    "bachelor party hindi song",
+    "bachelor party horror movie"
+  ],
+  "bachelor party i": [
+    "bachelor party ideas",
+    "bachelor party ideas for groom",
+    "bachelor party in vegas",
+    "bachelor party is that the footlong",
+    "bachelor party in the bungalow of the damned",
+    "bachelor party ideas for boys",
+    "bachelor party in scottsdale",
+    "bachelor party in nashville",
+    "bachelor party in las vegas",
+    "bachelor party in thailand"
+  ],
+  "bachelor party j": [
+    "bachelor party josh wolf",
+    "bachelor party judge judy",
+    "bachelor party japan",
+    "bachelor party juliet litman",
+    "bachelor party japanese businessmen",
+    "bachelor party job",
+    "bachelor party jukebox",
+    "bachelor party junnie boy",
+    "bachelor party jon olsson",
+    "bachelor party bachelor party"
+  ],
+  "bachelor party k": [
+    "bachelor party key and peele",
+    "bachelor party kannada movie",
+    "bachelor party king of the hill",
+    "bachelor party kidnap",
+    "bachelor party kannada",
+    "bachelor party kannada movie songs",
+    "bachelor party kya hoti hai",
+    "bachelor party ka video",
+    "bachelor party kabila",
+    "bachelor party ka"
+  ],
+  "bachelor party l": [
+    "bachelor party las vegas",
+    "bachelor party little demon",
+    "bachelor party locations",
+    "bachelor party lunch scene",
+    "bachelor party last scene",
+    "bachelor party last fight scene",
+    "bachelor party last song",
+    "bachelor party lay that pipe",
+    "bachelor party look",
+    "bachelor party love whatsapp status"
+  ],
+  "bachelor party m": [
+    "bachelor party movie",
+    "bachelor party movie scene",
+    "bachelor party movie donkey scene",
+    "bachelor party movie full",
+    "bachelor party movie bathroom scene",
+    "bachelor party movie trailer",
+    "bachelor party milt",
+    "bachelor party movie reaction",
+    "bachelor party music",
+    "bachelor party malayalam full movie"
+  ],
+  "bachelor party n": [
+    "bachelor party nick hot dog scene",
+    "bachelor party new orleans",
+    "bachelor party nashville",
+    "bachelor party natok",
+    "bachelor party new episode",
+    "bachelor party night",
+    "bachelor party nonstop mix",
+    "bachelor party new",
+    "bachelor party night before wedding",
+    "bachelor party notun natok"
+  ],
+  "bachelor party o": [
+    "bachelor party oingo boingo",
+    "bachelor party opening scene",
+    "bachelor party opening",
+    "bachelor party outfit for men",
+    "bachelor party outfit",
+    "bachelor party old serial",
+    "bachelor party host",
+    "bachelor party outfit ideas",
+    "bachelor party of kirti and naksh",
+    "bachelor party of arnav and khushi"
+  ],
+  "bachelor party p": [
+    "bachelor party podcast",
+    "bachelor party photoshoot",
+    "bachelor party playlist",
+    "bachelor party parks and rec",
+    "bachelor party prank",
+    "bachelor party porsche scene",
+    "bachelor party planning",
+    "bachelor party paprika",
+    "bachelor party photo",
+    "bachelor party party scene"
+  ],
+  "bachelor party q": [
+    "bachelor party quotes",
+    "barney bachelor party quinn",
+    "bachelor party drag queen",
+    "bachelor point party quiz",
+    "quan bachelor party",
+    "bachelor party mule",
+    "bachelor party hanks",
+    "bachelor party bachelor party",
+    "bachelor party ladies"
+  ],
+  "bachelor party r": [
+    "bachelor party reaction",
+    "bachelor party rudy",
+    "bachelor party ringer",
+    "bachelor party reggae",
+    "bachelor party reddit",
+    "bachelor party review",
+    "bachelor party rules",
+    "bachelor party rambo",
+    "bachelor party reel",
+    "bachelor party remix songs"
+  ],
+  "bachelor party s": [
+    "bachelor party songs",
+    "bachelor party soundtrack",
+    "bachelor party swoozie",
+    "bachelor party snl",
+    "bachelor party scene",
+    "bachelor party serial",
+    "bachelor party season 5",
+    "bachelor party stories",
+    "bachelor party scottsdale",
+    "bachelor party stand up comedy"
+  ],
+  "bachelor party t": [
+    "bachelor party tom hanks",
+    "bachelor party trailer",
+    "bachelor party tennis scene",
+    "bachelor party trailer 1984",
+    "bachelor party tamil serial",
+    "bachelor party the movie",
+    "bachelor party tom hanks full movie",
+    "bachelor party tim",
+    "bachelor party tom hanks donkey",
+    "bachelor party the ringer"
+  ],
+  "bachelor party u": [
+    "bachelor party update",
+    "bachelor party dress up ideas",
+    "bachelor party stand up comedy",
+    "bachelor party in usa",
+    "bachelor party dress up ideas for bride",
+    "bachelor party 2 update",
+    "bachelor party stand up",
+    "bachelor party new update",
+    "bachelor party cake stand up comedy",
+    "ultimate bachelor party"
+  ],
+  "bachelor party v": [
+    "bachelor party vegas",
+    "bachelor party vegas movie",
+    "bachelor party vegas trailer",
+    "bachelor party vlog",
+    "bachelor party vegas movie trailer",
+    "bachelor party vegas 2006",
+    "bachelor party video",
+    "bachelor party vegas things to do",
+    "bachelor party vs bachelorette",
+    "bachelor party vhs"
+  ],
+  "bachelor party w": [
+    "bachelor party with tom hanks",
+    "bachelor party we might be drunk",
+    "bachelor party why do good girls like bad boys",
+    "bachelor party wedding",
+    "bachelor party women",
+    "bachelor party wrestling joke",
+    "bachelor party we don't give",
+    "bachelor party window scene",
+    "bachelor party whatsapp status",
+    "bachelor party web series trailer"
+  ],
+  "bachelor party x": [],
+  "bachelor party y": [
+    "bachelor party yeh rishta kya kehlata hai",
+    "bachelor party yrkkh",
+    "bachelor party yeh rishta kya kehlata hai full episode",
+    "ashok bachelor party yeh hai mohabbatein",
+    "bachelor party anushree youtube channel",
+    "bachelor new year party",
+    "yrkkh bachelor party full episode",
+    "romi bachelor party in yeh hai mohabbatein",
+    "yash bachelor party in yrkkh full episode",
+    "bachelor party how i met your mother"
+  ],
+  "bachelor party z": [
+    "bachelor party zingo",
+    "bachelor party zingo regular show",
+    "bachelor party zone",
+    "bachelor party zee kannada",
+    "bachelor party adrian zmed",
+    "zach bachelor party",
+    "zeeshan bachelor party",
+    "zahid bachelor party",
+    "znmd bachelor party",
+    "regular show bachelor party zingo reaction"
+  ]
+}

--- a/data/seo/youtube-autocomplete/2026-07-10-questions.json
+++ b/data/seo/youtube-autocomplete/2026-07-10-questions.json
@@ -1,0 +1,313 @@
+{
+  "how to plan a bachelorette party": [
+    "how to plan a bachelorette party",
+    "how to throw a bachelorette party",
+    "how to organize a bachelorette party",
+    "how to plan a hen party",
+    "how to arrange bachelorette party"
+  ],
+  "how to plan a bachelor party": [
+    "how to plan a bachelor party",
+    "how to throw a bachelor party",
+    "how to organize bachelor party"
+  ],
+  "how much does a bachelorette party cost": [
+    "what is a bachelorette party"
+  ],
+  "who pays for bachelorette party": [
+    "cheap bachelorette party ideas"
+  ],
+  "who pays for the bachelor party": [],
+  "what to do in austin for bachelorette party": [
+    "what to do in bachelorette party"
+  ],
+  "what to do bachelor party austin": [
+    "what to do in bachelorette party",
+    "bachelor party austin tx",
+    "what to do in bachelor party"
+  ],
+  "bachelorette party itinerary": [
+    "bachelorette party planning",
+    "nashville bachelorette party itinerary",
+    "bachelorette party destinations",
+    "bachelorette party at home"
+  ],
+  "bachelorette party planning": [
+    "bachelorette party planning",
+    "hen party planning",
+    "bachelorette party ideas",
+    "bachelorette party ideas for bride",
+    "bachelorette party ideas indian",
+    "bachelorette party ideas games",
+    "bachelorette party ideas at home",
+    "bachelorette party ideas for groom",
+    "bachelorette party at home"
+  ],
+  "lake travis party boat": [
+    "lake travis party boat",
+    "lake travis party cove"
+  ],
+  "lake travis bachelorette": [
+    "lake travis resorts"
+  ],
+  "austin bachelorette party": [
+    "austin bachelorette party",
+    "austin texas bachelorette party"
+  ],
+  "how to plan a bachelorette": [
+    "how to plan a bachelorette party",
+    "how to plan a bachelorette trip",
+    "how to throw a bachelorette party",
+    "how to organize a bachelorette party",
+    "how to arrange bachelorette party"
+  ],
+  "how much bachelorette party": [
+    "what is bachelorette party",
+    "how to celebrate bachelorette party"
+  ],
+  "who pays for": [
+    "who pays for tariffs",
+    "who pays for the wedding",
+    "who pays for dates",
+    "who pays for the first date",
+    "who pays for shipping on ebay",
+    "who pays for unemployment",
+    "who pays for shipping on whatnot",
+    "who pays for dinner",
+    "who pays for credit card rewards",
+    "who pays for"
+  ],
+  "what to wear bachelorette": [
+    "what to wear bachelorette party"
+  ],
+  "what to pack bachelorette": [
+    "what to wear bachelorette party"
+  ],
+  "bachelorette weekend": [
+    "bachelorette weekend",
+    "bachelorette weekend vlog",
+    "bachelorette weekend ideas",
+    "miami bachelorette weekend",
+    "packing for bachelorette weekend",
+    "planning a bachelorette weekend",
+    "dhar mann bachelorette weekend"
+  ],
+  "bachelor party planning": [
+    "bachelor party planning",
+    "bachelor party planning tips"
+  ],
+  "bachelorette party checklist": [
+    "bachelorette party planning"
+  ],
+  "bachelorette party budget": [
+    "bachelorette party on a budget"
+  ],
+  "bachelorette party games": [
+    "bachelorette party games",
+    "bachelorette party games for bride",
+    "bachelorette party games funny",
+    "bachelorette party games india",
+    "hen party games",
+    "hen party games ideas",
+    "bachelorette party ideas games",
+    "bachelorette games"
+  ],
+  "how to plan a bachelorette party a": [
+    "how to plan a bachelorette party"
+  ],
+  "how to plan a bachelorette party b": [
+    "how to plan a bachelorette party"
+  ],
+  "how to plan a bachelorette party c": [
+    "how to plan a bachelorette party"
+  ],
+  "how to plan a bachelorette party d": [
+    "how to plan a bachelorette party"
+  ],
+  "how to plan a bachelorette party e": [
+    "how to plan a bachelorette party"
+  ],
+  "how to plan a bachelorette party f": [
+    "how to plan a bachelorette party"
+  ],
+  "how to plan a bachelorette party g": [
+    "how to plan a bachelorette party",
+    "how to plan a bachelorette trip"
+  ],
+  "how to plan a bachelorette party h": [
+    "how to plan a bachelorette party"
+  ],
+  "how to plan a bachelorette party i": [
+    "how to plan a bachelorette party",
+    "how to plan a bachelorette trip"
+  ],
+  "how to plan a bachelorette party j": [
+    "how to plan a bachelorette party"
+  ],
+  "how to plan a bachelorette party k": [
+    "how to plan a bachelorette party",
+    "how to plan a bachelorette trip"
+  ],
+  "how to plan a bachelorette party l": [
+    "how to plan a bachelorette party",
+    "how to plan a bachelorette trip"
+  ],
+  "how to plan a bachelorette party m": [
+    "how to plan a bachelorette party"
+  ],
+  "how to plan a bachelorette party n": [
+    "how to plan a bachelorette party"
+  ],
+  "how to plan a bachelorette party o": [
+    "how to plan a bachelorette party"
+  ],
+  "how to plan a bachelorette party p": [
+    "how to plan a bachelorette party"
+  ],
+  "how to plan a bachelorette party q": [
+    "how to plan a bachelorette party"
+  ],
+  "how to plan a bachelorette party r": [
+    "how to plan a bachelorette party"
+  ],
+  "how to plan a bachelorette party s": [
+    "how to plan a bachelorette party"
+  ],
+  "how to plan a bachelorette party t": [
+    "how to plan a bachelorette party"
+  ],
+  "how to plan a bachelorette party u": [
+    "how to plan a bachelorette party"
+  ],
+  "how to plan a bachelorette party v": [
+    "how to plan a bachelorette party"
+  ],
+  "how to plan a bachelorette party w": [
+    "how to plan a bachelorette party"
+  ],
+  "how to plan a bachelorette party x": [
+    "how to plan a bachelorette party"
+  ],
+  "how to plan a bachelorette party y": [
+    "how to plan a bachelorette party"
+  ],
+  "how to plan a bachelorette party z": [
+    "how to plan a bachelorette party"
+  ],
+  "austin bachelorette a": [
+    "austin bachelorette",
+    "austin bachelorette party"
+  ],
+  "austin bachelorette b": [
+    "austin butler bachelor party",
+    "austin bachelorette",
+    "austin bachelorette party"
+  ],
+  "austin bachelorette c": [
+    "chris austin bachelorette"
+  ],
+  "austin bachelorette d": [
+    "austin bachelorette party",
+    "austin bachelorette",
+    "austin texas bachelorette party"
+  ],
+  "austin bachelorette e": [],
+  "austin bachelorette f": [
+    "austin bachelorette party"
+  ],
+  "austin bachelorette g": [
+    "austin bachelorette"
+  ],
+  "austin bachelorette h": [
+    "austin bachelorette",
+    "austin bachelorette party",
+    "austin texas bachelorette party"
+  ],
+  "austin bachelorette i": [
+    "austin bachelorette",
+    "austin bachelorette party",
+    "austin texas bachelorette party"
+  ],
+  "austin bachelorette j": [
+    "austin bachelorette",
+    "austin bachelorette party",
+    "austin texas bachelorette party"
+  ],
+  "austin bachelorette k": [
+    "austin bachelorette",
+    "austin bachelorette party"
+  ],
+  "austin bachelorette l": [
+    "austin bachelorette",
+    "austin bachelorette party"
+  ],
+  "austin bachelorette m": [
+    "austin bachelorette",
+    "austin bachelorette party",
+    "austin texas bachelorette party"
+  ],
+  "austin bachelorette n": [
+    "austin bachelorette",
+    "austin texas bachelorette party",
+    "austin bachelorette party"
+  ],
+  "austin bachelorette o": [
+    "austin ott bachelorette",
+    "austin bachelorette",
+    "austin bachelorette party",
+    "austin texas bachelorette party"
+  ],
+  "austin bachelorette p": [
+    "austin bachelorette party",
+    "austin texas bachelorette party",
+    "austin tx bachelor party"
+  ],
+  "austin bachelorette q": [
+    "austin bachelorette",
+    "austin bachelorette party",
+    "austin texas bachelorette party"
+  ],
+  "austin bachelorette r": [
+    "austin bachelorette",
+    "austin bachelorette party",
+    "austin bradshaw"
+  ],
+  "austin bachelorette s": [
+    "austin bachelorette",
+    "austin bachelorette party",
+    "austin texas bachelorette party"
+  ],
+  "austin bachelorette t": [
+    "austin texas bachelorette party",
+    "austin bachelorette",
+    "austin bachelorette party"
+  ],
+  "austin bachelorette u": [
+    "austin bachelorette",
+    "austin bachelorette party",
+    "austin texas bachelorette party"
+  ],
+  "austin bachelorette v": [
+    "austin bachelorette party",
+    "austin bachelorette",
+    "austin texas bachelorette party"
+  ],
+  "austin bachelorette w": [
+    "austin bachelorette",
+    "austin bachelorette party",
+    "austin texas bachelorette party"
+  ],
+  "austin bachelorette x": [
+    "austin bachelorette",
+    "austin bachelorette party"
+  ],
+  "austin bachelorette y": [
+    "austin bachelorette",
+    "austin bachelorette party"
+  ],
+  "austin bachelorette z": [
+    "austin bachelorette",
+    "austin bachelorette party",
+    "austin texas bachelorette party"
+  ]
+}

--- a/data/seo/youtube-competitors/2026-07-10.md
+++ b/data/seo/youtube-competitors/2026-07-10.md
@@ -1,0 +1,44 @@
+# YouTube competitive read — bach queries (2026-07-10)
+
+Live YouTube search results (US, logged-in). Views/age as displayed.
+
+## Search: "how to plan a bachelorette party"
+
+Shorts row: "TOP 5 BACHELORETTE PARTY RULES" 14K · "BEST BACHELORETTE ACTIVITIES – Day 4 of Planning a Bachelorette Party in 30 Days!" 14K · "Everything you need to know for Austin Bachelorette Party" **2.5K (Austin-specific short exists, tiny)** · "DON'T SKIP on having a bachelorette party" 59K · anti-bachelorette rant 4.4M (comedy outlier)
+
+Long-form:
+| Video | Channel | Views | Age | Format |
+|---|---|---|---|---|
+| Maid of Honor Workshop Pt 2 (27:26) | The Unveiled Bride | 33K | 4y | step-by-step guide, 15 chapters |
+| BACHELORETTE PARTY PLANNING!! DIY With Me (Cricut vlog) | RemLife | 332K | 2y | personality vlog |
+| BACHELORETTE WEEKEND: Everything You NEED to Know | Jamie Wolfer | 73K | 5y | checklist guide |
+| How To Plan A Bachelorette Party / Wedding Etiquette | The Modern Lady | 32K | 9y | etiquette guide |
+| 7 Fun and Inexpensive Bachelorette Party Ideas | Popsugar | 165K | 11y | listicle |
+| Bachelorette Parties: Stories, Advice, Ideas | Emily Wilson | 26K | 6y | talk |
+| Expert tips for affordable bachelorette parties | CBS Mornings | 4.8K | 2y | news segment |
+| HELP! How to Plan a Bachelor/Bachelorette Party (14:28) | Abby Lee | 2.6K | 6y | Q&A (chapters = who plans/invite/when/where/budget) |
+
+READ: guide/checklist content wins this query but every winner is 4–11 years old and 10–27 min long. Nothing fresh, structured, and short exists. Abby Lee's chapter list (who plans / who to invite / when / where / budget) is exactly our Q&A format at 2.6K views — done badly; the format slot is open.
+
+## Search: "austin bachelorette party"
+
+| Video | Channel | Views | Age | Format |
+|---|---|---|---|---|
+| Austin Bachelorette Weekend (Lake Day chapter) | Kleine Powell | 17K | 1y | personal vlog |
+| VLOG: My Bachelorette Weekend in Austin | Nathalie Fischer | 14K | 3y | vlog |
+| Hosting my Sister's Bachelorette + Night Out in Austin | Michel Janse | 72K | 4y | hosting/prep vlog, 15 chapters |
+| FINDING THE PERFECT BACHELOR PARTY DESTINATION – AUSTIN | Dana Beers | 46K | 2y | sponsored entertainment (Pirate Water) |
+| The Ultimate Austin Bachelorette Party – Batch City Guides (3:23) | Batch | **329** | 1y | branded city guide |
+| Bachelorette & Bachelor fun on Lake Travis | Lake Travis Yacht Rentals | 323 / 59 | 1–3y | vendor promo |
+| WEDDING SERIES: Bachelorette in Austin (boat on Lake Travis) | Brianna Woodbine | 7.8K | 2y | vlog |
+
+READ: personal vlogs own the local query; branded city guides and vendor promos flop (Batch 329 views despite production quality). Boat day appears as a chapter in nearly every vlog. Sponsored ad slots on this query: Inn Cahoots (6th St lodging), Austin Party Bus ("BYOB"), BoatX ("$295/hr, BYOB, captain included") — BYOB is the commercial thread, and nobody's content answers how to stock the BYOB.
+
+## Search: "how to plan a bachelor party" (partial, from Google video pack + related)
+Tailored Fit (2:34, 54K views, 12 YEARS old) still ranks in Google's video pack; "Bachelor Party Guide: How to Plan the Perfect Night" short 6.5K. Same staleness pattern, worse.
+
+## Strategic conclusions
+1. Make the GUIDE video (targets "how to plan..." where guides win + video packs exist), not a city-guide brand video (proven flop) and not a vlog competitor.
+2. Keep it SHORT (3–5 min) with visible chapters — every incumbent is 10–27 min and old; fast-answer positioning is the open slot. Precedent: WedEverything's one combined bachelor/bachelorette video ranks in BOTH Google video packs.
+3. Austin flavor + boat/BYOB specificity = differentiation + the commercial hook nobody covers.
+4. Shorts: each chapter stands alone; shorts carousels exist on the etiquette/cost Google SERPs and Austin-specific shorts have almost no competition (2.5K views is the bar).

--- a/docs/seo/bach-video-brief-2026-07.md
+++ b/docs/seo/bach-video-brief-2026-07.md
@@ -1,5 +1,7 @@
 # Bach Video Production Brief — Q&A Listicle (2026-07-10)
 
+> **Script written:** the word-for-word plain-language script (with b-roll map, shot list, and the real-data claims awaiting Allan's sign-off) is at [bach-video-script-2026-07.md](./bach-video-script-2026-07.md).
+
 One combined bachelor + bachelorette video, bachelorette-led. **3–5 minutes, 10 questions, each question a keyword-targeted chapter.** Long-form lives on a new pillar blog post + both bach landers; each chapter becomes a standalone short mapped to a blog post.
 
 Evidence base (all raw files committed): `data/seo/semrush/2026-07-10/` (question keywords), `data/seo/serp-paa/2026-07-10.md` (PAA + SERP features), `data/seo/youtube-competitors/2026-07-10.md` (what performs), `data/seo/gsc/2026-07-09-segments.json` (our rankings), `data/seo/youtube-autocomplete/2026-07-10-questions.json` (live phrasings).

--- a/docs/seo/bach-video-brief-2026-07.md
+++ b/docs/seo/bach-video-brief-2026-07.md
@@ -1,0 +1,75 @@
+# Bach Video Production Brief — Q&A Listicle (2026-07-10)
+
+One combined bachelor + bachelorette video, bachelorette-led. **3–5 minutes, 10 questions, each question a keyword-targeted chapter.** Long-form lives on a new pillar blog post + both bach landers; each chapter becomes a standalone short mapped to a blog post.
+
+Evidence base (all raw files committed): `data/seo/semrush/2026-07-10/` (question keywords), `data/seo/serp-paa/2026-07-10.md` (PAA + SERP features), `data/seo/youtube-competitors/2026-07-10.md` (what performs), `data/seo/gsc/2026-07-09-segments.json` (our rankings), `data/seo/youtube-autocomplete/2026-07-10-questions.json` (live phrasings).
+
+## Why this exact format wins (from the data)
+
+1. **The "how to plan" SERPs have video packs owned by stale content** — the bachelorette pack's videos are 10–27 min from small channels; the bachelor pack still ranks a 2:34 video **from 2014**. A fresh, chaptered, fast-answer video is the open slot. Precedent: WedEverything's single combined video ranks in BOTH packs — one video CAN take both.
+2. **Etiquette/cost SERPs ("who pays", "how much") surface Short-video carousels** where 1–2 min clips from small accounts rank — the chop-into-shorts plan has a direct Google surface.
+3. **Branded city-guide videos flop on YouTube** (Batch's polished Austin guide: 329 views) while guide content wins the "how to plan" queries — so this is a planning guide with Austin flavor, not an "Austin guide" with planning flavor.
+4. **The Austin AI Overview scripts a Lake Travis boat day and says "pack a cooler" — but cites no alcohol delivery service.** The cooler-stocking answer is the unclaimed slot in both AI and search results. Question 7 exists to own it.
+5. Bach informational queries we already rank for (brunch pos 9, BBQ pos 22.7, budget pos 22.4, "how far ahead should I book" pos **1**) prove Google will rank us for bach questions.
+
+## The 10 questions (= chapters = shorts)
+
+| # | Chapter question (say it verbatim — it's the keyword) | Target keyword(s) + volume | Evidence | Blog destination |
+|---|---|---|---|---|
+| 1 | How do you plan a bachelorette party? | "how to plan a bachelorette party" 480/mo KD11 (+ organize/plan variants ≈740/mo) | video pack; top YT autocomplete; PAA | NEW pillar post + bachelorette pillar guide |
+| 2 | Who pays for the bachelorette party? | "who pays for bachelorette party" 880/mo KD11 (cluster ≈1,200) | PAA ×2 SERPs; shorts carousel on SERP | [how-to-split-costs-fairly-for-a-bachelorette-weekend-in-austin](../../content/blog/posts/how-to-split-costs-fairly-for-a-bachelorette-weekend-in-austin.mdx) |
+| 3 | How much does a bachelorette weekend actually cost (in Austin)? | "how much does a bachelorette party cost" 70/mo KD25 + cost cluster; Knot stat $1,300/pp | PAA; fly-rides.com published the Austin version 7 DAYS ago — respond | same split-costs post + NEW pillar (Austin $ section) |
+| 4 | When should the bach party happen — and how far ahead do you book? | timing cluster ≈1,600/mo KD6–26 ("when to have" 210, "how long before wedding" 70) | we already rank #1 for "how far ahead should i book for a bachelorette trip in austin" (GSC) | NEW pillar post |
+| 5 | What do you actually do at one? (Austin edition) | "what happens at bachelorette parties" 260 + "what to do for" cluster ≈1,000/mo KD11–26 | PAA; every Austin vlog = brunch/boat/Rainey | bachelorette pillar + themes/scavenger/brunch posts |
+| 6 | How much alcohol should you bring? | "bachelorette party drinks" 210/mo KD4; "how much alcohol to buy for bachelorette party" 20/mo | THE conversion chapter; legacy post exists; drink-calculator CTA | legacy [ultimate austin bachelorette alcohol guide](https://partyondelivery.com/blogs/news/the-ultimate-austin-bachelorette-party-alcohol-guide-what-to-order-when-to-order-and-how-much-you-actually-need) — flag for MDX migration |
+| 7 | What goes in the cooler for a Lake Travis boat day? | "lake travis party boat" (live YT autocomplete); "what to pack" phrasings | AI Overview says "pack a cooler," cites NO delivery service — own this answer; TABC/glass rules content exists | [what-to-pack-for-a-bachelor-weekend-on-lake-travis](../../content/blog/posts/what-to-pack-for-a-bachelor-weekend-on-lake-travis.mdx) + legacy boat-laws post |
+| 8 | Who plans the bachelor party — and who pays? | bachelor "who pays" cluster ≈2,200/mo KD7–20; "does the best man plan/pay" 90–110/mo | PAA on bachelor SERP | [austin-bachelor-party-do-s-and-don-ts](../../content/blog/posts/austin-bachelor-party-do-s-and-don-ts-for-first-time-planners.mdx) |
+| 9 | How do you plan a bachelor party (without it falling apart)? | plan cluster ≈1,150/mo KD10–26 | video pack w/ 2014 incumbent; "bachelor party austin tx" is live YT autocomplete | bachelor pillar + [stress-free itinerary post](../../content/blog/posts/how-to-create-a-stress-free-bachelor-itinerary-in-austin.mdx) |
+| 10 | Where should the group stay in Austin? | GSC "where to stay…" cluster (5 queries, pos 38–63); related searches on every Austin SERP | both Airbnb posts exist (bachelor + bachelorette) | [unique-airbnbs-for-large-bachelorette-groups](../../content/blog/posts/unique-airbnbs-for-large-bachelorette-groups-in-austin.mdx) + bachelor Airbnb post |
+
+Bonus short-only question (no long-form chapter): "What do you call a combined bachelor + bachelorette party?" (60/mo across 2 phrasings; fun social clip).
+
+## Long-form video spec
+
+- **Title (primary):** How to Plan a Bachelorette (or Bachelor) Party — 10 Questions Answered in 4 Minutes
+- **Title (alt, more Austin):** Bachelorette Party Planning: 10 Questions Everyone Asks, Answered Fast (Austin Edition)
+- **Length:** 3:30–4:30. ~20–25 sec per question. Pace IS the differentiator — say the answer first, then one supporting detail, next chapter.
+- **Chapters:** exact question phrasings above → YouTube chapter markers (each becomes a "key moment" in Google).
+- **Structure:** Cold open (10 sec: "Every bach party group asks the same ten questions. Here are the answers, fast.") → Q1–Q7 bachelorette-led → Q8–Q9 bachelor → Q10 shared → CTA (15 sec).
+- **CTA:** "Planning one in Austin? We deliver everything cold to your Airbnb or the marina — and the drink calculator figures out how much you need." → lander URL on screen.
+- **Shoot notes:** boat/lake footage is priority #1 (every winning Austin vlog features the boat day; sponsors all sell BYOB). Cooler pack-out shot for Q7 (the money shot — it's the unclaimed AI Overview answer). On-screen text = the question verbatim (keyword in the frame for both accessibility + shorts reuse).
+- **Answer content for Q2/Q3/Q4** (match SERP consensus, then better): guests pay own way + split the bride's share, MOH coordinates (Q2); $300–1,500/pp in Austin, national avg ~$1,300 (Q3); 1–4 months before the wedding, book boats/Airbnbs 2–3 months out — peak season sells out (Q4).
+
+## Shorts cut map (10 + 1 clips, 20–45 sec each)
+
+Each chapter exports as a vertical short: question on screen → answer → one-line CTA. Per-clip destinations:
+
+| Clip | Short title | Destination blog (embed once MDX supports it) | Platforms |
+|---|---|---|---|
+| Q1 | How to plan a bachelorette party in 30 seconds | new pillar post | YT Shorts, IG Reels, TikTok |
+| Q2 | Who ACTUALLY pays for the bachelorette party | split-costs post | all + this SERP has a shorts carousel |
+| Q3 | What a bachelorette weekend costs in Austin | split-costs post | all |
+| Q4 | When to book your Austin bach trip (it sells out) | new pillar post | all |
+| Q5 | What you actually do at an Austin bachelorette | themes post | all |
+| Q6 | How much alcohol for a bach weekend (formula) | legacy alcohol guide | all |
+| Q7 | Packing the cooler for Lake Travis (what's allowed) | lake-travis packing post | all — most Austin-differentiated clip |
+| Q8 | Best man rules: who plans, who pays | do's-and-don'ts post | all |
+| Q9 | Bachelor party planning, minus the chaos | itinerary post | all |
+| Q10 | Where bach groups stay in Austin | Airbnb posts | all |
+| Bonus | What's a combined bach party called? | none (social-only) | TikTok/Reels |
+
+**Honest constraint:** no social posting integration exists anywhere in the stack (site or tools) — every upload is manual. YouTube (long + Shorts) first; IG/TikTok as batch-upload sessions.
+
+## Embed & schema plan (separate PRs, after footage exists)
+
+1. **New pillar post** `austin-bach-party-questions-answered` — hosts the long-form embed + all 10 Q&As as text (FAQPage + VideoObject JSON-LD, matching the existing blog schema pattern). Added to both clusters in `src/lib/topic-clusters.ts`.
+2. **MDX video capability:** register `YouTubeEmbed` in `MDXContentRSC.tsx` components map (one line) so blog posts can embed clips.
+3. **Landers:** add embed section to `/austin-bachelorette-party-delivery` + `/austin-bachelor-party-delivery` (deliberate `LandingPageTemplate.tsx` change — sanctioned no-nav pages, own PR).
+
+## Follow-ups surfaced by this research
+
+- **Fix 3 orphaned bachelorette posts** (scavenger hunt, pool party, Airbnbs): add `pillarSlug` + add to `clusterSlugs` in `topic-clusters.ts`.
+- **fly-rides.com is moving on "bachelorette party cost Austin"** (published 7 days ago) — the new pillar's cost section is the response; don't wait long.
+- Migrate the legacy bachelorette alcohol guide to MDX (it's the Q6 destination but lives in the legacy JSON blob).
+- Internal links: birthday-ideas post (our #1 traffic asset) → bach pillars.
+- Measure from the GSC baseline in `data/seo/gsc/2026-07-09-segments.json` ~6 weeks after publish.

--- a/docs/seo/bach-video-script-2026-07.md
+++ b/docs/seo/bach-video-script-2026-07.md
@@ -1,0 +1,133 @@
+# Bach Video — Plain-Language Script (v1, 2026-07-10)
+
+Companion to [bach-video-brief-2026-07.md](./bach-video-brief-2026-07.md). Format per Allan's decisions: **~90% voiceover over b-roll; Allan on camera 3 times only** (hook, one expertise moment, CTA ≈ 8% of runtime). Venues and partners named. Real order data used — every internal number is flagged **[APPROVE]** and listed in the sign-off table at the bottom.
+
+**Runtime target: ~4:15.** VO is ~640 words at a relaxed 150 wpm. Every chapter title is the search phrase — say it out loud as written (it's the keyword) and put it on screen.
+
+Evidence sources: [internal-data-bach-2026-07-10.md](../../data/seo/internal-data-bach-2026-07-10.md) (real orders), published blog facts (venues, boat law, calculator math — `src/lib/drinkPlannerLogic.ts`), SERP/PAA research in `data/seo/serp-paa/2026-07-10.md`.
+
+---
+
+## COLD OPEN — 0:00–0:12 · **ALLAN ON CAMERA** (warehouse or van, holding a cooler)
+
+> "We've stocked drinks for **over five hundred Austin bachelor and bachelorette parties this year** [APPROVE-1]. Every group asks the same ten questions. Here are the answers — in four minutes."
+
+*On-screen:* "10 questions. 4 minutes." · *B-roll cut on "five hundred": rapid montage of delivery handoffs.*
+
+---
+
+## Q1 — "How do you plan a bachelorette party?" · 0:12–0:38
+
+**The opinion: five decisions, one decider. Group chats don't plan parties.**
+
+> "Five decisions, in this order: dates, city, headcount, house, one anchor activity. That's the whole job. The biggest mistake we see is planning by group chat — twelve people deciding nothing for three weeks. One person decides — usually the maid of honor — everyone else Venmos. In Austin the anchor activity picks itself: a boat day on Lake Travis."
+
+*On-screen:* the 5 decisions as a checklist, ticking off. · *B-roll:* HAVE — Austin skyline, lake wides. NEED — phone screen with a chaotic group chat (prop shot, 3 sec).
+
+## Q2 — "Who pays for the bachelorette party?" · 0:38–1:02
+
+**The opinion: the bride pays nothing — and gets no vote on budget.**
+
+> "Standard rule, and we're not going to fight it: everyone pays their own way, and the group splits the bride's share. The maid of honor collects the money — before the trip, not after. Our one hot take: if the bride isn't paying, the bride doesn't set the budget. Agree on a per-person number in week one and plan backwards from it."
+
+*On-screen:* "Everyone pays own way + split the bride's share." · *B-roll:* HAVE — group cheers/toast footage. NEED — Venmo request close-up (prop).
+
+## Q3 — "How much does a bachelorette weekend cost in Austin?" · 1:02–1:30
+
+**The opinion: $700–1,000 a head done right — half of what Nashville costs — and drinks are the cheapest line item if you don't buy them at bars.**
+
+> "Nationally, people now spend about thirteen hundred dollars a head on these weekends. Austin, done right, runs seven hundred to a thousand — house, boat, food, everything. Here's the part nobody does the math on: one big bar night runs eighty to a hundred bucks a person. Groups that stock the house and the boat with us average **around thirty dollars a person for the whole weekend's drinks** [APPROVE-2]. The bar is for one night. The cooler is for the weekend."
+
+*On-screen:* "$1,300 national avg → Austin: $700–$1,000" then "Bar night: ~$90/pp · Stocked weekend: ~$30/pp." · *B-roll:* HAVE — product/cooler shots, Rainey St night exteriors. · *Evidence: The Knot 2025 avg $1,300/pp; our pillar tiers $400–1,200; internal median group order $286.*
+
+## Q4 — "When should the bach party happen — and how far out do you book?" · 1:30–1:56
+
+**The opinion: 1–3 months before the wedding, spring or fall — and the boat is the thing that sells out.**
+
+> "Hold it one to three months before the wedding — close enough to feel real, far enough that nobody's stressed. In Austin, aim for March through May or September through October; nobody wants the lake in a hundred and five degrees. Book the house four months out and the boat at least eight weeks out — three months for peak Saturdays. And a confession from our own data: **half the groups that order drinks from us do it less than forty-eight hours before the party** [APPROVE-3]. Drinks, we can save same-day. The boat, nobody can."
+
+*On-screen:* timeline graphic: house −4mo · boat −8wks · drinks −48h (or same-day). · *B-roll:* HAVE — vans loading, same-day delivery. NEED — busy marina Saturday wide shot.
+
+## Q5 — "What do you actually do at an Austin bachelorette party?" · 1:56–2:24
+
+**The opinion: the Austin blueprint is brunch–boat–Rainey. Don't overstuff it.**
+
+> "The blueprint that never misses: Friday, everyone lands, stock the house, dinner and Rainey Street. Saturday is the boat day — that's the main event. Saturday night, dress up: Zanzibar rooftop or East Sixth. Sunday, brunch — Moonshine, Veracruz, or June's — and a slow exit. That's it. Three anchors, lots of air. The parties that go sideways are the ones with nine reservations. Wildcard if your group two-steps: the Broken Spoke."
+
+*On-screen:* Fri/Sat/Sun blueprint. · *B-roll:* HAVE — Austin streets, murals, skyline. NEED — brunch table spread, Rainey St golden hour, boat-deck party (the workhorse shot of the whole video).
+
+## Q6 — "How much alcohol do you actually need?" · 2:24–2:56 · **ALLAN ON CAMERA moment #2** (10 sec at the cooler, then VO)
+
+**The opinion: two drinks per person per hour on the water. Do the multiplication, add water, stop guessing.**
+
+> **[Allan, to camera, packing a cooler]:** "This is the only formula you need: two drinks per person, per hour."
+> **[VO resumes]:** "Ten people, four hours on the boat — eighty drinks. A full weekend? Plan on roughly thirty drinks a person and adjust for your crew. What do Austin bach parties actually order? **Seltzers outsell beer two to one — High Noon is our number-one bach product, period** [APPROVE-4]. Add a bottle of bubbly for every five people for the tower, and — this is the one everyone forgets — a case of water and a bag of ice for every ten people. The hangover isn't the alcohol. It's the sun."
+
+*On-screen:* "2 × people × hours" then "seltzers : beer = 2:1 at real bach parties." · *B-roll:* HAVE — product shots (High Noon, Surfside, Wycliff, Tito's), ice bags. NEED — cooler pack-out overhead (also the Q7 money shot). · *Evidence: drinkPlannerLogic.ts (2/person/hour, ice = 1 bag/10, multi-day = 16 drinking hours); internal top-products pull.*
+
+## Q7 — "What goes in the cooler for a Lake Travis boat day?" · 2:56–3:26
+
+**The opinion: cans only. Glass doesn't get on the boat, and the captain doesn't drink — that's the law.**
+
+> "Rules first, because they're real: no glass on the boat — cans and plastic only. And since the 2024 law, the person driving the boat can't drink at all. Texas isn't kidding; alcohol shows up in about a quarter of the state's boating deaths. So the cooler looks like this: seltzers and canned cocktails, water one-for-one with the booze, ice on top. Bubbly? Get it in cans. If you booked with **Premier Party Cruises**, this gets easy — **we deliver to their marina free, cooler and ice included, thirty to sixty minutes before you board** [APPROVE-5]. You show up, it's cold, you sail."
+
+*On-screen:* "NO GLASS · captain drinks nothing (2024 law)" then the cooler checklist. · *B-roll:* NEED — the money shot: overhead cooler pack-out, then marina handoff with a Premier boat behind (schedule with next Premier delivery). · *Evidence: legacy boat-laws post (2024 operator law, no-glass, TPWD ~25% stat); Premier partner page (free marina delivery, 30–60 min pre-departure).*
+
+## Q8 — "Who plans the bachelor party — and who pays?" · 3:26–3:44
+
+**The opinion: best man plans, group splits, groom pays roughly nothing.**
+
+> "Same structure, different title: the best man runs it, everyone covers their own costs, and the group splits the groom's share of the house and the boat. The groom covers his own flight — you're covering his weekend, not his travel. And decide the budget before you pick the city, not after."
+
+*On-screen:* "Best man plans · group splits · groom rides (mostly) free." · *B-roll:* HAVE — guys-group deliveries, kegs, BBQ-adjacent shots.
+
+## Q9 — "How do you plan a bachelor party in Austin?" · 3:44–4:04
+
+**The opinion: same blueprint, swap brunch for BBQ — and pre-order the brisket like you booked the boat.**
+
+> "Friday: land, stock up, Rainey Street. Saturday: Lake Travis, then Sixth Street if you must. Sunday: barbecue and recovery. One pro move separates the men from the boys here: Franklin and the big BBQ joints need group pre-orders days ahead — treat the brisket like the boat and book it. And no, you don't need six hours on Dirty Sixth. Two is plenty."
+
+*On-screen:* Fri/Sat/Sun again + "pre-order the BBQ." · *B-roll:* HAVE — Austin nightlife exteriors. NEED — BBQ spread (or license/shoot at pickup for a group order).
+
+## Q10 — "Where should the group stay in Austin?" · 4:04–4:22
+
+**The opinion: one house, walkable or on the water — never split the group across hotels.**
+
+> "One house, always — splitting the group across hotels kills the party. Bachelorettes: East Austin or South Congress, walkable to coffee and murals. Bachelors: downtown near Rainey, or go all-in on a Lake Travis house with a dock. Budget seventy-five to one-fifty a person per night, and book it four to six months out — the good ones go first."
+
+*On-screen:* map pins: East Austin · SoCo · Downtown · Lake Travis. · *B-roll:* HAVE — Austin neighborhoods. NEED — Airbnb arrival shot (bags in, cooler delivery at the door).
+
+## CTA — 4:22–4:40 · **ALLAN ON CAMERA #3** (van door slam, hand truck with boxes)
+
+> "If your party's in Austin: we're Party On Delivery. Everything in this video — the seltzers, the bubbly, the ice, the water — delivered cold to your Airbnb or straight to the marina. The free calculator on our site does the drink math for your exact group. Link's below. Go have the weekend."
+
+*On-screen:* partyondelivery.com/austin-bachelorette-party-delivery + calculator URL. *End screen: chapters menu (each question = a card) — feeds the shorts.*
+
+---
+
+## Real-data claims — ALLAN SIGN-OFF REQUIRED before publish
+
+| # | Claim in script | Raw data behind it | Suggested safe phrasing if uncomfortable |
+|---|---|---|---|
+| APPROVE-1 | "over five hundred Austin bachelor and bachelorette parties this year" | 532 bach dashboards created Jan–Jul 2026 (57 paid orders attached — the 532 counts groups who set up a party page) | "hundreds of Austin bach parties" |
+| APPROVE-2 | "around thirty dollars a person for the whole weekend's drinks" | median group order $286; assumes ~10-person group; covers what's ordered through us | "a fraction of one bar night" |
+| APPROVE-3 | "half the groups order less than 48 hours before" | median lead time 2.0 days (avg 5.5) | "most groups order days, not weeks, ahead" |
+| APPROVE-4 | "seltzers outsell beer two to one; High Noon is our #1 bach product" | seltzer units ≈148 vs beer ≈57; High Noon Variety 12pk = top item (52 units) | keep — this one is rock solid |
+| APPROVE-5 | "free marina delivery, cooler + ice, 30–60 min before boarding" | our own Premier partner page commitments | keep — it's our published offer |
+
+## Master shot list (NEED — one shoot day + one scheduled delivery)
+
+1. **Cooler pack-out, overhead** (Q6/Q7 money shot — also the #1 short)
+2. **Marina handoff with Premier boat** behind (schedule with next Premier delivery)
+3. **Boat-deck party footage** (join a friendly group's boat day or license UGC — releases needed)
+4. Rainey Street golden hour walk-through
+5. Brunch table spread (Moonshine or Veracruz — ask permission, tag them)
+6. Airbnb arrival: bags in, delivery at the door
+7. Prop shots: chaotic group chat screen, Venmo request
+8. Allan's 3 on-camera pieces (hook / formula / CTA) — one location each, < 60 sec total
+
+Existing b-roll assumed usable: delivery vans, handoffs, warehouse, product close-ups, Austin skyline/streets/murals. **Consistency notes for editors:** champagne = 5 glasses/bottle (calculator is source of truth, not the legacy post's 6–8); boat booking = "8+ weeks, 3 months for peak Saturdays" (reconciles pillar vs boat post); don't quote legacy post prose (template-mangled) — rules only.
+
+## Shorts note
+
+Each chapter cuts standalone (question on screen → answer → one beat of proof → logo). Q6 (formula) and Q7 (no-glass cooler) are the two strongest shorts — both have data/rules nobody else states on camera. The APPROVE-4 seltzer stat is the single most shareable line in the video.

--- a/docs/seo/bach-video-script-2026-07.md
+++ b/docs/seo/bach-video-script-2026-07.md
@@ -1,6 +1,6 @@
-# Bach Video — Plain-Language Script (v1, 2026-07-10)
+# Bach Video — Plain-Language Script (v1.1, 2026-07-10 — data claims APPROVED)
 
-Companion to [bach-video-brief-2026-07.md](./bach-video-brief-2026-07.md). Format per Allan's decisions: **~90% voiceover over b-roll; Allan on camera 3 times only** (hook, one expertise moment, CTA ≈ 8% of runtime). Venues and partners named. Real order data used — every internal number is flagged **[APPROVE]** and listed in the sign-off table at the bottom.
+Companion to [bach-video-brief-2026-07.md](./bach-video-brief-2026-07.md). Format per Allan's decisions: **~90% voiceover over b-roll; Allan on camera 3 times only** (hook, one expertise moment, CTA ≈ 8% of runtime). Venues and partners named. All 5 real-data claims were approved by Allan 2026-07-10 (decisions recorded in the table at the bottom) — **this script is shoot-ready as written.**
 
 **Runtime target: ~4:15.** VO is ~640 words at a relaxed 150 wpm. Every chapter title is the search phrase — say it out loud as written (it's the keyword) and put it on screen.
 
@@ -10,7 +10,7 @@ Evidence sources: [internal-data-bach-2026-07-10.md](../../data/seo/internal-dat
 
 ## COLD OPEN — 0:00–0:12 · **ALLAN ON CAMERA** (warehouse or van, holding a cooler)
 
-> "We've stocked drinks for **over five hundred Austin bachelor and bachelorette parties this year** [APPROVE-1]. Every group asks the same ten questions. Here are the answers — in four minutes."
+> "We've stocked drinks for **over five hundred Austin bachelor and bachelorette parties**. Every group asks the same ten questions. Here are the answers — in four minutes."
 
 *On-screen:* "10 questions. 4 minutes." · *B-roll cut on "five hundred": rapid montage of delivery handoffs.*
 
@@ -36,7 +36,7 @@ Evidence sources: [internal-data-bach-2026-07-10.md](../../data/seo/internal-dat
 
 **The opinion: $700–1,000 a head done right — half of what Nashville costs — and drinks are the cheapest line item if you don't buy them at bars.**
 
-> "Nationally, people now spend about thirteen hundred dollars a head on these weekends. Austin, done right, runs seven hundred to a thousand — house, boat, food, everything. Here's the part nobody does the math on: one big bar night runs eighty to a hundred bucks a person. Groups that stock the house and the boat with us average **around thirty dollars a person for the whole weekend's drinks** [APPROVE-2]. The bar is for one night. The cooler is for the weekend."
+> "Nationally, people now spend about thirteen hundred dollars a head on these weekends. Austin, done right, runs seven hundred to a thousand — house, boat, food, everything. Here's the part nobody does the math on: one big bar night runs eighty to a hundred bucks a person. Groups that stock the house and the boat with us average **around thirty dollars a person for the whole weekend's drinks**. The bar is for one night. The cooler is for the weekend."
 
 *On-screen:* "$1,300 national avg → Austin: $700–$1,000" then "Bar night: ~$90/pp · Stocked weekend: ~$30/pp." · *B-roll:* HAVE — product/cooler shots, Rainey St night exteriors. · *Evidence: The Knot 2025 avg $1,300/pp; our pillar tiers $400–1,200; internal median group order $286.*
 
@@ -44,9 +44,9 @@ Evidence sources: [internal-data-bach-2026-07-10.md](../../data/seo/internal-dat
 
 **The opinion: 1–3 months before the wedding, spring or fall — and the boat is the thing that sells out.**
 
-> "Hold it one to three months before the wedding — close enough to feel real, far enough that nobody's stressed. In Austin, aim for March through May or September through October; nobody wants the lake in a hundred and five degrees. Book the house four months out and the boat at least eight weeks out — three months for peak Saturdays. And a confession from our own data: **half the groups that order drinks from us do it less than forty-eight hours before the party** [APPROVE-3]. Drinks, we can save same-day. The boat, nobody can."
+> "Hold it one to three months before the wedding — close enough to feel real, far enough that nobody's stressed. In Austin, aim for March through May or September through October; nobody wants the lake in a hundred and five degrees. Book the house four months out and the boat at least eight weeks out — three months for peak Saturdays. And a confession from our own data: **half the groups that order drinks from us do it less than forty-eight hours before the party**. We'll take the save — we deliver same-day — but do yourself a favor and **order a week ahead**. That's how you get exactly what you want, not what's left."
 
-*On-screen:* timeline graphic: house −4mo · boat −8wks · drinks −48h (or same-day). · *B-roll:* HAVE — vans loading, same-day delivery. NEED — busy marina Saturday wide shot.
+*On-screen:* timeline graphic: house −4mo · boat −8wks · **drinks −7 days** (same-day possible). · *B-roll:* HAVE — vans loading, same-day delivery. NEED — busy marina Saturday wide shot.
 
 ## Q5 — "What do you actually do at an Austin bachelorette party?" · 1:56–2:24
 
@@ -61,7 +61,7 @@ Evidence sources: [internal-data-bach-2026-07-10.md](../../data/seo/internal-dat
 **The opinion: two drinks per person per hour on the water. Do the multiplication, add water, stop guessing.**
 
 > **[Allan, to camera, packing a cooler]:** "This is the only formula you need: two drinks per person, per hour."
-> **[VO resumes]:** "Ten people, four hours on the boat — eighty drinks. A full weekend? Plan on roughly thirty drinks a person and adjust for your crew. What do Austin bach parties actually order? **Seltzers outsell beer two to one — High Noon is our number-one bach product, period** [APPROVE-4]. Add a bottle of bubbly for every five people for the tower, and — this is the one everyone forgets — a case of water and a bag of ice for every ten people. The hangover isn't the alcohol. It's the sun."
+> **[VO resumes]:** "Ten people, four hours on the boat — eighty drinks. A full weekend? Plan on roughly thirty drinks a person and adjust for your crew. What do Austin bach parties actually order? **Seltzers outsell beer two to one — High Noon is our number-one bach product, period**. Add a bottle of bubbly for every five people for the tower, and — this is the one everyone forgets — a case of water and a bag of ice for every ten people. The hangover isn't the alcohol. It's the sun."
 
 *On-screen:* "2 × people × hours" then "seltzers : beer = 2:1 at real bach parties." · *B-roll:* HAVE — product shots (High Noon, Surfside, Wycliff, Tito's), ice bags. NEED — cooler pack-out overhead (also the Q7 money shot). · *Evidence: drinkPlannerLogic.ts (2/person/hour, ice = 1 bag/10, multi-day = 16 drinking hours); internal top-products pull.*
 
@@ -69,7 +69,7 @@ Evidence sources: [internal-data-bach-2026-07-10.md](../../data/seo/internal-dat
 
 **The opinion: cans only. Glass doesn't get on the boat, and the captain doesn't drink — that's the law.**
 
-> "Rules first, because they're real: no glass on the boat — cans and plastic only. And since the 2024 law, the person driving the boat can't drink at all. Texas isn't kidding; alcohol shows up in about a quarter of the state's boating deaths. So the cooler looks like this: seltzers and canned cocktails, water one-for-one with the booze, ice on top. Bubbly? Get it in cans. If you booked with **Premier Party Cruises**, this gets easy — **we deliver to their marina free, cooler and ice included, thirty to sixty minutes before you board** [APPROVE-5]. You show up, it's cold, you sail."
+> "Rules first, because they're real: no glass on the boat — cans and plastic only. And since the 2024 law, the person driving the boat can't drink at all. Texas isn't kidding; alcohol shows up in about a quarter of the state's boating deaths. So the cooler looks like this: seltzers and canned cocktails, water one-for-one with the booze, ice on top. Bubbly? Get it in cans. If you booked with **Premier Party Cruises**, this gets easy — **we deliver to their marina free, cooler and ice included, thirty to sixty minutes before you board**. You show up, it's cold, you sail."
 
 *On-screen:* "NO GLASS · captain drinks nothing (2024 law)" then the cooler checklist. · *B-roll:* NEED — the money shot: overhead cooler pack-out, then marina handoff with a Premier boat behind (schedule with next Premier delivery). · *Evidence: legacy boat-laws post (2024 operator law, no-glass, TPWD ~25% stat); Premier partner page (free marina delivery, 30–60 min pre-departure).*
 
@@ -105,15 +105,15 @@ Evidence sources: [internal-data-bach-2026-07-10.md](../../data/seo/internal-dat
 
 ---
 
-## Real-data claims — ALLAN SIGN-OFF REQUIRED before publish
+## Real-data claims — APPROVED by Allan 2026-07-10 (script above reflects final wording)
 
-| # | Claim in script | Raw data behind it | Suggested safe phrasing if uncomfortable |
+| # | Final claim in script | Raw data behind it | Allan's decision |
 |---|---|---|---|
-| APPROVE-1 | "over five hundred Austin bachelor and bachelorette parties this year" | 532 bach dashboards created Jan–Jul 2026 (57 paid orders attached — the 532 counts groups who set up a party page) | "hundreds of Austin bach parties" |
-| APPROVE-2 | "around thirty dollars a person for the whole weekend's drinks" | median group order $286; assumes ~10-person group; covers what's ordered through us | "a fraction of one bar night" |
-| APPROVE-3 | "half the groups order less than 48 hours before" | median lead time 2.0 days (avg 5.5) | "most groups order days, not weeks, ahead" |
-| APPROVE-4 | "seltzers outsell beer two to one; High Noon is our #1 bach product" | seltzer units ≈148 vs beer ≈57; High Noon Variety 12pk = top item (52 units) | keep — this one is rock solid |
-| APPROVE-5 | "free marina delivery, cooler + ice, 30–60 min before boarding" | our own Premier partner page commitments | keep — it's our published offer |
+| 1 | "over five hundred Austin bachelor and bachelorette parties" (**no time qualifier**) | 532 bach dashboards created in 2026 alone; all-time total is higher, so "500+ total" is conservative | ✅ Approved as "served total, don't specify the time" |
+| 2 | "around thirty dollars a person for the whole weekend's drinks" | median group order $286; ~10-person group; covers what's ordered through us | ✅ Approved |
+| 3 | "half the groups order less than 48 hours before" **+ pivot: "order a week ahead"** | median lead time 2.0 days (avg 5.5) | ✅ Stat approved, reframed per Allan: recommend ordering **7+ days out** (same-day stays the safety net, not the pitch) |
+| 4 | "seltzers outsell beer two to one; High Noon is our #1 bach product" | seltzer units ≈148 vs beer ≈57; High Noon Variety 12pk = top item (52 units) | ✅ Approved |
+| 5 | "free marina delivery, cooler + ice, 30–60 min before boarding" | our own Premier partner page commitments | ✅ Approved |
 
 ## Master shot list (NEED — one shoot day + one scheduled delivery)
 

--- a/docs/seo/corporate-video-brief-2026-07.md
+++ b/docs/seo/corporate-video-brief-2026-07.md
@@ -1,0 +1,51 @@
+# Corporate Video Production Brief — Q&A Listicle (drafted 2026-07-14, produce FALL 2026 for holiday season)
+
+Same format as [bach-video-brief-2026-07.md](./bach-video-brief-2026-07.md). Timing: **shoot September, publish by early October** — corporate holiday-party planning search starts rising in October, venues book by early November.
+
+Evidence: `data/seo/semrush/2026-07-09/keyword-magic-corporate-event-ideas.txt`, `data/seo/semrush/2026-07-14/keyword-magic-QUESTIONS-office-party.txt` + `keyword-magic-QUESTIONS-holiday-party.txt`, `data/seo/serp-paa/2026-07-14-wedding-corporate.md`, `data/seo/internal-data-wedding-corporate-2026-07-14.md`.
+
+## Why this angle (and not the others) — from the data
+
+1. **Question-answering demand barely exists for corporate drinks** — validated twice: "corporate event drinks" is 110/mo total; office-party planning questions run ~20/mo each; the "office party" question cluster is polluted by a movie and The Office episodes. The corporate audience *browses ideas*, it doesn't ask drink questions.
+2. **The idea cluster is the prize**: "corporate event ideas" 1,900/mo KD20 (13,450/mo across 1,285 kws, CPC $3–5), with a seasonal spike cluster — corporate christmas/holiday event ideas ~230/mo — and the single best corporate question found anywhere: **"how to plan a corporate holiday party" — 70/mo at KD 0.**
+3. **Video incumbents are stale on both engines**: no video pack on either corporate Google SERP; top YouTube result for "office holiday party ideas" is 7 years old (27K views). "corporate event ideas" is the top live YouTube autocomplete.
+4. **The differentiator chapter nobody makes**: tax questions ("are office parties tax deductible", QuickBooks expense categorization, ~100/mo combined) — real planner anxiety, zero event-content competition. Pair with the COI/TABC compliance answers already on our lander.
+5. **Local color**: Reddit r/Austin's "Corporate team event that isn't lame" ranks #1 for Austin searchers — the video's hook should answer that thread by name.
+
+## The 10 questions (= chapters = shorts) — holiday-forward
+
+| # | Chapter question | Target keyword(s) + volume | Evidence | Blog/page destination |
+|---|---|---|---|---|
+| 1 | What are corporate event ideas that aren't lame? | "corporate event ideas" 1,900/mo KD20 | top YT autocomplete; Reddit r/Austin #1 locally | corporate pillar |
+| 2 | How do you plan a corporate holiday party? (the 6-step timeline) | **70/mo KD 0** + template/budget variants | PAA "How to plan a company holiday party?" | [corporate-holiday-party-ideas post](../../content/blog/posts/corporate-holiday-party-ideas-for-austin-companies.mdx) + `/corporate/holiday-party` |
+| 3 | When do you book? (the September rule) | timing advice in every SERP incumbent | SERP consensus 6–12 mo; our lander offers 72h turnaround as the safety net; internal: median order lead 7 days | `/corporate/holiday-party` |
+| 4 | What does a company holiday party cost? | budget variants ("…on a budget") | our published FAQ: $500–2,000, 50-person ≈ $800–1,200; packages $1,499–3,999 | `/corporate/holiday-party` FAQ + `/austin-corporate-event-delivery` packages |
+| 5 | Is the company party tax-deductible? | tax cluster ~100/mo (office+holiday) | **the unclaimed chapter** — employee-party 100%-deductible rule; add "ask your CPA" line | NEW short post or holiday lander FAQ addition |
+| 6 | How much alcohol for an office party? | ~0/mo on Google — but it's the conversion chapter | CalculatorLanding math: guests × hours × 0.8–1.25; wine 5/bottle, spirits 17; NA drinks = guests × 2 | `/corporate/holiday-party` (calculator embedded) |
+| 7 | What do you actually serve? (the premium-and-local truth) | — | internal (n=11, directional): corporates buy Lalo Blanco, Daou, Willamette, Austin Beerworks — "your team notices the good bottles" | `/corporate/products` (Executive Selections) |
+| 8 | Happy hours & team-building formats that work | "corporate social event ideas" 110 KD4; happy hour post exists | cocktail-kit team builds, office happy hour | [professional happy hour post](../../content/blog/posts/how-to-host-a-professional-happy-hour-for-your-austin-team.mdx) |
+| 9 | Do you need TABC, bartenders, or a COI for an office party? | compliance long tail | lander already answers: TABC #P-200084398, $1M insured, COI on request, corporate cards/ACH | `/austin-corporate-event-delivery` FAQ |
+| 10 | How do you include remote employees? | 20/mo but CPC $2.69; "virtual holiday party" ~40/mo | growing planner concern; **shipping-kits capability needs Allan confirmation before scripting** | NEW angle |
+
+Bonus short-only: **"What are the 5 C's of event planning?"** (PAA verbatim — pure snippet-bait).
+
+## Long-form spec
+
+- **Title:** Corporate Event Ideas That Aren't Lame (Holiday Party Edition)
+- **Alt:** How to Plan a Company Holiday Party People Actually Enjoy
+- **Runtime:** 3:30–4:30, VO-over-b-roll, Allan <10% (hook answering the Reddit thread, the tax-deduction moment, CTA).
+- **Hook concept:** "There's a Reddit thread called 'corporate team event that isn't lame' with 460 comments. This is the answer, in four minutes."
+- **CTA:** one invoice, delivered cold, 20–500 guests, COI available → `/austin-corporate-event-delivery` + holiday lander's quote form.
+- **Seasonality:** front-load holiday framing but keep chapters evergreen (ideas/cost/compliance chapters work year-round; re-cut a spring version by swapping the hook).
+
+## Fixes BEFORE shooting (surfaced by this research)
+
+- **Two corporate calculators disagree with each other and with the wedding engine** (wine 4 vs 5 glasses/bottle; liquor 12 vs 17 drinks). Align on one canon before the video quotes any formula — small PR.
+- **Corporate link-graph gap**: no cluster post links to `/austin-corporate-event-delivery` or `/corporate/holiday-party` (only the pillar → old `/corporate`). Fix alongside the embed PR — the video's blog destinations need the lander links anyway.
+- Confirm remote-employee kit shipping (Q10) and whether the "100% buyback on unopened bottles" claim (corporate MDX calculator) is current policy.
+
+## Embed & follow-ups
+
+- Embed on `/austin-corporate-event-delivery` (LandingPageTemplate change — sanctioned no-nav page, own PR) + `/corporate/holiday-party` + the corporate pillar post (VideoObject schema).
+- Shorts: Q5 (tax) and Q2 (6-step plan) are the flagship clips; Q1 feeds the evergreen ideas query.
+- Measurement baseline: `/corporate` old URL had 820 impressions at pos 24.9 vs canonical lander's 77 — check the 301 consolidation is finishing before attributing video effects (GSC baseline in `data/seo/gsc/2026-07-09-segments.json`).

--- a/docs/seo/wedding-video-brief-2026-07.md
+++ b/docs/seo/wedding-video-brief-2026-07.md
@@ -1,0 +1,50 @@
+# Wedding Video Production Brief — Q&A Listicle (drafted 2026-07-14, produce FALL 2026)
+
+Same format as [bach-video-brief-2026-07.md](./bach-video-brief-2026-07.md): one 3–5 min long-form, ~10 keyword-targeted questions as chapters, chopped into per-question shorts. Timing: **produce September 2026** — engagement season peaks Nov–Feb and fall wedding-planning search rises from September.
+
+Evidence: `data/seo/semrush/2026-07-09/keyword-magic-how-much-alcohol-for-wedding.txt` + `keyword-magic-wedding-bar.txt`, `data/seo/semrush/2026-07-14/keyword-magic-QUESTIONS-wedding-alcohol.txt`, `data/seo/serp-paa/2026-07-14-wedding-corporate.md`, `data/seo/internal-data-wedding-corporate-2026-07-14.md`.
+
+## Why this video wins (from the data)
+
+1. **Biggest keyword prize of all three segments**: the wedding-alcohol question cluster alone is 6,180/mo at avg KD 11, plus the open-bar-cost sub-cluster (~2,500/mo, KD 3–18) inside the 85,820/mo "wedding bar" umbrella.
+2. **YouTube competition is effectively vacant**: the top "how much alcohol for wedding" video is 5 years old with 10K views; topical shorts sit at 232–1.7K views. Live YouTube autocomplete confirms the phrasing ("how much alcohol for wedding… of 150 / of 200", "wedding bar setup" = top suggestion).
+3. **The infrastructure already exists**: `/wedding-drink-calculator` (7 FAQs + HowTo schema, our Google Ad already serving on the money query) and `/weddings` (published $13–26/pp tiers, 6 FAQs, embedded calculator), plus a 12-post wedding cluster that already links to both. The video is the missing media layer on a complete funnel.
+4. **The money moment**: venue open bars run **$25–45/pp typical ($15–90 range)** per Zola/Curated/EventWorks — our published DELUXE tier is $26/pp. "Our most expensive package costs what a venue's cheapest open bar costs" is a data-backed haymaker. A top-ranked Facebook answer already says "buy your own" — we're agreeing with the consensus, with receipts.
+5. Google has **no video pack** on the how-much SERP (AI Overview + The Knot own it) — the win is calculator-page enrichment, Videos-tab presence, and shorts on the cost queries.
+
+## The 10 questions (= chapters = shorts)
+
+| # | Chapter question | Target keyword(s) + volume | Evidence | Blog/page destination |
+|---|---|---|---|---|
+| 1 | How much alcohol do you need for a wedding? | cluster ~2,500/mo KD 3–12 ("to buy for a wedding" 390, "for wedding" 170) | live YT autocomplete; our ad serves here | `/wedding-drink-calculator` |
+| 2 | How much for 100 / 150 / 200 guests? (worked examples) | "of 100" 90 KD5 + guest-count long tail (~400/mo); PAA "150 person" | YT autocomplete "of 150"/"of 200" | calculator + `/weddings` |
+| 3 | How much does an open bar cost — and is it worth it? | "how much is an open bar at a wedding" 720 KD18 + cost cluster ~2,500/mo | PAA verbatim ("Is open bar worth it?") | NEW post or bar-service guide post |
+| 4 | Open bar vs buying your own: the real math | "price for open bar at wedding" 390 KD3; "wedding open bar math" (YT) | $25–45/pp venue vs our $13–26/pp tiers | `/weddings` packages section |
+| 5 | What's the right liquor/wine/beer split? | "wedding bar menu" 1,600 KD15 adjacent; 50/20/30-rule PAA | calculator math: 30/40/30 full bar, 55/45 beer-wine; internal: weddings are wine-first (whites + bubbly lead) | [ultimate-guide-austin-wedding-bar-service](../../content/blog/posts/ultimate-guide-austin-wedding-bar-service.mdx) |
+| 6 | Who pays for the alcohol at a wedding? | "who pays for alcohol at wedding" ~170/mo KD 14–15 | questions pull | wedding pillar |
+| 7 | How much champagne for the toast? | champagne/toast long tail | calculator: 1 serving/person, 5 servings/bottle | [signature-wedding-cocktails post](../../content/blog/posts/signature-wedding-cocktails-texas-heat.mdx) |
+| 8 | Where do you buy wedding alcohol in bulk — and what about leftovers? | "where to buy alcohol in bulk for wedding" ~330/mo KD 16–19 (transactional!) | questions pull; **buyback policy claim needs Allan confirmation** (published only on the corporate calculator today) | `/weddings` + calculator |
+| 9 | Do you need a bartender, license, or insurance to serve at your wedding? | license/insurance questions ~100/mo | `/weddings` FAQ already answers (TABC-certified partners, licensed + insured) | `/weddings` FAQ section |
+| 10 | When do you order — and how? | timing long tail | internal: median lead 10 days; recommend 2–3 weeks + calculator first | calculator |
+
+Bonus short-only: **"Do wedding venues water down alcohol?"** (20/mo, maximally spicy, shorts-native).
+
+## Long-form spec
+
+- **Title:** How Much Alcohol Do You Need for a Wedding? (100–200 Guests)
+- **Alt:** Wedding Alcohol Math: Open Bar vs Buying Your Own (Real Numbers)
+- **Runtime:** 3:30–4:30; same VO-over-b-roll format as bach (Allan <10%: hook, the open-bar-math moment, CTA).
+- **Spine:** the calculator's documented rule — `guests × (hours + 1)` drinks (≈600 drinks for 100 guests × 5 hrs), 30/40/30 split, champagne 1/person at 5/bottle. Say the formula on camera; show worked examples for 100/150/200 on screen.
+- **CTA:** the free calculator → quote → we deliver cold to the venue. Note the Lake Travis / Hill Country venue delivery answer from the `/weddings` FAQ.
+- **Internal-data claims for the fall script (Allan pre-approval, small sample n=15):** avg wedding order ~$1,000; weddings are wine-and-bubbly-first (prosecco + sauv blanc top the list); median order lead 10 days.
+
+## Consistency fixes BEFORE shooting (surfaced by this research)
+
+- **The three calculators disagree**: wedding engine says wine = 5 glasses/bottle & spirits 17 drinks; the corporate MDX calculator says wine 4 & liquor 12. Pick one canon (recommend the wedding engine's numbers, they match the bach script) and align the corporate components — separate small PR.
+- **Buyback claim** ("100% buyback on unopened bottles") appears only on the corporate MDX calculator — confirm whether it applies to weddings before the video promises it.
+
+## Embed & follow-ups
+
+- Embed on `/wedding-drink-calculator` (primary; VideoObject schema next to the existing HowTo/FAQ schema) + `/weddings`.
+- Shorts: Q3/Q4 (open-bar cost/math) are the flagship clips — the cost SERPs are where shorts surface. Bonus "watered down" short for socials.
+- Link graph is already healthy (~10 posts → calculator); no orphan fixes needed on the wedding side.

--- a/docs/seo/youtube-keyword-research-2026-07.md
+++ b/docs/seo/youtube-keyword-research-2026-07.md
@@ -1,0 +1,105 @@
+# YouTube Keyword Research — 3 Segment Videos (2026-07-09)
+
+Research for 3 YouTube videos to embed on the segment landing pages:
+bach → `/austin-bachelor-party-delivery` + `/austin-bachelorette-party-delivery`,
+wedding → `/weddings` + `/wedding-drink-calculator`,
+corporate → `/austin-corporate-event-delivery`.
+
+## Data sources (all captured 2026-07-09, raw files committed alongside this doc)
+
+| Source | What | Raw data |
+|---|---|---|
+| Google Search Console (first-party API) | Actual rankings, last 90 days (2026-04-09 → 2026-07-06), segment-filtered, positions 5–25 flagged | `data/seo/gsc/2026-07-09-segments.json` |
+| SEMrush Keyword Magic + Organic Rankings (browser session) | Volume, KD, CPC, intent for 8 seed clusters | `data/seo/semrush/2026-07-09/*.txt` |
+| YouTube autocomplete (suggest endpoint, 131 queries + live search-bar verification) | Real user phrasings on YouTube | `data/seo/youtube-autocomplete/2026-07-09.json` |
+| Live Google SERP checks (3 primary keywords) | Video-pack presence, who ranks | notes below |
+
+**Method caveats:**
+- The raw suggest endpoint is not reliably US-localized; every finalist was re-verified by typing into the real YouTube search bar (US, logged-in). Where they disagreed, the live search bar won — e.g. "how much alcohol for wedding" IS in live US autocomplete but absent from the raw endpoint.
+- Live checks ran from an Austin IP on Allan's Google account, so local suggestions ("austin bachelorette party", Reddit r/Austin ranking #1 for corporate) may be geo/personalization-boosted. That skew matches our actual customers, but don't read national intent into them.
+- **No video pack appeared on any of the 3 primary Google SERPs** (desktop, Austin). SEMrush "SF" counts include other features (AI Overview, PAA, discussions). So the Google-side win from these videos is landing-page enrichment (dwell time, content depth) and Videos-tab/thumbnail presence — not a carousel slot waiting to be taken. The YouTube-side win is search + suggested traffic on the broad phrasings.
+
+## Key GSC facts (our actual rankings, 90 days)
+
+- 106 segment queries sit in the video-moveable position 5–25 range (39 bach, 62 wedding, 5 corporate).
+- `bachelor party alcohol delivery austin` — pos 18.8, 121 impressions, 0 clicks → lands on `/` (homepage), **not** the bachelor lander.
+- `bachelorette party alcohol delivery austin` — pos 22.9, 91 impr, 0 clicks → also lands on `/`.
+- `wedding drink delivery` — pos 15.0, 96 impr → `/`.
+- `wedding bar` — pos 49.3, 88 impr → `/weddings`; `bar packages for weddings` — pos 69 → `/weddings`.
+- Corporate is thin: best is `where to get soft drinks delivered for corporate events?` pos 7.9, 49 impr.
+- Bach blog posts already win informational Austin queries (brunch pos 9–10, BBQ pos 22.7).
+
+---
+
+## Segment 1 — Bach (bachelor + bachelorette)
+
+**Verdict: viable, but NOT with the "how much alcohol" angle.** The bachelorette-alcohol cluster is ~420/mo total and skews *non-alcoholic* ("non alcoholic bachelorette party ideas" is its biggest term). The drinks/planning angle is where the volume is. On YouTube, bachelorette content is planning/vlog/ideas — "drinks" doesn't even autocomplete after "bachelorette party d" (decorations/dresses/drama do). "austin bachelorette party" is the TOP live autocomplete for "bachelorette party aust", and "yacht bachelorette party" + "bachelorette party cruise" appear — the Lake Travis boat angle has real YouTube phrasing.
+
+| Keyword | Vol/mo | KD | CPC | Video in Google SERP | In YT autocomplete | We rank | Rec |
+|---|---|---|---|---|---|---|---|
+| bachelorette party drinks | 210 | 4 | 0.32 | no pack | no (planning terms instead) | – | **primary (Google)** |
+| bachelorette party drink recipes | 140 | 6 | 0.37 | no pack | no | – | secondary |
+| bachelor party drinking games | 170 | 3 | 0.18 | not checked | yes ("bachelor party games") | – | secondary |
+| bachelor party drinks | 140 | 12 | 0.32 | not checked | no | – | secondary |
+| austin bachelorette party | ~25 impr/mo (GSC) | – | – | no pack | **yes — top suggestion** | pos 49 | **primary (YouTube)** |
+| bachelor party austin tx | low | – | – | not checked | yes — top for "bachelor party a" | pos 44.9 | secondary |
+| bachelorette party alcohol delivery austin | 10 | n/a | – | not checked | no | **pos 22.9 → wrong page (/)** | embed target |
+| bachelor party alcohol delivery austin | ~10 (121 impr GSC) | n/a | – | not checked | no | **pos 18.8 → wrong page (/)** | embed target |
+| how much alcohol to buy for bachelorette party | 20 | n/a | 0.00 | not checked | no | – | skip |
+| bachelorette party alcohol checklist (seed) | ~0 | – | – | – | no | – | skip |
+
+**One video for both bachelor + bachelorette is the right call at this volume** — bachelorette leads (higher volume + top autocomplete), bachelor gets a section + end-screen.
+
+## Segment 2 — Wedding
+
+**Verdict: the strongest segment by far — two stacked clusters, both low-KD.**
+(1) The "how much alcohol" calculator cluster: 3,580/mo total, avg KD 10, and we already own `/wedding-drink-calculator` (our Google Ad already serves on it; The Knot owns organic #1 with an AI Overview above it).
+(2) The open-bar-cost cluster inside "wedding bar" (85,820/mo umbrella): ~2,500/mo combined on cost phrasings at KD 3–18. Live YouTube autocomplete confirms both phrasings: "how much alcohol for wedding (of 150 / of 200)" and "wedding bar setup" (top suggestion) / "wedding open bar math".
+
+| Keyword | Vol/mo | KD | CPC | Video in Google SERP | In YT autocomplete | We rank | Rec |
+|---|---|---|---|---|---|---|---|
+| how much alcohol to buy for a wedding | 390 | 7 | 0.37 | no pack (AI Overview + PAA) | yes (live) | – | **primary** |
+| how much alcohol for wedding | 170 | 5 | 0.47 | no pack | yes (live, + "of 150", "of 200") | – | **primary phrasing** |
+| how much alcohol to buy for wedding | 210 | 7 | 0.60 | no pack | yes | – | primary variant |
+| how much is an open bar at a wedding | 720 | 18 | 1.42 | not checked | yes ("wedding open bar math") | – | **secondary / video #2 seed** |
+| open bar wedding cost | 590 | 10 | 1.52 | not checked | yes | – | secondary |
+| price for open bar at wedding | 390 | 3 | 1.64 | not checked | yes | – | secondary |
+| wedding bar menu | 1,600 | 15 | 1.10 | not checked | yes | – | secondary |
+| wedding bar setup (from YT) | low Google | – | – | – | **yes — top suggestion** | – | YouTube title phrasing |
+| how much alcohol for a wedding of 100 | 90 | 5 | 0.40 | not checked | yes | – | title modifier |
+| wedding alcohol calculator cluster (calculator ×16 kws) | ~200 | ~10 | – | no pack | no | our page + ad | embed target |
+| wedding drink delivery | ~30 (96 impr GSC) | – | – | not checked | no | **pos 15 → /** | embed target |
+| stock the bar party for wedding | 170 | 12 | 0.59 | not checked | no ("stock the bar party" generic) | – | skip for video |
+| byob wedding venue austin (seed) | ~0 | – | – | – | no | – | skip |
+
+## Segment 3 — Corporate
+
+**Verdict: the briefed angle ("how much alcohol for corporate event", "office party bar setup") is a dead end — say so and pivot.** "Corporate event drinks" totals 110/mo (half of it Houston venue queries); "office party" appears once at 0 volume in the entire party-alcohol-quantity cluster. The real cluster is **"corporate event ideas"**: 1,900/mo head KD20, 13,450/mo across 1,285 keywords, CPC $3–5, and it's the top live YouTube autocomplete for "corporate event id". Bonus local signal: for an Austin searcher, Google ranks Reddit r/Austin "Corporate team event that isn't lame" #1 — planners here search broad, then localize.
+
+| Keyword | Vol/mo | KD | CPC | Video in Google SERP | In YT autocomplete | We rank | Rec |
+|---|---|---|---|---|---|---|---|
+| corporate event ideas | 1,900 | 20 | 3.95 | no pack | **yes — top suggestion** | – | **primary** |
+| fun corporate event ideas | 480 | 28 | 3.88 | no pack | yes (variants) | – | secondary |
+| ideas for corporate events | 320 | 9 | 3.95 | no pack | yes | – | secondary |
+| corporate event entertainment ideas | 260 | 16 | 3.28 | not checked | yes | – | secondary |
+| corporate social event ideas | 110 | 4 | 3.78 | not checked | no | – | secondary |
+| corporate holiday event ideas | 50 | 14 | 4.60 | not checked | no | – | seasonal secondary |
+| office party ideas (from YT) | not pulled | – | – | – | yes | – | YouTube phrasing |
+| where to get soft drinks delivered for corporate events? | ~10 (49 impr GSC) | – | – | not checked | no | **pos 7.9** | leave to page |
+| how much alcohol for corporate event (seed) | ~0 | – | – | – | no | – | **skip — no demand** |
+| company party drink calculator (seed) | ~0 | – | – | – | no | – | skip |
+| corporate event bartending austin (seed) | ~0 | – | – | – | no | – | skip |
+
+---
+
+## Final picks (one per segment)
+
+| Segment | Primary Google keyword (page/embed target) | Exact YouTube title phrasing (user language) |
+|---|---|---|
+| Wedding | **how much alcohol to buy for a wedding** (390/mo KD7; cluster 3,580/mo) | **"How Much Alcohol Do You Need for a Wedding? (100–200 Guests)"** — "how much alcohol for wedding" + guest counts are verbatim live autocomplete |
+| Bach | **bachelorette party drinks** (210/mo KD4; + fix the two "…alcohol delivery austin" queries at pos 18.8/22.9 landing on `/`) | **"Austin Bachelorette Party: Drinks, Boat Day & What to Plan"** — "austin bachelorette party" is the top live autocomplete |
+| Corporate | **corporate event ideas** (1,900/mo KD20) — Austin-modified on the page | **"Corporate Event Ideas That Aren't Lame (Happy Hour Edition)"** — "corporate event ideas" is the top live autocomplete; "not lame" mirrors the Reddit thread Google ranks #1 locally |
+
+Production order by expected ROI: **wedding first** (volume + existing calculator page + existing ad), bach second (fixes two wrong-page rankings), corporate third (biggest reach but weakest purchase intent).
+
+Full strategy, briefs, and embed plan: `docs/seo/youtube-strategy-2026-07.md`.

--- a/docs/seo/youtube-strategy-2026-07.md
+++ b/docs/seo/youtube-strategy-2026-07.md
@@ -8,7 +8,7 @@ Companion to [youtube-keyword-research-2026-07.md](./youtube-keyword-research-20
 
 Each video does two jobs. **On the landing page** it deepens the page that already half-ranks for its money terms (dwell time, content depth, a second indexable asset) — note there is currently no video carousel on these SERPs to hijack, so the Google win is indirect. **On YouTube** it fishes where planners actually search, which per both this research and the 2026-06 vidIQ study means broad planning phrasings ("corporate event ideas", "austin bachelorette party"), not hyperlocal service terms. Titles use the exact live-autocomplete phrasing; the Austin/service specificity lives in the content, description, and end-screen CTA, not the title.
 
-## Video 1 — Wedding (FALL 2026)
+## Video 1 — Wedding (FALL 2026 — full brief: [wedding-video-brief-2026-07.md](./wedding-video-brief-2026-07.md), supersedes this sketch)
 
 - **Title:** How Much Alcohol Do You Need for a Wedding? (100–200 Guests)
 - **Target:** Google "how much alcohol to buy for a wedding" cluster (3,580/mo, KD~10); YouTube "how much alcohol for wedding" (live-verified autocomplete incl. "of 150" / "of 200")
@@ -36,7 +36,7 @@ Each video does two jobs. **On the landing page** it deepens the page that alrea
 - **One video covers both genders** — bachelorette carries ~3× bachelor volume; splitting halves the effort budget for the weakest marginal gain.
 - **Note:** the "how much alcohol for a bachelorette party" angle tested dead (20/mo, cluster skews non-alcoholic) — deliberately not the hook.
 
-## Video 3 — Corporate (FALL 2026 — holiday-party season timing)
+## Video 3 — Corporate (FALL 2026 — full brief: [corporate-video-brief-2026-07.md](./corporate-video-brief-2026-07.md), supersedes this sketch)
 
 - **Title:** Corporate Event Ideas That Aren't Lame (Happy Hour Edition)
 - **Target:** YouTube + Google "corporate event ideas" (1,900/mo KD20; 13,450/mo cluster; top live autocomplete). The briefed angles ("how much alcohol for corporate event", "office party bar setup", "company party drink calculator") all tested at ~0 volume — skipped per research.

--- a/docs/seo/youtube-strategy-2026-07.md
+++ b/docs/seo/youtube-strategy-2026-07.md
@@ -1,0 +1,59 @@
+# YouTube Strategy — 3 Segment Videos (draft, 2026-07-09)
+
+Companion to [youtube-keyword-research-2026-07.md](./youtube-keyword-research-2026-07.md) — read that for the data behind every keyword here.
+
+## Strategy in one paragraph
+
+Each video does two jobs. **On the landing page** it deepens the page that already half-ranks for its money terms (dwell time, content depth, a second indexable asset) — note there is currently no video carousel on these SERPs to hijack, so the Google win is indirect. **On YouTube** it fishes where planners actually search, which per both this research and the 2026-06 vidIQ study means broad planning phrasings ("corporate event ideas", "austin bachelorette party"), not hyperlocal service terms. Titles use the exact live-autocomplete phrasing; the Austin/service specificity lives in the content, description, and end-screen CTA, not the title.
+
+## Video 1 — Wedding (produce first)
+
+- **Title:** How Much Alcohol Do You Need for a Wedding? (100–200 Guests)
+- **Target:** Google "how much alcohol to buy for a wedding" cluster (3,580/mo, KD~10); YouTube "how much alcohol for wedding" (live-verified autocomplete incl. "of 150" / "of 200")
+- **Embeds on:** `/wedding-drink-calculator` (primary) and `/weddings`
+- **Outline (5–7 min):**
+  1. The rule of thumb: 1 drink/guest/hour + 15% buffer (this is what the AI Overview cites — say it better, with a real Austin wedding example)
+  2. The 50/25/25 liquor/beer/wine split, and when to flip it for Texas summer weddings
+  3. Worked examples on screen: 100 / 150 / 200 guests — exact bottle counts
+  4. What venues charge for open bar vs. buying it yourself (tease: this is Video 1b territory)
+  5. CTA: "we built a free calculator that does this for your exact guest count" → wedding-drink-calculator; end-screen to the bach video
+- **Why first:** biggest cluster, lowest effective competition (The Knot ranks with a text page; nobody owns a good video), the landing page and a live Google Ads campaign already exist — the video compounds spend already happening.
+- **Follow-up candidate (Video 1b):** "What an Open Bar Really Costs (DIY vs Venue)" — open-bar-cost sub-cluster, ~2,500/mo at KD 3–18, "wedding open bar math" is verbatim YouTube autocomplete, and it's PartyOn's exact value proposition.
+
+## Video 2 — Bach (bachelorette-led, bachelor section inside)
+
+- **Title:** Austin Bachelorette Party: Drinks, Boat Day & What to Plan
+- **Target:** YouTube "austin bachelorette party" (top live autocomplete); Google "bachelorette party drinks" (210/mo KD4) + repair-by-association for `bachelorette party alcohol delivery austin` (pos 22.9) and `bachelor party alcohol delivery austin` (pos 18.8), which today land on the homepage instead of the landers
+- **Embeds on:** `/austin-bachelorette-party-delivery` (primary) and `/austin-bachelor-party-delivery`
+- **Outline (5–7 min):**
+  1. The Austin bachelorette weekend shape: house day → Lake Travis boat day → Rainey/6th night ("yacht bachelorette party" and "bachelorette party cruise" are real YouTube phrasings — lean into boat footage)
+  2. Drinks that survive a boat: seltzers, batched cocktails, what NOT to bring (glass) — natural segue to delivery
+  3. Signature drink + supplies checklist for the house (drink recipes = the 140/mo secondary)
+  4. Bachelor version in 60 seconds: kegs, BBQ pairing, golf-cart coolers
+  5. CTA: "we deliver all of it cold to your Airbnb or the marina" → lander
+- **One video covers both genders** — bachelorette carries ~3× bachelor volume; splitting halves the effort budget for the weakest marginal gain.
+- **Note:** the "how much alcohol for a bachelorette party" angle tested dead (20/mo, cluster skews non-alcoholic) — deliberately not the hook.
+
+## Video 3 — Corporate (produce last)
+
+- **Title:** Corporate Event Ideas That Aren't Lame (Happy Hour Edition)
+- **Target:** YouTube + Google "corporate event ideas" (1,900/mo KD20; 13,450/mo cluster; top live autocomplete). The briefed angles ("how much alcohol for corporate event", "office party bar setup", "company party drink calculator") all tested at ~0 volume — skipped per research.
+- **Embeds on:** `/austin-corporate-event-delivery`
+- **Outline (5–7 min):**
+  1. Hook: the Reddit r/Austin thread "corporate team event that isn't lame" ranks #1 here — answer it
+  2. 8–10 event formats ranked by effort: office happy hour, cocktail-kit team build, casino night, boat outing…
+  3. The drinks logistics section nobody covers: quantities for 50/100 people, TABC/venue rules in Texas offices
+  4. Seasonal spin: holiday party planning timeline (corporate christmas/holiday event ideas = 190/mo combined, December spike)
+  5. CTA: happy-hour delivery + bartending → lander
+- **Positioning caveat (honest):** highest reach, weakest purchase intent, and CPC $3–5 says event *vendors* are the ones paying for this audience. Expect brand/discovery value more than direct orders; that's why it's third.
+
+## Production & measurement notes
+
+- **Channel reality check:** no posting integration exists anywhere in the stack; YouTube is embed-only today. Uploading is manual (that's fine — 3 videos).
+- **Embedding:** `src/components/YouTubeEmbed.tsx` already exists (used on partner pages). The bachelor/bachelorette/corporate landers render through `LandingPageTemplate.tsx` — the sanctioned no-nav paid landers — so adding an embed section there is a deliberate template change in its own PR, not a drive-by. `/weddings` and `/wedding-drink-calculator` are standard pages; embeds are straightforward.
+- **Schema:** add `VideoObject` JSON-LD on each embedding page (mirror the Article/FAQ JSON-LD pattern already used on blog posts).
+- **Measure (re-check ~2026-09-01, gives 6+ weeks):**
+  - GSC position deltas on each video's embed-target queries (the pos 5–25 flags in `data/seo/gsc/2026-07-09-segments.json` are the baseline)
+  - YouTube Studio: impressions + CTR on the three target phrasings
+  - GA4: engagement time on embedding pages before/after; `lead_*` key events on the landers
+- **Out of scope for this doc:** video production itself, channel setup/branding, Shorts strategy (the vault's Metricool/Reels plan covers social distribution separately).

--- a/docs/seo/youtube-strategy-2026-07.md
+++ b/docs/seo/youtube-strategy-2026-07.md
@@ -49,6 +49,14 @@ Each video does two jobs. **On the landing page** it deepens the page that alrea
   5. CTA: happy-hour delivery + bartending → lander
 - **Positioning caveat (honest):** highest reach, weakest purchase intent, and CPC $3–5 says event *vendors* are the ones paying for this audience. Expect brand/discovery value more than direct orders; that's why it's third.
 
+## Distribution & targeting (added 2026-07-14)
+
+"Targeted to Austin" means three different things — the videos are built to work at all three layers without re-cutting:
+
+1. **Organic YouTube search: no geo-targeting exists.** Titles are deliberately BROAD because hyperlocal event terms have almost no YouTube volume (2026-06 vidIQ study + 2026-07 competitive reads; the one Austin-specific bachelorette short found has 2.5K views). Austin lives *inside* each video — venue names, Lake Travis footage, description, pinned comment, end-screen CTA to the lander. Out-of-market viewers cost nothing and their watch time helps ranking. Exception that proves the rule: the bach video's YouTube target IS "austin bachelorette party" — the one local phrasing verified as a top live autocomplete.
+2. **Landing-page embeds: Austin-targeted by construction.** Viewers on `/wedding-drink-calculator`, the bach landers, and the corporate pages arrived from Austin-intent searches or Austin ad clicks — this is the conversion layer and needs no targeting work.
+3. **Paid YouTube (if/when funded): the only layer with real geo-targeting, and it's a campaign setting, not a video property.** Build as a Google Ads video campaign targeting the **Austin DMA, presence-only**, mirroring the search campaigns — and apply the standard delivery-footprint exclusions (never target Round Rock, Pflugerville, Leander, Dripping Springs, Buda, Kyle). The per-question shorts are the ad creative (15–45s, question-first hooks); no separate cut needed. Use the per-occasion `lead_*` key events as conversion goals (never "Submit lead forms" — it double-counts).
+
 ## Production & measurement notes
 
 - **Channel reality check:** no posting integration exists anywhere in the stack; YouTube is embed-only today. Uploading is manual (that's fine — 3 videos).

--- a/docs/seo/youtube-strategy-2026-07.md
+++ b/docs/seo/youtube-strategy-2026-07.md
@@ -1,12 +1,14 @@
-# YouTube Strategy — 3 Segment Videos (draft, 2026-07-09)
+# YouTube Strategy — 3 Segment Videos (updated 2026-07-10)
 
 Companion to [youtube-keyword-research-2026-07.md](./youtube-keyword-research-2026-07.md) — read that for the data behind every keyword here.
+
+> **Order changed 2026-07-10 (seasonality beats raw ROI): BACH FIRST — it's peak bach season now; wedding and corporate move to fall.** The bach video also changed format: a 3–5 min Q&A listicle (10 keyword-targeted questions as chapters) that gets chopped into per-question shorts. Full deep-dive research + shoot-ready spec: **[bach-video-brief-2026-07.md](./bach-video-brief-2026-07.md)** — it supersedes the Video 2 sketch below. Wedding and corporate briefs below remain the plan for fall.
 
 ## Strategy in one paragraph
 
 Each video does two jobs. **On the landing page** it deepens the page that already half-ranks for its money terms (dwell time, content depth, a second indexable asset) — note there is currently no video carousel on these SERPs to hijack, so the Google win is indirect. **On YouTube** it fishes where planners actually search, which per both this research and the 2026-06 vidIQ study means broad planning phrasings ("corporate event ideas", "austin bachelorette party"), not hyperlocal service terms. Titles use the exact live-autocomplete phrasing; the Austin/service specificity lives in the content, description, and end-screen CTA, not the title.
 
-## Video 1 — Wedding (produce first)
+## Video 1 — Wedding (FALL 2026)
 
 - **Title:** How Much Alcohol Do You Need for a Wedding? (100–200 Guests)
 - **Target:** Google "how much alcohol to buy for a wedding" cluster (3,580/mo, KD~10); YouTube "how much alcohol for wedding" (live-verified autocomplete incl. "of 150" / "of 200")
@@ -20,7 +22,7 @@ Each video does two jobs. **On the landing page** it deepens the page that alrea
 - **Why first:** biggest cluster, lowest effective competition (The Knot ranks with a text page; nobody owns a good video), the landing page and a live Google Ads campaign already exist — the video compounds spend already happening.
 - **Follow-up candidate (Video 1b):** "What an Open Bar Really Costs (DIY vs Venue)" — open-bar-cost sub-cluster, ~2,500/mo at KD 3–18, "wedding open bar math" is verbatim YouTube autocomplete, and it's PartyOn's exact value proposition.
 
-## Video 2 — Bach (bachelorette-led, bachelor section inside)
+## Video 2 — Bach (NOW — see [bach-video-brief-2026-07.md](./bach-video-brief-2026-07.md), which supersedes this sketch)
 
 - **Title:** Austin Bachelorette Party: Drinks, Boat Day & What to Plan
 - **Target:** YouTube "austin bachelorette party" (top live autocomplete); Google "bachelorette party drinks" (210/mo KD4) + repair-by-association for `bachelorette party alcohol delivery austin` (pos 22.9) and `bachelor party alcohol delivery austin` (pos 18.8), which today land on the homepage instead of the landers
@@ -34,7 +36,7 @@ Each video does two jobs. **On the landing page** it deepens the page that alrea
 - **One video covers both genders** — bachelorette carries ~3× bachelor volume; splitting halves the effort budget for the weakest marginal gain.
 - **Note:** the "how much alcohol for a bachelorette party" angle tested dead (20/mo, cluster skews non-alcoholic) — deliberately not the hook.
 
-## Video 3 — Corporate (produce last)
+## Video 3 — Corporate (FALL 2026 — holiday-party season timing)
 
 - **Title:** Corporate Event Ideas That Aren't Lame (Happy Hour Edition)
 - **Target:** YouTube + Google "corporate event ideas" (1,900/mo KD20; 13,450/mo cluster; top live autocomplete). The briefed angles ("how much alcohol for corporate event", "office party bar setup", "company party drink calculator") all tested at ~0 volume — skipped per research.


### PR DESCRIPTION
## What

Two commits, docs + raw research data only (no code):

1. **YouTube keyword research + 3-video strategy** — ranked keyword tables per segment (GSC first-party, SEMrush, live-verified YouTube autocomplete) + video briefs.
2. **Bach deep-dive (2026-07-10): order changed to BACH FIRST** (peak season now; wedding + corporate → fall). New shoot-ready brief: `docs/seo/bach-video-brief-2026-07.md` — a 3–5 min Q&A listicle (10 keyword-targeted questions as chapters), chopped into per-question shorts, each mapped to an existing or new blog post.

## Key findings (bach deep-dive)

- Both **"how to plan a bachelor(ette) party" SERPs have video packs held by stale content** — the bachelor pack still ranks a 2:34 video from 2014. One combined video can take both (WedEverything precedent).
- **"Who pays" / cost SERPs surface Short-video carousels** where small accounts rank — direct Google surface for the shorts strategy.
- The **Austin bachelorette AI Overview scripts a Lake Travis boat day and says "pack a cooler" — but cites no alcohol delivery service.** Question 7 targets that unclaimed slot.
- Branded city-guide videos flop on YouTube (Batch: 329 views); planning-guide content wins the "how to plan" queries.
- Biggest question clusters: who-pays (~1,200/mo bachelorette + ~2,200/mo bachelor, KD 7–20), timing (~1,600/mo). "How much alcohol for bachelorette party" is dead (20/mo) — alcohol is the conversion chapter, not the hook.
- Local competitor fly-rides.com published "bachelorette party cost in Austin" on 2026-07-03.

## Gates (after rebase on latest main)

- `npx tsc --noEmit` ✓ clean
- `npm run lint` ✓ 0 errors
- `npm run test:run` ✓ 690/690

🤖 Generated with [Claude Code](https://claude.com/claude-code)