### PR TITLE
feat(hq): Email hub — segmented band, kill-switch card, kit toggles (phase 6)

### DIFF
--- a/src/app/admin/email-signups/page.tsx
+++ b/src/app/admin/email-signups/page.tsx
@@ -2,8 +2,7 @@ import Link from 'next/link';
 import { prisma } from '@/lib/database/client';
 import { getOpsSession } from '@/lib/auth/ops-session';
 import type { Prisma } from '@prisma/client';
-import SectionSubNav from '@/components/backend/SectionSubNav';
-import { EMAIL_SUBNAV } from '@/components/backend/subnav-items';
+import EmailHubBand from '@/components/admin/emails/EmailHubBand';
 
 /**
  * Admin → Emails → Signups.
@@ -95,10 +94,9 @@ export default async function EmailSignupsPage({
   ]);
 
   return (
-    <div className="p-4 md:p-8 bg-gray-50 min-h-screen">
-      <div className="mb-4">
-        <SectionSubNav items={EMAIL_SUBNAV} />
-      </div>
+    <div className="bg-gray-50 min-h-screen">
+      <EmailHubBand active="signups" />
+      <div className="p-4 md:p-8">
       {/* Header */}
       <div className="mb-6">
         <div className="flex items-center gap-3 mb-1">
@@ -194,6 +192,7 @@ export default async function EmailSignupsPage({
         * Drink-calculator leads live in a separate legacy table and aren&apos;t listed above — count shown for completeness.
         Newsletter signups appear here once <code className="bg-gray-100 px-1 rounded">/api/newsletter</code> is deployed (PR&nbsp;#157).
       </p>
+      </div>
     </div>
   );
 }

--- a/src/app/admin/emails/followups/page.tsx
+++ b/src/app/admin/emails/followups/page.tsx
@@ -10,8 +10,7 @@
  */
 
 import type { ReactElement } from 'react';
-import SectionSubNav from '@/components/backend/SectionSubNav';
-import { EMAIL_SUBNAV } from '@/components/backend/subnav-items';
+import EmailHubBand from '@/components/admin/emails/EmailHubBand';
 import CopyEditorPanel from '@/components/admin/followups/CopyEditorPanel';
 import FlagsPanel from '@/components/admin/followups/FlagsPanel';
 import QueuePanel from '@/components/admin/followups/QueuePanel';
@@ -22,9 +21,9 @@ import TestSendPanel from '@/components/admin/followups/TestSendPanel';
 
 export default function FollowupsAdminPage(): ReactElement {
   return (
-    <div className="p-4 md:p-8 bg-gray-50 min-h-screen space-y-6">
-      <SectionSubNav items={EMAIL_SUBNAV} />
-      <div className="flex items-center justify-between flex-wrap gap-2">
+    <div className="bg-gray-50 min-h-screen">
+      <EmailHubBand active="followups" />
+      <div className="p-4 md:p-8 space-y-6">
         <div>
           <h1 className="font-heading text-3xl tracking-[0.1em] text-gray-900">Follow-Ups</h1>
           <p className="text-sm text-gray-500">
@@ -32,15 +31,15 @@ export default function FollowupsAdminPage(): ReactElement {
             Engine runs every 15 minutes.
           </p>
         </div>
-      </div>
 
-      <FlagsPanel />
-      <CopyEditorPanel />
-      <TestSendPanel />
-      <StatsPanel />
-      <QueuePanel />
-      <SentLogPanel />
-      <SuppressionsPanel />
+        <FlagsPanel />
+        <StatsPanel />
+        <QueuePanel />
+        <SentLogPanel />
+        <CopyEditorPanel />
+        <TestSendPanel />
+        <SuppressionsPanel />
+      </div>
     </div>
   );
 }

--- a/src/app/admin/emails/page.tsx
+++ b/src/app/admin/emails/page.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback, ReactElement } from 'react';
-import SectionSubNav from '@/components/backend/SectionSubNav';
-import { EMAIL_SUBNAV } from '@/components/backend/subnav-items';
+import EmailHubBand from '@/components/admin/emails/EmailHubBand';
 
 type EmailType = 'order-confirmation' | 'delivery-en-route' | 'delivery-completed' | 'payment-failed' | 'refund-processed' | 'order-cancelled' | 'invoice' | 'affiliate-welcome' | 'affiliate-prospect' | 'dashboard-link';
 
@@ -261,10 +260,9 @@ export default function EmailPreviewPage(): ReactElement {
   }, []);
 
   return (
-    <div className="p-4 md:p-8 bg-gray-50 min-h-screen">
-      <div className="mb-4">
-        <SectionSubNav items={EMAIL_SUBNAV} />
-      </div>
+    <div className="bg-gray-50 min-h-screen">
+      <EmailHubBand active="templates" />
+      <div className="p-4 md:p-8">
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-8">
         <div className="flex items-center gap-3">
           <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-pink-500 to-pink-600 flex items-center justify-center shadow-lg">
@@ -538,6 +536,7 @@ export default function EmailPreviewPage(): ReactElement {
           </div>
         </>
       )}
