### PR TITLE
feat(hq): Order action sheet + slide-to-confirm refunds (phase 4 PR-D, supersedes #221)

### DIFF
--- a/src/app/ops/orders/[id]/page.tsx
+++ b/src/app/ops/orders/[id]/page.tsx
@@ -1264,7 +1264,7 @@ export default function OrderDetailPage(): ReactElement {
                               setRefundType('custom');
                               setShowActionSheet(true);
                             }}
-                            disabled={!order.payment.stripePaymentIntentId}
+                            disabled={refundProcessing || !order.payment.stripePaymentIntentId}
                             className="mt-2 px-3 py-1.5 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed"
                             title={!order.payment.stripePaymentIntentId ? 'No Stripe payment found for this order' : ''}
                           >
@@ -1717,7 +1717,13 @@ export default function OrderDetailPage(): ReactElement {
         refundReason={refundReason}
         refundType={refundType}
         refundProcessing={refundProcessing}
-        onRefundAmount={setRefundAmount}
+        onRefundAmount={(amount) => {
+          setRefundAmount(amount);
+          // Any preset/manual amount change inside the sheet detaches the
+          // refund from a prefilled amendment — otherwise a mismatched
+          // amount could stamp that amendment REFUNDED (security review).
+          setPendingAmendmentId(null);
+        }}
         onRefundReason={setRefundReason}
         onRefundType={setRefundType}
         onMarkDelivered={() => {

--- a/src/app/ops/orders/[id]/page.tsx
+++ b/src/app/ops/orders/[id]/page.tsx
@@ -9,6 +9,7 @@ import DeliveryCard from '@/components/ops/orders/detail/DeliveryCard';
 import ItemsCard from '@/components/ops/orders/detail/ItemsCard';
 import PaymentCard from '@/components/ops/orders/detail/PaymentCard';
 import DetailStickyBar, { nextTransition } from '@/components/ops/orders/detail/DetailStickyBar';
+import OrderActionSheet from '@/components/ops/orders/detail/OrderActionSheet';
 import { getStatusColor, formatDateTime, SectionHeader } from '@/components/ops/orders/detail/shared';
 import type { OrderDetail } from '@/components/ops/orders/detail/types';
 
@@ -98,8 +99,8 @@ export default function OrderDetailPage(): ReactElement {
   const searchRef = useRef<HTMLDivElement>(null);
   const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Refund dialog state
-  const [showRefundDialog, setShowRefundDialog] = useState(false);
+  // Action sheet + refund state
+  const [showActionSheet, setShowActionSheet] = useState(false);
   const [refundAmount, setRefundAmount] = useState(0);
   const [refundReason, setRefundReason] = useState('');
   const [refundProcessing, setRefundProcessing] = useState(false);
@@ -386,11 +387,12 @@ export default function OrderDetailPage(): ReactElement {
             await sendAmendmentInvoice(amendment.id);
           }
         } else if (amendment.amountDelta < 0) {
-          // Negative delta -- show refund dialog
+          // Negative delta -- open the action sheet's refund zone prefilled
           setPendingAmendmentId(amendment.id);
           setRefundAmount(Math.abs(amendment.amountDelta));
           setRefundReason('Order amendment');
-          setShowRefundDialog(true);
+          setRefundType('custom');
+          setShowActionSheet(true);
         }
         setIsEditing(false);
         setPreview(null);
@@ -447,8 +449,11 @@ export default function OrderDetailPage(): ReactElement {
             ? `Refund of $${refundAmount.toFixed(2)} processed — WARNING: ${data.warning}`
             : `Refund of $${refundAmount.toFixed(2)} processed successfully`
         );
-        setShowRefundDialog(false);
+        setShowActionSheet(false);
         setPendingAmendmentId(null);
+        setRefundAmount(0);
+        setRefundReason('');
+        setRefundType('custom');
         await fetchOrder();
       } else {
         alert(data.error || 'Failed to process refund');
@@ -699,12 +704,13 @@ export default function OrderDetailPage(): ReactElement {
     }
   }
 
-  function openRefundDialog(): void {
+  function openActionSheet(): void {
+    // Fresh open: clear any leftover refund prefill from an abandoned flow
     setRefundType('custom');
     setRefundAmount(0);
     setRefundReason('');
     setPendingAmendmentId(null);
-    setShowRefundDialog(true);
+    setShowActionSheet(true);
   }
 
   function openReturnDialog(): void {
@@ -878,7 +884,7 @@ export default function OrderDetailPage(): ReactElement {
             onCopySummary={handleCopySummary}
             onPrint={handlePrint}
             onSendReceipt={handleSendReceipt}
-            onOpenRefund={openRefundDialog}
+            onOpenActions={openActionSheet}
             onOpenReturn={openReturnDialog}
             onEnterEdit={enterEditMode}
             onOpenCancel={openCancelDialog}
@@ -1255,7 +1261,8 @@ export default function OrderDetailPage(): ReactElement {
                               setPendingAmendmentId(amendment.id);
                               setRefundAmount(Math.abs(amendment.amountDelta));
                               setRefundReason('Order amendment');
-                              setShowRefundDialog(true);
+                              setRefundType('custom');
+                              setShowActionSheet(true);
                             }}
                             disabled={!order.payment.stripePaymentIntentId}
                             className="mt-2 px-3 py-1.5 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed"
@@ -1587,7 +1594,9 @@ export default function OrderDetailPage(): ReactElement {
       </div>
 
       {/* Sticky next-transition bar (MARK PACKED → MARK OUT → MARK DELIVERED) */}
-      {showStickyBar && <DetailStickyBar order={order} saving={saving} onAdvance={updateOrder} />}
+      {showStickyBar && (
+        <DetailStickyBar order={order} saving={saving} onAdvance={updateOrder} onOpenActions={openActionSheet} />
+      )}
 
       {/* Edit Bar (sticky bottom in edit mode) */}
       {isEditing && (
@@ -1695,165 +1704,35 @@ export default function OrderDetailPage(): ReactElement {
         </div>
       )}
 
-      {/* Refund Confirmation Dialog */}
-      {showRefundDialog && (
-        <div className="fixed inset-0 bg-black/50 z-[60] flex items-center justify-center p-4 print:hidden">
-          <div className="bg-white rounded-xl shadow-2xl max-w-md w-full p-6">
-            <h3 className="text-lg font-bold text-gray-900 mb-4">Process Refund</h3>
-            <div className="space-y-4">
-              {/* Quick-select refund type buttons */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">Refund Type</label>
-                <div className="flex flex-wrap gap-2">
-                  {order.pricing.deliveryFee > 0 && (
-                    <button
-                      onClick={() => {
-                        setRefundType('delivery');
-                        setRefundAmount(order.pricing.deliveryFee);
-                        setRefundReason('Delivery fee refund');
-                      }}
-                      className={`px-3 py-1.5 text-sm font-medium rounded-full border transition-colors ${
-                        refundType === 'delivery'
-                          ? 'bg-blue-100 text-blue-700 border-blue-300'
-                          : 'bg-gray-50 text-gray-600 border-gray-200 hover:bg-gray-100'
-                      }`}
-                    >
-                      Delivery Fee (${order.pricing.deliveryFee.toFixed(2)})
-                    </button>
-                  )}
-                  {order.pricing.tipAmount > 0 && (
-                    <button
-                      onClick={() => {
-                        setRefundType('tip');
-                        setRefundAmount(order.pricing.tipAmount);
-                        setRefundReason('Tip refund');
-                      }}
-                      className={`px-3 py-1.5 text-sm font-medium rounded-full border transition-colors ${
-                        refundType === 'tip'
-                          ? 'bg-blue-100 text-blue-700 border-blue-300'
-                          : 'bg-gray-50 text-gray-600 border-gray-200 hover:bg-gray-100'
-                      }`}
-                    >
-                      Tip (${order.pricing.tipAmount.toFixed(2)})
-                    </button>
-                  )}
-                  {order.pricing.deliveryFee > 0 && order.pricing.tipAmount > 0 && (
-                    <button
-                      onClick={() => {
-                        setRefundType('delivery_tip');
-                        setRefundAmount(order.pricing.deliveryFee + order.pricing.tipAmount);
-                        setRefundReason('Delivery fee + tip refund');
-                      }}
-                      className={`px-3 py-1.5 text-sm font-medium rounded-full border transition-colors ${
-                        refundType === 'delivery_tip'
-                          ? 'bg-blue-100 text-blue-700 border-blue-300'
-                          : 'bg-gray-50 text-gray-600 border-gray-200 hover:bg-gray-100'
-                      }`}
-                    >
-                      Delivery + Tip (${(order.pricing.deliveryFee + order.pricing.tipAmount).toFixed(2)})
-                    </button>
-                  )}
-                  <button
-                    onClick={() => {
-                      const captured = order.refunds?.stripeCapturedAmount ?? order.pricing.total;
-                      const maxRefundable = captured - (order.refunds?.totalRefunded || 0);
-                      setRefundType('full');
-                      setRefundAmount(Math.max(0, maxRefundable));
-                      setRefundReason('Full refund');
-                    }}
-                    className={`px-3 py-1.5 text-sm font-medium rounded-full border transition-colors ${
-                      refundType === 'full'
-                        ? 'bg-blue-100 text-blue-700 border-blue-300'
-                        : 'bg-gray-50 text-gray-600 border-gray-200 hover:bg-gray-100'
-                    }`}
-                  >
-                    Full Refund (${Math.max(0, (order.refunds?.stripeCapturedAmount ?? order.pricing.total) - (order.refunds?.totalRefunded || 0)).toFixed(2)})
-                  </button>
-                  <button
-                    onClick={() => {
-                      setRefundType('custom');
-                      setRefundAmount(0);
-                      setRefundReason('');
-                    }}
-                    className={`px-3 py-1.5 text-sm font-medium rounded-full border transition-colors ${
-                      refundType === 'custom'
-                        ? 'bg-blue-100 text-blue-700 border-blue-300'
-                        : 'bg-gray-50 text-gray-600 border-gray-200 hover:bg-gray-100'
-                    }`}
-                  >
-                    Custom
-                  </button>
-                </div>
-              </div>
-
-              {/* Amount input */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Refund Amount</label>
-                <div className="flex items-center gap-2">
-                  <span className="text-gray-500">$</span>
-                  <input
-                    type="number"
-                    value={refundAmount}
-                    onChange={(e) => {
-                      setRefundAmount(parseFloat(e.target.value) || 0);
-                      setRefundType('custom');
-                    }}
-                    step="0.01"
-                    min="0"
-                    className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  />
-                </div>
-                {order.refunds && order.refunds.totalRefunded > 0 && (
-                  <p className="text-xs text-gray-500 mt-1">
-                    Previously refunded: ${order.refunds.totalRefunded.toFixed(2)} | Max remaining: ${Math.max(0, (order.refunds.stripeCapturedAmount ?? order.pricing.total) - order.refunds.totalRefunded).toFixed(2)}
-                  </p>
-                )}
-              </div>
-
-              {/* Reason input */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Reason</label>
-                <input
-                  type="text"
-                  value={refundReason}
-                  onChange={(e) => setRefundReason(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  placeholder="Reason for refund"
-                />
-              </div>
-
-              {/* Warning */}
-              <div className="bg-red-50 border border-red-200 rounded-lg p-3">
-                <p className="text-sm text-red-800">
-                  This will process a refund of <strong>${refundAmount.toFixed(2)}</strong> via Stripe.
-                  The customer will receive an email notification.
-                </p>
-              </div>
-
-              {/* Buttons */}
-              <div className="flex items-center justify-end gap-3 pt-2">
-                <button
-                  onClick={() => {
-                    setShowRefundDialog(false);
-                    setPendingAmendmentId(null);
-                    setRefundType('custom');
-                  }}
-                  className="px-4 py-2 text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200"
-                >
-                  Cancel
-                </button>
-                <button
-                  onClick={processRefund}
-                  disabled={refundProcessing || refundAmount <= 0}
-                  className="px-6 py-2 bg-red-600 text-white rounded-lg font-semibold hover:bg-red-700 disabled:opacity-50"
-                >
-                  {refundProcessing ? 'Processing...' : 'Confirm Refund'}
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
+      {/* Order action sheet (overflow actions + refund zone) */}
+      <OrderActionSheet
+        open={showActionSheet}
+        onClose={() => setShowActionSheet(false)}
+        order={order}
+        canAmend={!!canAmend}
+        saving={saving}
+        sendingReceipt={sendingReceipt}
+        sendingReview={sendingReview}
+        refundAmount={refundAmount}
+        refundReason={refundReason}
+        refundType={refundType}
+        refundProcessing={refundProcessing}
+        onRefundAmount={setRefundAmount}
+        onRefundReason={setRefundReason}
+        onRefundType={setRefundType}
+        onMarkDelivered={() => {
+          setShowActionSheet(false);
+          updateOrder({ fulfillmentStatus: 'DELIVERED' });
+        }}
+        onPrint={handlePrint}
+        onSendReceipt={handleSendReceipt}
+        onAmend={enterEditMode}
+        onRequestReview={() => {
+          setShowActionSheet(false);
+          handleSendReview();
+        }}
+        onProcessRefund={processRefund}
+      />
 
       {/* Return Dialog */}
       {showReturnDialog && order && (

--- a/src/components/ops/orders/FilterSheet.tsx
+++ b/src/components/ops/orders/FilterSheet.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ReactElement } from 'react';
+import BottomSheet from '@/components/backend/kit/BottomSheet';
 import type { OrdersViewFilters } from './useOrdersView';
 
 const RARE_FULFILLMENT = ['PARTIAL', 'IN_TRANSIT', 'OUT_FOR_DELIVERY', 'FULFILLED'];
@@ -39,8 +40,8 @@ function FilterGroup({ label, children }: { label: string; children: React.React
 }
 
 /**
- * The "More filters" panel: bottom sheet on mobile, inline dropdown panel on
- * desktop. All controls are touch-friendly pills — no <select>s.
+ * The "More filters" sheet on kit/BottomSheet. All controls are
+ * touch-friendly pills — no <select>s.
  */
 export default function FilterSheet({
   open,
@@ -63,53 +64,27 @@ export default function FilterSheet({
   deliveryTypes: string[];
   onClearAll: () => void;
 }): ReactElement | null {
-  if (!open) return null;
-
   return (
-    <>
-      {/* Backdrop (mobile sheet) */}
-      <div
-        className="fixed inset-0 bg-black/40 z-40 md:hidden print:hidden"
-        onClick={onClose}
-        aria-hidden="true"
-      />
-      <div
-        className={[
-          'print:hidden z-50',
-          // Mobile: bottom sheet
-          'fixed inset-x-0 bottom-0 max-h-[80vh] overflow-y-auto rounded-t-2xl bg-white shadow-2xl safe-area-bottom',
-          // Desktop: inline panel
-          'md:static md:max-h-none md:rounded-xl md:shadow-sm md:border md:border-gray-200 md:mb-3',
-        ].join(' ')}
-        role="dialog"
-        aria-label="More filters"
-      >
-        {/* Drag handle (mobile only) */}
-        <div className="md:hidden flex justify-center pt-2">
-          <span className="w-10 h-1 rounded-full bg-gray-300" />
+    <BottomSheet open={open} onClose={onClose} title="Filters">
+      <div className="pb-2 space-y-4">
+        <div className="flex items-center justify-end gap-2 -mt-1">
+          <button
+            type="button"
+            onClick={onClearAll}
+            className="min-h-[44px] px-3 text-sm font-medium text-gray-500 hover:text-gray-800 touch-manipulation"
+          >
+            Clear all
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="min-h-[44px] px-4 text-sm font-semibold text-white bg-brand-blue rounded-lg touch-manipulation"
+          >
+            Done
+          </button>
         </div>
-        <div className="px-4 py-3 space-y-4">
-          <div className="flex items-center justify-between">
-            <h3 className="text-base font-bold text-gray-900">Filters</h3>
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={onClearAll}
-                className="min-h-[44px] px-3 text-sm font-medium text-gray-500 hover:text-gray-800 touch-manipulation"
-              >
-                Clear all
-              </button>
-              <button
-                type="button"
-                onClick={onClose}
-                className="min-h-[44px] px-4 text-sm font-semibold text-white bg-brand-blue rounded-lg touch-manipulation"
-              >
-                Done
-              </button>
-            </div>
-          </div>
 
-          <FilterGroup label="Order status">
+        <FilterGroup label="Order status">
             <Pill active={filters.status === ''} onClick={() => onChange({ status: '' })}>All</Pill>
             {statuses.map((s) => (
               <Pill key={s} active={filters.status === s} onClick={() => onChange({ status: s })}>
@@ -139,15 +114,14 @@ export default function FilterSheet({
             <Pill active={filters.reviewSent === 'sent'} onClick={() => onChange({ reviewSent: 'sent' })}>Review sent</Pill>
           </FilterGroup>
 
-          <FilterGroup label="More fulfillment states">
-            {RARE_FULFILLMENT.map((f) => (
-              <Pill key={f} active={fulfillment === f} onClick={() => onFulfillmentChange(f)}>
-                {f}
-              </Pill>
-            ))}
-          </FilterGroup>
-        </div>
+        <FilterGroup label="More fulfillment states">
+          {RARE_FULFILLMENT.map((f) => (
+            <Pill key={f} active={fulfillment === f} onClick={() => onFulfillmentChange(f)}>
+              {f}
+            </Pill>
+          ))}
+        </FilterGroup>
       </div>
-    </>
+    </BottomSheet>
   );
 }

--- a/src/components/ops/orders/detail/DetailHeader.tsx
+++ b/src/components/ops/orders/detail/DetailHeader.tsx
@@ -20,7 +20,7 @@ export default function DetailHeader({
   onCopySummary,
   onPrint,
   onSendReceipt,
-  onOpenRefund,
+  onOpenActions,
   onOpenReturn,
   onEnterEdit,
   onOpenCancel,
@@ -33,7 +33,7 @@ export default function DetailHeader({
   onCopySummary: () => void;
   onPrint: () => void;
   onSendReceipt: () => void;
-  onOpenRefund: () => void;
+  onOpenActions: () => void;
   onOpenReturn: () => void;
   onEnterEdit: () => void;
   onOpenCancel: () => void;
@@ -138,17 +138,16 @@ export default function DetailHeader({
           </button>
         )}
 
-        {order.payment.stripePaymentIntentId && (
-          <button
-            onClick={onOpenRefund}
-            className="px-4 py-2 bg-white border border-red-200 text-red-700 rounded-lg font-medium hover:bg-red-50 transition-colors shadow-sm flex items-center gap-2"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
-            </svg>
-            Issue Refund
-          </button>
-        )}
+        <button
+          onClick={onOpenActions}
+          className="px-4 py-2 bg-white border border-gray-200 text-gray-700 rounded-lg font-medium hover:bg-gray-50 transition-colors shadow-sm flex items-center gap-2"
+          title="Order actions (delivered, invoice, review, refund)"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" />
+          </svg>
+          Actions
+        </button>
 
         {order.payment.stripePaymentIntentId && (order.status === 'DELIVERED' || order.fulfillmentStatus === 'DELIVERED') && (
           <button

--- a/src/components/ops/orders/detail/DetailStickyBar.tsx
+++ b/src/components/ops/orders/detail/DetailStickyBar.tsx
@@ -32,10 +32,12 @@ export default function DetailStickyBar({
   order,
   saving,
   onAdvance,
+  onOpenActions,
 }: {
   order: OrderDetail;
   saving: boolean;
   onAdvance: (updates: Record<string, unknown>) => void;
+  onOpenActions?: () => void;
 }): ReactElement | null {
   const next = nextTransition(order);
   if (!next) return null;
@@ -50,6 +52,20 @@ export default function DetailStickyBar({
       >
         {saving ? 'Saving…' : next.label}
       </button>
+      {onOpenActions && (
+        <button
+          type="button"
+          onClick={onOpenActions}
+          aria-label="More actions"
+          className="w-[52px] min-h-[52px] flex-shrink-0 rounded-lg border border-gray-300 bg-white text-gray-700 flex items-center justify-center hover:bg-gray-50 transition-colors touch-manipulation"
+        >
+          <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
+            <circle cx="5" cy="12" r="1.8" />
+            <circle cx="12" cy="12" r="1.8" />
+            <circle cx="19" cy="12" r="1.8" />
+          </svg>
+        </button>
+      )}
     </StickyActionBar>
   );
 }

--- a/src/components/ops/orders/detail/OrderActionSheet.tsx
+++ b/src/components/ops/orders/detail/OrderActionSheet.tsx
@@ -1,0 +1,303 @@
+'use client';
+
+import { ReactElement, ReactNode } from 'react';
+import BottomSheet from '@/components/backend/kit/BottomSheet';
+import SlideToConfirm from './SlideToConfirm';
+import type { OrderDetail } from './types';
+
+function ActionRow({
+  icon,
+  label,
+  hint,
+  disabled = false,
+  onClick,
+}: {
+  icon: ReactNode;
+  label: string;
+  hint?: string;
+  disabled?: boolean;
+  onClick: () => void;
+}): ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="w-full min-h-[52px] flex items-center gap-3 px-1 py-2 text-left border-b border-gray-100 last:border-b-0 disabled:opacity-40 hover:bg-gray-50 transition-colors touch-manipulation"
+    >
+      <span className="text-gray-500 flex-shrink-0">{icon}</span>
+      <span className="flex-1 min-w-0">
+        <span className="block text-sm font-semibold text-gray-900">{label}</span>
+        {hint && <span className="block text-sm text-gray-500">{hint}</span>}
+      </span>
+    </button>
+  );
+}
+
+/**
+ * Order overflow action sheet: the everyday actions plus an isolated red
+ * refund zone. Refunds are exact-amount, preset-chipped, and confirmed by a
+ * slide gesture — never a bare tap. All money state and the processRefund
+ * call live in the page; the server enforces the Stripe-authoritative cap.
+ */
+export default function OrderActionSheet({
+  open,
+  onClose,
+  order,
+  canAmend,
+  saving,
+  sendingReceipt,
+  sendingReview,
+  refundAmount,
+  refundReason,
+  refundType,
+  refundProcessing,
+  onRefundAmount,
+  onRefundReason,
+  onRefundType,
+  onMarkDelivered,
+  onPrint,
+  onSendReceipt,
+  onAmend,
+  onRequestReview,
+  onProcessRefund,
+}: {
+  open: boolean;
+  onClose: () => void;
+  order: OrderDetail;
+  canAmend: boolean;
+  saving: boolean;
+  sendingReceipt: boolean;
+  sendingReview: boolean;
+  refundAmount: number;
+  refundReason: string;
+  refundType: string;
+  refundProcessing: boolean;
+  onRefundAmount: (amount: number) => void;
+  onRefundReason: (reason: string) => void;
+  onRefundType: (type: string) => void;
+  onMarkDelivered: () => void;
+  onPrint: () => void;
+  onSendReceipt: () => void;
+  onAmend: () => void;
+  onRequestReview: () => void;
+  onProcessRefund: () => void;
+}): ReactElement | null {
+  const delivered = order.fulfillmentStatus === 'DELIVERED';
+  const cancelled = order.status === 'CANCELLED';
+  const maxRefundable = Math.max(
+    0,
+    (order.refunds?.stripeCapturedAmount ?? order.pricing.total) - (order.refunds?.totalRefunded || 0),
+  );
+
+  const chip = (active: boolean): string =>
+    `min-h-[44px] px-3 text-sm font-semibold rounded-lg border transition-colors touch-manipulation ${
+      active
+        ? 'bg-white border-red-400 text-red-800 shadow-sm'
+        : 'bg-red-100/60 border-red-200 text-red-700 hover:bg-white'
+    }`;
+
+  return (
+    <BottomSheet open={open} onClose={onClose} title="Order actions">
+      <div className="pb-2">
+        {!delivered && !cancelled && (
+          <ActionRow
+            icon={
+              <svg className="w-[22px] h-[22px]" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            }
+            label="Mark delivered"
+            hint="Completes fulfillment and releases inventory"
+            disabled={saving}
+            onClick={onMarkDelivered}
+          />
+        )}
+        <ActionRow
+          icon={
+            <svg className="w-[22px] h-[22px]" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6.72 13.829c-.24.03-.48.062-.72.096m.72-.096a42.415 42.415 0 0110.56 0m-10.56 0L6.34 18m10.94-4.171c.24.03.48.062.72.096m-.72-.096L17.66 18m0 0l.229 2.523a1.125 1.125 0 01-1.12 1.227H7.231c-.662 0-1.18-.568-1.12-1.227L6.34 18m11.318 0h1.091A2.25 2.25 0 0021 15.75V9.456c0-1.081-.768-2.015-1.837-2.175a48.055 48.055 0 00-1.913-.247M6.34 18H5.25A2.25 2.25 0 013 15.75V9.456c0-1.081.768-2.015 1.837-2.175a48.041 48.041 0 011.913-.247m10.5 0a48.536 48.536 0 00-10.5 0m10.5 0V3.375c0-.621-.504-1.125-1.125-1.125h-8.25c-.621 0-1.125.504-1.125 1.125v3.659" />
+            </svg>
+          }
+          label="Print pick sheet"
+          hint="The paper order sheet with pick checkboxes"
+          onClick={() => {
+            onClose();
+            onPrint();
+          }}
+        />
+        {order.financialStatus === 'PAID' && (
+          <ActionRow
+            icon={
+              <svg className="w-[22px] h-[22px]" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" />
+              </svg>
+            }
+            label="Send invoice copy"
+            hint={`Emails the receipt to ${order.customerSnapshot.email || order.customer.email}`}
+            disabled={sendingReceipt}
+            onClick={onSendReceipt}
+          />
+        )}
+        {canAmend && (
+          <ActionRow
+            icon={
+              <svg className="w-[22px] h-[22px]" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z" />
+              </svg>
+            }
+            label="Amend order"
+            hint="Edit items, fees, and delivery details"
+            onClick={() => {
+              onClose();
+              onAmend();
+            }}
+          />
+        )}
+        <ActionRow
+          icon={
+            <svg className="w-[22px] h-[22px]" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z" />
+            </svg>
+          }
+          label="Request review"
+          hint={
+            order.reviewRequestSentAt
+              ? `Already sent ${new Date(order.reviewRequestSentAt).toLocaleDateString()}`
+              : 'Texts the customer a review link'
+          }
+          disabled={sendingReview || !!order.reviewRequestSentAt}
+          onClick={onRequestReview}
+        />
+
+        {/* Refund zone — isolated, red, slide-to-confirm */}
+        {order.payment.stripePaymentIntentId && (
+          <div className="mt-4 mb-2 rounded-xl border border-red-200 bg-red-50 p-4">
+            <div className="flex items-baseline justify-between gap-3 mb-3">
+              <h3 className="font-heading font-bold text-base tracking-[0.08em] uppercase text-red-900">
+                Refund
+              </h3>
+              <span className="text-sm font-semibold text-red-800 tabular-nums">
+                Max ${maxRefundable.toFixed(2)}
+              </span>
+            </div>
+
+            <div className="flex flex-wrap gap-1.5 mb-3">
+              {order.pricing.deliveryFee > 0 && (
+                <button
+                  type="button"
+                  className={chip(refundType === 'delivery')}
+                  onClick={() => {
+                    onRefundType('delivery');
+                    onRefundAmount(order.pricing.deliveryFee);
+                    onRefundReason('Delivery fee refund');
+                  }}
+                >
+                  Delivery ${order.pricing.deliveryFee.toFixed(2)}
+                </button>
+              )}
+              {order.pricing.tipAmount > 0 && (
+                <button
+                  type="button"
+                  className={chip(refundType === 'tip')}
+                  onClick={() => {
+                    onRefundType('tip');
+                    onRefundAmount(order.pricing.tipAmount);
+                    onRefundReason('Tip refund');
+                  }}
+                >
+                  Tip ${order.pricing.tipAmount.toFixed(2)}
+                </button>
+              )}
+              {order.pricing.deliveryFee > 0 && order.pricing.tipAmount > 0 && (
+                <button
+                  type="button"
+                  className={chip(refundType === 'delivery_tip')}
+                  onClick={() => {
+                    onRefundType('delivery_tip');
+                    onRefundAmount(order.pricing.deliveryFee + order.pricing.tipAmount);
+                    onRefundReason('Delivery fee + tip refund');
+                  }}
+                >
+                  Delivery + Tip
+                </button>
+              )}
+              <button
+                type="button"
+                className={chip(refundType === 'full')}
+                onClick={() => {
+                  onRefundType('full');
+                  onRefundAmount(maxRefundable);
+                  onRefundReason('Full refund');
+                }}
+              >
+                Full ${maxRefundable.toFixed(2)}
+              </button>
+              <button
+                type="button"
+                className={chip(refundType === 'custom')}
+                onClick={() => {
+                  onRefundType('custom');
+                  onRefundAmount(0);
+                  onRefundReason('');
+                }}
+              >
+                Custom
+              </button>
+            </div>
+
+            <div className="grid grid-cols-[110px_1fr] gap-2 mb-3">
+              <label className="block">
+                <span className="block text-xs font-semibold text-red-900/70 uppercase tracking-wider mb-1">Amount</span>
+                <div className="flex items-center gap-1 bg-white border border-red-200 rounded-lg px-2">
+                  <span className="text-gray-500 text-sm">$</span>
+                  <input
+                    type="number"
+                    inputMode="decimal"
+                    value={refundAmount}
+                    onChange={(e) => {
+                      onRefundAmount(parseFloat(e.target.value) || 0);
+                      onRefundType('custom');
+                    }}
+                    step="0.01"
+                    min="0"
+                    className="w-full min-h-[44px] text-base font-semibold text-gray-900 focus:outline-none tabular-nums"
+                  />
+                </div>
+              </label>
+              <label className="block">
+                <span className="block text-xs font-semibold text-red-900/70 uppercase tracking-wider mb-1">Reason</span>
+                <input
+                  type="text"
+                  value={refundReason}
+                  onChange={(e) => onRefundReason(e.target.value)}
+                  placeholder="Reason for refund"
+                  className="w-full min-h-[44px] px-3 bg-white border border-red-200 rounded-lg text-base text-gray-900 focus:outline-none focus:ring-2 focus:ring-red-400"
+                />
+              </label>
+            </div>
+
+            {order.refunds && order.refunds.totalRefunded > 0 && (
+              <p className="text-sm text-red-800 mb-3">
+                Previously refunded ${order.refunds.totalRefunded.toFixed(2)} across {order.refunds.count} refund{order.refunds.count === 1 ? '' : 's'}.
+              </p>
+            )}
+
+            <SlideToConfirm
+              label={
+                refundProcessing
+                  ? 'Processing…'
+                  : `Slide to refund $${refundAmount.toFixed(2)}`
+              }
+              disabled={refundProcessing || refundAmount <= 0 || refundAmount > maxRefundable}
+              onConfirm={onProcessRefund}
+            />
+            <p className="mt-2 text-sm text-red-900/70">
+              Refunds are exact-amount, two-step, and logged. The customer is emailed.
+            </p>
+          </div>
+        )}
+      </div>
+    </BottomSheet>
+  );
+}

--- a/src/components/ops/orders/detail/SlideToConfirm.tsx
+++ b/src/components/ops/orders/detail/SlideToConfirm.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { ReactElement, useRef, useState } from 'react';
+
+const THUMB_W = 44;
+
+/**
+ * Slide-to-confirm control for money-out actions (refunds). The gesture must
+ * START on the thumb and travel the full track — tapping the track does
+ * nothing, so an accidental tap can never confirm. Keyboard: focus the thumb
+ * and hold ArrowRight to walk it across; reaching the end confirms.
+ */
+export default function SlideToConfirm({
+  label,
+  disabled = false,
+  onConfirm,
+}: {
+  label: string;
+  disabled?: boolean;
+  onConfirm: () => void;
+}): ReactElement {
+  const [pct, setPctState] = useState(0);
+  const pctRef = useRef(0);
+  const trackRef = useRef<HTMLDivElement>(null);
+  const dragging = useRef(false);
+  const startX = useRef(0);
+  const fired = useRef(false);
+
+  // Ref mirrors state so pointer-up reads the live position, not a stale render
+  function setPct(v: number): void {
+    pctRef.current = v;
+    setPctState(v);
+  }
+
+  function travel(): number {
+    return (trackRef.current?.offsetWidth ?? 300) - THUMB_W - 8;
+  }
+
+  function fire(): void {
+    if (fired.current) return;
+    fired.current = true;
+    onConfirm();
+    // Reset after the action kicks off so a re-render mid-flight is clean
+    setTimeout(() => {
+      fired.current = false;
+      setPct(0);
+    }, 400);
+  }
+
+  function handlePointerDown(e: React.PointerEvent<HTMLButtonElement>): void {
+    if (disabled) return;
+    dragging.current = true;
+    startX.current = e.clientX;
+    e.currentTarget.setPointerCapture(e.pointerId);
+  }
+
+  function handlePointerMove(e: React.PointerEvent<HTMLButtonElement>): void {
+    if (!dragging.current || disabled) return;
+    const next = Math.min(100, Math.max(0, ((e.clientX - startX.current) / travel()) * 100));
+    setPct(next);
+  }
+
+  function handlePointerUp(): void {
+    if (!dragging.current) return;
+    dragging.current = false;
+    if (pctRef.current >= 96) fire();
+    else setPct(0);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLButtonElement>): void {
+    if (disabled) return;
+    if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      const next = Math.min(100, pctRef.current + 10);
+      setPct(next);
+      if (next >= 100) fire();
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      setPct(Math.max(0, pctRef.current - 10));
+    } else if (e.key === 'Escape') {
+      setPct(0);
+    }
+  }
+
+  return (
+    <div
+      ref={trackRef}
+      className={`relative h-12 rounded-lg overflow-hidden select-none ${
+        disabled ? 'bg-red-300' : 'bg-red-600'
+      }`}
+    >
+      <div className="absolute inset-0 flex items-center justify-center px-12 text-white text-sm font-bold tracking-[0.05em] uppercase pointer-events-none whitespace-nowrap overflow-hidden">
+        {label}
+      </div>
+      <div
+        className="absolute inset-y-0 left-0 bg-red-900/40 pointer-events-none"
+        style={{ width: `${pct}%` }}
+      />
+      <button
+        type="button"
+        disabled={disabled}
+        aria-label={label}
+        role="slider"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={Math.round(pct)}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        onKeyDown={handleKeyDown}
+        onBlur={() => !dragging.current && setPct(0)}
+        className="absolute top-1 bottom-1 w-11 rounded-md bg-white shadow flex items-center justify-center cursor-grab active:cursor-grabbing disabled:cursor-not-allowed touch-none focus:outline-none focus:ring-2 focus:ring-brand-blue focus:ring-offset-2"
+        style={{ left: `calc(4px + (100% - ${THUMB_W + 8}px) * ${pct / 100})` }}
+      >
+        <svg className="w-5 h-5 text-red-600" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/src/components/ops/orders/detail/SlideToConfirm.tsx
+++ b/src/components/ops/orders/detail/SlideToConfirm.tsx
@@ -63,12 +63,23 @@ export default function SlideToConfirm({
   function handlePointerUp(): void {
     if (!dragging.current) return;
     dragging.current = false;
+    if (disabled) {
+      setPct(0);
+      return;
+    }
     if (pctRef.current >= 96) fire();
     else setPct(0);
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLButtonElement>): void {
     if (disabled) return;
+    // Auto-repeat from a held key must not count — each step requires a
+    // distinct physical press, or holding ArrowRight would fire a refund
+    // in under a second (security review, PR-D).
+    if (e.repeat) {
+      if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') e.preventDefault();
+      return;
+    }
     if (e.key === 'ArrowRight') {
       e.preventDefault();
       const next = Math.min(100, pctRef.current + 10);


### PR DESCRIPTION
Re-lands **#221**, which GitHub falsely marked "merged" when its stacked base branch was deleted (its recorded merge commit isn't reachable from main and the content never landed — the known stale-head trap from PR #202).

Same content as #221 at approval time, rebased onto main: **Allan approved the preview**, the security review passed with all findings fixed, and the rebase folds in #225's server-side warning (`processRefund` now surfaces the amendment-mismatch warning through the action sheet).

Gates on the rebased head: tsc ✓ · lint ✓ · **690/690** tests (includes #225's 11 refund-guard tests) ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)