### PR TITLE
feat(hq): Orders list visual pass — kit badges, TODAY marker (phase 4 PR-B) — PREVIEW GATE

### DIFF
--- a/src/components/ops/orders/BulkActionBar.tsx
+++ b/src/components/ops/orders/BulkActionBar.tsx
@@ -33,14 +33,14 @@ export default function BulkActionBar({
     <div className="fixed bottom-[var(--pod-tab-h,0px)] inset-x-0 md:left-[232px] z-40 print:hidden">
       <div className="mx-auto max-w-7xl px-3 pb-3 safe-area-bottom">
         <div className="flex items-center gap-2 rounded-xl border border-blue-200 bg-white shadow-2xl px-3 py-2">
-          <span className="text-sm font-bold text-blue-900 whitespace-nowrap">
+          <span className="font-heading text-base font-bold text-gray-900 whitespace-nowrap tabular-nums">
             {count} selected
           </span>
           <button
             type="button"
             onClick={onFulfill}
             disabled={fulfilling}
-            className="min-h-[44px] px-4 bg-gradient-to-r from-green-600 to-green-700 text-white text-sm font-semibold rounded-lg hover:from-green-700 hover:to-green-800 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 touch-manipulation"
+            className="min-h-[44px] px-4 bg-green-600 text-white font-heading text-sm font-bold tracking-[0.08em] uppercase rounded-lg hover:bg-green-700 active:bg-green-800 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 touch-manipulation"
           >
             {fulfilling ? (
               <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">

--- a/src/components/ops/orders/DaySectionHeader.tsx
+++ b/src/components/ops/orders/DaySectionHeader.tsx
@@ -64,6 +64,9 @@ export default function DaySectionHeader({
         {isOverdue ? `⚠ ${label}` : label}
       </h2>
       <div className="text-sm font-medium opacity-90 whitespace-nowrap">
+        <span className="hidden sm:inline">
+          {orderIds.length} order{orderIds.length === 1 ? '' : 's'} ·{' '}
+        </span>
         {cardCount} cooler{cardCount === 1 ? '' : 's'} · {fmtMoney(total)}
       </div>
       {onPack && (

--- a/src/components/ops/orders/OrderGroupCard.tsx
+++ b/src/components/ops/orders/OrderGroupCard.tsx
@@ -52,9 +52,9 @@ export default function OrderGroupCard({
       id={htmlId}
       data-share-code={c.shareCode || undefined}
       className={[
-        'overflow-hidden border border-gray-200 bg-white break-inside-avoid rounded-lg print:rounded-none',
+        'overflow-hidden border border-gray-200 bg-white break-inside-avoid rounded-xl print:rounded-none',
         'print:border-gray-400',
-        c.isVeryLarge ? 'border-l-4 border-l-orange-500' : '',
+        c.isVeryLarge ? 'border-l-4 border-l-brand-yellow print:border-l-orange-500' : '',
       ].join(' ')}
     >
       {/* Banner */}
@@ -69,19 +69,25 @@ export default function OrderGroupCard({
           <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-bold tracking-[0.08em] ${pill.cls}`}>
             {pill.label}
           </span>
-          <span className="text-sm md:text-base font-bold text-gray-900 leading-none">
+          <span className="font-heading text-xl md:text-2xl font-bold text-brand-blue leading-none print:text-base print:text-gray-900">
             {c.deliveryTime || 'TBD'}
           </span>
           <span className={`inline-flex items-center px-2.5 py-1 rounded text-xs font-extrabold tracking-[0.06em] uppercase leading-none ${typeTag.cls}`}>
             {typeTag.label}
           </span>
           {c.isVeryLarge && (
-            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-bold tracking-[0.08em] bg-orange-100 text-orange-800 ring-1 ring-orange-400">
-              VERY LARGE
-            </span>
+            <>
+              {/* Screen: the brand XL flag chip; print keeps the explicit wording */}
+              <span className="print:hidden inline-flex items-center px-2 py-[3px] rounded text-xs font-bold tracking-[0.05em] uppercase bg-brand-yellow text-gray-900">
+                XL
+              </span>
+              <span className="hidden print:inline-flex items-center px-2 py-0.5 rounded text-xs font-bold tracking-[0.08em] bg-orange-100 text-orange-800 ring-1 ring-orange-400">
+                VERY LARGE
+              </span>
+            </>
           )}
           {unpaidCount > 0 && (
-            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-bold tracking-[0.08em] bg-red-100 text-red-800 ring-1 ring-red-300">
+            <span className="inline-flex items-center px-2 py-[3px] rounded text-xs font-bold tracking-[0.05em] uppercase bg-red-100 text-red-800 print:ring-1 print:ring-red-300">
               {unpaidCount} UNPAID
             </span>
           )}

--- a/src/components/ops/orders/OrderSubCard.tsx
+++ b/src/components/ops/orders/OrderSubCard.tsx
@@ -3,8 +3,44 @@
 import { ReactElement, useState } from 'react';
 import Link from 'next/link';
 import OrderItemsChecklist from './OrderItemsChecklist';
-import { fmtMoney, getFulfillmentColor, getStatusColor } from './format';
+import { fmtMoney } from './format';
 import type { OrdersViewOrder } from '@/lib/ops/orders-view-data';
+
+/** Flat kit-spec badge tints (tinted = state, solid = act-now). */
+function statusTint(status: string): string {
+  switch (status) {
+    case 'CONFIRMED':
+      return 'bg-green-100 text-green-800';
+    case 'PENDING':
+      return 'bg-amber-100 text-amber-800';
+    case 'CANCELLED':
+    case 'REFUNDED':
+      return 'bg-red-100 text-red-800';
+    case 'PROCESSING':
+    case 'OUT_FOR_DELIVERY':
+      return 'bg-blue-100 text-blue-800';
+    case 'DELIVERED':
+      return 'bg-green-100 text-green-800';
+    default:
+      return 'bg-gray-100 text-gray-500';
+  }
+}
+
+function fulfillmentTint(status: string): string {
+  switch (status) {
+    case 'DELIVERED':
+      return 'bg-green-600 text-white'; // act-now solid
+    case 'UNFULFILLED':
+      return 'bg-amber-100 text-amber-800';
+    case 'IN_TRANSIT':
+    case 'OUT_FOR_DELIVERY':
+      return 'bg-blue-100 text-blue-800';
+    case 'FAILED':
+      return 'bg-red-600 text-white';
+    default:
+      return 'bg-gray-100 text-gray-500';
+  }
+}
 
 /**
  * One payer's order inside a cooler card: selection checkbox, order link,
@@ -71,21 +107,22 @@ export default function OrderSubCard({
         </span>
       </div>
 
-      {/* Badges: status / fulfillment / unpaid / review */}
+      {/* Badges: status / fulfillment / unpaid / review — kit badge spec:
+          tinted = state, solid = act-now (DELIVERED). Screen-only. */}
       <div className="mt-1 flex flex-wrap items-center gap-1 print:hidden">
-        <span className={`inline-flex px-2 py-0.5 text-xs font-semibold rounded-full ${getStatusColor(order.status)}`}>
+        <span className={`inline-flex px-2 py-[3px] text-xs font-bold tracking-[0.05em] uppercase rounded ${statusTint(order.status)}`}>
           {order.status}
         </span>
-        <span className={`inline-flex px-2 py-0.5 text-xs font-semibold rounded-full ${getFulfillmentColor(order.fulfillmentStatus)}`}>
+        <span className={`inline-flex px-2 py-[3px] text-xs font-bold tracking-[0.05em] uppercase rounded ${fulfillmentTint(order.fulfillmentStatus)}`}>
           {order.fulfillmentStatus}
         </span>
         {unpaid && (
-          <span className="inline-flex px-2 py-0.5 text-xs font-bold rounded-full bg-red-100 text-red-800 ring-1 ring-red-300">
+          <span className="inline-flex px-2 py-[3px] text-xs font-bold tracking-[0.05em] uppercase rounded bg-red-100 text-red-800">
             {order.financialStatus}
           </span>
         )}
         {order.reviewRequestSentAt && (
-          <span className="inline-flex px-2 py-0.5 text-xs font-semibold rounded-full bg-blue-50 text-blue-700 border border-blue-200">
+          <span className="inline-flex px-2 py-[3px] text-xs font-bold tracking-[0.05em] uppercase rounded bg-blue-100 text-blue-800">
             Review sent
           </span>
         )}

--- a/src/components/ops/orders/OrdersStatsStrip.tsx
+++ b/src/components/ops/orders/OrdersStatsStrip.tsx
@@ -18,27 +18,10 @@ interface Tile {
  * weekly StatsGrid.
  */
 export default function OrdersStatsStrip({ data }: { data: OrdersViewResponse }): ReactElement {
-  const g = data.stats.global;
   const r = data.stats.range;
 
-  const deltaStr =
-    g.revenueChangePct === null
-      ? '—'
-      : `${g.revenueChangePct > 0 ? '+' : ''}${g.revenueChangePct.toFixed(1)}%`;
-
-  const globalTiles: Tile[] = [
-    { label: 'Pending fulfillment', value: String(g.pendingFulfillment), accent: 'text-orange-600' },
-    { label: "Today's orders", value: String(g.todayOrders) },
-    { label: "Today's revenue", value: fmtMoney(g.todayRevenue) },
-    {
-      label: '30-day revenue',
-      value: fmtMoney(g.last30Revenue),
-      accent: 'text-brand-blue',
-      sub: g.revenueChangePct === null ? undefined : `${deltaStr} vs prior`,
-    },
-    { label: 'Total orders', value: g.total.toLocaleString() },
-  ];
-
+  // The global business tiles (today's revenue/orders, 30-day, pending)
+  // moved to the Today Shift Board — this strip is range-scoped only now.
   const rangeTiles: Tile[] = [
     { label: 'Coolers', value: String(r.coolers) },
     { label: 'Payments', value: String(r.payments) },
@@ -54,12 +37,7 @@ export default function OrdersStatsStrip({ data }: { data: OrdersViewResponse })
     },
   ];
 
-  return (
-    <div className="space-y-2">
-      <TileRow tiles={globalTiles} printHidden />
-      <TileRow tiles={rangeTiles} />
-    </div>
-  );
+  return <TileRow tiles={rangeTiles} />;
 }
 
 function TileRow({ tiles, printHidden = false }: { tiles: Tile[]; printHidden?: boolean }): ReactElement {

--- a/src/components/ops/orders/UnifiedOrdersView.tsx
+++ b/src/components/ops/orders/UnifiedOrdersView.tsx
@@ -14,6 +14,7 @@ import PickSheetPrint from './print/PickSheetPrint';
 import ReviewRequestModal from './ReviewRequestModal';
 import ShortageListModal from './ShortageListModal';
 import { buildShortageList } from './shortage';
+import { todayCT } from './client-today';
 import { EMPTY_FILTERS, useOrdersView } from './useOrdersView';
 import { cacheChecks, fetchChecks, loadCachedChecks } from './usePickChecks';
 import { deliveryTimeMinutes, fmtDateLong, formatDate, formatDateTime } from './format';
@@ -447,7 +448,7 @@ export default function UnifiedOrdersView({
         {data?.days.map((day) =>
           renderSection({
             key: day.date,
-            label: fmtDateLong(day.date),
+            label: `${day.date === todayCT() ? 'TODAY · ' : ''}${fmtDateLong(day.date)}`,
             variant: 'day',
             cards: day.cards,
             total: day.total,


### PR DESCRIPTION
## ⏸ Preview-gated — Allan approves on phone before merge

Second of the stacked Orders PRs. Restyle-in-place: **every capability kept**, colors/typography moved onto the kit language.

## What changed (screen)
- Cooler-card banner: delivery time now Barlow Condensed brand-blue; **XL** brand-yellow chip (was 'VERY LARGE' text); flat kit badges everywhere (tinted = state; solid green DELIVERED / solid red FAILED = act-now)
- Day headers: **TODAY ·** prefix on today's section + order count ('12 orders · 5 coolers · $2,340')
- Stats strip: global business tiles removed (the Today tab owns those now) — range tiles stay
- Bulk bar: flat green Barlow FULFILL

## What did NOT change (deliberate — flagged for your judgment)
- **DayTiles kept** (the mockup retired them): they're the live pack-progress overview when a day is collapsed — green-up as items get packed. The design had no replacement.
- **No collapsed cards**: your cooler cards ARE the printed weekly sheet, and pickers read item lists while pulling bottles. Collapsing them = more taps in the cooler + a forked print tree. If you want the collapsed pattern after seeing this, PR-C/D can revisit.
- **Pick checklist keeps Stock / Pack / Short-by** (mockup showed one checkbox — that's a downgrade of a tool you use).
- Print output: time/badge tweaks aside, the paper weekly sheet keeps its explicit wording ('VERY LARGE') and layout; print trees untouched.

## Check on preview
1. `/ops/orders` on your phone — badges/type feel, TODAY header, day select-all + Pack + collapse still work
2. Pick a few checklist items — state should stick (and sync across devices)
3. Desktop: Print checklist + one pick sheet — paper unchanged

## Gates
tsc 0 · lint 0 · 679/679 · smoke 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)