+      </div>
     </div>
   );
 }

--- a/src/components/admin/emails/EmailHubBand.tsx
+++ b/src/components/admin/emails/EmailHubBand.tsx
@@ -1,0 +1,25 @@
+import { ReactElement } from 'react';
+import NavyBand from '@/components/backend/shell/NavyBand';
+import SegmentedControl from '@/components/backend/kit/SegmentedControl';
+
+const SEGMENTS = [
+  { key: 'templates', label: 'Templates', href: '/admin/emails' },
+  { key: 'followups', label: 'Follow-Ups', href: '/admin/emails/followups' },
+  { key: 'signups', label: 'Signups', href: '/admin/email-signups' },
+];
+
+/**
+ * Navy band + segmented control shared by the three Email hub views.
+ * Segments are links — each view is its own route under the hub.
+ */
+export default function EmailHubBand({
+  active,
+}: {
+  active: 'templates' | 'followups' | 'signups';
+}): ReactElement {
+  return (
+    <NavyBand>
+      <SegmentedControl segments={SEGMENTS} active={active} className="max-w-xl" />
+    </NavyBand>
+  );
+}

--- a/src/components/admin/followups/FlagsPanel.tsx
+++ b/src/components/admin/followups/FlagsPanel.tsx
@@ -2,10 +2,13 @@
 
 /**
  * Master kill switch + per-journey flag toggles with queue counts.
- * Data: GET/POST /api/ops/followups/flags.
+ * Data: GET/POST /api/ops/followups/flags. The master card is the navy
+ * kill switch from the HQ design — nothing sends while it's off,
+ * regardless of journey flags, and flipping it pauses the queue instantly.
  */
 
 import { useCallback, useEffect, useState, type ReactElement } from 'react';
