### PR TITLE
feat(hq): Order detail — stepper, sticky transition bar, pick checklist (phase 4 PR-C) — PREVIEW GATE

### DIFF
--- a/src/app/ops/orders/[id]/page.tsx
+++ b/src/app/ops/orders/[id]/page.tsx
@@ -2,151 +2,14 @@
 
 import { useState, useEffect, ReactElement, useCallback, useRef } from 'react';
 import Link from 'next/link';
-import { useParams, useRouter } from 'next/navigation';
-
-interface OrderItem {
-  id: string;
-  product: { id: string; title: string; handle: string };
-  variant: { id: string; title: string; sku: string } | null;
-  title: string;
-  variantTitle: string | null;
-  sku: string | null;
-  quantity: number;
-  refundedQuantity: number;
-  price: number;
-  total: number;
-  imageUrl?: string | null;
-  bundleComponents?: { title: string; variantTitle: string | null; quantity: number }[];
-}
-
-interface Amendment {
-  id: string;
-  type: string;
-  changes: {
-    added: { title: string; quantity: number; price: number }[];
-    removed: { title: string; quantity: number; price: number }[];
-    modified: { title: string; oldQuantity: number; newQuantity: number; price: number }[];
-    deliveryFeeChange: { from: number; to: number } | null;
-  };
-  previousTotal: number;
-  newTotal: number;
-  amountDelta: number;
-  resolution: string;
-  draftOrderId: string | null;
-  refundId: string | null;
-  notes: string | null;
-  processedBy: string | null;
-  createdAt: string;
-  resolvedAt: string | null;
-}
-
-interface OrderDetail {
-  id: string;
-  orderNumber: string;
-  status: string;
-  financialStatus: string;
-  fulfillmentStatus: string;
-  cruiseType: 'DISCO' | 'PRIVATE' | null;
-  cruiseBoat: string | null;
-  customer: {
-    id: string;
-    email: string;
-    name: string;
-    phone: string | null;
-  };
-  customerSnapshot: {
-    name: string | null;
-    email: string | null;
-    phone: string | null;
-  };
-  items: OrderItem[];
-  pricing: {
-    subtotal: number;
-    discountCode: string | null;
-    discountAmount: number;
-    taxAmount: number;
-    deliveryFee: number;
-    tipAmount: number;
-    total: number;
-  };
-  delivery: {
-    date: string;
-    time: string;
-    type: string;
-    address: {
-      address1: string;
-      address2: string;
-      city: string;
-      state: string;
-      zip: string;
-      country: string;
-    };
-    phone: string | null;
-    instructions: string | null;
-  };
-  payment: {
-    stripePaymentIntentId: string | null;
-    stripeCheckoutSessionId: string | null;
-    stripeChargeId: string | null;
-  };
-  shopify: {
-    orderId: string | null;
-    orderNumber: string | null;
-  };
-  groupOrder: {
-    id: string | null;
-    isGroupOrder: boolean;
-    name: string | null;
-    shareCode: string | null;
-    status: string | null;
-    siblingOrders: {
-      id: string;
-      orderNumber: string;
-      customerName: string;
-      total: number;
-      status: string;
-    }[];
-  };
-  groupOrderV2: {
-    id: string;
-    isGroupOrder: boolean;
-    name: string;
-    shareCode: string;
-    hostName: string;
-    siblingOrders: {
-      id: string;
-      orderNumber: string;
-      customerName: string;
-      total: number;
-      status: string;
-      fulfillmentStatus: string;
-    }[];
-  } | null;
-  affiliate: {
-    id: string;
-    code: string;
-    businessName: string;
-    contactName: string;
-    phone: string | null;
-  } | null;
-  amendments: Amendment[];
-  notes: {
-    customer: string | null;
-    internal: string | null;
-  };
-  createdAt: string;
-  updatedAt: string;
-  navigation: {
-    previousOrderId: string | null;
-    nextOrderId: string | null;
-  };
-  reviewRequestSentAt: string | null;
-  refunds: {
-    totalRefunded: number;
-    count: number;
-    stripeCapturedAmount: number | null;
-  };
-}
+import { useParams } from 'next/navigation';
+import DetailHeader from '@/components/ops/orders/detail/DetailHeader';
+import StatusStepperCard from '@/components/ops/orders/detail/StatusStepperCard';
+import DeliveryCard from '@/components/ops/orders/detail/DeliveryCard';
+import ItemsCard from '@/components/ops/orders/detail/ItemsCard';
+import PaymentCard from '@/components/ops/orders/detail/PaymentCard';
+import { getStatusColor, formatDateTime, SectionHeader } from '@/components/ops/orders/detail/shared';
+import type { OrderDetail } from '@/components/ops/orders/detail/types';
 
 interface EditItem {
   productId: string;
@@ -193,8 +56,6 @@ interface PreviewData {
   warnings: string[];
 }
 
-const STATUS_OPTIONS = ['PENDING', 'CONFIRMED', 'PROCESSING', 'OUT_FOR_DELIVERY', 'DELIVERED', 'CANCELLED'];
-const FULFILLMENT_OPTIONS = ['UNFULFILLED', 'PENDING', 'IN_TRANSIT', 'OUT_FOR_DELIVERY', 'DELIVERED', 'FAILED'];
 const TIME_SLOTS = [
   '10:00 AM', '10:30 AM', '11:00 AM', '11:30 AM',
   '12:00 PM', '12:30 PM', '1:00 PM', '1:30 PM',
@@ -204,66 +65,8 @@ const TIME_SLOTS = [
   '8:00 PM', '8:30 PM', '9:00 PM',
 ];
 
-function getStatusColor(status: string): string {
-  const colors: Record<string, string> = {
-    PENDING: 'bg-yellow-100 text-yellow-700 border-yellow-200',
-    CONFIRMED: 'bg-blue-100 text-blue-700 border-blue-200',
-    PROCESSING: 'bg-purple-100 text-purple-700 border-purple-200',
-    OUT_FOR_DELIVERY: 'bg-indigo-100 text-indigo-700 border-indigo-200',
-    DELIVERED: 'bg-green-100 text-green-700 border-green-200',
-    COMPLETED: 'bg-green-100 text-green-700 border-green-200',
-    CANCELLED: 'bg-red-100 text-red-700 border-red-200',
-    PAID: 'bg-green-100 text-green-700 border-green-200',
-    PARTIALLY_PAID: 'bg-yellow-100 text-yellow-700 border-yellow-200',
-    PARTIALLY_REFUNDED: 'bg-yellow-100 text-yellow-700 border-yellow-200',
-    REFUNDED: 'bg-gray-100 text-gray-700 border-gray-200',
-    FULFILLED: 'bg-green-100 text-green-700 border-green-200',
-    UNFULFILLED: 'bg-orange-100 text-orange-700 border-orange-200',
-    IN_TRANSIT: 'bg-blue-100 text-blue-700 border-blue-200',
-    PARTIAL: 'bg-yellow-100 text-yellow-700 border-yellow-200',
-    FAILED: 'bg-red-100 text-red-700 border-red-200',
-    INVOICE_SENT: 'bg-blue-100 text-blue-700 border-blue-200',
-    WAIVED: 'bg-gray-100 text-gray-700 border-gray-200',
-  };
-  return colors[status] || 'bg-gray-100 text-gray-700 border-gray-200';
-}
-
-function formatDate(dateString: string): string {
-  return new Date(dateString).toLocaleDateString('en-US', {
-    weekday: 'long',
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-    timeZone: 'UTC',
-  });
-}
-
-function formatDateTime(dateString: string): string {
-  return new Date(dateString).toLocaleString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-    timeZone: 'UTC',
-  });
-}
-
-function SectionHeader({ icon, title, action }: { icon: ReactElement; title: string; action?: ReactElement }): ReactElement {
-  return (
-    <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100 bg-gray-50">
-      <div className="flex items-center gap-3">
-        <span className="text-gray-400">{icon}</span>
-        <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
-      </div>
-      {action}
-    </div>
-  );
-}
-
 export default function OrderDetailPage(): ReactElement {
   const params = useParams();
-  const router = useRouter();
   const orderId = params?.id as string;
 
   const [order, setOrder] = useState<OrderDetail | null>(null);
@@ -879,6 +682,20 @@ export default function OrderDetailPage(): ReactElement {
     }
   }
 
+  function openRefundDialog(): void {
+    setRefundType('custom');
+    setRefundAmount(0);
+    setRefundReason('');
+    setPendingAmendmentId(null);
+    setShowRefundDialog(true);
+  }
+
+  function openReturnDialog(): void {
+    setReturnItems({});
+    setReturnReason('');
+    setShowReturnDialog(true);
+  }
+
   function handlePrint(): void {
     window.print();
   }
