### PR TITLE
fix(finance): map truncated WF distributor descriptors to COGS (+ recategorize flag)

### DIFF
--- a/scripts/finance/backfill-bank-categories.ts
+++ b/scripts/finance/backfill-bank-categories.ts
@@ -9,23 +9,39 @@
  * scripts/finance/backfill-monthly-rollups.ts so the rollups pick up the
  * bank-sourced expenses and 2026 months flip to reliable.
  *
+ * By default this only stamps NOT-YET-categorized outflows (bankDerivedCategory
+ * IS NULL) — matching the idempotent daily-sync path. Pass `--recategorize`
+ * (alias `--force`) to also RE-run the categorizer over already-tagged outflows:
+ * it clears their bankDerivedCategory first, then re-stamps every unmatched
+ * production outflow through the current `categorizeBankOutflow` rules. Use this
+ * after a COGS_MERCHANT_RULES change so mis-tagged rows (e.g. a distributor that
+ * previously fell into meals/office) self-correct — the null-only sync never
+ * revisits them on its own.
+ *
  * Usage:
  *   set -a && source .env.local && set +a
- *   npx tsx scripts/finance/backfill-bank-categories.ts [--dry-run]
+ *   npx tsx scripts/finance/backfill-bank-categories.ts [--dry-run] [--recategorize|--force]
  */
 
 import { prisma } from '../../src/lib/database/client';
 import { categorizeBankOutflows } from '../../src/lib/finance/plaid-sync-service';
 