+import Toggle from '@/components/backend/kit/Toggle';
 
 interface JourneyCounts {
   scheduled: number;
@@ -30,34 +33,6 @@ interface FlagsResponse {
   success: boolean;
   master: { key: string; enabled: boolean };
   journeys: JourneyFlag[];
-}
-
-function Toggle({
-  enabled,
-  busy,
-  onChange,
-}: {
-  enabled: boolean;
-  busy: boolean;
-  onChange: (next: boolean) => void;
-}): ReactElement {
-  return (
-    <button
-      type="button"
-      disabled={busy}
-      onClick={() => onChange(!enabled)}
-      className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors disabled:opacity-50 ${
-        enabled ? 'bg-brand-blue' : 'bg-gray-300'
-      }`}
-      aria-pressed={enabled}
-    >
-      <span
-        className={`inline-block h-4 w-4 rounded-full bg-white shadow transform transition-transform ${
-          enabled ? 'translate-x-6' : 'translate-x-1'
-        }`}
-      />
-    </button>
-  );
 }
 
 export default function FlagsPanel(): ReactElement {
@@ -103,41 +78,55 @@ export default function FlagsPanel(): ReactElement {
   }
 
   return (
-    <div className="card">
-      <div className="flex items-center justify-between mb-4">
-        <div>
-          <h2 className="text-lg font-bold tracking-[0.08em] text-gray-900">Master Switch</h2>
-          <p className="text-sm text-gray-500">
-            Nothing sends while this is off, regardless of journey flags.
+    <div className="space-y-4">
+      {/* Master kill switch — navy card */}
+      <div className="bg-navy rounded-xl p-4 sm:p-5 flex items-center justify-between gap-4">
+        <div className="min-w-0">
+          <h2 className="font-heading font-bold text-lg tracking-[0.08em] uppercase text-white">
+            Automation
+          </h2>
+          <p className="text-sm text-[#8FA3B5]">
+            Master switch — pauses the queue instantly. Nothing sends while off, regardless of flow flags.
           </p>
         </div>
         <Toggle
-          enabled={data.master.enabled}
-          busy={busyKey === data.master.key}
+          size="master"
+          checked={data.master.enabled}
+          disabled={busyKey === data.master.key}
+          label="Follow-up automation master switch"
           onChange={(next) => void toggle(data.master.key, next)}
         />
       </div>
-      {error && <p className="text-sm text-red-600 mb-3">{error}</p>}
 
-      <div className="divide-y divide-gray-100">
+      {error && <p className="text-sm font-medium text-red-600">{error}</p>}
+
+      {/* Per-flow rows */}
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm divide-y divide-gray-100 overflow-hidden">
         {data.journeys.map((j) => (
-          <div key={j.key} className="py-3 flex items-start justify-between gap-4">
+          <div
+            key={j.key}
+            className={`px-4 py-3 min-h-[64px] flex items-center justify-between gap-4 ${
+              j.enabled ? '' : 'opacity-60'
+            }`}
+          >
             <div className="min-w-0">
               <div className="flex items-center gap-2 flex-wrap">
                 <span className="font-semibold text-gray-900 text-sm">{j.label}</span>
-                <span className="text-xs bg-gray-100 text-gray-600 rounded px-1.5 py-0.5">
+                <span className="inline-flex items-center px-2 py-[3px] rounded text-xs font-bold tracking-[0.05em] uppercase bg-gray-100 text-gray-500">
                   phase {j.phase} · {j.steps} touch{j.steps > 1 ? 'es' : ''}
                 </span>
               </div>
               <p className="text-sm text-gray-500 mt-0.5">{j.description}</p>
-              <p className="text-xs text-gray-400 mt-1">
+              <p className="text-sm text-gray-400 mt-0.5">
                 queued {j.counts.scheduled} · sent {j.counts.sent} · canceled {j.counts.canceled} ·
                 suppressed {j.counts.suppressed} · failed {j.counts.failed}
               </p>
             </div>
             <Toggle
-              enabled={j.enabled}
-              busy={busyKey === j.featureFlag}
+              size="row"
+              checked={j.enabled}
+              disabled={busyKey === j.featureFlag}
+              label={`${j.label} flow`}
               onChange={(next) => void toggle(j.featureFlag, next)}
             />
           </div>

--- a/src/components/admin/followups/QueuePanel.tsx
+++ b/src/components/admin/followups/QueuePanel.tsx
@@ -58,7 +58,12 @@ export default function QueuePanel(): ReactElement {
 
   return (
     <div className="card">
-      <h2 className="text-lg font-bold tracking-[0.08em] text-gray-900 mb-1">Upcoming Queue</h2>
+      <div className="flex items-baseline justify-between gap-3 mb-1">
+        <h2 className="text-lg font-bold tracking-[0.08em] text-gray-900">Next in Queue</h2>
+        <a href="#sent-log" className="text-sm font-semibold text-brand-blue hover:underline">
+          Sent log ↓
+        </a>
+      </div>
       <p className="text-sm text-gray-500 mb-4">
         Next 50 scheduled sends. The engine re-checks every cancel condition before sending.
       </p>
@@ -68,50 +73,40 @@ export default function QueuePanel(): ReactElement {
       ) : jobs.length === 0 ? (
         <p className="text-sm text-gray-500">Nothing queued.</p>
       ) : (
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="text-left text-gray-500 border-b border-gray-200">
-                <th className="py-2 pr-4 font-semibold">Journey</th>
-                <th className="py-2 pr-4 font-semibold">Step</th>
-                <th className="py-2 pr-4 font-semibold">To</th>
-                <th className="py-2 pr-4 font-semibold">Sends at</th>
-                <th className="py-2 pr-4 font-semibold">Status</th>
-                <th className="py-2" />
-              </tr>
-            </thead>
-            <tbody>
-              {jobs.map((job) => (
-                <tr key={job.id} className="border-b border-gray-100">
-                  <td className="py-2 pr-4 text-gray-900">{job.journeyKey}</td>
-                  <td className="py-2 pr-4 text-gray-700">{job.step}</td>
-                  <td className="py-2 pr-4 text-gray-700">{job.email}</td>
-                  <td className="py-2 pr-4 text-gray-700">
-                    {new Date(job.scheduledFor).toLocaleString('en-US', {
-                      timeZone: 'America/Chicago',
-                      month: 'short',
-                      day: 'numeric',
-                      hour: 'numeric',
-                      minute: '2-digit',
-                    })}
-                  </td>
-                  <td className="py-2 pr-4 text-gray-700">{job.status}</td>
-                  <td className="py-2 text-right">
-                    {job.status === 'scheduled' && (
-                      <button
-                        type="button"
-                        onClick={() => void cancel(job.id)}
-                        disabled={busyId === job.id}
-                        className="btn-ghost text-red-600 disabled:opacity-50"
-                      >
-                        Cancel
-                      </button>
-                    )}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <div className="divide-y divide-gray-100 -mx-2">
+          {jobs.map((job) => (
+            <div key={job.id} className="px-2 py-2.5 min-h-[52px] flex flex-wrap items-center gap-x-3 gap-y-1">
+              <div className="flex-1 min-w-[180px]">
+                <p className="text-sm font-semibold text-gray-900">
+                  {job.email}
+                  <span className="ml-2 text-gray-400 font-normal">step {job.step}</span>
+                </p>
+                <p className="text-sm text-gray-500">{job.journeyKey}</p>
+              </div>
+              <div className="text-sm font-semibold text-gray-700 tabular-nums whitespace-nowrap">
+                {new Date(job.scheduledFor).toLocaleString('en-US', {
+                  timeZone: 'America/Chicago',
+                  month: 'short',
+                  day: 'numeric',
+                  hour: 'numeric',
+                  minute: '2-digit',
+                })}
+              </div>
+              <span className="inline-flex items-center px-2 py-[3px] rounded text-xs font-bold tracking-[0.05em] uppercase bg-blue-100 text-blue-800">
+                {job.status}
+              </span>
+              {job.status === 'scheduled' && (
+                <button
+                  type="button"
+                  onClick={() => void cancel(job.id)}
+                  disabled={busyId === job.id}
+                  className="min-h-[36px] px-3 text-sm font-semibold text-red-600 hover:bg-red-50 rounded-lg disabled:opacity-50 touch-manipulation"
+                >
+                  Cancel
+                </button>
+              )}
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/src/components/admin/followups/SentLogPanel.tsx
+++ b/src/components/admin/followups/SentLogPanel.tsx
@@ -43,7 +43,7 @@ export default function SentLogPanel(): ReactElement {
   }, []);
 
   return (
-    <div className="card">
+    <div className="card" id="sent-log">
       <h2 className="text-lg font-bold tracking-[0.08em] text-gray-900 mb-1">Sent Log</h2>
       <p className="text-sm text-gray-500 mb-4">Last 100 follow-up emails.</p>
       {error && <p className="text-sm text-red-600 mb-3">{error}</p>}

--- a/src/components/admin/followups/StatsPanel.tsx
+++ b/src/components/admin/followups/StatsPanel.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useEffect, useState, type ReactElement } from 'react';
+import KPITile from '@/components/backend/kit/KPITile';
 
 interface StatRow {
   journeyKey: string;
@@ -17,6 +18,7 @@ interface StatRow {
 
 export default function StatsPanel(): ReactElement {
   const [stats, setStats] = useState<StatRow[] | null>(null);
+  const [queued, setQueued] = useState<number | null>(null);
   const [error, setError] = useState('');
 
   useEffect(() => {
@@ -27,7 +29,24 @@ export default function StatsPanel(): ReactElement {
         else setError('Failed to load stats');
       })
       .catch(() => setError('Failed to load stats'));
+    // Queued total comes from the flags payload's per-journey counts
+    fetch('/api/ops/followups/flags')
+      .then((res) => res.json())
+      .then((json) => {
+        if (json.success) {
+          const total = (json.journeys as { counts: { scheduled: number } }[]).reduce(
+            (sum, j) => sum + j.counts.scheduled,
+            0,
+          );
+          setQueued(total);
+        }
+      })
+      .catch(() => undefined);
   }, []);
+
+  const totalSends = stats?.reduce((sum, r) => sum + r.sends, 0) ?? 0;
+  const totalOpens = stats?.reduce((sum, r) => sum + r.opens, 0) ?? 0;
+  const openRate = totalSends > 0 ? Math.round((totalOpens / totalSends) * 100) : 0;
 
   return (
     <div className="card">
@@ -35,6 +54,17 @@ export default function StatsPanel(): ReactElement {
       <p className="text-sm text-gray-500 mb-4">
         Orders within 30 days of a send, matched by email; each order counts once.
       </p>
+
+      <div className="grid grid-cols-3 gap-2.5 mb-4">
+        <KPITile label="Queued" value={queued != null ? String(queued) : '—'} />
+        <KPITile label="Sent" value={String(totalSends)} delta="all time" />
+        <KPITile
+          label="Open rate"
+          value={totalSends > 0 ? `${openRate}%` : '—'}
+          delta={totalSends > 0 ? `${totalOpens} opens` : 'no sends yet'}
+          deltaTone={totalSends > 0 && openRate >= 30 ? 'green' : 'gray'}
+        />
+      </div>
       {error && <p className="text-sm text-red-600 mb-3">{error}</p>}
       {!stats ? (
         <p className="text-sm text-gray-500">Loading stats…</p>

--- a/src/components/backend/subnav-items.ts
+++ b/src/components/backend/subnav-items.ts
@@ -7,13 +7,6 @@ export const CATALOG_SUBNAV: SectionSubNavItem[] = [
   { href: '/ops/collections', label: 'Collections' },
 ];
 
-/** Admin Email group: template previews, follow-up engine, collected signups. */
-export const EMAIL_SUBNAV: SectionSubNavItem[] = [
-  { href: '/admin/emails', label: 'Templates' },
-  { href: '/admin/emails/followups', label: 'Follow-Ups' },
-  { href: '/admin/email-signups', label: 'Signups' },
-];
-
 /** Admin Partners group: affiliate program + discount codes. */
 export const PARTNERS_SUBNAV: SectionSubNavItem[] = [
   { href: '/admin/affiliates', label: 'Affiliates' },


### PR DESCRIPTION
## Phase 6 — Email hub restyle (auto-ship)

Per the approved HQ plan: this phase is auto-ship when gates pass (no preview gate — it re-chromes admin-only surfaces; all flow flags remain OFF and untouched).

- **EmailHubBand** (NavyBand + SegmentedControl links) replaces `SectionSubNav` on Templates / Follow-Ups / Signups; dead `EMAIL_SUBNAV` removed.
- **Follow-Ups view per the design handoff**: navy **master kill-switch card** (64×36 kit/Toggle, "pauses queue instantly") on the existing `/api/ops/followups/flags` API; per-flow rows ≥64px with 52×30 kit/Toggles (paused rows dimmed); **stats strip ×3** (Queued · Sent · Open rate) above the conversion table; **Next in Queue** card with stacked rows (no horizontal table on mobile) + Sent-log anchor. Panels reordered to match the design.
- **Templates + Signups re-chromed only** — band swap, all content/behavior untouched.
- No API changes, no flag changes. The follow-ups system stays exactly as merged in #183–#187 (all flags OFF).

### Gates
`npx tsc --noEmit` ✓ · `npm run lint` ✓ no errors · `npm run test:run` ✓ 679/679 · webpack dev smoke: all three routes 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)