@@ -1034,171 +851,20 @@ export default function OrderDetailPage(): ReactElement {
       <div className={`p-4 md:p-8 bg-gray-50 min-h-screen print:hidden ${isEditing ? 'pb-48' : ''}`}>
         <div className="max-w-7xl mx-auto">
           {/* Header */}
-          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-8">
-            <div className="flex items-center gap-4">
-              <Link
-                href="/ops/orders"
-                className="p-2 text-gray-400 hover:text-gray-600 hover:bg-white rounded-lg transition-colors"
-              >
-                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-                </svg>
-              </Link>
-              <div>
-                <div className="flex items-center gap-3">
-                  <h1 className="text-3xl font-bold text-gray-900">
-                    Order #{order.orderNumber}
-                  </h1>
-                  {order.groupOrder.isGroupOrder && (
-                    <span className="px-3 py-1 text-sm font-medium bg-purple-100 text-purple-700 border border-purple-200 rounded-full">
-                      Group Order
-                    </span>
-                  )}
-                  {order.cruiseType && (
-                    <span
-                      className={`px-3 py-1 text-sm font-semibold rounded-full border ${
-                        order.cruiseType === 'DISCO'
-                          ? 'bg-orange-500 text-white border-orange-700'
-                          : 'bg-teal-600 text-white border-teal-800'
-                      }`}
-                      title={order.cruiseBoat ? `Boat: ${order.cruiseBoat}` : undefined}
-                    >
-                      {order.cruiseType === 'DISCO' ? 'Disco Cruise' : 'Private Cruise'}
-                      {order.cruiseBoat ? ` · ${order.cruiseBoat}` : ''}
-                    </span>
-                  )}
-                </div>
-                <p className="text-gray-500 mt-1">
-                  Created {formatDateTime(order.createdAt)}
-                </p>
-              </div>
-            </div>
-
-            <div className="flex items-center gap-3">
-              {/* Prev/Next Navigation */}
-              <div className="flex items-center border border-gray-200 rounded-lg overflow-hidden shadow-sm">
-                <button
-                  onClick={() => order.navigation.previousOrderId && router.push(`/ops/orders/${order.navigation.previousOrderId}`)}
-                  disabled={!order.navigation.previousOrderId}
-                  className="p-2 bg-white text-gray-700 hover:bg-gray-50 transition-colors disabled:opacity-30 disabled:cursor-not-allowed border-r border-gray-200"
-                  title="Previous order (by delivery date)"
-                >
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-                  </svg>
-                </button>
-                <button
-                  onClick={() => order.navigation.nextOrderId && router.push(`/ops/orders/${order.navigation.nextOrderId}`)}
-                  disabled={!order.navigation.nextOrderId}
-                  className="p-2 bg-white text-gray-700 hover:bg-gray-50 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
-                  title="Next order (by delivery date)"
-                >
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                  </svg>
-                </button>
-              </div>
-
-              <button
-                onClick={handleCopySummary}
-                className="px-4 py-2 bg-white border border-gray-200 text-gray-700 rounded-lg font-medium hover:bg-gray-50 transition-colors shadow-sm flex items-center gap-2"
-              >
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
-                </svg>
-                Copy Summary
-              </button>
-
-              <button
-                onClick={handlePrint}
-                className="px-4 py-2 bg-white border border-gray-200 text-gray-700 rounded-lg font-medium hover:bg-gray-50 transition-colors shadow-sm flex items-center gap-2"
-              >
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z" />
-                </svg>
-                Print
-              </button>
-
-              {order.financialStatus === 'PAID' && (
-                <button
-                  onClick={handleSendReceipt}
-                  disabled={sendingReceipt}
-                  className="px-4 py-2 bg-white border border-green-200 text-green-700 rounded-lg font-medium hover:bg-green-50 transition-colors shadow-sm flex items-center gap-2 disabled:opacity-50"
-                >
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                  </svg>
-                  {sendingReceipt ? 'Sending...' : 'Send Receipt'}
-                </button>
-              )}
-
-              {order.payment.stripePaymentIntentId && (
-                <button
-                  onClick={() => {
-                    setRefundType('custom');
-                    setRefundAmount(0);
-                    setRefundReason('');
-                    setPendingAmendmentId(null);
-                    setShowRefundDialog(true);
-                  }}
-                  className="px-4 py-2 bg-white border border-red-200 text-red-700 rounded-lg font-medium hover:bg-red-50 transition-colors shadow-sm flex items-center gap-2"
-                >
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
-                  </svg>
-                  Issue Refund
-                </button>
-              )}
-
-              {order.payment.stripePaymentIntentId && (order.status === 'DELIVERED' || order.fulfillmentStatus === 'DELIVERED') && (
-                <button
-                  onClick={() => {
-                    setReturnItems({});
-                    setReturnReason('');
-                    setShowReturnDialog(true);
-                  }}
-                  className="px-4 py-2 bg-white border border-orange-200 text-orange-700 rounded-lg font-medium hover:bg-orange-50 transition-colors shadow-sm flex items-center gap-2"
-                >
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 15v-1a4 4 0 00-4-4H8m0 0l3 3m-3-3l3-3m9 14V5a2 2 0 00-2-2H6a2 2 0 00-2 2v16l4-2 4 2 4-2 4 2z" />
-                  </svg>
-                  Process Return
-                </button>
-              )}
-
-              {canAmend && !isEditing && (
-                <>
-                  <button
-                    onClick={enterEditMode}
-                    className="px-4 py-2 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 transition-colors shadow-sm flex items-center gap-2"
-                  >
-                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                    </svg>
-                    Edit Order
-                  </button>
-                  <button
-                    onClick={openCancelDialog}
-                    className="px-4 py-2 bg-red-600 text-white rounded-lg font-medium hover:bg-red-700 transition-colors shadow-sm flex items-center gap-2"
-                  >
-                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                    Cancel Order
-                  </button>
-                </>
-              )}
-
-              {isEditing && (
-                <button
-                  onClick={cancelEditMode}
-                  className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg font-medium hover:bg-gray-200 transition-colors"
-                >
-                  Cancel
-                </button>
-              )}
-            </div>
-          </div>
+          <DetailHeader
+            order={order}
+            isEditing={isEditing}
+            canAmend={!!canAmend}
+            sendingReceipt={sendingReceipt}
+            onCopySummary={handleCopySummary}
+            onPrint={handlePrint}
+            onSendReceipt={handleSendReceipt}
+            onOpenRefund={openRefundDialog}
+            onOpenReturn={openReturnDialog}
+            onEnterEdit={enterEditMode}
+            onOpenCancel={openCancelDialog}
+            onCancelEdit={cancelEditMode}
+          />
 
           {/* Edit mode banner */}
           {isEditing && (
@@ -1213,86 +879,21 @@ export default function OrderDetailPage(): ReactElement {
           )}
 
           {/* Status Cards */}
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
-            <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-5">
-              <label className="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-3">
-                Order Status
-              </label>
-              <select
-                value={order.status}
-                onChange={(e) => updateOrder({ status: e.target.value })}
-                disabled={saving}
-                className={`w-full px-4 py-2.5 rounded-lg border-2 ${getStatusColor(order.status)} font-semibold focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer`}
-              >
-                {STATUS_OPTIONS.map((s) => (
-                  <option key={s} value={s}>{s}</option>
-                ))}
-              </select>
-            </div>
-
-            <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-5">
-              <label className="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-3">
-                Payment Status
-              </label>
-              <div className={`px-4 py-2.5 rounded-lg border-2 ${getStatusColor(order.financialStatus)} font-semibold text-center`}>
-                {order.financialStatus}
-              </div>
-            </div>
-
-            <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-5">
-              <label className="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-3">
-                Fulfillment
-              </label>
-              <select
-                value={order.fulfillmentStatus}
-                onChange={(e) => updateOrder({ fulfillmentStatus: e.target.value })}
-                disabled={saving}
-                className={`w-full px-4 py-2.5 rounded-lg border-2 ${getStatusColor(order.fulfillmentStatus)} font-semibold focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer`}
-              >
-                {FULFILLMENT_OPTIONS.map((s) => (
-                  <option key={s} value={s}>{s}</option>
-                ))}
-              </select>
-
-              {/* Review request prompt */}
-              {showReviewPrompt && !order.reviewRequestSentAt && (
-                <div className="mt-3 p-3 bg-blue-50 border border-blue-200 rounded-lg">
-                  <p className="text-sm font-medium text-blue-900 mb-2">
-                    Send review request to {order.customerSnapshot.name || order.customer.name}?
-                  </p>
-                  {(order.customerSnapshot.phone || order.customer.phone || order.delivery.phone) ? (
-                    <div className="flex gap-2">
-                      <button
-                        onClick={handleSendReview}
-                        disabled={sendingReview}
-                        className="px-3 py-1.5 text-xs font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
-                      >
-                        {sendingReview ? 'Sending...' : 'Send'}
-                      </button>
-                      <button
-                        onClick={() => setShowReviewPrompt(false)}
-                        className="px-3 py-1.5 text-xs font-medium text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors"
-                      >
-                        Skip
-                      </button>
-                    </div>
-                  ) : (
-                    <p className="text-xs text-blue-700">No phone number available</p>
-                  )}
-                </div>
-              )}
-              {order.reviewRequestSentAt && (
-                <p className="mt-2 text-xs text-gray-500">
-                  Review request sent {new Date(order.reviewRequestSentAt).toLocaleDateString()}
-                </p>
-              )}
-            </div>
-          </div>
+          <StatusStepperCard
+            order={order}
+            saving={saving}
+            showReviewPrompt={showReviewPrompt}
+            sendingReview={sendingReview}
+            onUpdateOrder={updateOrder}
+            onSendReview={handleSendReview}
+            onDismissReview={() => setShowReviewPrompt(false)}
+          />
 
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
             {/* Left Column - Order Details */}
             <div className="lg:col-span-2 space-y-6">
               {/* Delivery Details */}
+              {isEditing ? (
               <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
                 <SectionHeader
                   icon={
@@ -1304,8 +905,6 @@ export default function OrderDetailPage(): ReactElement {
                   title="Delivery Details"
                 />
                 <div className="p-6">
-                  {isEditing ? (
-                    <>
                       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
                         <div>
                           <label className="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Delivery Date</label>
@@ -1399,56 +998,14 @@ export default function OrderDetailPage(): ReactElement {
                           />
                         </div>
                       </div>
-                    </>
-                  ) : (
-                    <>
-                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-6">
-                        <div className="bg-blue-50 rounded-lg p-4 border border-blue-100">
-                          <p className="text-xs font-medium text-blue-600 uppercase tracking-wider mb-1">Delivery Date</p>
-                          <p className="font-bold text-gray-900 text-lg">{formatDate(order.delivery.date)}</p>
-                        </div>
-                        <div className="bg-blue-50 rounded-lg p-4 border border-blue-100">
-                          <p className="text-xs font-medium text-blue-600 uppercase tracking-wider mb-1">Time Window</p>
-                          <p className="font-bold text-gray-900 text-lg">{order.delivery.time}</p>
-                        </div>
-                      </div>
-                      <div className="space-y-4">
-                        <div>
-                          <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Delivery Address</p>
-                          <p className="font-medium text-gray-900">
-                            {order.delivery.address.address1}
-                            {order.delivery.address.address2 && `, ${order.delivery.address.address2}`}
-                          </p>
-                          <p className="text-gray-600">
-                            {order.delivery.address.city}, {order.delivery.address.state} {order.delivery.address.zip}
-                          </p>
-                        </div>
-                        {order.delivery.phone && (
-                          <div>
-                            <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Delivery Phone</p>
-                            <a href={`tel:${order.delivery.phone}`} className="text-blue-600 hover:underline font-medium">
-                              {order.delivery.phone}
-                            </a>
-                          </div>
-                        )}
-                        {order.delivery.instructions && (
-                          <div>
-                            <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Delivery Instructions</p>
-                            <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 text-gray-800">
-                              <svg className="w-5 h-5 text-yellow-500 inline mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                              </svg>
-                              {order.delivery.instructions}
-                            </div>
-                          </div>
-                        )}
-                      </div>
-                    </>
-                  )}
                 </div>
               </div>
+              ) : (
+                <DeliveryCard order={order} />
+              )}
 
               {/* Order Items */}
+              {isEditing ? (
               <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
                 <SectionHeader
                   icon={
@@ -1459,8 +1016,7 @@ export default function OrderDetailPage(): ReactElement {
                   title="Order Items"
                 />
 
-                {/* Product search (edit mode only) */}
-                {isEditing && (
+                {/* Product search */}
                   <div className="px-6 py-4 border-b border-gray-100 bg-blue-50" ref={searchRef}>
                     <div className="relative">
                       <input
@@ -1505,12 +1061,9 @@ export default function OrderDetailPage(): ReactElement {
                       )}
                     </div>
                   </div>
-                )}
 
                 <div className="divide-y divide-gray-100">
-                  {isEditing ? (
-                    // Edit mode items
-                    editItems.map((item) => (
+                  {editItems.map((item) => (
                       <div
                         key={`${item.productId}-${item.variantId}`}
                         className={`px-6 py-4 flex items-center justify-between ${item.isNew ? 'bg-green-50' : ''}`}
@@ -1557,43 +1110,7 @@ export default function OrderDetailPage(): ReactElement {
                           </button>
                         </div>
                       </div>
-                    ))
-                  ) : (
-                    // Read-only items
-                    order.items.map((item) => (
-                      <div key={item.id} className="px-6 py-4 flex items-center justify-between hover:bg-gray-50 transition-colors">
-                        <div className="flex items-center gap-3 flex-1">
-                          {item.imageUrl ? (
-                            <img src={item.imageUrl} alt="" className="w-10 h-10 rounded-lg object-cover border border-gray-100 flex-shrink-0" />
-                          ) : (
-                            <div className="w-10 h-10 rounded-lg bg-gray-100 flex-shrink-0" />
-                          )}
-                          <div>
-                          <p className="font-semibold text-gray-900">{item.title}</p>
-                          {item.variantTitle && item.variantTitle !== 'Default Title' && (
-                            <p className="text-sm text-gray-500">{item.variantTitle}</p>
-                          )}
-                          {item.sku && (
-                            <p className="text-xs text-gray-400 font-mono">SKU: {item.sku}</p>
-                          )}
-                          {item.refundedQuantity > 0 && (
-                            <span className="inline-flex items-center px-2 py-0.5 mt-1 text-xs font-medium bg-orange-100 text-orange-700 border border-orange-200 rounded-full">
-                              {item.refundedQuantity} returned
-                            </span>
-                          )}
-                          </div>
-                        </div>
-                        <div className="text-right">
-                          <p className="font-semibold text-gray-900">
-                            {item.quantity} x ${item.price.toFixed(2)}
-                          </p>
-                          <p className="text-sm text-gray-500">
-                            ${item.total.toFixed(2)}
-                          </p>
-                        </div>
-                      </div>
-                    ))
-                  )}
+                    ))}
                 </div>
 
                 {/* Pricing Summary */}
@@ -1616,24 +1133,20 @@ export default function OrderDetailPage(): ReactElement {
                   )}
                   <div className="flex justify-between text-sm">
                     <span className="text-gray-600">Delivery Fee</span>
-                    {isEditing ? (
-                      <div className="flex items-center gap-2">
-                        <span className="text-gray-400">$</span>
-                        <input
-                          type="number"
-                          value={editDeliveryFee}
-                          onChange={(e) => {
-                            setEditDeliveryFee(parseFloat(e.target.value) || 0);
-                            setPreview(null);
-                          }}
-                          step="0.01"
-                          min="0"
-                          className="w-20 px-2 py-1 border border-gray-300 rounded text-right focus:outline-none focus:ring-2 focus:ring-blue-500"
-                        />
-                      </div>
-                    ) : (
-                      <span className="text-gray-900 font-medium">${order.pricing.deliveryFee.toFixed(2)}</span>
-                    )}
+                    <div className="flex items-center gap-2">
+                      <span className="text-gray-400">$</span>
+                      <input
+                        type="number"
+                        value={editDeliveryFee}
+                        onChange={(e) => {
+                          setEditDeliveryFee(parseFloat(e.target.value) || 0);
+                          setPreview(null);
+                        }}
+                        step="0.01"
+                        min="0"
+                        className="w-20 px-2 py-1 border border-gray-300 rounded text-right focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      />
+                    </div>
                   </div>
                   <div className="flex justify-between text-sm">
                     <span className="text-gray-600">Tax (8.25%)</span>
@@ -1651,6 +1164,9 @@ export default function OrderDetailPage(): ReactElement {
                   </div>
                 </div>
               </div>
+              ) : (
+                <ItemsCard order={order} />
+              )}
 
               {/* Amendment History */}
               {order.amendments && order.amendments.length > 0 && (
@@ -1965,40 +1481,7 @@ export default function OrderDetailPage(): ReactElement {
               )}
 
               {/* Payment Info */}
-              <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
-                <SectionHeader
-                  icon={
-                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
-                    </svg>
-                  }
-                  title="Payment"
-                />
-                <div className="p-6 space-y-4">
-                  <div>
-                    <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">Status</p>
-                    <span className={`inline-flex px-3 py-1.5 rounded-lg border text-sm font-semibold ${getStatusColor(order.financialStatus)}`}>
-                      {order.financialStatus}
-                    </span>
-                  </div>
-                  {order.payment.stripePaymentIntentId && (
-                    <div>
-                      <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Stripe Payment ID</p>
-                      <p className="text-xs font-mono text-gray-600 bg-gray-50 p-2 rounded break-all">
-                        {order.payment.stripePaymentIntentId}
-                      </p>
-                    </div>
-                  )}
-                  {order.shopify.orderId && (
-                    <div>
-                      <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Shopify Order</p>
-                      <p className="text-sm text-gray-600">
-                        #{order.shopify.orderNumber}
-                      </p>
-                    </div>
-                  )}
-                </div>
-              </div>
+              <PaymentCard order={order} />
 
               {/* Affiliate Attribution */}
               <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">

--- a/src/app/ops/orders/[id]/page.tsx
+++ b/src/app/ops/orders/[id]/page.tsx
@@ -8,6 +8,7 @@ import StatusStepperCard from '@/components/ops/orders/detail/StatusStepperCard'
 import DeliveryCard from '@/components/ops/orders/detail/DeliveryCard';
 import ItemsCard from '@/components/ops/orders/detail/ItemsCard';
 import PaymentCard from '@/components/ops/orders/detail/PaymentCard';
+import DetailStickyBar, { nextTransition } from '@/components/ops/orders/detail/DetailStickyBar';
 import { getStatusColor, formatDateTime, SectionHeader } from '@/components/ops/orders/detail/shared';
 import type { OrderDetail } from '@/components/ops/orders/detail/types';
 
@@ -580,6 +581,18 @@ export default function OrderDetailPage(): ReactElement {
 
   async function updateOrder(updates: Record<string, unknown>): Promise<void> {
     if (!order) return;
+    const prev = order;
+
+    // Optimistic: reflect status changes instantly (stepper/sticky bar), then
+    // reconcile with the server; roll back + refetch if the write fails.
+    const optimistic: Partial<OrderDetail> = {};
+    if (typeof updates.status === 'string') optimistic.status = updates.status;
+    if (typeof updates.fulfillmentStatus === 'string') {
+      optimistic.fulfillmentStatus = updates.fulfillmentStatus;
+      // Mirrors the API: DELIVERED fulfillment auto-sets order status
+      if (updates.fulfillmentStatus === 'DELIVERED') optimistic.status = 'DELIVERED';
+    }
+    if (Object.keys(optimistic).length > 0) setOrder({ ...prev, ...optimistic });
     setSaving(true);
 
     try {
@@ -594,13 +607,17 @@ export default function OrderDetailPage(): ReactElement {
       if (data.success) {
         await fetchOrder();
         // Show review prompt when fulfillment changes to DELIVERED
-        if (updates.fulfillmentStatus === 'DELIVERED' && !order.reviewRequestSentAt) {
+        if (updates.fulfillmentStatus === 'DELIVERED' && !prev.reviewRequestSentAt) {
           setShowReviewPrompt(true);
         }
       } else {
+        setOrder(prev);
+        await fetchOrder();
         alert('Failed to update order: ' + data.error);
       }
     } catch {
+      setOrder(prev);
+      await fetchOrder();
       alert('Failed to update order');
     } finally {
       setSaving(false);
@@ -840,6 +857,8 @@ export default function OrderDetailPage(): ReactElement {
     );
   }
 
+  const showStickyBar = !isEditing && nextTransition(order) !== null;
+
   return (
     <>
       {toast && (
@@ -848,7 +867,7 @@ export default function OrderDetailPage(): ReactElement {
         </div>
       )}
       {/* Screen View */}
-      <div className={`p-4 md:p-8 bg-gray-50 min-h-screen print:hidden ${isEditing ? 'pb-48' : ''}`}>
+      <div className={`p-4 md:p-8 bg-gray-50 min-h-screen print:hidden ${isEditing ? 'pb-48' : showStickyBar ? 'pb-28' : ''}`}>
         <div className="max-w-7xl mx-auto">
           {/* Header */}
           <DetailHeader
@@ -1566,6 +1585,9 @@ export default function OrderDetailPage(): ReactElement {
           </div>
         </div>
       </div>
+
+      {/* Sticky next-transition bar (MARK PACKED → MARK OUT → MARK DELIVERED) */}
+      {showStickyBar && <DetailStickyBar order={order} saving={saving} onAdvance={updateOrder} />}
 
       {/* Edit Bar (sticky bottom in edit mode) */}
       {isEditing && (

--- a/src/components/ops/orders/detail/DeliveryCard.tsx
+++ b/src/components/ops/orders/detail/DeliveryCard.tsx
@@ -1,0 +1,66 @@
+import { ReactElement } from 'react';
+import { formatDate, SectionHeader } from './shared';
+import type { OrderDetail } from './types';
+
+/**
+ * Read-only delivery details card: date/time, address, phone, instructions.
+ * The edit-mode delivery form stays in the page (edit mode is page-owned).
+ */
+export default function DeliveryCard({ order }: { order: OrderDetail }): ReactElement {
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+      <SectionHeader
+        icon={
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+        }
+        title="Delivery Details"
+      />
+      <div className="p-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-6">
+          <div className="bg-blue-50 rounded-lg p-4 border border-blue-100">
+            <p className="text-xs font-medium text-blue-600 uppercase tracking-wider mb-1">Delivery Date</p>
+            <p className="font-bold text-gray-900 text-lg">{formatDate(order.delivery.date)}</p>
+          </div>
+          <div className="bg-blue-50 rounded-lg p-4 border border-blue-100">
+            <p className="text-xs font-medium text-blue-600 uppercase tracking-wider mb-1">Time Window</p>
+            <p className="font-bold text-gray-900 text-lg">{order.delivery.time}</p>
+          </div>
+        </div>
+        <div className="space-y-4">
+          <div>
+            <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Delivery Address</p>
+            <p className="font-medium text-gray-900">
+              {order.delivery.address.address1}
+              {order.delivery.address.address2 && `, ${order.delivery.address.address2}`}
+            </p>
+            <p className="text-gray-600">
+              {order.delivery.address.city}, {order.delivery.address.state} {order.delivery.address.zip}
+            </p>
+          </div>
+          {order.delivery.phone && (
+            <div>
+              <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Delivery Phone</p>
+              <a href={`tel:${order.delivery.phone}`} className="text-blue-600 hover:underline font-medium">
+                {order.delivery.phone}
+              </a>
+            </div>
+          )}
+          {order.delivery.instructions && (
+            <div>
+              <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Delivery Instructions</p>
+              <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 text-gray-800">
+                <svg className="w-5 h-5 text-yellow-500 inline mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                {order.delivery.instructions}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ops/orders/detail/DeliveryCard.tsx
+++ b/src/components/ops/orders/detail/DeliveryCard.tsx
@@ -1,64 +1,109 @@
 import { ReactElement } from 'react';
-import { formatDate, SectionHeader } from './shared';
+import { formatDate } from './shared';
 import type { OrderDetail } from './types';
 
 /**
- * Read-only delivery details card: date/time, address, phone, instructions.
- * The edit-mode delivery form stays in the page (edit mode is page-owned).
+ * Read-only delivery details card: date/time tiles, address, instructions,
+ * and Call / Text / Map contact actions (tel:, sms:, Google Maps deep link).
+ * The edit-mode delivery form stays in the page.
  */
 export default function DeliveryCard({ order }: { order: OrderDetail }): ReactElement {
+  const phone = order.delivery.phone || order.customer.phone || order.customerSnapshot.phone;
+  const addr = order.delivery.address;
+  const mapsQuery = encodeURIComponent(
+    [addr.address1, addr.address2, addr.city, addr.state, addr.zip].filter(Boolean).join(', '),
+  );
+
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
-      <SectionHeader
-        icon={
-          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
-          </svg>
-        }
-        title="Delivery Details"
-      />
-      <div className="p-6">
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-6">
-          <div className="bg-blue-50 rounded-lg p-4 border border-blue-100">
-            <p className="text-xs font-medium text-blue-600 uppercase tracking-wider mb-1">Delivery Date</p>
-            <p className="font-bold text-gray-900 text-lg">{formatDate(order.delivery.date)}</p>
+    <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+      <div className="px-4 sm:px-6 py-3.5 border-b border-gray-100">
+        <h2 className="font-heading font-bold text-lg tracking-[0.08em] uppercase text-gray-900">
+          Delivery
+        </h2>
+      </div>
+      <div className="p-4 sm:p-6">
+        <div className="grid grid-cols-2 gap-3 mb-4">
+          <div className="bg-gray-50 rounded-lg p-3 border border-gray-100">
+            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-0.5">Date</p>
+            <p className="font-heading font-bold text-gray-900 text-lg leading-snug">{formatDate(order.delivery.date)}</p>
           </div>
-          <div className="bg-blue-50 rounded-lg p-4 border border-blue-100">
-            <p className="text-xs font-medium text-blue-600 uppercase tracking-wider mb-1">Time Window</p>
-            <p className="font-bold text-gray-900 text-lg">{order.delivery.time}</p>
+          <div className="bg-gray-50 rounded-lg p-3 border border-gray-100">
+            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-0.5">Window</p>
+            <p className="font-heading font-bold text-gray-900 text-lg leading-snug">{order.delivery.time}</p>
           </div>
         </div>
-        <div className="space-y-4">
+
+        <div className="space-y-3">
           <div>
-            <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Delivery Address</p>
-            <p className="font-medium text-gray-900">
-              {order.delivery.address.address1}
-              {order.delivery.address.address2 && `, ${order.delivery.address.address2}`}
+            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Address</p>
+            <p className="text-sm font-medium text-gray-900">
+              {addr.address1}
+              {addr.address2 && `, ${addr.address2}`}
             </p>
-            <p className="text-gray-600">
-              {order.delivery.address.city}, {order.delivery.address.state} {order.delivery.address.zip}
+            <p className="text-sm text-gray-600">
+              {addr.city}, {addr.state} {addr.zip}
             </p>
           </div>
-          {order.delivery.phone && (
+          {phone && (
             <div>
-              <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Delivery Phone</p>
-              <a href={`tel:${order.delivery.phone}`} className="text-blue-600 hover:underline font-medium">
-                {order.delivery.phone}
+              <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Phone</p>
+              <a href={`tel:${phone}`} className="text-sm text-brand-blue hover:underline font-medium">
+                {phone}
               </a>
             </div>
           )}
           {order.delivery.instructions && (
-            <div>
-              <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Delivery Instructions</p>
-              <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 text-gray-800">
-                <svg className="w-5 h-5 text-yellow-500 inline mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-                {order.delivery.instructions}
-              </div>
+            <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-3 text-sm text-gray-800">
+              <span className="font-bold">Instructions: </span>
+              {order.delivery.instructions}
             </div>
           )}
+        </div>
+
+        {/* Contact actions */}
+        <div className="grid grid-cols-3 gap-2 mt-4">
+          {phone ? (
+            <a
+              href={`tel:${phone}`}
+              className="min-h-[48px] inline-flex items-center justify-center gap-1.5 rounded-lg border border-brand-blue text-brand-blue font-heading font-bold text-[13px] tracking-[0.08em] uppercase hover:bg-blue-50 transition-colors touch-manipulation"
+            >
+              <svg className="w-[17px] h-[17px]" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
+              </svg>
+              Call
+            </a>
+          ) : (
+            <span className="min-h-[48px] inline-flex items-center justify-center rounded-lg border border-gray-200 text-gray-300 font-heading font-bold text-[13px] tracking-[0.08em] uppercase">
+              Call
+            </span>
+          )}
+          {phone ? (
+            <a
+              href={`sms:${phone}`}
+              className="min-h-[48px] inline-flex items-center justify-center gap-1.5 rounded-lg border border-brand-blue text-brand-blue font-heading font-bold text-[13px] tracking-[0.08em] uppercase hover:bg-blue-50 transition-colors touch-manipulation"
+            >
+              <svg className="w-[17px] h-[17px]" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
+              </svg>
+              Text
+            </a>
+          ) : (
+            <span className="min-h-[48px] inline-flex items-center justify-center rounded-lg border border-gray-200 text-gray-300 font-heading font-bold text-[13px] tracking-[0.08em] uppercase">
+              Text
+            </span>
+          )}
+          <a
+            href={`https://www.google.com/maps/search/?api=1&query=${mapsQuery}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="min-h-[48px] inline-flex items-center justify-center gap-1.5 rounded-lg border border-brand-blue text-brand-blue font-heading font-bold text-[13px] tracking-[0.08em] uppercase hover:bg-blue-50 transition-colors touch-manipulation"
+          >
+            <svg className="w-[17px] h-[17px]" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+            Map
+          </a>
         </div>
       </div>
     </div>

--- a/src/components/ops/orders/detail/DetailHeader.tsx
+++ b/src/components/ops/orders/detail/DetailHeader.tsx
@@ -3,6 +3,7 @@
 import { ReactElement } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import HqBadge from '@/components/backend/kit/Badge';
 import { formatDateTime } from './shared';
 import type { OrderDetail } from './types';
 
@@ -52,21 +53,19 @@ export default function DetailHeader({
           </svg>
         </Link>
         <div>
-          <div className="flex items-center gap-3">
-            <h1 className="text-3xl font-bold text-gray-900">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5">
+            <h1 className="font-heading font-bold text-2xl sm:text-3xl tracking-[0.06em] uppercase text-gray-900">
               Order #{order.orderNumber}
             </h1>
             {order.groupOrder.isGroupOrder && (
-              <span className="px-3 py-1 text-sm font-medium bg-purple-100 text-purple-700 border border-purple-200 rounded-full">
-                Group Order
-              </span>
+              <HqBadge variant="blue">Group Order</HqBadge>
             )}
             {order.cruiseType && (
               <span
-                className={`px-3 py-1 text-sm font-semibold rounded-full border ${
+                className={`inline-flex items-center px-2 py-[3px] rounded text-xs font-bold tracking-[0.05em] uppercase whitespace-nowrap ${
                   order.cruiseType === 'DISCO'
-                    ? 'bg-orange-500 text-white border-orange-700'
-                    : 'bg-teal-600 text-white border-teal-800'
+                    ? 'bg-orange-500 text-white'
+                    : 'bg-teal-600 text-white'
                 }`}
                 title={order.cruiseBoat ? `Boat: ${order.cruiseBoat}` : undefined}
               >
@@ -75,13 +74,13 @@ export default function DetailHeader({
               </span>
             )}
           </div>
-          <p className="text-gray-500 mt-1">
-            Created {formatDateTime(order.createdAt)}
+          <p className="text-sm text-gray-500 mt-1">
+            {order.customer.name || order.customerSnapshot.name || 'Guest'} · ${order.pricing.total.toFixed(2)} · Created {formatDateTime(order.createdAt)}
           </p>
         </div>
       </div>
 
-      <div className="flex items-center gap-3">
+      <div className="flex flex-wrap items-center gap-2 sm:gap-3">
         {/* Prev/Next Navigation */}
         <div className="flex items-center border border-gray-200 rounded-lg overflow-hidden shadow-sm">
           <button

--- a/src/components/ops/orders/detail/DetailHeader.tsx
+++ b/src/components/ops/orders/detail/DetailHeader.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { ReactElement } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { formatDateTime } from './shared';
+import type { OrderDetail } from './types';
+
+/**
+ * Order detail page header: back link, order number + flags, created stamp,
+ * prev/next navigation, and the action button row. All handlers live in the
+ * page — this component only renders.
+ */
+export default function DetailHeader({
+  order,
+  isEditing,
+  canAmend,
+  sendingReceipt,
+  onCopySummary,
+  onPrint,
+  onSendReceipt,
+  onOpenRefund,
+  onOpenReturn,
+  onEnterEdit,
+  onOpenCancel,
+  onCancelEdit,
+}: {
+  order: OrderDetail;
+  isEditing: boolean;
+  canAmend: boolean;
+  sendingReceipt: boolean;
+  onCopySummary: () => void;
+  onPrint: () => void;
+  onSendReceipt: () => void;
+  onOpenRefund: () => void;
+  onOpenReturn: () => void;
+  onEnterEdit: () => void;
+  onOpenCancel: () => void;
+  onCancelEdit: () => void;
+}): ReactElement {
+  const router = useRouter();
+
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-8">
+      <div className="flex items-center gap-4">
+        <Link
+          href="/ops/orders"
+          className="p-2 text-gray-400 hover:text-gray-600 hover:bg-white rounded-lg transition-colors"
+        >
+          <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+        </Link>
+        <div>
+          <div className="flex items-center gap-3">
+            <h1 className="text-3xl font-bold text-gray-900">
+              Order #{order.orderNumber}
+            </h1>
+            {order.groupOrder.isGroupOrder && (
+              <span className="px-3 py-1 text-sm font-medium bg-purple-100 text-purple-700 border border-purple-200 rounded-full">
+                Group Order
+              </span>
+            )}
+            {order.cruiseType && (
+              <span
+                className={`px-3 py-1 text-sm font-semibold rounded-full border ${
+                  order.cruiseType === 'DISCO'
+                    ? 'bg-orange-500 text-white border-orange-700'
+                    : 'bg-teal-600 text-white border-teal-800'
+                }`}
+                title={order.cruiseBoat ? `Boat: ${order.cruiseBoat}` : undefined}
+              >
+                {order.cruiseType === 'DISCO' ? 'Disco Cruise' : 'Private Cruise'}
+                {order.cruiseBoat ? ` · ${order.cruiseBoat}` : ''}
+              </span>
+            )}
+          </div>
+          <p className="text-gray-500 mt-1">
+            Created {formatDateTime(order.createdAt)}
+          </p>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3">
+        {/* Prev/Next Navigation */}
+        <div className="flex items-center border border-gray-200 rounded-lg overflow-hidden shadow-sm">
+          <button
+            onClick={() => order.navigation.previousOrderId && router.push(`/ops/orders/${order.navigation.previousOrderId}`)}
+            disabled={!order.navigation.previousOrderId}
+            className="p-2 bg-white text-gray-700 hover:bg-gray-50 transition-colors disabled:opacity-30 disabled:cursor-not-allowed border-r border-gray-200"
+            title="Previous order (by delivery date)"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+          </button>
+          <button
+            onClick={() => order.navigation.nextOrderId && router.push(`/ops/orders/${order.navigation.nextOrderId}`)}
+            disabled={!order.navigation.nextOrderId}
+            className="p-2 bg-white text-gray-700 hover:bg-gray-50 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+            title="Next order (by delivery date)"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </button>
+        </div>
+
+        <button
+          onClick={onCopySummary}
+          className="px-4 py-2 bg-white border border-gray-200 text-gray-700 rounded-lg font-medium hover:bg-gray-50 transition-colors shadow-sm flex items-center gap-2"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
+          </svg>
+          Copy Summary
+        </button>
+
+        <button
+          onClick={onPrint}
+          className="px-4 py-2 bg-white border border-gray-200 text-gray-700 rounded-lg font-medium hover:bg-gray-50 transition-colors shadow-sm flex items-center gap-2"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z" />
+          </svg>
+          Print
+        </button>
+
+        {order.financialStatus === 'PAID' && (
+          <button
+            onClick={onSendReceipt}
+            disabled={sendingReceipt}
+            className="px-4 py-2 bg-white border border-green-200 text-green-700 rounded-lg font-medium hover:bg-green-50 transition-colors shadow-sm flex items-center gap-2 disabled:opacity-50"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+            {sendingReceipt ? 'Sending...' : 'Send Receipt'}
+          </button>
+        )}
+
+        {order.payment.stripePaymentIntentId && (
+          <button
+            onClick={onOpenRefund}
+            className="px-4 py-2 bg-white border border-red-200 text-red-700 rounded-lg font-medium hover:bg-red-50 transition-colors shadow-sm flex items-center gap-2"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
+            </svg>
+            Issue Refund
+          </button>
+        )}
+
+        {order.payment.stripePaymentIntentId && (order.status === 'DELIVERED' || order.fulfillmentStatus === 'DELIVERED') && (
+          <button
+            onClick={onOpenReturn}
+            className="px-4 py-2 bg-white border border-orange-200 text-orange-700 rounded-lg font-medium hover:bg-orange-50 transition-colors shadow-sm flex items-center gap-2"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 15v-1a4 4 0 00-4-4H8m0 0l3 3m-3-3l3-3m9 14V5a2 2 0 00-2-2H6a2 2 0 00-2 2v16l4-2 4 2 4-2 4 2z" />
+          </svg>
+            Process Return
+          </button>
+        )}
+
+        {canAmend && !isEditing && (
+          <>
+            <button
+              onClick={onEnterEdit}
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 transition-colors shadow-sm flex items-center gap-2"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+              </svg>
+              Edit Order
+            </button>
+            <button
+              onClick={onOpenCancel}
+              className="px-4 py-2 bg-red-600 text-white rounded-lg font-medium hover:bg-red-700 transition-colors shadow-sm flex items-center gap-2"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+              Cancel Order
+            </button>
+          </>
+        )}
+
+        {isEditing && (
+          <button
+            onClick={onCancelEdit}
+            className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg font-medium hover:bg-gray-200 transition-colors"
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ops/orders/detail/DetailStickyBar.tsx
+++ b/src/components/ops/orders/detail/DetailStickyBar.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { ReactElement } from 'react';
+import StickyActionBar from '@/components/backend/kit/StickyActionBar';
+import type { OrderDetail } from './types';
+
+const TRANSITIONS: Record<string, { label: string; to: string }> = {
+  UNFULFILLED: { label: 'Mark Packed', to: 'PENDING' },
+  PENDING: { label: 'Mark Out', to: 'OUT_FOR_DELIVERY' },
+  IN_TRANSIT: { label: 'Mark Delivered', to: 'DELIVERED' },
+  OUT_FOR_DELIVERY: { label: 'Mark Delivered', to: 'DELIVERED' },
+};
+
+/**
+ * The next fulfillment transition for an order, or null when there is none
+ * (delivered, failed, or cancelled). Shared with the page so it can pad the
+ * content bottom only when the bar renders.
+ */
+export function nextTransition(
+  order: Pick<OrderDetail, 'status' | 'fulfillmentStatus'>,
+): { label: string; to: string } | null {
+  if (order.status === 'CANCELLED' || order.fulfillmentStatus === 'FAILED') return null;
+  return TRANSITIONS[order.fulfillmentStatus] ?? null;
+}
+
+/**
+ * Sticky bottom bar with the single yellow next-transition action
+ * (MARK PACKED → MARK OUT → MARK DELIVERED). Writes go through the page's
+ * optimistic updateOrder; the bar hides when no transition applies.
+ */
+export default function DetailStickyBar({
+  order,
+  saving,
+  onAdvance,
+}: {
+  order: OrderDetail;
+  saving: boolean;
+  onAdvance: (updates: Record<string, unknown>) => void;
+}): ReactElement | null {
+  const next = nextTransition(order);
+  if (!next) return null;
+
+  return (
+    <StickyActionBar>
+      <button
+        type="button"
+        onClick={() => onAdvance({ fulfillmentStatus: next.to })}
+        disabled={saving}
+        className="flex-1 min-h-[52px] rounded-lg bg-brand-yellow text-gray-900 font-heading font-bold text-base tracking-[0.08em] uppercase hover:bg-yellow-400 active:bg-yellow-500 disabled:opacity-60 transition-colors touch-manipulation"
+      >
+        {saving ? 'Saving…' : next.label}
+      </button>
+    </StickyActionBar>
+  );
+}

--- a/src/components/ops/orders/detail/ItemsCard.tsx
+++ b/src/components/ops/orders/detail/ItemsCard.tsx
@@ -1,0 +1,96 @@
+import { ReactElement } from 'react';
+import { SectionHeader } from './shared';
+import type { OrderDetail } from './types';
+
+/**
+ * Read-only order items card with the pricing summary footer. Edit-mode item
+ * management (product search, quantity steppers) stays in the page.
+ */
+export default function ItemsCard({ order }: { order: OrderDetail }): ReactElement {
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+      <SectionHeader
+        icon={
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z" />
+          </svg>
+        }
+        title="Order Items"
+      />
+
+      <div className="divide-y divide-gray-100">
+        {order.items.map((item) => (
+          <div key={item.id} className="px-6 py-4 flex items-center justify-between hover:bg-gray-50 transition-colors">
+            <div className="flex items-center gap-3 flex-1">
+              {item.imageUrl ? (
+                <img src={item.imageUrl} alt="" className="w-10 h-10 rounded-lg object-cover border border-gray-100 flex-shrink-0" />
+              ) : (
+                <div className="w-10 h-10 rounded-lg bg-gray-100 flex-shrink-0" />
+              )}
+              <div>
+                <p className="font-semibold text-gray-900">{item.title}</p>
+                {item.variantTitle && item.variantTitle !== 'Default Title' && (
+                  <p className="text-sm text-gray-500">{item.variantTitle}</p>
+                )}
+                {item.sku && (
+                  <p className="text-xs text-gray-400 font-mono">SKU: {item.sku}</p>
+                )}
+                {item.refundedQuantity > 0 && (
+                  <span className="inline-flex items-center px-2 py-0.5 mt-1 text-xs font-medium bg-orange-100 text-orange-700 border border-orange-200 rounded-full">
+                    {item.refundedQuantity} returned
+                  </span>
+                )}
+              </div>
+            </div>
+            <div className="text-right">
+              <p className="font-semibold text-gray-900">
+                {item.quantity} x ${item.price.toFixed(2)}
+              </p>
+              <p className="text-sm text-gray-500">
+                ${item.total.toFixed(2)}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Pricing Summary */}
+      <div className="px-6 py-4 bg-gray-50 border-t border-gray-100 space-y-2">
+        <div className="flex justify-between text-sm">
+          <span className="text-gray-600">Subtotal</span>
+          <span className="text-gray-900 font-medium">${order.pricing.subtotal.toFixed(2)}</span>
+        </div>
+        {order.pricing.discountAmount > 0 && (
+          <div className="flex justify-between text-sm">
+            <span className="text-gray-600">
+              Discount {order.pricing.discountCode && (
+                <span className="inline-flex px-2 py-0.5 bg-green-100 text-green-700 text-xs font-medium rounded ml-2">
+                  {order.pricing.discountCode}
+                </span>
+              )}
+            </span>
+            <span className="text-green-600 font-medium">-${order.pricing.discountAmount.toFixed(2)}</span>
+          </div>
+        )}
+        <div className="flex justify-between text-sm">
+          <span className="text-gray-600">Delivery Fee</span>
+          <span className="text-gray-900 font-medium">${order.pricing.deliveryFee.toFixed(2)}</span>
+        </div>
+        <div className="flex justify-between text-sm">
+          <span className="text-gray-600">Tax (8.25%)</span>
+          <span className="text-gray-900 font-medium">${order.pricing.taxAmount.toFixed(2)}</span>
+        </div>
+        {order.pricing.tipAmount > 0 && (
+          <div className="flex justify-between text-sm">
+            <span className="text-gray-600">Tip</span>
+            <span className="text-amber-600 font-medium">${order.pricing.tipAmount.toFixed(2)}</span>
+          </div>
+        )}
+        <div className="flex justify-between text-xl font-bold pt-3 mt-3 border-t border-gray-200">
+          <span>Total</span>
+          <span className="text-blue-600">${order.pricing.total.toFixed(2)}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ops/orders/detail/ItemsCard.tsx
+++ b/src/components/ops/orders/detail/ItemsCard.tsx
@@ -1,95 +1,80 @@
-import { ReactElement } from 'react';
-import { SectionHeader } from './shared';
+'use client';
+
+import { ReactElement, useState } from 'react';
+import OrderItemsChecklist from '../OrderItemsChecklist';
 import type { OrderDetail } from './types';
 
 /**
- * Read-only order items card with the pricing summary footer. Edit-mode item
- * management (product search, quantity steppers) stays in the page.
+ * Read-only order items card with an expandable pick checklist. The
+ * checklist reuses OrderItemsChecklist, so pick state shares the exact
+ * TITLE-derived item keys and /api/ops/orders/[id]/picks persistence the
+ * orders list uses — both surfaces see the same live progress. Edit-mode
+ * item management stays in the page; the pricing summary lives in
+ * PaymentCard.
  */
 export default function ItemsCard({ order }: { order: OrderDetail }): ReactElement {
+  const [showChecklist, setShowChecklist] = useState(false);
+  const totalUnits = order.items.reduce((sum, item) => sum + item.quantity, 0);
+
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
-      <SectionHeader
-        icon={
-          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z" />
-          </svg>
-        }
-        title="Order Items"
-      />
+    <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+      <div className="flex items-center justify-between gap-3 px-4 sm:px-6 py-3.5 border-b border-gray-100">
+        <h2 className="font-heading font-bold text-lg tracking-[0.08em] uppercase text-gray-900">
+          Items · {order.items.length}
+        </h2>
+        <span className="text-sm font-semibold text-gray-500 whitespace-nowrap">{totalUnits} units</span>
+      </div>
 
       <div className="divide-y divide-gray-100">
         {order.items.map((item) => (
-          <div key={item.id} className="px-6 py-4 flex items-center justify-between hover:bg-gray-50 transition-colors">
-            <div className="flex items-center gap-3 flex-1">
-              {item.imageUrl ? (
-                <img src={item.imageUrl} alt="" className="w-10 h-10 rounded-lg object-cover border border-gray-100 flex-shrink-0" />
-              ) : (
-                <div className="w-10 h-10 rounded-lg bg-gray-100 flex-shrink-0" />
+          <div key={item.id} className="px-4 sm:px-6 py-3 flex items-center gap-3 min-h-[56px]">
+            {item.imageUrl ? (
+              <img src={item.imageUrl} alt="" className="w-10 h-10 rounded-lg object-cover border border-gray-100 flex-shrink-0" />
+            ) : (
+              <div className="w-10 h-10 rounded-lg bg-gray-100 flex-shrink-0" />
+            )}
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-semibold text-gray-900">{item.title}</p>
+              {item.variantTitle && item.variantTitle !== 'Default Title' && (
+                <p className="text-sm text-gray-500">{item.variantTitle}</p>
               )}
-              <div>
-                <p className="font-semibold text-gray-900">{item.title}</p>
-                {item.variantTitle && item.variantTitle !== 'Default Title' && (
-                  <p className="text-sm text-gray-500">{item.variantTitle}</p>
-                )}
-                {item.sku && (
-                  <p className="text-xs text-gray-400 font-mono">SKU: {item.sku}</p>
-                )}
-                {item.refundedQuantity > 0 && (
-                  <span className="inline-flex items-center px-2 py-0.5 mt-1 text-xs font-medium bg-orange-100 text-orange-700 border border-orange-200 rounded-full">
-                    {item.refundedQuantity} returned
-                  </span>
-                )}
-              </div>
+              {item.refundedQuantity > 0 && (
+                <span className="inline-flex items-center px-2 py-[3px] mt-1 rounded text-xs font-bold tracking-[0.05em] uppercase bg-amber-100 text-amber-800">
+                  {item.refundedQuantity} returned
+                </span>
+              )}
             </div>
-            <div className="text-right">
-              <p className="font-semibold text-gray-900">
-                {item.quantity} x ${item.price.toFixed(2)}
+            <div className="text-right flex-shrink-0">
+              <p className="text-sm font-semibold text-gray-900 tabular-nums">
+                {item.quantity} × ${item.price.toFixed(2)}
               </p>
-              <p className="text-sm text-gray-500">
-                ${item.total.toFixed(2)}
-              </p>
+              <p className="text-sm text-gray-500 tabular-nums">${item.total.toFixed(2)}</p>
             </div>
           </div>
         ))}
       </div>
 
-      {/* Pricing Summary */}
-      <div className="px-6 py-4 bg-gray-50 border-t border-gray-100 space-y-2">
-        <div className="flex justify-between text-sm">
-          <span className="text-gray-600">Subtotal</span>
-          <span className="text-gray-900 font-medium">${order.pricing.subtotal.toFixed(2)}</span>
-        </div>
-        {order.pricing.discountAmount > 0 && (
-          <div className="flex justify-between text-sm">
-            <span className="text-gray-600">
-              Discount {order.pricing.discountCode && (
-                <span className="inline-flex px-2 py-0.5 bg-green-100 text-green-700 text-xs font-medium rounded ml-2">
-                  {order.pricing.discountCode}
-                </span>
-              )}
-            </span>
-            <span className="text-green-600 font-medium">-${order.pricing.discountAmount.toFixed(2)}</span>
+      <div className="px-4 sm:px-6 py-2 border-t border-gray-100 bg-gray-50">
+        <button
+          type="button"
+          onClick={() => setShowChecklist(!showChecklist)}
+          className="min-h-[44px] -ml-1 px-1 text-sm font-heading font-bold tracking-[0.08em] uppercase text-brand-blue hover:text-blue-800 touch-manipulation"
+        >
+          {showChecklist ? 'Hide pick checklist' : 'Pick checklist'}
+        </button>
+        {showChecklist && (
+          <div className="pb-2">
+            <OrderItemsChecklist
+              orderId={order.id}
+              items={order.items.map((item) => ({
+                quantity: item.quantity,
+                title: item.title,
+                bundleComponents: item.bundleComponents,
+              }))}
+              refreshKey={showChecklist}
+            />
           </div>
         )}
-        <div className="flex justify-between text-sm">
-          <span className="text-gray-600">Delivery Fee</span>
-          <span className="text-gray-900 font-medium">${order.pricing.deliveryFee.toFixed(2)}</span>
-        </div>
-        <div className="flex justify-between text-sm">
-          <span className="text-gray-600">Tax (8.25%)</span>
-          <span className="text-gray-900 font-medium">${order.pricing.taxAmount.toFixed(2)}</span>
-        </div>
-        {order.pricing.tipAmount > 0 && (
-          <div className="flex justify-between text-sm">
-            <span className="text-gray-600">Tip</span>
-            <span className="text-amber-600 font-medium">${order.pricing.tipAmount.toFixed(2)}</span>
-          </div>
-        )}
-        <div className="flex justify-between text-xl font-bold pt-3 mt-3 border-t border-gray-200">
-          <span>Total</span>
-          <span className="text-blue-600">${order.pricing.total.toFixed(2)}</span>
-        </div>
       </div>
     </div>
   );

--- a/src/components/ops/orders/detail/PaymentCard.tsx
+++ b/src/components/ops/orders/detail/PaymentCard.tsx
@@ -1,0 +1,43 @@
+import { ReactElement } from 'react';
+import { getStatusColor, SectionHeader } from './shared';
+import type { OrderDetail } from './types';
+
+/** Payment info card: financial status, Stripe payment id, Shopify order ref. */
+export default function PaymentCard({ order }: { order: OrderDetail }): ReactElement {
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+      <SectionHeader
+        icon={
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
+          </svg>
+        }
+        title="Payment"
+      />
+      <div className="p-6 space-y-4">
+        <div>
+          <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">Status</p>
+          <span className={`inline-flex px-3 py-1.5 rounded-lg border text-sm font-semibold ${getStatusColor(order.financialStatus)}`}>
+            {order.financialStatus}
+          </span>
+        </div>
+        {order.payment.stripePaymentIntentId && (
+          <div>
+            <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Stripe Payment ID</p>
+            <p className="text-xs font-mono text-gray-600 bg-gray-50 p-2 rounded break-all">
+              {order.payment.stripePaymentIntentId}
+            </p>
+          </div>
+        )}
+        {order.shopify.orderId && (
+          <div>
+            <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Shopify Order</p>
+            <p className="text-sm text-gray-600">
+              #{order.shopify.orderNumber}
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ops/orders/detail/PaymentCard.tsx
+++ b/src/components/ops/orders/detail/PaymentCard.tsx
@@ -1,29 +1,83 @@
 import { ReactElement } from 'react';
-import { getStatusColor, SectionHeader } from './shared';
+import HqBadge, { HqBadgeVariant } from '@/components/backend/kit/Badge';
 import type { OrderDetail } from './types';
 
-/** Payment info card: financial status, Stripe payment id, Shopify order ref. */
+function financialBadgeVariant(status: string): HqBadgeVariant {
+  if (status === 'PAID') return 'green';
+  if (status === 'REFUNDED' || status === 'WAIVED') return 'gray';
+  if (status === 'PARTIALLY_REFUNDED' || status === 'PARTIALLY_PAID') return 'amber';
+  if (status === 'INVOICE_SENT') return 'blue';
+  return 'red';
+}
+
+/**
+ * Payment card: financial status badge, the full pricing breakdown
+ * (subtotal → total, exact amounts always), refunds to date, and the
+ * Stripe/Shopify references.
+ */
 export default function PaymentCard({ order }: { order: OrderDetail }): ReactElement {
+  const { pricing, refunds } = order;
+
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
-      <SectionHeader
-        icon={
-          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
-          </svg>
-        }
-        title="Payment"
-      />
-      <div className="p-6 space-y-4">
-        <div>
-          <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">Status</p>
-          <span className={`inline-flex px-3 py-1.5 rounded-lg border text-sm font-semibold ${getStatusColor(order.financialStatus)}`}>
-            {order.financialStatus}
-          </span>
+    <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+      <div className="flex items-center justify-between gap-3 px-4 sm:px-6 py-3.5 border-b border-gray-100">
+        <h2 className="font-heading font-bold text-lg tracking-[0.08em] uppercase text-gray-900">
+          Payment
+        </h2>
+        <HqBadge variant={financialBadgeVariant(order.financialStatus)}>
+          {order.financialStatus.replace(/_/g, ' ')}
+        </HqBadge>
+      </div>
+      <div className="p-4 sm:p-6 space-y-4">
+        <div className="space-y-2">
+          <div className="flex justify-between text-sm">
+            <span className="text-gray-600">Subtotal</span>
+            <span className="text-gray-900 font-medium tabular-nums">${pricing.subtotal.toFixed(2)}</span>
+          </div>
+          {pricing.discountAmount > 0 && (
+            <div className="flex justify-between text-sm">
+              <span className="text-gray-600">
+                Discount
+                {pricing.discountCode && (
+                  <span className="inline-flex px-2 py-0.5 bg-green-100 text-green-800 text-xs font-bold rounded ml-2">
+                    {pricing.discountCode}
+                  </span>
+                )}
+              </span>
+              <span className="text-green-600 font-medium tabular-nums">-${pricing.discountAmount.toFixed(2)}</span>
+            </div>
+          )}
+          <div className="flex justify-between text-sm">
+            <span className="text-gray-600">Delivery Fee</span>
+            <span className="text-gray-900 font-medium tabular-nums">${pricing.deliveryFee.toFixed(2)}</span>
+          </div>
+          <div className="flex justify-between text-sm">
+            <span className="text-gray-600">Tax (8.25%)</span>
+            <span className="text-gray-900 font-medium tabular-nums">${pricing.taxAmount.toFixed(2)}</span>
+          </div>
+          {pricing.tipAmount > 0 && (
+            <div className="flex justify-between text-sm">
+              <span className="text-gray-600">Tip</span>
+              <span className="text-amber-600 font-medium tabular-nums">${pricing.tipAmount.toFixed(2)}</span>
+            </div>
+          )}
+          <div className="flex justify-between items-baseline pt-3 mt-1 border-t border-gray-200">
+            <span className="font-heading font-bold text-base tracking-[0.05em] uppercase text-gray-900">Total</span>
+            <span className="font-heading font-bold text-2xl text-gray-900 tabular-nums">${pricing.total.toFixed(2)}</span>
+          </div>
+          {refunds && refunds.totalRefunded > 0 && (
+            <div className="flex justify-between text-sm pt-1">
+              <span className="text-red-700 font-medium">
+                Refunded ({refunds.count})
+              </span>
+              <span className="text-red-700 font-semibold tabular-nums">-${refunds.totalRefunded.toFixed(2)}</span>
+            </div>
+          )}
         </div>
+
         {order.payment.stripePaymentIntentId && (
           <div>
-            <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Stripe Payment ID</p>
+            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Stripe Payment ID</p>
             <p className="text-xs font-mono text-gray-600 bg-gray-50 p-2 rounded break-all">
               {order.payment.stripePaymentIntentId}
             </p>
@@ -31,7 +85,7 @@ export default function PaymentCard({ order }: { order: OrderDetail }): ReactEle
         )}
         {order.shopify.orderId && (
           <div>
-            <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Shopify Order</p>
+            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Shopify Order</p>
             <p className="text-sm text-gray-600">
               #{order.shopify.orderNumber}
             </p>

--- a/src/components/ops/orders/detail/StatusStepperCard.tsx
+++ b/src/components/ops/orders/detail/StatusStepperCard.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { ReactElement } from 'react';
+import { getStatusColor } from './shared';
+import type { OrderDetail } from './types';
+
+const STATUS_OPTIONS = ['PENDING', 'CONFIRMED', 'PROCESSING', 'OUT_FOR_DELIVERY', 'DELIVERED', 'CANCELLED'];
+const FULFILLMENT_OPTIONS = ['UNFULFILLED', 'PENDING', 'IN_TRANSIT', 'OUT_FOR_DELIVERY', 'DELIVERED', 'FAILED'];
+
+/**
+ * Order/payment/fulfillment status controls for the detail page, including
+ * the post-delivery review-request prompt. Status writes go through the
+ * page's updateOrder handler.
+ */
+export default function StatusStepperCard({
+  order,
+  saving,
+  showReviewPrompt,
+  sendingReview,
+  onUpdateOrder,
+  onSendReview,
+  onDismissReview,
+}: {
+  order: OrderDetail;
+  saving: boolean;
+  showReviewPrompt: boolean;
+  sendingReview: boolean;
+  onUpdateOrder: (updates: Record<string, unknown>) => void;
+  onSendReview: () => void;
+  onDismissReview: () => void;
+}): ReactElement {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+      <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-5">
+        <label className="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-3">
+          Order Status
+        </label>
+        <select
+          value={order.status}
+          onChange={(e) => onUpdateOrder({ status: e.target.value })}
+          disabled={saving}
+          className={`w-full px-4 py-2.5 rounded-lg border-2 ${getStatusColor(order.status)} font-semibold focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer`}
+        >
+          {STATUS_OPTIONS.map((s) => (
+            <option key={s} value={s}>{s}</option>
+          ))}
+        </select>
+      </div>
+
+      <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-5">
+        <label className="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-3">
+          Payment Status
+        </label>
+        <div className={`px-4 py-2.5 rounded-lg border-2 ${getStatusColor(order.financialStatus)} font-semibold text-center`}>
+          {order.financialStatus}
+        </div>
+      </div>
+
+      <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-5">
+        <label className="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-3">
+          Fulfillment
+        </label>
+        <select
+          value={order.fulfillmentStatus}
+          onChange={(e) => onUpdateOrder({ fulfillmentStatus: e.target.value })}
+          disabled={saving}
+          className={`w-full px-4 py-2.5 rounded-lg border-2 ${getStatusColor(order.fulfillmentStatus)} font-semibold focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer`}
+        >
+          {FULFILLMENT_OPTIONS.map((s) => (
+            <option key={s} value={s}>{s}</option>
+          ))}
+        </select>
+
+        {/* Review request prompt */}
+        {showReviewPrompt && !order.reviewRequestSentAt && (
+          <div className="mt-3 p-3 bg-blue-50 border border-blue-200 rounded-lg">
+            <p className="text-sm font-medium text-blue-900 mb-2">
+              Send review request to {order.customerSnapshot.name || order.customer.name}?
+            </p>
+            {(order.customerSnapshot.phone || order.customer.phone || order.delivery.phone) ? (
+              <div className="flex gap-2">
+                <button
+                  onClick={onSendReview}
+                  disabled={sendingReview}
+                  className="px-3 py-1.5 text-xs font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+                >
+                  {sendingReview ? 'Sending...' : 'Send'}
+                </button>
+                <button
+                  onClick={onDismissReview}
+                  className="px-3 py-1.5 text-xs font-medium text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors"
+                >
+                  Skip
+                </button>
+              </div>
+            ) : (
+              <p className="text-xs text-blue-700">No phone number available</p>
+            )}
+          </div>
+        )}
+        {order.reviewRequestSentAt && (
+          <p className="mt-2 text-xs text-gray-500">
+            Review request sent {new Date(order.reviewRequestSentAt).toLocaleDateString()}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ops/orders/detail/StatusStepperCard.tsx
+++ b/src/components/ops/orders/detail/StatusStepperCard.tsx
@@ -1,16 +1,42 @@
 'use client';
 
 import { ReactElement } from 'react';
+import StatusStepper from '@/components/backend/kit/StatusStepper';
+import HqBadge from '@/components/backend/kit/Badge';
 import { getStatusColor } from './shared';
 import type { OrderDetail } from './types';
 
 const STATUS_OPTIONS = ['PENDING', 'CONFIRMED', 'PROCESSING', 'OUT_FOR_DELIVERY', 'DELIVERED', 'CANCELLED'];
 const FULFILLMENT_OPTIONS = ['UNFULFILLED', 'PENDING', 'IN_TRANSIT', 'OUT_FOR_DELIVERY', 'DELIVERED', 'FAILED'];
+const STEPS = ['PAID', 'PACKING', 'OUT', 'DELIVERED'];
 
 /**
- * Order/payment/fulfillment status controls for the detail page, including
- * the post-delivery review-request prompt. Status writes go through the
- * page's updateOrder handler.
+ * Stepper position for an order. A step earns its checkmark when its action
+ * completes: PAID from financialStatus; MARK PACKED (→ PENDING) completes
+ * PACKING; MARK OUT (→ OUT_FOR_DELIVERY, IN_TRANSIT displays the same)
+ * completes OUT; DELIVERED completes all four. Unpaid orders hold at PAID.
+ */
+export function stepperIndex(order: Pick<OrderDetail, 'financialStatus' | 'fulfillmentStatus'>): number {
+  const paid = ['PAID', 'PARTIALLY_REFUNDED', 'REFUNDED'].includes(order.financialStatus);
+  if (!paid) return 0;
+  switch (order.fulfillmentStatus) {
+    case 'DELIVERED':
+      return 4;
+    case 'OUT_FOR_DELIVERY':
+    case 'IN_TRANSIT':
+      return 3;
+    case 'PENDING':
+      return 2;
+    default:
+      return 1;
+  }
+}
+
+/**
+ * Order progress card: the PAID → PACKING → OUT → DELIVERED stepper (FAILED
+ * renders as a red badge override), a manual-override disclosure with the
+ * raw status/fulfillment selects, and the post-delivery review prompt.
+ * Status writes go through the page's optimistic updateOrder handler.
  */
 export default function StatusStepperCard({
   order,
@@ -29,81 +55,96 @@ export default function StatusStepperCard({
   onSendReview: () => void;
   onDismissReview: () => void;
 }): ReactElement {
+  const unpaid = !['PAID', 'PARTIALLY_REFUNDED', 'REFUNDED'].includes(order.financialStatus);
+  const cancelled = order.status === 'CANCELLED';
+
   return (
-    <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
-      <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-5">
-        <label className="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-3">
-          Order Status
-        </label>
-        <select
-          value={order.status}
-          onChange={(e) => onUpdateOrder({ status: e.target.value })}
-          disabled={saving}
-          className={`w-full px-4 py-2.5 rounded-lg border-2 ${getStatusColor(order.status)} font-semibold focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer`}
-        >
-          {STATUS_OPTIONS.map((s) => (
-            <option key={s} value={s}>{s}</option>
-          ))}
-        </select>
-      </div>
-
-      <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-5">
-        <label className="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-3">
-          Payment Status
-        </label>
-        <div className={`px-4 py-2.5 rounded-lg border-2 ${getStatusColor(order.financialStatus)} font-semibold text-center`}>
-          {order.financialStatus}
+    <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4 sm:p-5 mb-6">
+      {(unpaid || cancelled) && (
+        <div className="mb-3 flex flex-wrap items-center gap-2">
+          {cancelled && <HqBadge variant="red">Cancelled</HqBadge>}
+          {unpaid && <HqBadge variant="amber">{order.financialStatus.replace(/_/g, ' ')}</HqBadge>}
         </div>
-      </div>
+      )}
 
-      <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-5">
-        <label className="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-3">
-          Fulfillment
-        </label>
-        <select
-          value={order.fulfillmentStatus}
-          onChange={(e) => onUpdateOrder({ fulfillmentStatus: e.target.value })}
-          disabled={saving}
-          className={`w-full px-4 py-2.5 rounded-lg border-2 ${getStatusColor(order.fulfillmentStatus)} font-semibold focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer`}
-        >
-          {FULFILLMENT_OPTIONS.map((s) => (
-            <option key={s} value={s}>{s}</option>
-          ))}
-        </select>
+      <StatusStepper
+        steps={STEPS}
+        currentIndex={stepperIndex(order)}
+        failed={order.fulfillmentStatus === 'FAILED'}
+      />
 
-        {/* Review request prompt */}
-        {showReviewPrompt && !order.reviewRequestSentAt && (
-          <div className="mt-3 p-3 bg-blue-50 border border-blue-200 rounded-lg">
-            <p className="text-sm font-medium text-blue-900 mb-2">
-              Send review request to {order.customerSnapshot.name || order.customer.name}?
-            </p>
-            {(order.customerSnapshot.phone || order.customer.phone || order.delivery.phone) ? (
-              <div className="flex gap-2">
-                <button
-                  onClick={onSendReview}
-                  disabled={sendingReview}
-                  className="px-3 py-1.5 text-xs font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
-                >
-                  {sendingReview ? 'Sending...' : 'Send'}
-                </button>
-                <button
-                  onClick={onDismissReview}
-                  className="px-3 py-1.5 text-xs font-medium text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors"
-                >
-                  Skip
-                </button>
-              </div>
-            ) : (
-              <p className="text-xs text-blue-700">No phone number available</p>
-            )}
-          </div>
-        )}
-        {order.reviewRequestSentAt && (
-          <p className="mt-2 text-xs text-gray-500">
-            Review request sent {new Date(order.reviewRequestSentAt).toLocaleDateString()}
+      {/* Review request prompt (after marking delivered) */}
+      {showReviewPrompt && !order.reviewRequestSentAt && (
+        <div className="mt-4 p-3 bg-blue-50 border border-blue-200 rounded-lg">
+          <p className="text-sm font-medium text-blue-900 mb-2">
+            Send review request to {order.customerSnapshot.name || order.customer.name}?
           </p>
-        )}
-      </div>
+          {(order.customerSnapshot.phone || order.customer.phone || order.delivery.phone) ? (
+            <div className="flex gap-2">
+              <button
+                onClick={onSendReview}
+                disabled={sendingReview}
+                className="min-h-[36px] px-3 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+              >
+                {sendingReview ? 'Sending...' : 'Send'}
+              </button>
+              <button
+                onClick={onDismissReview}
+                className="min-h-[36px] px-3 text-sm font-medium text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors"
+              >
+                Skip
+              </button>
+            </div>
+          ) : (
+            <p className="text-sm text-blue-700">No phone number available</p>
+          )}
+        </div>
+      )}
+      {order.reviewRequestSentAt && (
+        <p className="mt-3 text-sm text-gray-500">
+          Review request sent {new Date(order.reviewRequestSentAt).toLocaleDateString()}
+        </p>
+      )}
+
+      {/* Manual override: full status control beyond the stepper's happy path
+          (CANCELLED, FAILED, reverting a mistaken advance) */}
+      <details className="mt-4">
+        <summary className="cursor-pointer select-none text-sm font-semibold text-gray-500 hover:text-gray-700 min-h-[36px] flex items-center touch-manipulation">
+          Set status manually
+        </summary>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-2">
+          <div>
+            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1.5">
+              Order Status
+            </label>
+            <select
+              value={order.status}
+              onChange={(e) => onUpdateOrder({ status: e.target.value })}
+              disabled={saving}
+              className={`w-full px-3 py-2 rounded-lg border-2 ${getStatusColor(order.status)} text-sm font-semibold focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer`}
+            >
+              {STATUS_OPTIONS.map((s) => (
+                <option key={s} value={s}>{s}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1.5">
+              Fulfillment
+            </label>
+            <select
+              value={order.fulfillmentStatus}
+              onChange={(e) => onUpdateOrder({ fulfillmentStatus: e.target.value })}
+              disabled={saving}
+              className={`w-full px-3 py-2 rounded-lg border-2 ${getStatusColor(order.fulfillmentStatus)} text-sm font-semibold focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer`}
+            >
+              {FULFILLMENT_OPTIONS.map((s) => (
+                <option key={s} value={s}>{s}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </details>
     </div>
   );
 }

--- a/src/components/ops/orders/detail/shared.tsx
+++ b/src/components/ops/orders/detail/shared.tsx
@@ -1,0 +1,62 @@
+import { ReactElement } from 'react';
+
+/** Tinted badge classes for order/financial/fulfillment status values. */
+export function getStatusColor(status: string): string {
+  const colors: Record<string, string> = {
+    PENDING: 'bg-yellow-100 text-yellow-700 border-yellow-200',
+    CONFIRMED: 'bg-blue-100 text-blue-700 border-blue-200',
+    PROCESSING: 'bg-purple-100 text-purple-700 border-purple-200',
+    OUT_FOR_DELIVERY: 'bg-indigo-100 text-indigo-700 border-indigo-200',
+    DELIVERED: 'bg-green-100 text-green-700 border-green-200',
+    COMPLETED: 'bg-green-100 text-green-700 border-green-200',
+    CANCELLED: 'bg-red-100 text-red-700 border-red-200',
+    PAID: 'bg-green-100 text-green-700 border-green-200',
+    PARTIALLY_PAID: 'bg-yellow-100 text-yellow-700 border-yellow-200',
+    PARTIALLY_REFUNDED: 'bg-yellow-100 text-yellow-700 border-yellow-200',
+    REFUNDED: 'bg-gray-100 text-gray-700 border-gray-200',
+    FULFILLED: 'bg-green-100 text-green-700 border-green-200',
+    UNFULFILLED: 'bg-orange-100 text-orange-700 border-orange-200',
+    IN_TRANSIT: 'bg-blue-100 text-blue-700 border-blue-200',
+    PARTIAL: 'bg-yellow-100 text-yellow-700 border-yellow-200',
+    FAILED: 'bg-red-100 text-red-700 border-red-200',
+    INVOICE_SENT: 'bg-blue-100 text-blue-700 border-blue-200',
+    WAIVED: 'bg-gray-100 text-gray-700 border-gray-200',
+  };
+  return colors[status] || 'bg-gray-100 text-gray-700 border-gray-200';
+}
+
+/** Long-form delivery date, rendered in UTC to match the stored date. */
+export function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleDateString('en-US', {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+/** Short date + time, rendered in UTC to match stored timestamps. */
+export function formatDateTime(dateString: string): string {
+  return new Date(dateString).toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone: 'UTC',
+  });
+}
+
+/** Card section header: icon + title, optional right-aligned action. */
+export function SectionHeader({ icon, title, action }: { icon: ReactElement; title: string; action?: ReactElement }): ReactElement {
+  return (
+    <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100 bg-gray-50">
+      <div className="flex items-center gap-3">
+        <span className="text-gray-400">{icon}</span>
+        <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+      </div>
+      {action}
+    </div>
+  );
+}

--- a/src/components/ops/orders/detail/types.ts
+++ b/src/components/ops/orders/detail/types.ts
@@ -1,0 +1,148 @@
+/**
+ * Types for the order detail page (/ops/orders/[id]) and its extracted
+ * view cards. Shapes mirror the GET /api/v1/admin/orders/[id] payload.
+ */
+
+export interface OrderItem {
+  id: string;
+  product: { id: string; title: string; handle: string };
+  variant: { id: string; title: string; sku: string } | null;
+  title: string;
+  variantTitle: string | null;
+  sku: string | null;
+  quantity: number;
+  refundedQuantity: number;
+  price: number;
+  total: number;
+  imageUrl?: string | null;
+  bundleComponents?: { title: string; variantTitle: string | null; quantity: number }[];
+}
+
+export interface Amendment {
+  id: string;
+  type: string;
+  changes: {
+    added: { title: string; quantity: number; price: number }[];
+    removed: { title: string; quantity: number; price: number }[];
+    modified: { title: string; oldQuantity: number; newQuantity: number; price: number }[];
+    deliveryFeeChange: { from: number; to: number } | null;
+  };
+  previousTotal: number;
+  newTotal: number;
+  amountDelta: number;
+  resolution: string;
+  draftOrderId: string | null;
+  refundId: string | null;
+  notes: string | null;
+  processedBy: string | null;
+  createdAt: string;
+  resolvedAt: string | null;
+}
+
+export interface OrderDetail {
+  id: string;
+  orderNumber: string;
+  status: string;
+  financialStatus: string;
+  fulfillmentStatus: string;
+  cruiseType: 'DISCO' | 'PRIVATE' | null;
+  cruiseBoat: string | null;
+  customer: {
+    id: string;
+    email: string;
+    name: string;
+    phone: string | null;
+  };
+  customerSnapshot: {
+    name: string | null;
+    email: string | null;
+    phone: string | null;
+  };
+  items: OrderItem[];
+  pricing: {
+    subtotal: number;
+    discountCode: string | null;
+    discountAmount: number;
+    taxAmount: number;
+    deliveryFee: number;
+    tipAmount: number;
+    total: number;
+  };
+  delivery: {
+    date: string;
+    time: string;
+    type: string;
+    address: {
+      address1: string;
+      address2: string;
+      city: string;
+      state: string;
+      zip: string;
+      country: string;
+    };
+    phone: string | null;
+    instructions: string | null;
+  };
+  payment: {
+    stripePaymentIntentId: string | null;
+    stripeCheckoutSessionId: string | null;
+    stripeChargeId: string | null;
+  };
+  shopify: {
+    orderId: string | null;
+    orderNumber: string | null;
+  };
+  groupOrder: {
+    id: string | null;
+    isGroupOrder: boolean;
+    name: string | null;
+    shareCode: string | null;
+    status: string | null;
+    siblingOrders: {
+      id: string;
+      orderNumber: string;
+      customerName: string;
+      total: number;
+      status: string;
+    }[];
+  };
+  groupOrderV2: {
+    id: string;
+    isGroupOrder: boolean;
+    name: string;
+    shareCode: string;
+    hostName: string;
+    siblingOrders: {
+      id: string;
+      orderNumber: string;
+      customerName: string;
+      total: number;
+      status: string;
+      fulfillmentStatus: string;
+    }[];
+  } | null;
+  affiliate: {
+    id: string;
+    code: string;
+    businessName: string;
+    contactName: string;
+    phone: string | null;
+  } | null;
+  amendments: Amendment[];
+  notes: {
+    customer: string | null;
+    internal: string | null;
+  };
+  createdAt: string;
+  updatedAt: string;
+  navigation: {
+    previousOrderId: string | null;
+    nextOrderId: string | null;
+  };
+  reviewRequestSentAt: string | null;
+  refunds: {
+    totalRefunded: number;
+    count: number;
+    stripeCapturedAmount: number | null;
+  };
+}


### PR DESCRIPTION
## Phase 4 PR-C — order detail extraction + restyle (preview-gated)

**⛔ MERGE GATE: Allan approves the Vercel preview on his phone first.** Preview URL posted in a comment once the deployment is up.

### Commit 1 — pure extraction (zero visual change)
View-mode JSX moves into `src/components/ops/orders/detail/` (DetailHeader, StatusStepperCard, DeliveryCard, ItemsCard, PaymentCard + shared helpers/types). Page keeps ALL state/handlers, edit mode, dialogs, Print View. Page: 2,767 → 2,250 lines.

### Commit 2 — restyle + behavior
- **Status stepper** (kit/StatusStepper): PAID → PACKING → OUT → DELIVERED. PAID from `financialStatus`; a step earns its ✓ when its action completes (UNFULFILLED → PACKING active; PENDING → PACKING ✓; OUT_FOR_DELIVERY / IN_TRANSIT → OUT ✓; DELIVERED → all ✓). FAILED renders as red badge override.
- **Sticky bar** (kit/StickyActionBar, above the tab bar): one yellow button with the next transition — MARK PACKED → MARK OUT → MARK DELIVERED via existing `PUT /api/v1/admin/orders/[id]`. Hidden while editing / delivered / failed / cancelled.
- **Optimistic updates**: status flips render instantly, roll back + refetch on failure. DELIVERED → review prompt preserved.
- **ItemsCard**: expandable pick checklist reusing `OrderItemsChecklist` — same **TITLE-keyed** pick state + `/api/ops/orders/[id]/picks` PUT as the orders list (frozen contract untouched); Stock/Pack/Short-by 3-state kept.
- **DeliveryCard**: Call / Text / Map (tel:, sms:, Google Maps) ≥48px targets.
- **PaymentCard**: pricing breakdown + refunded-to-date + Stripe ID.

### Deliberate deviations (for preview judgment)
1. **Raw status/fulfillment selects kept** under a "Set status manually" disclosure in the stepper card — the mockup drops them, but they're the only path to CANCELLED/FAILED/reverting a mis-tap.
2. **Pick checklist is collapsed by default** behind a toggle (mirrors the list pattern; avoids duplicating the item rows).
3. **Item prices stay visible** on detail rows (mockup showed bare checklist rows).
4. Page lands at ~2,290 lines, above the plan's ~1,100–1,300 estimate — that estimate assumed moving edit mode out too; the binding constraint "edit mode stays in page.tsx" won. PR-D shrinks it further (refund dialog retirement).

### Untouched (protected)
`usePickChecks`, picks API, edit mode, Return/Cancel/Refund dialogs, **detail Print View**, all print CSS, all API routes.

### Gates
- `npx tsc --noEmit` ✓ clean · `npm run lint` ✓ no errors · `npm run test:run` ✓ 679/679
- Webpack dev smoke: `/ops/orders/[id]` compiles + renders (HTTP 200)
- **Manual print QA required at preview** (weekly checklist / pick sheet / detail Print View) — print trees untouched by construction, but eyes on paper is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)