-const UNCATEGORIZED_OUTFLOW = {
+// Unmatched production outflows the categorizer will process (mirrors the
+// WHERE clause in categorizeBankOutflows, minus the bankDerivedCategory gate).
+const OUTFLOW: {
+  pending: false;
+  matchedQbExpenseId: null;
+  amount: { gt: number };
+} = {
   pending: false,
   matchedQbExpenseId: null,
-  bankDerivedCategory: null,
   amount: { gt: 0 }, // Plaid convention: positive = outflow
 };
 
 async function main(): Promise<void> {
   const dryRun = process.argv.includes('--dry-run');
+  const recategorize =
+    process.argv.includes('--recategorize') || process.argv.includes('--force');
   const items = await prisma.plaidItem.findMany({
     where: { environment: 'production' },
     select: { id: true, institutionName: true },
@@ -39,8 +55,9 @@ async function main(): Promise<void> {
     return;
   }
 
+  const mode = recategorize ? ' (RECATEGORIZE — re-stamps ALL outflows)' : '';
   console.log(
-    `[backfill-bank-categories] ${items.length} production item(s)` +
+    `[backfill-bank-categories] ${items.length} production item(s)${mode}` +
       (dryRun ? ' (dry-run — no writes)' : '')
   );
 
@@ -50,12 +67,27 @@ async function main(): Promise<void> {
     const label = item.institutionName ?? item.id.slice(0, 8);
 
     if (dryRun) {
-      const pending = await prisma.plaidTransaction.count({
-        where: { plaidItemId: item.id, ...UNCATEGORIZED_OUTFLOW },
-      });
-      console.log(`  ${label}: ${pending} uncategorized outflow(s) would be stamped`);
-      totalCategorized += pending;
+      // In recategorize mode every unmatched outflow is re-stamped; otherwise
+      // only the not-yet-categorized ones.
+      const where = recategorize
+        ? { plaidItemId: item.id, ...OUTFLOW }
+        : { plaidItemId: item.id, ...OUTFLOW, bankDerivedCategory: null };
+      const n = await prisma.plaidTransaction.count({ where });
+      console.log(
+        `  ${label}: ${n} outflow(s) would be ${recategorize ? 're-stamped' : 'stamped'}`
+      );
+      totalCategorized += n;
       continue;
+    }
+
+    // Recategorize: clear the existing tags so the (idempotent, null-only)
+    // categorizer revisits every unmatched outflow with the current rules.
+    if (recategorize) {
+      const { count } = await prisma.plaidTransaction.updateMany({
+        where: { plaidItemId: item.id, ...OUTFLOW, bankDerivedCategory: { not: null } },
+        data: { bankDerivedCategory: null, isBankDerivedExpense: false },
+      });
+      console.log(`  ${label}: cleared ${count} existing categor${count === 1 ? 'y' : 'ies'}`);
     }
 
     // categorizeBankOutflows handles up to 1000 rows per call — drain the backlog.
@@ -74,7 +106,7 @@ async function main(): Promise<void> {
 
   console.log(
     `[backfill-bank-categories] done — ${totalCategorized} ` +
-      (dryRun ? 'pending' : `categorized (${totalExpenses} expenses)`) +
+      (dryRun ? (recategorize ? 'to re-stamp' : 'pending') : `categorized (${totalExpenses} expenses)`) +
       (dryRun ? '' : '. Next: re-run scripts/finance/backfill-monthly-rollups.ts')
   );
 }

--- a/scripts/finance/backfill-bank-categories.ts
+++ b/scripts/finance/backfill-bank-categories.ts
@@ -11,12 +11,15 @@
  *
  * By default this only stamps NOT-YET-categorized outflows (bankDerivedCategory
  * IS NULL) — matching the idempotent daily-sync path. Pass `--recategorize`
- * (alias `--force`) to also RE-run the categorizer over already-tagged outflows:
- * it clears their bankDerivedCategory first, then re-stamps every unmatched
- * production outflow through the current `categorizeBankOutflow` rules. Use this
- * after a COGS_MERCHANT_RULES change so mis-tagged rows (e.g. a distributor that
- * previously fell into meals/office) self-correct — the null-only sync never
- * revisits them on its own.
+ * (alias `--force`) to also RE-run the categorizer over already-tagged outflows.
+ * Use this after a rule change (e.g. COGS_MERCHANT_RULES) so mis-tagged rows
+ * self-correct — the null-only sync never revisits them on its own.
+ *
+ * The recategorize pass updates each row IN PLACE (old category → new category)
+ * inside a transaction, and logs every change (old → new, count, $). It never
+ * clears a row to NULL first, so there is no window where a row is missing from
+ * the rollup's expense totals even if the run is interrupted, and the change log
+ * is a reversible audit trail of exactly what moved.
  *
  * Usage:
  *   set -a && source .env.local && set +a
@@ -25,6 +28,10 @@
 
 import { prisma } from '../../src/lib/database/client';
 import { categorizeBankOutflows } from '../../src/lib/finance/plaid-sync-service';
+import {
+  categorizeBankOutflow,
+  isBankExpenseCategory,
+} from '../../src/lib/finance/plaid-category-map';
 
 // Unmatched production outflows the categorizer will process (mirrors the
 // WHERE clause in categorizeBankOutflows, minus the bankDerivedCategory gate).
@@ -37,6 +44,69 @@ const OUTFLOW: {
   matchedQbExpenseId: null,
   amount: { gt: 0 }, // Plaid convention: positive = outflow
 };
+
+const TX_CHUNK = 500; // cap per-transaction update count on large accounts
+
+/**
+ * Recompute every unmatched production outflow for one item through the current
+ * `categorizeBankOutflow` rules and update the changed rows in place. Returns a
+ * change log keyed `oldCat->newCat` → { count, cents }. Read-only when dryRun.
+ */
+async function recategorizeItem(
+  itemId: string,
+  dryRun: boolean
+): Promise<{ scanned: number; changed: number; log: Map<string, { count: number; cents: number }> }> {
+  const rows = await prisma.plaidTransaction.findMany({
+    where: { plaidItemId: itemId, ...OUTFLOW },
+    select: {
+      id: true,
+      name: true,
+      merchantName: true,
+      amount: true,
+      bankDerivedCategory: true,
+      isBankDerivedExpense: true,
+      personalFinanceCategoryPrimary: true,
+      personalFinanceCategoryDetailed: true,
+    },
+  });
+
+  const log = new Map<string, { count: number; cents: number }>();
+  const updates: ReturnType<typeof prisma.plaidTransaction.update>[] = [];
+  for (const r of rows) {
+    const newCat = categorizeBankOutflow({
+      name: r.name,
+      merchantName: r.merchantName,
+      personalFinanceCategoryPrimary: r.personalFinanceCategoryPrimary,
+      personalFinanceCategoryDetailed: r.personalFinanceCategoryDetailed,
+    });
+    const newIsExp = isBankExpenseCategory(newCat);
+    if (r.bankDerivedCategory === newCat && r.isBankDerivedExpense === newIsExp) continue;
+
+    const key = `${r.bankDerivedCategory ?? 'null'}->${newCat}`;
+    const entry = log.get(key) ?? { count: 0, cents: 0 };
+    entry.count += 1;
+    entry.cents += Math.round(Number(r.amount) * 100);
+    log.set(key, entry);
+
+    if (!dryRun) {
+      updates.push(
+        prisma.plaidTransaction.update({
+          where: { id: r.id },
+          data: { bankDerivedCategory: newCat, isBankDerivedExpense: newIsExp },
+        })
+      );
+    }
+  }
+
+  // Apply in bounded transactions — each row moves old→new atomically, so an
+  // interrupted run never leaves a row uncategorized.
+  for (let i = 0; i < updates.length; i += TX_CHUNK) {
+    await prisma.$transaction(updates.slice(i, i + TX_CHUNK));
+  }
+
+  const changed = [...log.values()].reduce((s, e) => s + e.count, 0);
+  return { scanned: rows.length, changed, log };
+}
 
 async function main(): Promise<void> {
   const dryRun = process.argv.includes('--dry-run');
@@ -55,7 +125,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  const mode = recategorize ? ' (RECATEGORIZE — re-stamps ALL outflows)' : '';
+  const mode = recategorize ? ' (RECATEGORIZE — in-place recompute of ALL outflows)' : '';
   console.log(
     `[backfill-bank-categories] ${items.length} production item(s)${mode}` +
       (dryRun ? ' (dry-run — no writes)' : '')
@@ -66,28 +136,28 @@ async function main(): Promise<void> {
   for (const item of items) {
     const label = item.institutionName ?? item.id.slice(0, 8);
 
-    if (dryRun) {
-      // In recategorize mode every unmatched outflow is re-stamped; otherwise
-      // only the not-yet-categorized ones.
-      const where = recategorize
-        ? { plaidItemId: item.id, ...OUTFLOW }
-        : { plaidItemId: item.id, ...OUTFLOW, bankDerivedCategory: null };
-      const n = await prisma.plaidTransaction.count({ where });
+    // --- Recategorize path: in-place recompute + change log. ---
+    if (recategorize) {
+      const { scanned, changed, log } = await recategorizeItem(item.id, dryRun);
       console.log(
-        `  ${label}: ${n} outflow(s) would be ${recategorize ? 're-stamped' : 'stamped'}`
+        `  ${label}: ${scanned} outflow(s) scanned, ${changed} ` +
+          `${dryRun ? 'would change' : 'changed'}`
       );
-      totalCategorized += n;
+      for (const [move, e] of [...log.entries()].sort((a, b) => b[1].cents - a[1].cents)) {
+        console.log(`      ${move}: ${e.count} row(s), $${(e.cents / 100).toFixed(2)}`);
+      }
+      totalCategorized += changed;
       continue;
     }
 
-    // Recategorize: clear the existing tags so the (idempotent, null-only)
-    // categorizer revisits every unmatched outflow with the current rules.
-    if (recategorize) {
-      const { count } = await prisma.plaidTransaction.updateMany({
-        where: { plaidItemId: item.id, ...OUTFLOW, bankDerivedCategory: { not: null } },
-        data: { bankDerivedCategory: null, isBankDerivedExpense: false },
+    // --- Default path: stamp not-yet-categorized rows only. ---
+    if (dryRun) {
+      const n = await prisma.plaidTransaction.count({
+        where: { plaidItemId: item.id, ...OUTFLOW, bankDerivedCategory: null },
       });
-      console.log(`  ${label}: cleared ${count} existing categor${count === 1 ? 'y' : 'ies'}`);
+      console.log(`  ${label}: ${n} uncategorized outflow(s) would be stamped`);
+      totalCategorized += n;
+      continue;
     }
 
     // categorizeBankOutflows handles up to 1000 rows per call — drain the backlog.
@@ -104,9 +174,13 @@ async function main(): Promise<void> {
     totalExpenses += itemExpenses;
   }
 
+  const tail = recategorize
+    ? `${totalCategorized} row(s) ${dryRun ? 'would change' : 'changed'}`
+    : dryRun
+      ? `${totalCategorized} pending`
+      : `${totalCategorized} categorized (${totalExpenses} expenses)`;
   console.log(
-    `[backfill-bank-categories] done — ${totalCategorized} ` +
-      (dryRun ? (recategorize ? 'to re-stamp' : 'pending') : `categorized (${totalExpenses} expenses)`) +
+    `[backfill-bank-categories] done — ${tail}` +
       (dryRun ? '' : '. Next: re-run scripts/finance/backfill-monthly-rollups.ts')
   );
 }

--- a/src/lib/finance/__tests__/plaid-category-map.test.ts
+++ b/src/lib/finance/__tests__/plaid-category-map.test.ts
@@ -29,6 +29,61 @@ describe('categorizeBankOutflow', () => {
     expect(categorizeBankOutflow({ name: "SPEC'S #45 AUSTIN", merchantName: null })).toBe('cogs');
   });
 
+  it('maps TRUNCATED Wells Fargo distributor descriptors to cogs (real bank names)', () => {
+    // Wells Fargo truncates each descriptor; without the widened rules these
+    // land in meals/office and understate COGS ~$7-12K/month.
+    // RNDC → "Republic Nationa Fintech" (trailing 'l' cut). Plaid tags it
+    // FOOD_AND_DRINK → 'meals' without the allowlist.
+    expect(
+      categorizeBankOutflow({
+        name: 'Republic Nationa Fintech',
+        merchantName: null,
+        personalFinanceCategoryPrimary: 'FOOD_AND_DRINK',
+        personalFinanceCategoryDetailed: null,
+      })
+    ).toBe('cogs');
+    // Capital Reyes (Reyes Beverage) → "Capital Reyes Di FINTECHEFT…" → 'meals' without the rule.
+    expect(
+      categorizeBankOutflow({
+        name: 'Capital Reyes Di FINTECHEFT 250601',
+        merchantName: null,
+        personalFinanceCategoryPrimary: 'FOOD_AND_DRINK',
+        personalFinanceCategoryDetailed: null,
+      })
+    ).toBe('cogs');
+    // Brown Distributing → "Brown Distributi Fintech" → 'office' (GENERAL_MERCHANDISE) without the rule.
+    expect(
+      categorizeBankOutflow({
+        name: 'Brown Distributi Fintech',
+        merchantName: null,
+        personalFinanceCategoryPrimary: 'GENERAL_MERCHANDISE',
+        personalFinanceCategoryDetailed: null,
+      })
+    ).toBe('cogs');
+  });
+
+  it('maps the other Austin beverage / mixer suppliers to cogs (beer, mixers, liquor-for-resale, grocery)', () => {
+    // Beer distributor, mixer brand, liquor retail-for-resale, distributor, and
+    // the cocktail-kit produce vendor — all bought for resale → COGS, not meals/office.
+    expect(
+      categorizeBankOutflow({
+        name: 'Austin Beerworks Fintech',
+        merchantName: 'Austin Beerworks',
+        personalFinanceCategoryPrimary: 'FOOD_AND_DRINK',
+        personalFinanceCategoryDetailed: null,
+      })
+    ).toBe('cogs');
+    expect(categorizeBankOutflow({ name: 'Fresh Victor Shop.', merchantName: 'Fresh Victor' })).toBe(
+      'cogs'
+    );
+    expect(categorizeBankOutflow({ name: 'Twin Liquors #12 AUSTIN', merchantName: 'Twin Liquors' })).toBe(
+      'cogs'
+    );
+    expect(categorizeBankOutflow({ name: 'Coast To Coast Dis', merchantName: null })).toBe('cogs');
+    expect(categorizeBankOutflow({ name: 'H-E-B #572 AUSTIN TX', merchantName: 'H-E-B' })).toBe('cogs');
+    expect(categorizeBankOutflow({ name: 'HEB GAS', merchantName: null })).toBe('cogs');
+  });
+
   it('maps transfers / card payments / loans to non_operating (never an expense)', () => {
     expect(
       categorizeBankOutflow({

--- a/src/lib/finance/__tests__/plaid-category-map.test.ts
+++ b/src/lib/finance/__tests__/plaid-category-map.test.ts
@@ -62,9 +62,9 @@ describe('categorizeBankOutflow', () => {
     ).toBe('cogs');
   });
 
-  it('maps the other Austin beverage / mixer suppliers to cogs (beer, mixers, liquor-for-resale, grocery)', () => {
-    // Beer distributor, mixer brand, liquor retail-for-resale, distributor, and
-    // the cocktail-kit produce vendor — all bought for resale → COGS, not meals/office.
+  it('maps the single-purpose beverage / mixer suppliers to cogs unconditionally', () => {
+    // Beer distributor, mixer brand, liquor retail-for-resale, and the beverage
+    // distributor — 100% resale inventory → COGS regardless of Plaid category.
     expect(
       categorizeBankOutflow({
         name: 'Austin Beerworks Fintech',
@@ -79,9 +79,45 @@ describe('categorizeBankOutflow', () => {
     expect(categorizeBankOutflow({ name: 'Twin Liquors #12 AUSTIN', merchantName: 'Twin Liquors' })).toBe(
       'cogs'
     );
+    // Coast to Coast Distributing — WF truncates to "…Dis"; the "dis" anchor is required.
     expect(categorizeBankOutflow({ name: 'Coast To Coast Dis', merchantName: null })).toBe('cogs');
-    expect(categorizeBankOutflow({ name: 'H-E-B #572 AUSTIN TX', merchantName: 'H-E-B' })).toBe('cogs');
-    expect(categorizeBankOutflow({ name: 'HEB GAS', merchantName: null })).toBe('cogs');
+    // …but a generic "Coast to Coast" (e.g. a moving company) must NOT match.
+    expect(categorizeBankOutflow({ name: 'Coast To Coast Movers', merchantName: null })).not.toBe(
+      'cogs'
+    );
+  });
+
+  it('maps H-E-B to cogs ONLY for grocery purchases, never fuel (mixed merchant)', () => {
+    // Every real H-E-B outflow in the first WF sync was FOOD_AND_DRINK_GROCERIES —
+    // cocktail-kit produce/mixers bought for resale → COGS.
+    expect(
+      categorizeBankOutflow({
+        name: 'H-E-B #572 AUSTIN TX',
+        merchantName: 'H-E-B',
+        personalFinanceCategoryPrimary: 'FOOD_AND_DRINK',
+        personalFinanceCategoryDetailed: 'FOOD_AND_DRINK_GROCERIES',
+      })
+    ).toBe('cogs');
+    // But an H-E-B FUEL fill-up must keep its real category, NOT be swept into COGS.
+    expect(
+      categorizeBankOutflow({
+        name: 'H-E-B FUEL #14',
+        merchantName: 'H-E-B',
+        personalFinanceCategoryPrimary: 'TRANSPORTATION',
+        personalFinanceCategoryDetailed: 'TRANSPORTATION_GAS',
+      })
+    ).toBe('fuel');
+    // …and an in-store cafe/BBQ-counter lunch (FOOD_AND_DRINK but NOT groceries)
+    // is a `meals` expense, not resale inventory — the coarse primary must not
+    // sweep it into COGS.
+    expect(
+      categorizeBankOutflow({
+        name: 'H-E-B TRUE TEXAS BBQ',
+        merchantName: 'H-E-B',
+        personalFinanceCategoryPrimary: 'FOOD_AND_DRINK',
+        personalFinanceCategoryDetailed: 'FOOD_AND_DRINK_RESTAURANT',
+      })
+    ).toBe('meals');
   });
 
   it('maps transfers / card payments / loans to non_operating (never an expense)', () => {

--- a/src/lib/finance/plaid-category-map.ts
+++ b/src/lib/finance/plaid-category-map.ts
@@ -31,10 +31,25 @@ import { type CategorySlug, NAME_KEYWORD_RULES } from './qb-account-map';
  * statement descriptors after the first production sync.
  */
 export const COGS_MERCHANT_RULES: readonly RegExp[] = [
-  /\brndc\b|republic\s*national/i,
+  // RNDC / Republic National. Wells Fargo TRUNCATES the descriptor to
+  // "Republic Nationa Fintech" (trailing 'l' cut), so match `nationa` not
+  // `national` — `nationa` subsumes the full spelling too.
+  /\brndc\b|republic\s*nationa/i,
   /southern\s*glazer'?s?/i,
   /total\s*wine/i,
   /spec'?s\b/i,
+  // Capital Reyes (Reyes Beverage). WF descriptor: "Capital Reyes Di FINTECHEFT…".
+  /capital\s*reyes|\breyes\b.*distribut/i,
+  // Brown Distributing. WF descriptor: "Brown Distributi Fintech" (truncated).
+  /brown\s*distribut/i,
+  // Additional Austin-area beverage / mixer suppliers surfaced by the first WF
+  // sync — all previously fell into meals/office. Beer, mixers, and liquor
+  // bought for resale are cost-of-goods for an alcohol-delivery business.
+  /austin\s*beerworks/i, // local brewery — wholesale beer
+  /fresh\s*victor/i, // premium cocktail-mixer brand
+  /twin\s*liquors?/i, // liquor retail bought for resale (cf. Total Wine / Spec's)
+  /coast\s*to\s*coast/i, // Coast to Coast Distributing (WF truncates to "…Dis")
+  /\bh[-\s]?e[-\s]?b\b/i, // H-E-B — cocktail-kit produce/mixers (the fresh-produce resale vendor)
 ];
 
 /**

--- a/src/lib/finance/plaid-category-map.ts
+++ b/src/lib/finance/plaid-category-map.ts
@@ -6,13 +6,16 @@
  * dormant for a month (e.g. all of 2026), the bank outflow IS the expense.
  *
  * Precedence (first match wins):
- *   1. Distributor / wholesale-alcohol merchant allowlist → `cogs`.
+ *   1. Single-purpose distributor / supplier allowlist → `cogs` unconditionally.
  *      Plaid's category taxonomy has NO wholesale-alcohol signal, so without
  *      this, alcohol buys land in GENERAL_MERCHANDISE → wrong. This is the
  *      single biggest threat to a trustworthy 2026 gross-margin number — extend
  *      `COGS_MERCHANT_RULES` against real bank-statement names after the first
  *      production sync.
- *   2. Plaid Personal Finance Category — detailed (most specific).
+ *   2. Plaid Personal Finance Category — detailed (most specific), with a
+ *      conditional `cogs` step (2a): mixed grocery merchants (`H-E-B`) map to
+ *      `cogs` ONLY when the detailed PFC is a resale grocery subtype, so a fuel
+ *      or cafe purchase at the same store keeps its real category.
  *   3. Plaid Personal Finance Category — primary (coarser).
  *   4. Merchant / name keywords (reuses qb-account-map's NAME_KEYWORD_RULES).
  *   5. Fallback → `other`.
@@ -44,13 +47,40 @@ export const COGS_MERCHANT_RULES: readonly RegExp[] = [
   /brown\s*distribut/i,
   // Additional Austin-area beverage / mixer suppliers surfaced by the first WF
   // sync — all previously fell into meals/office. Beer, mixers, and liquor
-  // bought for resale are cost-of-goods for an alcohol-delivery business.
+  // bought for resale are cost-of-goods for an alcohol-delivery business. These
+  // are single-purpose suppliers (100% of their spend is resale inventory), so
+  // — like the distributors above — they map to cogs unconditionally.
   /austin\s*beerworks/i, // local brewery — wholesale beer
   /fresh\s*victor/i, // premium cocktail-mixer brand
   /twin\s*liquors?/i, // liquor retail bought for resale (cf. Total Wine / Spec's)
-  /coast\s*to\s*coast/i, // Coast to Coast Distributing (WF truncates to "…Dis")
-  /\bh[-\s]?e[-\s]?b\b/i, // H-E-B — cocktail-kit produce/mixers (the fresh-produce resale vendor)
+  /coast\s*to\s*coast\s*dis/i, // Coast to Coast Distributing (WF truncates to "…Dis"); require the "dis" anchor so an unrelated "Coast to Coast" business can't false-match
 ];
+
+/**
+ * MIXED-merchant grocers whose spend is COGS only for a grocery/food purchase.
+ * Unlike the single-purpose suppliers in `COGS_MERCHANT_RULES`, these are
+ * full-service stores (groceries + fuel + pharmacy + general merch), so mapping
+ * every debit to cogs would sweep a fuel fill-up or pharmacy run into COGS and
+ * overstate it. Instead these map to cogs ONLY when Plaid's category confirms a
+ * grocery/food purchase (see `GROCERY_PFC_PRIMARY`); otherwise the normal PFC
+ * precedence applies (e.g. a fuel purchase → `fuel`).
+ *
+ * H-E-B is the fresh-produce / mixer vendor for cocktail kits (resale) — every
+ * H-E-B outflow in the first WF sync was PFC `FOOD_AND_DRINK_GROCERIES`.
+ */
+export const COGS_GROCERY_MERCHANT_RULES: readonly RegExp[] = [
+  /\bh[-\s]?e[-\s]?b\b/i, // H-E-B — cocktail-kit produce/mixers (resale)
+];
+
+/**
+ * Plaid PFC `detailed` values that confirm a resale grocery purchase, for the
+ * mixed-merchant grocery rules above. Deliberately narrow: the coarse
+ * `FOOD_AND_DRINK` PRIMARY also covers restaurant / fast-food / coffee (H-E-B
+ * stores have in-house cafes — a staff lunch is a `meals` expense, not resale
+ * inventory), and `GENERAL_MERCHANDISE` is non-food retail. Only the
+ * `FOOD_AND_DRINK_GROCERIES` detailed subtype maps to cogs.
+ */
+const GROCERY_PFC_DETAILED: ReadonlySet<string> = new Set(['FOOD_AND_DRINK_GROCERIES']);
 
 /**
  * Plaid PFC `detailed` → CategorySlug. Only the business-relevant
@@ -119,12 +149,21 @@ export interface BankOutflowLike {
 export function categorizeBankOutflow(txn: BankOutflowLike): CategorySlug {
   const text = `${txn.merchantName ?? ''} ${txn.name ?? ''}`.trim();
 
-  // 1. Distributor / wholesale-alcohol allowlist → cogs (Plaid has no such signal).
+  // 1. Single-purpose distributor / supplier allowlist → cogs unconditionally
+  // (100% of their spend is resale inventory; Plaid has no wholesale signal).
   for (const re of COGS_MERCHANT_RULES) {
     if (re.test(text)) return 'cogs';
   }
   // 2. Plaid PFC detailed.
   const detailed = txn.personalFinanceCategoryDetailed;
+  // 2a. Mixed grocery merchants (e.g. H-E-B) → cogs ONLY when Plaid's DETAILED
+  // category confirms a resale grocery purchase — so a fuel fill-up, pharmacy
+  // run, or in-store cafe lunch keeps its real category instead of COGS.
+  if (detailed && GROCERY_PFC_DETAILED.has(detailed)) {
+    for (const re of COGS_GROCERY_MERCHANT_RULES) {
+      if (re.test(text)) return 'cogs';
+    }
+  }
   if (detailed && PFC_DETAILED_MAP[detailed]) return PFC_DETAILED_MAP[detailed];
   // 3. Plaid PFC primary.
   const primary = txn.personalFinanceCategoryPrimary;


### PR DESCRIPTION
## What

Several alcohol/mixer distributors were mis-categorized in the bank-derived expense path because **Wells Fargo truncates the bank descriptors**, so they didn't match the seeded COGS allowlist — landing in `meals`/`office` and **understating COGS** (and overstating gross margin) for every 2026 month.

Widen `COGS_MERCHANT_RULES` to catch the real WF descriptors, and add a `--recategorize` flag so already-tagged prod rows self-correct.

### Distributors now mapped to COGS
| Descriptor (real WF text) | Was | Now |
|---|---|---|
| `Republic Nationa Fintech` (RNDC — trailing 'l' truncated) | meals | cogs |
| `Capital Reyes Di FINTECHEFT…` (Reyes Beverage) | meals | cogs |
| `Brown Distributi Fintech` | office | cogs |
| `Austin Beerworks` (brewery) | meals | cogs |
| `Fresh Victor` (cocktail mixers) | office | cogs |
| `Twin Liquors` (liquor-for-resale) | meals | cogs |
| `Coast To Coast Dis` (distributor) | meals | cogs |
| `H-E-B` (cocktail-kit produce) — **only when PFC=`FOOD_AND_DRINK_GROCERIES`** | meals | cogs |

### `--recategorize`/`--force` flag
The daily sync + default backfill only touch rows where `bankDerivedCategory IS NULL`, so mis-tagged rows never self-correct after a rule change. The flag recomputes each unmatched production outflow **in place** (old→new) inside bounded transactions — no window where a row is excluded from expense totals — and **logs every category change** as an audit trail. `--dry-run --recategorize` previews the plan with zero writes.

## Why it's net-income-neutral
Reclassification moves the same dollars from `meals`/`office` (OpEx) to `cogs` — both above/below the gross-profit line but summing to the same total expense. Gross margin corrects; **net income is unchanged.**

## Verified on prod (April 2026 reference month)
| | Before | After |
|---|---|---|
| COGS | $10,425 | **$16,872** |
| Gross margin | 65.6% | **44.4%** |
| Net income | $11,065 | **$11,065 (Δ$0)** |
| netIncomeReliable | true | **true** |

68 rows recategorized (52 meals→cogs, 16 office→cogs); rollups rebuilt (66 months); **zero unintended flips** (checked all Apr–Jun outflows). May/June net & flags unchanged.

## Reviews
- ✅ `security-reviewer`: initial pass found H-E-B over-broad (forced *all* H-E-B incl. fuel → COGS ahead of Plaid's signal) — **fixed**: H-E-B now gated on `FOOD_AND_DRINK_GROCERIES` detailed PFC, `coast-to-coast` tightened, recategorize made atomic + auditable. Re-review: **SAFE TO MERGE**, follow-up MEDIUM also applied.
- ✅ `/code-review` (high): approve
- ✅ 694 tests pass, tsc 0 errors, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)