### PR TITLE
feat(hq): Today "Shift Board" at /ops/today (phase 2)

### DIFF
--- a/src/app/api/ops/today/route.ts
+++ b/src/app/api/ops/today/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
+import { getTodayData } from '@/lib/ops/today-data';
+
+export const dynamic = 'force-dynamic';
+
+/** GET /api/ops/today — the Shift Board aggregate (KPIs, triage, runs). */
+export async function GET(): Promise<NextResponse> {
+  const auth = await requireOpsAuth();
+  if (auth instanceof NextResponse) return auth;
+
+  try {
+    const data = await getTodayData(auth.role === 'admin' ? 'admin' : 'employee');
+    return NextResponse.json({ success: true, data });
+  } catch (error) {
+    console.error('[ops/today] aggregate failed:', error);
+    return NextResponse.json(
+      { success: false, error: 'Failed to build today view' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/ops/page.tsx
+++ b/src/app/ops/page.tsx
@@ -7,7 +7,7 @@ export default function OpsPage() {
   const router = useRouter();
 
   useEffect(() => {
-    router.replace('/ops/orders');
+    router.replace('/ops/today');
   }, [router]);
 
   return null;

--- a/src/app/ops/today/page.tsx
+++ b/src/app/ops/today/page.tsx
@@ -1,64 +1,260 @@
 'use client';
 
-import { ReactElement } from 'react';
+import { ReactElement, useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
-import { HqIcon } from '@/components/backend/shell/icons';
+import KPITile from '@/components/backend/kit/KPITile';
+import TriageRow from '@/components/backend/kit/TriageRow';
+import HqBadge, { type HqBadgeVariant } from '@/components/backend/kit/Badge';
+import SkeletonCard from '@/components/backend/kit/SkeletonCard';
+import type { TodayData } from '@/lib/ops/today-data';
+
+const SEVERITY_BADGE: Record<string, HqBadgeVariant> = {
+  red: 'red',
+  amber: 'amber',
+  blue: 'blue',
+};
+
+function greeting(): string {
+  const hour = Number(
+    new Intl.DateTimeFormat('en-US', {
+      hour: 'numeric',
+      hour12: false,
+      timeZone: 'America/Chicago',
+    }).format(new Date()),
+  );
+  if (hour < 12) return 'Good morning';
+  if (hour < 17) return 'Good afternoon';
+  return 'Good evening';
+}
+
+function fmtMoney(n: number): string {
+  return `$${n.toLocaleString('en-US', { maximumFractionDigits: 0 })}`;
+}
 
 /**
- * /ops/today — the HQ home. Phase-1 stub so the Today tab has a real
- * destination; the full "Shift Board" (KPIs, triage, today's runs) ships in
- * the next phase against a new /api/today aggregate.
+ * /ops/today — the "Shift Board": what needs me in the next 5 seconds.
+ * KPI grid → quick actions → triage queue → today's runs. Data comes from
+ * one aggregate call (GET /api/ops/today) so the screen paints in a single
+ * round trip; skeletons mirror the final layout.
  */
 export default function TodayPage(): ReactElement {
-  const now = new Date();
-  const eyebrow = now
+  const [data, setData] = useState<TodayData | null>(null);
+  const [error, setError] = useState(false);
+
+  const load = useCallback((): void => {
+    fetch('/api/ops/today')
+      .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`${res.status}`))))
+      .then((body) => {
+        if (body?.success) {
+          setData(body.data);
+          setError(false);
+        } else {
+          setError(true);
+        }
+      })
+      .catch(() => setError(true));
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const eyebrow = new Date()
     .toLocaleDateString('en-US', {
       weekday: 'long',
       month: 'short',
       day: 'numeric',
       timeZone: 'America/Chicago',
     })
-    .toUpperCase();
+    .toUpperCase()
+    .replace(',', ' ·');
 
-  const links = [
-    { href: '/ops/orders', label: 'Orders', desc: "Today's deliveries, invoices, carts", icon: 'orders' as const },
-    { href: '/ops/products', label: 'Catalog', desc: 'Products, stock, collections', icon: 'catalog' as const },
-    { href: '/ops/events', label: 'Events', desc: 'Rosters and headcounts', icon: 'events' as const },
-  ];
+  const k = data?.kpis;
 
   return (
-    <div>
-      <div className="bg-navy text-white px-4 pt-2 pb-6 md:px-8">
-        <div className="max-w-5xl mx-auto">
-          <div className="font-heading font-semibold text-xs tracking-[0.18em] text-gold">
-            {eyebrow.replace(',', ' ·')}
+    <div className="min-h-screen bg-gray-50" style={{ overscrollBehaviorY: 'contain' }}>
+      {/* Navy header band */}
+      <div className="bg-navy text-white px-4 pt-2 pb-5 md:px-8">
+        <div className="max-w-5xl mx-auto flex items-end justify-between gap-3">
+          <div>
+            <div className="font-heading font-semibold text-xs tracking-[0.18em] text-gold">
+              {eyebrow}
+            </div>
+            <h1 className="font-heading font-bold text-2xl tracking-[0.08em] uppercase mt-0.5">
+              {greeting()}
+            </h1>
           </div>
-          <h1 className="font-heading font-bold text-2xl tracking-[0.08em] uppercase mt-0.5">
-            Command Center
-          </h1>
+          <button
+            type="button"
+            onClick={() => {
+              setData(null);
+              load();
+            }}
+            aria-label="Refresh"
+            className="w-10 h-10 shrink-0 rounded-lg bg-white/10 flex items-center justify-center hover:bg-white/20 transition-colors"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+            </svg>
+          </button>
         </div>
       </div>
-      <div className="px-4 py-4 md:px-8 max-w-5xl mx-auto space-y-2">
-        {links.map((l) => (
+
+      <div className="px-4 py-4 md:px-8 max-w-5xl mx-auto space-y-4">
+        {error && (
+          <div className="bg-red-50 border border-red-200 text-red-700 rounded-xl p-4 text-sm">
+            Couldn&apos;t load the board.{' '}
+            <button type="button" onClick={load} className="font-semibold underline">
+              Retry
+            </button>
+          </div>
+        )}
+
+        {/* KPI grid */}
+        {k ? (
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-2.5">
+            <KPITile
+              label="Booked today"
+              value={fmtMoney(k.revenueToday)}
+              delta={
+                k.revenueDeltaPct === null
+                  ? `${k.ordersBookedToday} order${k.ordersBookedToday === 1 ? '' : 's'}`
+                  : `${k.revenueDeltaPct >= 0 ? '▲' : '▼'} ${Math.abs(k.revenueDeltaPct).toFixed(0)}% vs last ${new Date().toLocaleDateString('en-US', { weekday: 'short', timeZone: 'America/Chicago' })}`
+              }
+              deltaTone={
+                k.revenueDeltaPct === null ? 'gray' : k.revenueDeltaPct >= 0 ? 'green' : 'red'
+              }
+            />
+            <KPITile
+              label="Deliveries"
+              value={`${k.deliveriesDone}/${k.deliveriesTotal}`}
+              delta={k.nextRunTime ? `next ${k.nextRunTime}` : k.deliveriesTotal > 0 ? 'all done' : 'none today'}
+              deltaTone={k.deliveriesTotal > 0 && k.deliveriesDone === k.deliveriesTotal ? 'green' : 'gray'}
+            />
+            <KPITile
+              label="Alerts"
+              value={String(k.alertsCount)}
+              valueTone={k.alertsCount > 0 ? 'red' : 'default'}
+              delta={k.alertsBreakdown}
+              deltaTone={k.alertsCount > 0 ? 'red' : 'green'}
+            />
+            <KPITile
+              label="Unpaid carts (30d)"
+              value={fmtMoney(k.unpaidCartTotal)}
+              delta={`${k.unpaidCartCount} open · ${k.staleCartCount} >24h`}
+              deltaTone={k.staleCartCount > 0 ? 'red' : 'gray'}
+            />
+          </div>
+        ) : (
+          !error && (
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-2.5">
+              <SkeletonCard variant="tile" />
+              <SkeletonCard variant="tile" />
+              <SkeletonCard variant="tile" />
+              <SkeletonCard variant="tile" />
+            </div>
+          )
+        )}
+
+        {/* Quick actions */}
+        <div className="grid grid-cols-3 gap-2">
           <Link
-            key={l.href}
-            href={l.href}
-            className="flex items-center gap-4 bg-white rounded-xl border border-gray-200 p-4 hover:shadow-md transition-shadow min-h-[64px]"
+            href="/ops/orders/create"
+            className="min-h-[44px] inline-flex items-center justify-center rounded-lg bg-brand-yellow text-gray-900 font-heading font-bold text-[13px] tracking-[0.08em] uppercase hover:bg-yellow-400 transition-colors"
           >
-            <span className="text-brand-blue">
-              <HqIcon name={l.icon} size={24} />
-            </span>
-            <span className="flex-1">
-              <span className="block font-heading font-bold text-lg tracking-[0.05em] uppercase text-gray-900">
-                {l.label}
-              </span>
-              <span className="block text-sm text-gray-500">{l.desc}</span>
-            </span>
+            ＋ Invoice
           </Link>
-        ))}
-        <p className="text-sm text-gray-400 pt-2">
-          The full Shift Board (KPIs, alerts, today&apos;s runs) lands here next.
-        </p>
+          <Link
+            href="/admin/customers"
+            className="min-h-[44px] inline-flex items-center justify-center rounded-lg bg-white border border-gray-200 text-gray-700 font-heading font-bold text-[13px] tracking-[0.08em] uppercase hover:bg-gray-50 transition-colors"
+          >
+            Customer
+          </Link>
+          <Link
+            href="/ops/inventory"
+            className="min-h-[44px] inline-flex items-center justify-center rounded-lg bg-white border border-gray-200 text-gray-700 font-heading font-bold text-[13px] tracking-[0.08em] uppercase hover:bg-gray-50 transition-colors"
+          >
+            Stock
+          </Link>
+        </div>
+
+        {/* Needs attention */}
+        {data ? (
+          data.triage.length > 0 && (
+            <div className="bg-white rounded-xl border border-gray-200 p-[14px]">
+              <div className="flex items-center gap-2 mb-1">
+                <svg className="w-4 h-4 text-amber-500" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126z" />
+                  <path strokeLinecap="round" d="M12 17.25h.007" />
+                </svg>
+                <h2 className="font-heading font-bold text-base tracking-[0.08em] uppercase text-gray-900">
+                  Needs attention
+                </h2>
+              </div>
+              {data.triage.map((t) => (
+                <TriageRow
+                  key={t.key}
+                  badge={<HqBadge variant={SEVERITY_BADGE[t.severity]}>{t.badge}</HqBadge>}
+                  title={t.title}
+                  actionLabel={t.actionLabel}
+                  actionHref={t.href}
+                />
+              ))}
+            </div>
+          )
+        ) : (
+          !error && <SkeletonCard rows={3} />
+        )}
+
+        {/* Today's runs */}
+        {data ? (
+          <div className="bg-white rounded-xl border border-gray-200 p-[14px]">
+            <div className="flex items-center justify-between mb-1">
+              <h2 className="font-heading font-bold text-base tracking-[0.08em] uppercase text-gray-900">
+                Today&apos;s runs
+              </h2>
+              <Link href="/ops/orders" className="text-sm font-semibold text-brand-blue">
+                All orders →
+              </Link>
+            </div>
+            {data.runs.length === 0 ? (
+              <p className="text-sm text-gray-500 py-3">No deliveries today.</p>
+            ) : (
+              data.runs.map((r, i) => (
+                <Link
+                  key={`${r.orderNumber ?? i}-${r.time}`}
+                  href={r.href}
+                  className="flex items-center gap-3 min-h-[52px] py-2 border-t border-gray-100 first:border-t-0 hover:bg-gray-50 -mx-2 px-2 rounded-lg transition-colors"
+                >
+                  <div className="w-[58px] shrink-0 font-heading font-bold text-base text-brand-blue leading-tight">
+                    {r.time || '—'}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm font-semibold text-gray-900 truncate">
+                      {r.name}
+                      {r.orderNumber !== null && (
+                        <span className="text-gray-400 font-normal"> · #{r.orderNumber}</span>
+                      )}
+                    </div>
+                    <div className="text-xs text-gray-500">{r.context}</div>
+                  </div>
+                  <div className="flex gap-1 shrink-0">
+                    {r.flags.map((f) => (
+                      <HqBadge
+                        key={f}
+                        variant={f === 'DONE' ? 'solid-green' : f === 'XL' ? 'brand' : 'blue'}
+                      >
+                        {f}
+                      </HqBadge>
+                    ))}
+                  </div>
+                </Link>
+              ))
+            )}
+          </div>
+        ) : (
+          !error && <SkeletonCard rows={4} />
+        )}
       </div>
     </div>
   );

--- a/src/components/backend/shell/useBackendAuth.ts
+++ b/src/components/backend/shell/useBackendAuth.ts
@@ -61,7 +61,7 @@ export function useBackendAuth(): BackendAuth {
   // Employees never see /admin/* (preserves the pre-shell admin layout rule)
   useEffect(() => {
     if (isAuthenticated && role === 'employee' && pathname?.startsWith('/admin')) {
-      router.replace('/ops/orders');
+      router.replace('/ops/today');
     }
   }, [isAuthenticated, role, pathname, router]);
 
@@ -86,10 +86,10 @@ export function useBackendAuth(): BackendAuth {
 
         if (data.role === 'employee') {
           if (pathname?.startsWith('/admin') || pathname === '/ops') {
-            router.push('/ops/orders');
+            router.push('/ops/today');
           }
         } else if (pathname === '/ops') {
-          router.push('/ops/orders');
+          router.push('/ops/today');
         } else if (pathname === '/admin') {
           router.push('/admin/dashboard');
         }

--- a/src/lib/ops/__tests__/today-data.test.ts
+++ b/src/lib/ops/__tests__/today-data.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for the Shift Board aggregate (getTodayData). Sources are
+ * mocked; these verify the assembly logic: run/delivery bucketing by card,
+ * triage ordering + role gating, stale-cart rules (first tab OPEN + >24h),
+ * and the last-week revenue delta.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const prismaMock = vi.hoisted(() => ({
+  $queryRaw: vi.fn(),
+  groupOrderV2: { findMany: vi.fn() },
+  order: { aggregate: vi.fn() },
+  recommendationItem: { count: vi.fn() },
+  operationsRecommendation: { count: vi.fn() },
+  financeRecommendation: { count: vi.fn() },
+}));
+
+const ordersViewMock = vi.hoisted(() => ({ getOrdersView: vi.fn() }));
+const eventsMock = vi.hoisted(() => ({ getOpsEventSummaries: vi.fn() }));
+const groupingMock = vi.hoisted(() => ({ todayCT: vi.fn() }));
+
+vi.mock('@/lib/database/client', () => ({ prisma: prismaMock }));
+vi.mock('../orders-view-data', () => ({ getOrdersView: ordersViewMock.getOrdersView }));
+vi.mock('@/lib/events/ops-summary', () => ({ getOpsEventSummaries: eventsMock.getOpsEventSummaries }));
+vi.mock('../cooler-grouping', () => ({ todayCT: groupingMock.todayCT }));
+
+import { getTodayData } from '../today-data';
+
+function makeCard(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    deliveryTime: '11:30 AM',
+    displayName: 'Sarah M',
+    total: 480,
+    totalItems: 8,
+    isCooler: true,
+    isVeryLarge: false,
+    isBoatish: false,
+    orders: [
+      { id: 'o1', orderNumber: 2481, status: 'CONFIRMED', fulfillmentStatus: 'UNFULFILLED' },
+    ],
+    ...overrides,
+  };
+}
+
+function baseView(cards: Array<Record<string, unknown>>, overdueCards: Array<Record<string, unknown>> = []): Record<string, unknown> {
+  return {
+    days: [{ date: '2026-07-09', total: 0, cards }],
+    overdue: { cards: overdueCards, total: 0 },
+    stats: { global: { todayRevenue: 1000, todayOrders: 3 } },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  groupingMock.todayCT.mockReturnValue('2026-07-09');
+  prismaMock.$queryRaw.mockResolvedValue([{ low: BigInt(0), out: BigInt(0), oversold: BigInt(0) }]);
+  prismaMock.groupOrderV2.findMany.mockResolvedValue([]);
+  prismaMock.order.aggregate.mockResolvedValue({ _sum: { total: 0 } });
+  prismaMock.recommendationItem.count.mockResolvedValue(0);
+  prismaMock.operationsRecommendation.count.mockResolvedValue(0);
+  prismaMock.financeRecommendation.count.mockResolvedValue(0);
+  eventsMock.getOpsEventSummaries.mockResolvedValue([]);
+  ordersViewMock.getOrdersView.mockResolvedValue(baseView([makeCard()]));
+});
+
+describe('getTodayData', () => {
+  it('counts deliveries by card and computes next run from first undone card', async () => {
+    ordersViewMock.getOrdersView.mockResolvedValue(
+      baseView([
+        makeCard({
+          deliveryTime: '10:00 AM',
+          orders: [{ id: 'a', orderNumber: 1, status: 'CONFIRMED', fulfillmentStatus: 'DELIVERED' }],
+        }),
+        makeCard({ deliveryTime: '2:00 PM' }),
+        makeCard({
+          deliveryTime: '4:00 PM',
+          orders: [{ id: 'c', orderNumber: 3, status: 'CANCELLED', fulfillmentStatus: 'UNFULFILLED' }],
+        }),
+      ]),
+    );
+
+    const data = await getTodayData('admin');
+    expect(data.kpis.deliveriesTotal).toBe(2); // cancelled-only card excluded
+    expect(data.kpis.deliveriesDone).toBe(1);
+    expect(data.kpis.nextRunTime).toBe('2:00 PM');
+    expect(data.runs).toHaveLength(2);
+    expect(data.runs[0].flags).toContain('DONE');
+  });
+
+  it('orders triage worst-first and gates recs to admin', async () => {
+    prismaMock.$queryRaw.mockResolvedValue([{ low: BigInt(2), out: BigInt(1), oversold: BigInt(1) }]);
+    prismaMock.recommendationItem.count.mockResolvedValue(4);
+
+    const admin = await getTodayData('admin');
+    const keys = admin.triage.map((t) => t.key);
+    expect(keys.indexOf('oversold')).toBeLessThan(keys.indexOf('out'));
+    expect(keys.indexOf('out')).toBeLessThan(keys.indexOf('low'));
+    expect(keys).toContain('recs');
+
+    const employee = await getTodayData('employee');
+    expect(employee.triage.map((t) => t.key)).not.toContain('recs');
+    expect(prismaMock.recommendationItem.count).toHaveBeenCalledTimes(1); // admin call only
+  });
+
+  it('counts only OPEN first-tab carts; stale = older than 24h', async () => {
+    const old = new Date(Date.now() - 48 * 60 * 60 * 1000);
+    const fresh = new Date(Date.now() - 1 * 60 * 60 * 1000);
+    prismaMock.groupOrderV2.findMany.mockResolvedValue([
+      // stale + open → counted + stale
+      { createdAt: old, tabs: [{ status: 'OPEN', draftItems: [{ price: 10, quantity: 2 }] }] },
+      // LOCKED first tab → excluded entirely (can't take money without reopening)
+      { createdAt: old, tabs: [{ status: 'LOCKED', draftItems: [{ price: 5, quantity: 1 }] }] },
+      // fresh + open → counted, not stale yet
+      { createdAt: fresh, tabs: [{ status: 'OPEN', draftItems: [{ price: 20, quantity: 1 }] }] },
+      // zero-value cart → ignored entirely
+      { createdAt: old, tabs: [{ status: 'OPEN', draftItems: [] }] },
+    ]);
+
+    const data = await getTodayData('admin');
+    expect(data.kpis.unpaidCartCount).toBe(2);
+    expect(data.kpis.unpaidCartTotal).toBe(40);
+    expect(data.kpis.staleCartCount).toBe(1);
+
+    // 30-day window is part of the query contract
+    const where = prismaMock.groupOrderV2.findMany.mock.calls[0][0].where;
+    expect(where.createdAt.gte).toBeInstanceOf(Date);
+  });
+
+  it('computes revenue delta vs same weekday last week', async () => {
+    prismaMock.order.aggregate.mockResolvedValue({ _sum: { total: 800 } });
+    const data = await getTodayData('admin');
+    expect(data.kpis.revenueToday).toBe(1000);
+    expect(data.kpis.revenueDeltaPct).toBeCloseTo(25);
+
+    prismaMock.order.aggregate.mockResolvedValue({ _sum: { total: 0 } });
+    const noBaseline = await getTodayData('admin');
+    expect(noBaseline.kpis.revenueDeltaPct).toBeNull();
+  });
+
+  it('flags below-minimum ticketed events', async () => {
+    eventsMock.getOpsEventSummaries.mockResolvedValue([
+      {
+        key: 'full-moon',
+        title: 'Full Moon Party',
+        status: 'upcoming',
+        detailPath: '/ops/full-moon',
+        ticketed: { ticketsSold: 3, minimum: 32, postponed: false },
+      },
+      {
+        key: 'past-event',
+        title: 'Old Party',
+        status: 'past',
+        detailPath: '/ops/rsvps',
+        ticketed: { ticketsSold: 0, minimum: 10, postponed: false },
+      },
+    ]);
+
+    const data = await getTodayData('admin');
+    const eventRows = data.triage.filter((t) => t.key.startsWith('event-'));
+    expect(eventRows).toHaveLength(1);
+    expect(eventRows[0].title).toContain('3/32');
+  });
+});

--- a/src/lib/ops/today-data.ts
+++ b/src/lib/ops/today-data.ts
@@ -1,0 +1,350 @@
+/**
+ * Aggregate builder for the HQ "Today" Shift Board (GET /api/ops/today).
+ * Composes the existing lib builders directly (no HTTP fan-out) so the screen
+ * paints in one round trip and every number matches its source-of-truth
+ * surface: orders-view (runs/deliveries/revenue), unpaid carts, stock counts,
+ * event rosters, recommendation counts.
+ */
+
+import { prisma } from '@/lib/database/client';
+import { FinancialStatus, OrderStatus, Prisma } from '@prisma/client';
+import { getOrdersView } from './orders-view-data';
+import { getOpsEventSummaries } from '@/lib/events/ops-summary';
+import { todayCT } from './cooler-grouping';
+
+const LOW_STOCK_THRESHOLD = 10; // mirrors /api/v1/inventory
+const STALE_CART_HOURS = 24;
+
+export interface TodayKpis {
+  /** Booking-dated (orders CREATED today, PAID) — mirrors orders-view stats. */
+  revenueToday: number;
+  /** % vs the same weekday last week (booking-dated). Null = no baseline. */
+  revenueDeltaPct: number | null;
+  ordersBookedToday: number;
+  deliveriesTotal: number;
+  deliveriesDone: number;
+  nextRunTime: string | null;
+  alertsCount: number;
+  alertsBreakdown: string;
+  unpaidCartTotal: number;
+  unpaidCartCount: number;
+  staleCartCount: number;
+}
+
+export interface TodayTriageItem {
+  key: string;
+  severity: 'red' | 'amber' | 'blue';
+  badge: string;
+  title: string;
+  actionLabel: string;
+  href: string;
+}
+
+export interface TodayRun {
+  time: string;
+  name: string;
+  orderNumber: number | null;
+  context: string;
+  flags: string[];
+  href: string;
+}
+
+export interface TodayData {
+  kpis: TodayKpis;
+  triage: TodayTriageItem[];
+  runs: TodayRun[];
+  generatedAt: string;
+}
+
+interface StockCounts {
+  low: number;
+  out: number;
+  oversold: number;
+}
+
+/**
+ * Low/out/oversold counts among ACTIVE, inventory-tracked variants.
+ * track_inventory=false items (evergreen cocktail kits, HEB produce) are
+ * deliberately excluded — they are always orderable by design and would be
+ * permanent false alarms here.
+ */
+async function getStockCounts(): Promise<StockCounts> {
+  const rows = await prisma.$queryRaw<
+    Array<{ low: bigint; out: bigint; oversold: bigint }>
+  >(Prisma.sql`
+    SELECT
+      COUNT(*) FILTER (
+        WHERE (pv.inventory_quantity - pv.committed_quantity) > 0
+          AND (pv.inventory_quantity - pv.committed_quantity) <= ${LOW_STOCK_THRESHOLD}
+      ) AS low,
+      COUNT(*) FILTER (
+        WHERE (pv.inventory_quantity - pv.committed_quantity) = 0
+      ) AS out,
+      COUNT(*) FILTER (
+        WHERE (pv.inventory_quantity - pv.committed_quantity) < 0
+      ) AS oversold
+    FROM product_variants pv
+    JOIN products p ON p.id = pv.product_id
+    WHERE p.status = 'ACTIVE' AND pv.track_inventory = true
+  `);
+  const r = rows[0];
+  return {
+    low: Number(r?.low ?? 0),
+    out: Number(r?.out ?? 0),
+    oversold: Number(r?.oversold ?? 0),
+  };
+}
+
+interface CartSummary {
+  unpaidTotal: number;
+  unpaidCount: number;
+  staleCount: number;
+}
+
+/**
+ * Unpaid-cart rollup, scoped to the ACTIONABLE universe: carts created in the
+ * last 30 days whose first tab is still OPEN (the real join/order gate —
+ * locked/closed dashboards can't take money without reopening, so they are
+ * neither counted nor nudge-listed). "Stale" = open longer than 24h.
+ */
+async function getUnpaidCartSummary(now: Date): Promise<CartSummary> {
+  const windowStart = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+  const carts = await prisma.groupOrderV2.findMany({
+    where: {
+      createdAt: { gte: windowStart },
+      tabs: { some: { draftItems: { some: {} } } },
+    },
+    orderBy: { createdAt: 'desc' },
+    take: 500,
+    select: {
+      createdAt: true,
+      tabs: {
+        select: {
+          status: true,
+          draftItems: { select: { price: true, quantity: true } },
+        },
+      },
+    },
+  });
+
+  let unpaidTotal = 0;
+  let unpaidCount = 0;
+  let staleCount = 0;
+  const staleCutoff = now.getTime() - STALE_CART_HOURS * 60 * 60 * 1000;
+
+  for (const cart of carts) {
+    if (cart.tabs[0]?.status !== 'OPEN') continue;
+    const cartTotal = cart.tabs.reduce(
+      (sum, tab) =>
+        sum + tab.draftItems.reduce((s, i) => s + Number(i.price) * i.quantity, 0),
+      0,
+    );
+    if (cartTotal <= 0) continue;
+    unpaidCount += 1;
+    unpaidTotal += cartTotal;
+    if (cart.createdAt.getTime() < staleCutoff) staleCount += 1;
+  }
+
+  return {
+    unpaidTotal: Math.round(unpaidTotal * 100) / 100,
+    unpaidCount,
+    staleCount,
+  };
+}
+
+/** Booking-dated PAID revenue for the same weekday last week (delta baseline). */
+async function getLastWeekSameDayRevenue(): Promise<number> {
+  const todayStart = new Date();
+  todayStart.setHours(0, 0, 0, 0);
+  const start = new Date(todayStart.getTime() - 7 * 24 * 60 * 60 * 1000);
+  const end = new Date(start.getTime() + 24 * 60 * 60 * 1000);
+  const agg = await prisma.order.aggregate({
+    where: {
+      financialStatus: FinancialStatus.PAID,
+      status: { not: OrderStatus.CANCELLED },
+      createdAt: { gte: start, lt: end },
+    },
+    _sum: { total: true },
+  });
+  return Number(agg._sum.total || 0);
+}
+
+const OPEN_REC_STATUSES = ['open', 'approved'];
+
+async function getRecsOpenCount(): Promise<number> {
+  const counts = await Promise.all([
+    prisma.recommendationItem.count({ where: { status: { in: OPEN_REC_STATUSES } } }),
+    prisma.operationsRecommendation.count({ where: { status: { in: OPEN_REC_STATUSES } } }),
+    prisma.financeRecommendation.count({ where: { status: { in: OPEN_REC_STATUSES } } }),
+  ]);
+  return counts.reduce((a, b) => a + b, 0);
+}
+
+/** Build the full Shift Board payload. `role` gates admin-only triage rows. */
+export async function getTodayData(role: 'admin' | 'employee'): Promise<TodayData> {
+  const now = new Date();
+
+  const [view, stock, carts, lastWeekRevenue, events, recsOpen] = await Promise.all([
+    getOrdersView({ days: 1 }),
+    getStockCounts(),
+    getUnpaidCartSummary(now),
+    getLastWeekSameDayRevenue(),
+    getOpsEventSummaries(),
+    role === 'admin' ? getRecsOpenCount() : Promise.resolve(0),
+  ]);
+
+  const todayKey = todayCT();
+  const todayCards = view.days.find((d) => d.date === todayKey)?.cards ?? [];
+
+  // Deliveries count RUNS (cooler cards), matching how the day is worked.
+  // A card is done when every non-cancelled order on it is delivered.
+  const activeCards = todayCards.filter((c) =>
+    c.orders.some((o) => o.status !== 'CANCELLED'),
+  );
+  const cardDone = (c: (typeof todayCards)[number]): boolean =>
+    c.orders
+      .filter((o) => o.status !== 'CANCELLED')
+      .every((o) => o.fulfillmentStatus === 'DELIVERED');
+  // Slot strings can be ranges ("10:00 AM - 10:30 AM") — show the start.
+  const slotStart = (slot: string | null | undefined): string | null =>
+    slot ? slot.split(' - ')[0].trim() : null;
+  const deliveriesTotal = activeCards.length;
+  const deliveriesDone = activeCards.filter(cardDone).length;
+  const nextRunTime = slotStart(activeCards.find((c) => !cardDone(c))?.deliveryTime);
+
+  // Events needing attention: ticketed, upcoming, under minimum
+  const eventsBelowMin = events.filter(
+    (e) =>
+      e.ticketed &&
+      !e.ticketed.postponed &&
+      (e.status === 'active' || e.status === 'upcoming' || e.status === 'today') &&
+      e.ticketed.ticketsSold < e.ticketed.minimum,
+  );
+
+  const overdueCount = view.overdue?.cards.length ?? 0;
+
+  // Triage assembly — worst first
+  const triage: TodayTriageItem[] = [];
+  if (stock.oversold > 0) {
+    triage.push({
+      key: 'oversold',
+      severity: 'red',
+      badge: 'OVERSOLD',
+      title: `${stock.oversold} variant${stock.oversold === 1 ? '' : 's'} oversold — orders waiting`,
+      actionLabel: 'Fix',
+      href: '/ops/inventory?filter=oversold',
+    });
+  }
+  if (stock.out > 0) {
+    triage.push({
+      key: 'out',
+      severity: 'red',
+      badge: 'OUT',
+      title: `${stock.out} product${stock.out === 1 ? '' : 's'} out of stock`,
+      actionLabel: 'Restock',
+      href: '/ops/inventory?filter=out_of_stock',
+    });
+  }
+  if (overdueCount > 0) {
+    triage.push({
+      key: 'overdue',
+      severity: 'red',
+      badge: 'OVERDUE',
+      title: `${overdueCount} past delivery${overdueCount === 1 ? '' : 'ies'} still unfulfilled`,
+      actionLabel: 'Review',
+      href: '/ops/orders',
+    });
+  }
+  for (const e of eventsBelowMin) {
+    triage.push({
+      key: `event-${e.key}`,
+      severity: 'amber',
+      badge: 'EVENT',
+      title: `${e.title}: ${e.ticketed!.ticketsSold}/${e.ticketed!.minimum} minimum`,
+      actionLabel: 'Roster',
+      href: e.detailPath,
+    });
+  }
+  if (carts.staleCount > 0) {
+    triage.push({
+      key: 'stale-carts',
+      severity: 'amber',
+      badge: 'CARTS',
+      title: `${carts.staleCount} unpaid cart${carts.staleCount === 1 ? '' : 's'} sitting >24h`,
+      actionLabel: 'Nudge',
+      href: '/ops/orders?view=carts',
+    });
+  }
+  if (stock.low > 0) {
+    triage.push({
+      key: 'low',
+      severity: 'amber',
+      badge: 'LOW',
+      title: `${stock.low} product${stock.low === 1 ? '' : 's'} running low`,
+      actionLabel: 'Review',
+      href: '/ops/inventory?filter=low_stock',
+    });
+  }
+  if (recsOpen > 0) {
+    triage.push({
+      key: 'recs',
+      severity: 'blue',
+      badge: 'RECS',
+      title: `${recsOpen} recommendation${recsOpen === 1 ? '' : 's'} waiting on a decision`,
+      actionLabel: 'Review',
+      href: '/admin/recommendations',
+    });
+  }
+
+  const runs: TodayRun[] = activeCards.map((c) => {
+    const firstOrder = c.orders[0];
+    const flags: string[] = [];
+    if (c.isBoatish) flags.push('BOAT');
+    if (c.isVeryLarge) flags.push('XL');
+    if (cardDone(c)) flags.push('DONE');
+    return {
+      time: slotStart(c.deliveryTime) || '',
+      name: c.displayName,
+      orderNumber: firstOrder?.orderNumber ?? null,
+      context: `${c.totalItems} item${c.totalItems === 1 ? '' : 's'} · $${c.total.toFixed(0)}${c.isCooler ? ' · cooler' : ''}`,
+      flags,
+      href: firstOrder ? `/ops/orders/${firstOrder.id}` : '/ops/orders',
+    };
+  });
+
+  const alertsCount = triage.filter((t) => t.severity !== 'blue').length;
+  const alertsBreakdown =
+    [
+      stock.out + stock.oversold > 0 ? `${stock.out + stock.oversold} stock` : null,
+      overdueCount > 0 ? `${overdueCount} overdue` : null,
+      carts.staleCount > 0 ? `${carts.staleCount} carts` : null,
+      eventsBelowMin.length > 0 ? `${eventsBelowMin.length} event` : null,
+    ]
+      .filter(Boolean)
+      .join(' · ') || 'all clear';
+
+  const revenueToday = view.stats.global.todayRevenue;
+  const revenueDeltaPct =
+    lastWeekRevenue > 0
+      ? ((revenueToday - lastWeekRevenue) / lastWeekRevenue) * 100
+      : null;
+
+  return {
+    kpis: {
+      revenueToday,
+      revenueDeltaPct,
+      ordersBookedToday: view.stats.global.todayOrders,
+      deliveriesTotal,
+      deliveriesDone,
+      nextRunTime,
+      alertsCount,
+      alertsBreakdown,
+      unpaidCartTotal: carts.unpaidTotal,
+      unpaidCartCount: carts.unpaidCount,
+      staleCartCount: carts.staleCount,
+    },
+    triage,
+    runs,
+    generatedAt: now.toISOString(),
+  };
+}


### PR DESCRIPTION
## What

Phase 2 of Party On HQ: the **Today home screen** — answers "what needs me right now" in one glance, and is now the post-login landing for both portals.

### One aggregate call
`GET /api/ops/today` (`src/lib/ops/today-data.ts`) composes lib builders directly — no HTTP fan-out:
- **Booked today** $ + % vs same weekday last week (booking-dated PAID, mirrors orders-view semantics — labeled honestly)
- **Deliveries** counted as **runs** (cooler cards), done = every non-cancelled order delivered; next undone slot surfaced
- **Stock counts** via one raw SQL over ACTIVE + `track_inventory` variants (evergreen kits/produce excluded — they'd be permanent false alarms)
- **Unpaid carts** scoped to the actionable universe: first tab OPEN (the real join/order gate per ops memory) + created in last 30 days; stale = >24h. Real-data check: 33 carts/$19.9K actionable vs 200/$66K unscoped
- **Events** below ticket minimum (Full Moon currently 3/32 → shows up correctly)
- **Recs** open count (admin only — employees never pay for those queries)

### Screen
Navy band (date eyebrow, time-of-day greeting, refresh) → 2×2 KPI grid (4-across desktop) → quick actions (＋Invoice / Customer / Stock) → **Needs attention** triage (worst-first, deep-linking actions) → **Today's runs** (start-time column, BOAT/XL/DONE flags, tap-through to order detail). Skeletons mirror final layout.

## Verified
- `tsc` 0 · lint 0 errors · full suite green (+5 today-data unit tests: card bucketing, triage ordering + role gating, stale-cart rules, revenue delta, event minimums)
- **Live read-only run against prod data**: KPIs/triage/runs all correct (first run today: 10:00 AM boat XL)
- Dev smoke: /ops/today 200; /api/ops/today returns 401 unauthenticated

🤖 Generated with [Claude Code](https://claude.com/claude-code)