### PR TITLE
feat(finance): recurring monthly-close P&L email (PR D, Phase 5)

### DIFF
--- a/src/app/api/cron/finance-monthly-close/route.ts
+++ b/src/app/api/cron/finance-monthly-close/route.ts
@@ -1,0 +1,125 @@
+/**
+ * GET /api/cron/finance-monthly-close
+ *
+ * Finance Director Phase 5 — the recurring monthly-close P&L email. On the 1st
+ * of each month it closes the PRIOR month: reads that month's
+ * `finance_monthly_rollup`, renders a P&L (Revenue → COGS → Gross Profit → OpEx
+ * → Net) and reconciliation status, and emails it via Resend.
+ *
+ * Net income is rendered ONLY when the rollup's `dataHealth.netIncomeReliable`
+ * is true (the honesty gate); otherwise the email shows "Pending" + the flags.
+ * Bank-sourced figures are labelled cash-basis.
+ *
+ * Schedule: 1st of month, 14:00 UTC (after the nightly rollup keeps the trailing
+ * months fresh). Bearer auth: `Authorization: Bearer ${CRON_SECRET}`.
+ *
+ * Optional `?month=YYYY-MM` closes a specific month instead of last month —
+ * handy for manual re-sends / testing (e.g. `?month=2026-04`).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { resend } from '@/lib/email/resend-client';
+import { buildMonthlyClosePayload } from '@/lib/finance/monthly-close-payload';
+import {
+  renderFinanceMonthlyCloseEmail,
+  renderFinanceMonthlyCloseText,
+} from '@/lib/email/templates/finance-monthly-close';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 120;
+
+/**
+ * Translate a `?month=YYYY-MM` override into the `now` the payload builder
+ * expects — the builder closes the month BEFORE `now`, so to close month M we
+ * pass the 1st of M+1. Returns null on a malformed value.
+ */
+function nowForMonthParam(monthParam: string): Date | null {
+  const m = /^(\d{4})-(\d{2})$/.exec(monthParam);
+  if (!m) return null;
+  const year = Number(m[1]);
+  const month = Number(m[2]); // 1-12
+  if (month < 1 || month > 12) return null;
+  // Guard the 2-digit-year footgun: Date.UTC(26, …) resolves to 1926, not 2026.
+  if (year < 2000 || year > 2100) return null;
+  // 1st of the following month (UTC) → resolveCloseMonth() maps back to (year, month).
+  return new Date(Date.UTC(year, month, 1));
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const secret = process.env.CRON_SECRET;
+  const auth = request.headers.get('authorization');
+  // Guard against an unset secret so `Bearer undefined` can never authenticate.
+  if (!secret || auth !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const monthParam = request.nextUrl.searchParams.get('month');
+  let now = new Date();
+  if (monthParam) {
+    const overridden = nowForMonthParam(monthParam);
+    if (!overridden) {
+      return NextResponse.json({ error: 'Invalid month — use YYYY-MM' }, { status: 400 });
+    }
+    now = overridden;
+  }
+
+  let payload;
+  try {
+    payload = await buildMonthlyClosePayload(now);
+  } catch (err) {
+    // Fail soft (matches the email-send path) — a DB error returns a clean 500
+    // rather than an unhandled rejection; Vercel logs it for retry.
+    console.error('[finance-monthly-close] payload build failed:', err);
+    return NextResponse.json(
+      { ok: false, error: err instanceof Error ? err.message : String(err) },
+      { status: 500 }
+    );
+  }
+  if (!payload) {
+    // No rollup for the closed month yet — skip rather than invent numbers.
+    return NextResponse.json({
+      ok: true,
+      skipped: 'no finance_monthly_rollup row for the closed month',
+    });
+  }
+
+  const recipient =
+    process.env.FINANCE_BRIEFING_TO ||
+    process.env.OPS_BRIEFING_TO ||
+    process.env.MARKETING_BRIEFING_TO ||
+    'allan@partyondelivery.com';
+
+  // Deliver email — fails soft so the cron stays green and can be retried.
+  let email: { sent: boolean; error?: string } = { sent: false, error: 'not attempted' };
+  if (!resend) {
+    email = { sent: false, error: 'RESEND_API_KEY not configured' };
+  } else {
+    try {
+      const html = renderFinanceMonthlyCloseEmail(payload);
+      const text = renderFinanceMonthlyCloseText(payload);
+      const fromEmail = process.env.RESEND_FROM_EMAIL || 'orders@partyondelivery.com';
+      const netTag = payload.netIncomeReliable ? '' : ' (net income pending)';
+      await resend.emails.send({
+        from: `Party On Delivery — Finance Director <${fromEmail}>`,
+        to: recipient,
+        subject: `Finance monthly close — ${payload.monthLabel}${netTag}`,
+        html,
+        text,
+      });
+      email = { sent: true };
+    } catch (err) {
+      email = { sent: false, error: err instanceof Error ? err.message : String(err) };
+      console.error('[finance-monthly-close] email send failed:', err);
+    }
+  }
+
+  return NextResponse.json({
+    ok: true,
+    period: payload.period,
+    month: payload.monthLabel,
+    netIncomeReliable: payload.netIncomeReliable,
+    expenseSource: payload.expenseSource,
+    revenueCents: payload.revenueCents,
+    delivery: { email, recipient },
+  });
+}

--- a/src/lib/email/templates/__tests__/finance-monthly-close.test.ts
+++ b/src/lib/email/templates/__tests__/finance-monthly-close.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect } from 'vitest';
+import {
+  renderFinanceMonthlyCloseEmail,
+  renderFinanceMonthlyCloseText,
+} from '../finance-monthly-close';
+import {
+  shapeMonthlyClosePayload,
+  type RollupRow,
+} from '@/lib/finance/monthly-close-payload';
+
+/** April-like rollup: bank-sourced, reliable, net +$11,065. */
+function reliableRollup(over: Partial<RollupRow> = {}): RollupRow {
+  return {
+    year: 2026,
+    month: 4,
+    revenueCents: 3_034_900,
+    revenueFromShopifyCents: 0,
+    revenueFromOrdersCents: 3_034_900,
+    orderCount: 89,
+    cogsCents: 1_687_200,
+    grossProfitCents: 1_347_600,
+    opexCents: 241_100,
+    netIncomeCents: 1_106_500, // $11,065 — distinctive
+    expenseCategories: [
+      { category: 'cogs', label: 'Cost of Goods', cents: 1_687_200, topVendor: 'Southern Glazer', topVendorCents: 900_000 },
+      { category: 'advertising', label: 'Advertising', cents: 180_000, topVendor: 'Google Ads', topVendorCents: 180_000 },
+      { category: 'fuel', label: 'Fuel', cents: 61_100, topVendor: 'Shell', topVendorCents: 61_100 },
+    ],
+    dataHealth: {
+      expenseSource: 'bank',
+      netIncomeReliable: true,
+      incomeReconciled: true,
+      otherIncomeCents: 0,
+      flags: [],
+    },
+    ...over,
+  };
+}
+
+/**
+ * June-like rollup: bank-sourced but FLAGGED (deposit anomaly). Numbers are
+ * INTERNALLY CONSISTENT (net = grossProfit − opex, as real rollup rows always
+ * are) so the honesty-gate test proves the withheld net can't be reconstructed
+ * from the displayed figures — not merely that a substring is absent.
+ *   gross profit 60_800 − opex 369_900 = net -309_100 ($3,091 loss)
+ */
+function flaggedRollup(over: Partial<RollupRow> = {}): RollupRow {
+  return {
+    year: 2026,
+    month: 6,
+    revenueCents: 1_813_600,
+    revenueFromShopifyCents: 0,
+    revenueFromOrdersCents: 1_813_600,
+    orderCount: 100,
+    cogsCents: 1_752_800,
+    grossProfitCents: 60_800,
+    opexCents: 369_900,
+    netIncomeCents: -309_100, // = 60_800 − 369_900
+    expenseCategories: [
+      { category: 'cogs', label: 'Cost of Goods', cents: 1_752_800, topVendor: 'Southern Glazer', topVendorCents: 900_000 },
+      { category: 'professional', label: 'Professional fees', cents: 249_000, topVendor: 'Google Ads', topVendorCents: 249_000 },
+      { category: 'office', label: 'Office', cents: 120_900, topVendor: 'Barrett Distributing', topVendorCents: 120_900 },
+    ],
+    dataHealth: {
+      expenseSource: 'bank',
+      netIncomeReliable: false,
+      incomeReconciled: false,
+      otherIncomeCents: 1_531_500,
+      flags: ['$15315 of bank deposits exceed known Stripe revenue — possible other income'],
+    },
+    ...over,
+  };
+}
+
+/**
+ * QB-sourced month flagged by the discrepancy check (flag #5). Reconstruction
+ * chain the security review found: flag reveals COGS+OpEx total → OpEx = total −
+ * COGS(shown) → net = grossProfit(shown) − OpEx. The flag must therefore carry
+ * NO dollar total, and the email must withhold OpEx. Distinct figures so each
+ * absence assertion is meaningful.
+ *   revenue 9000 · cogs 4000 · gross profit 5000 · opex 3200 · net 1800
+ *   total expense (cogs+opex) = 7200
+ */
+function qbDiscrepancyRollup(over: Partial<RollupRow> = {}): RollupRow {
+  return {
+    year: 2024,
+    month: 8,
+    revenueCents: 900_000,
+    revenueFromShopifyCents: 900_000,
+    revenueFromOrdersCents: 0,
+    orderCount: 40,
+    cogsCents: 400_000,
+    grossProfitCents: 500_000,
+    opexCents: 320_000,
+    netIncomeCents: 180_000, // = 500_000 − 320_000
+    expenseCategories: [
+      { category: 'cogs', label: 'Cost of Goods', cents: 400_000, topVendor: 'RNDC', topVendorCents: 400_000 },
+      { category: 'rent', label: 'Rent', cents: 320_000, topVendor: 'Landlord LLC', topVendorCents: 320_000 },
+    ],
+    dataHealth: {
+      expenseSource: 'qb',
+      netIncomeReliable: false,
+      incomeReconciled: null,
+      otherIncomeCents: null,
+      // Qualitative flag (post-fix): a RATIO, never the raw QB expense total.
+      flags: ['bank outflows exceed QB-booked expenses by ~80% — QB books may be incomplete this month'],
+    },
+    ...over,
+  };
+}
+
+/** Early-2026-like rollup: no expense source yet. */
+function noExpenseRollup(over: Partial<RollupRow> = {}): RollupRow {
+  return {
+    year: 2026,
+    month: 2,
+    revenueCents: 790_800,
+    revenueFromShopifyCents: 100_000,
+    revenueFromOrdersCents: 690_800,
+    orderCount: 25,
+    cogsCents: null,
+    grossProfitCents: null,
+    opexCents: null,
+    netIncomeCents: null,
+    expenseCategories: [],
+    dataHealth: {
+      // Matches real early-2026 rows: a production bank item EXISTS (so
+      // incomeReconciled is false, not null) but has no data for this month yet.
+      // The template must still NOT claim a deposit anomaly.
+      expenseSource: 'none',
+      netIncomeReliable: false,
+      incomeReconciled: false,
+      otherIncomeCents: null,
+      flags: ['no expense source this month — QB not material and no production bank data'],
+    },
+    ...over,
+  };
+}
+
+const GEN = new Date('2026-05-01T14:00:00.000Z');
+
+describe('shapeMonthlyClosePayload', () => {
+  it('computes margin, MoM, cash-basis, and excludes COGS from OpEx rows', () => {
+    const p = shapeMonthlyClosePayload({
+      rollup: reliableRollup(),
+      prior: reliableRollup({ month: 3, revenueCents: 2_519_000, netIncomeCents: 500_000 }),
+      generatedAt: GEN,
+      baseUrl: 'https://example.com',
+    });
+    expect(p.monthLabel).toBe('April 2026');
+    expect(p.period).toBe('2026-04');
+    expect(p.cashBasis).toBe(true); // bank-sourced
+    expect(p.grossMarginPct).toBeCloseTo(44.4, 1);
+    expect(p.revenueMoMPct).toBeCloseTo(20.5, 1); // 3,034,900 vs 2,519,000
+    // OpEx rows exclude the cogs category and are sorted desc.
+    expect(p.opexRows.map((r) => r.label)).toEqual(['Advertising', 'Fuel']);
+    expect(p.opexRows.some((r) => r.label === 'Cost of Goods')).toBe(false);
+    expect(p.cogsTopVendor).toBe('Southern Glazer');
+    expect(p.dashboardUrl).toBe('https://example.com/admin/finance');
+  });
+
+  it('carries netIncomeReliable=true only for a clean month', () => {
+    expect(shapeMonthlyClosePayload({ rollup: reliableRollup(), prior: null, generatedAt: GEN }).netIncomeReliable).toBe(true);
+    expect(shapeMonthlyClosePayload({ rollup: flaggedRollup(), prior: null, generatedAt: GEN }).netIncomeReliable).toBe(false);
+    expect(shapeMonthlyClosePayload({ rollup: noExpenseRollup(), prior: null, generatedAt: GEN }).netIncomeReliable).toBe(false);
+  });
+
+  it('handles expenseSource=none gracefully (null money, no crash)', () => {
+    const p = shapeMonthlyClosePayload({ rollup: noExpenseRollup(), prior: null, generatedAt: GEN });
+    expect(p.expenseSource).toBe('none');
+    expect(p.cogsCents).toBeNull();
+    expect(p.grossMarginPct).toBeNull();
+    expect(p.opexRows).toEqual([]);
+  });
+});
+
+describe('renderFinanceMonthlyCloseEmail', () => {
+  it('renders an HTML doc with the month in the title', () => {
+    const html = renderFinanceMonthlyCloseEmail(
+      shapeMonthlyClosePayload({ rollup: reliableRollup(), prior: null, generatedAt: GEN })
+    );
+    expect(html).toContain('<!doctype html>');
+    expect(html).toContain('Finance Monthly Close — April 2026');
+  });
+
+  it('shows the net income number ONLY when reliable', () => {
+    const html = renderFinanceMonthlyCloseEmail(
+      shapeMonthlyClosePayload({ rollup: reliableRollup(), prior: null, generatedAt: GEN })
+    );
+    expect(html).toContain('$11,065'); // net income rendered
+    expect(html).toContain('44.4%'); // gross margin
+    expect(html).toContain('cash-basis');
+  });
+
+  it('WITHHOLDS net income AND operating expenses when unreliable, so net is not reconstructable', () => {
+    const html = renderFinanceMonthlyCloseEmail(
+      shapeMonthlyClosePayload({ rollup: flaggedRollup(), prior: null, generatedAt: GEN })
+    );
+    expect(html).toContain('Pending'); // net income line
+    expect(html).toContain('Withheld'); // operating expenses withheld
+    expect(html).toContain('bank deposits exceed known Stripe revenue'); // the flag
+    // Gross margin story is still shown (gross profit $608 is Revenue − COGS anyway).
+    expect(html).toContain('$608');
+    // The withheld net income figure must NOT appear...
+    expect(html).not.toContain('3,091');
+    // ...and OpEx — the ONLY input needed to derive net from the shown gross
+    // profit — must be withheld too (figure + its category vendors absent).
+    expect(html).not.toContain('$3,699');
+    expect(html).not.toContain('Barrett Distributing');
+  });
+
+  it('does not leak net income via a QB-discrepancy flag (reconstruction chain closed)', () => {
+    const html = renderFinanceMonthlyCloseEmail(
+      shapeMonthlyClosePayload({ rollup: qbDiscrepancyRollup(), prior: null, generatedAt: GEN })
+    );
+    expect(html).toContain('$4,000'); // COGS shown
+    expect(html).toContain('$5,000'); // gross profit shown
+    expect(html).toContain('Withheld'); // OpEx withheld
+    // None of the reconstruction inputs may appear anywhere in the render:
+    expect(html).not.toContain('$3,200'); // OpEx
+    expect(html).not.toContain('$7,200'); // COGS+OpEx total (what the old flag leaked)
+    expect(html).not.toContain('$1,800'); // net income
+  });
+
+  it('handles a month with no expense source', () => {
+    const html = renderFinanceMonthlyCloseEmail(
+      shapeMonthlyClosePayload({ rollup: noExpenseRollup(), prior: null, generatedAt: GEN })
+    );
+    expect(html).toContain('none yet');
+    expect(html).toContain('Pending');
+    // No bank data for the month → must NOT claim a deposit anomaly.
+    expect(html).not.toContain('exceed');
+  });
+});
+
+describe('renderFinanceMonthlyCloseText', () => {
+  it('renders net income for a reliable month and withholds it otherwise', () => {
+    const good = renderFinanceMonthlyCloseText(
+      shapeMonthlyClosePayload({ rollup: reliableRollup(), prior: null, generatedAt: GEN })
+    );
+    expect(good).toContain('NET INCOME: $11,065');
+
+    const bad = renderFinanceMonthlyCloseText(
+      shapeMonthlyClosePayload({ rollup: flaggedRollup(), prior: null, generatedAt: GEN })
+    );
+    expect(bad).toContain('NET INCOME: Pending');
+    expect(bad).not.toContain('3,091'); // net figure withheld
+    expect(bad).not.toContain('$3,699'); // opex withheld → net not reconstructable
+  });
+});

--- a/src/lib/email/templates/finance-monthly-close.ts
+++ b/src/lib/email/templates/finance-monthly-close.ts
@@ -1,0 +1,340 @@
+/**
+ * Finance Director — monthly-close P&L email template.
+ *
+ * Same cream-paper / gold-accent aesthetic as the weekly finance briefing, but
+ * structured as a P&L statement: Revenue → COGS → Gross Profit (margin) → OpEx
+ * by category → Net income.
+ *
+ * HONESTY GATE: net income renders as a number ONLY when
+ * `payload.netIncomeReliable` is true. Otherwise it shows "Pending" plus the
+ * `dataHealth` flags that explain why — never a number the data can't support.
+ *
+ * The bank-sourced figures are CASH-BASIS (alcohol PURCHASED that month, not
+ * cost-of-goods-SOLD); the template labels this so a lumpy restock month isn't
+ * misread as a margin collapse.
+ */
+
+import type {
+  MonthlyClosePayload,
+  MonthlyCloseExpenseRow,
+} from '@/lib/finance/monthly-close-payload';
+
+const COLORS = {
+  paper: '#FBFAF5',
+  ink: '#0a0a0a',
+  inkBody: '#1a1a1a',
+  hairline: '#e7e3d6',
+  goldAccent: '#7a6a1f',
+  gold: '#D4AF37',
+  blue: '#0B74B8',
+  good: '#15803d',
+  caution: '#d97706',
+  urgent: '#dc2626',
+  muteText: '#6b6b6b',
+};
+
+function esc(s: string): string {
+  // Vendor / merchant names come from QuickBooks + Plaid (external systems), so
+  // escape the full set incl. the single quote — defense-in-depth even though
+  // interpolations currently sit in double-quoted attributes / text nodes.
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/** Whole-dollar money for the P&L (cents rounded). Negative → parenthesised. */
+function money(cents: number): string {
+  const dollars = Math.round(cents / 100);
+  const abs = Math.abs(dollars).toLocaleString('en-US');
+  return dollars < 0 ? `($${abs})` : `$${abs}`;
+}
+
+function pct(p: number | null): string {
+  return p === null ? '—' : `${p.toFixed(1)}%`;
+}
+
+/** One P&L line: label on the left, amount right-aligned. `strong` bolds it. */
+function plLine(
+  label: string,
+  amount: string,
+  opts: { strong?: boolean; indent?: boolean; sub?: string; color?: string } = {}
+): string {
+  const weight = opts.strong ? '700' : '400';
+  const size = opts.strong ? '15px' : '14px';
+  const pad = opts.indent ? '0 0 0 20px' : '0';
+  const sub = opts.sub
+    ? `<div style="font-size:11px;color:${COLORS.muteText};font-weight:400;">${esc(opts.sub)}</div>`
+    : '';
+  return `
+    <tr>
+      <td style="padding:7px 0;border-bottom:1px solid ${COLORS.hairline};">
+        <div style="font-size:${size};color:${COLORS.inkBody};font-weight:${weight};padding:${pad};">${esc(label)}</div>
+        ${sub}
+      </td>
+      <td align="right" style="padding:7px 0;border-bottom:1px solid ${COLORS.hairline};white-space:nowrap;">
+        <span style="font-size:${size};color:${opts.color ?? COLORS.ink};font-weight:${weight};">${esc(amount)}</span>
+      </td>
+    </tr>`;
+}
+
+function opexRowsHtml(rows: MonthlyCloseExpenseRow[]): string {
+  if (rows.length === 0) return '';
+  return rows
+    .map((r) =>
+      plLine(r.label, money(r.cents), {
+        indent: true,
+        sub: r.topVendor ? `top: ${r.topVendor}` : undefined,
+      })
+    )
+    .join('');
+}
+
+function flagsBlock(flags: string[]): string {
+  if (flags.length === 0) return '';
+  return `
+    <div style="background:${COLORS.paper};border-left:3px solid ${COLORS.caution};padding:12px 16px;margin:16px 0 0 0;">
+      <div style="font-size:11px;color:${COLORS.caution};text-transform:uppercase;letter-spacing:0.1em;font-weight:700;margin-bottom:8px;">Why net income is withheld (${flags.length})</div>
+      ${flags
+        .map(
+          (f) =>
+            `<div style="font-size:13px;color:${COLORS.inkBody};line-height:1.5;margin-bottom:6px;">• ${esc(f)}</div>`
+        )
+        .join('')}
+    </div>`;
+}
+
+/** Reconciliation status: income-vs-deposits check + the "other income" gap. */
+function reconciliationBlock(d: MonthlyClosePayload): string {
+  const rows: string[] = [];
+
+  if (d.expenseSource === 'none') {
+    // No bank/QB data for this month — nothing to reconcile; don't claim a
+    // deposit anomaly that doesn't exist.
+    rows.push(
+      `Expense source: <strong>none yet</strong> — no QuickBooks or production bank data for this month, so COGS / OpEx / net income are unavailable. (Early-2026 months fill in automatically as Plaid backfills more bank history.)`
+    );
+    return `
+    <div style="background:${COLORS.paper};padding:14px 16px;margin:20px 0 0 0;border:1px solid ${COLORS.hairline};">
+      <div style="font-size:11px;color:${COLORS.muteText};text-transform:uppercase;letter-spacing:0.1em;font-weight:600;margin-bottom:8px;">Reconciliation status</div>
+      <div style="font-size:13px;color:${COLORS.inkBody};line-height:1.7;">${rows.join('<br>')}</div>
+    </div>`;
+  }
+
+  rows.push(
+    `Expense source: <strong>${d.expenseSource === 'bank' ? 'bank feed (cash-basis)' : 'QuickBooks'}</strong>`
+  );
+
+  if (d.incomeReconciled === true) {
+    rows.push(`Income: ✅ bank deposits reconcile to known Stripe revenue.`);
+  } else if (d.incomeReconciled === false) {
+    const gap = d.otherIncomeCents ? ` (~${money(d.otherIncomeCents)} unexplained)` : '';
+    rows.push(
+      `Income: ⚠️ bank deposits <strong>exceed</strong> known Stripe revenue${gap}. This is an <strong>operator question</strong>, not a bug — the account both repays a loan and receives non-sales deposits (loan proceeds / owner capital / transfers / possibly unrecorded income). Confirm what these deposits are; once explained, the month's net income becomes reliable.`
+    );
+  }
+
+  return `
+    <div style="background:${COLORS.paper};padding:14px 16px;margin:20px 0 0 0;border:1px solid ${COLORS.hairline};">
+      <div style="font-size:11px;color:${COLORS.muteText};text-transform:uppercase;letter-spacing:0.1em;font-weight:600;margin-bottom:8px;">Reconciliation status</div>
+      <div style="font-size:13px;color:${COLORS.inkBody};line-height:1.7;">
+        ${rows.join('<br>')}
+      </div>
+    </div>`;
+}
+
+/** The net-income line — the honesty gate lives here. */
+function netIncomeHtml(d: MonthlyClosePayload): string {
+  if (d.netIncomeReliable && d.netIncomeCents !== null) {
+    const color = d.netIncomeCents >= 0 ? COLORS.good : COLORS.urgent;
+    return plLine('Net income', money(d.netIncomeCents), { strong: true, color });
+  }
+  return plLine('Net income', 'Pending', {
+    strong: true,
+    color: COLORS.caution,
+    sub: 'withheld until the data is complete — see below',
+  });
+}
+
+export function renderFinanceMonthlyCloseEmail(d: MonthlyClosePayload): string {
+  const revMoM =
+    d.revenueMoMPct !== null
+      ? `<span style="font-size:11px;color:${
+          d.revenueMoMPct >= 0 ? COLORS.good : COLORS.urgent
+        };"> ${d.revenueMoMPct >= 0 ? '↑' : '↓'} ${Math.abs(d.revenueMoMPct).toFixed(1)}% vs prior month</span>`
+      : '';
+
+  const cogsLabel = d.cashBasis ? 'COGS (cash-basis — alcohol purchased)' : 'COGS';
+  const hasExpenses = d.expenseSource !== 'none';
+
+  // P&L body — revenue always; COGS/GP/OpEx/net only when an expense source exists.
+  const plRows: string[] = [
+    plLine('Revenue', money(d.revenueCents), {
+      strong: true,
+      sub: `${d.orderCount} orders · ${money(d.revenueFromOrdersCents)} dashboard + ${money(
+        d.revenueFromShopifyCents
+      )} Shopify`,
+    }),
+  ];
+
+  const cogsLine = plLine(cogsLabel, d.cogsCents === null ? '—' : money(d.cogsCents), {
+    indent: true,
+    sub: d.cogsTopVendor ? `top: ${d.cogsTopVendor}` : undefined,
+  });
+  const grossProfitLine = plLine(
+    'Gross profit',
+    d.grossProfitCents === null ? '—' : money(d.grossProfitCents),
+    { strong: true, sub: `gross margin ${pct(d.grossMarginPct)}` }
+  );
+
+  if (!hasExpenses) {
+    plRows.push(
+      plLine('Expenses', 'Pending', {
+        indent: true,
+        sub: 'awaiting bank / QuickBooks data for this month',
+      })
+    );
+  } else if (d.netIncomeReliable) {
+    plRows.push(
+      cogsLine,
+      grossProfitLine,
+      plLine('Operating expenses', d.opexCents === null ? '—' : money(d.opexCents), { strong: true }),
+      opexRowsHtml(d.opexRows)
+    );
+  } else {
+    // HONESTY GATE: net income is unreliable this month. Show COGS + gross margin
+    // (gross profit is just Revenue − COGS, already visible), but WITHHOLD
+    // operating expenses so the unreliable net income CANNOT be reconstructed as
+    // (gross profit − operating expenses). Net income itself renders "Pending".
+    plRows.push(
+      cogsLine,
+      grossProfitLine,
+      plLine('Operating expenses', 'Withheld', {
+        strong: true,
+        sub: 'withheld until the flags below are resolved — net income can’t be stated',
+      })
+    );
+  }
+  // Net income line always renders — as a number only when reliable, else "Pending".
+  plRows.push(netIncomeHtml(d));
+
+  const bodyTable = `
+    <table cellpadding="0" cellspacing="0" border="0" width="100%">
+      ${plRows.join('')}
+    </table>`;
+
+  return `<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Finance Monthly Close — ${esc(d.monthLabel)}</title>
+</head>
+<body style="margin:0;padding:0;background:#f6f3ea;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table cellpadding="0" cellspacing="0" border="0" width="100%" style="background:#f6f3ea;padding:32px 0;">
+    <tr>
+      <td align="center">
+        <table cellpadding="0" cellspacing="0" border="0" width="600" style="background:#ffffff;border:1px solid ${COLORS.hairline};">
+          <!-- header -->
+          <tr>
+            <td style="padding:28px 32px 16px 32px;border-bottom:1px solid ${COLORS.hairline};">
+              <div style="font-size:11px;color:${COLORS.goldAccent};text-transform:uppercase;letter-spacing:0.15em;font-weight:600;">Finance Director · monthly close</div>
+              <h1 style="font-size:24px;color:${COLORS.ink};margin:8px 0 4px 0;font-weight:700;">${esc(d.monthLabel)} P&amp;L${revMoM}</h1>
+              <div style="font-size:12px;color:${COLORS.muteText};">Generated ${esc(new Date(d.generatedAtIso).toUTCString())}${
+                d.cashBasis ? ' · figures are cash-basis' : ''
+              }</div>
+            </td>
+          </tr>
+
+          <!-- P&L body -->
+          <tr>
+            <td style="padding:20px 32px;">
+              ${bodyTable}
+              ${!d.netIncomeReliable ? flagsBlock(d.flags) : ''}
+              ${reconciliationBlock(d)}
+
+              <!-- CTA -->
+              <table cellpadding="0" cellspacing="0" border="0" width="100%" style="margin-top:20px;">
+                <tr>
+                  <td align="center">
+                    <a href="${esc(d.dashboardUrl)}" style="display:inline-block;background:${COLORS.blue};color:#ffffff;text-decoration:none;padding:12px 22px;font-size:13px;font-weight:600;">Open finance dashboard</a>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- footer -->
+          <tr>
+            <td style="padding:16px 32px 24px 32px;border-top:1px solid ${COLORS.hairline};">
+              <div style="font-size:11px;color:${COLORS.muteText};line-height:1.5;">
+                Party On Delivery · Finance Director (Phase 5)<br>
+                Generated automatically on the 1st of each month at 14:00 UTC${
+                  d.cashBasis
+                    ? '. Cash-basis: COGS is alcohol purchased that month (cash to distributors), not cost-of-goods-sold — restock months spike.'
+                    : '.'
+                }
+              </div>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+}
+
+export function renderFinanceMonthlyCloseText(d: MonthlyClosePayload): string {
+  const lines: string[] = [];
+  lines.push(`Finance Monthly Close — ${d.monthLabel}${d.cashBasis ? ' (cash-basis)' : ''}`);
+  lines.push('');
+  const momText = d.revenueMoMPct !== null ? ` (${d.revenueMoMPct >= 0 ? '+' : ''}${d.revenueMoMPct.toFixed(1)}% MoM)` : '';
+  lines.push(`Revenue: ${money(d.revenueCents)}${momText} — ${d.orderCount} orders`);
+
+  if (d.expenseSource === 'none') {
+    lines.push('');
+    lines.push('Expenses: none yet (no QB or production bank data this month).');
+    lines.push('Net income: Pending.');
+  } else {
+    lines.push(
+      `${d.cashBasis ? 'COGS (cash-basis)' : 'COGS'}: ${d.cogsCents === null ? '—' : money(d.cogsCents)}` +
+        (d.cogsTopVendor ? ` (top: ${d.cogsTopVendor})` : '')
+    );
+    lines.push(
+      `Gross profit: ${d.grossProfitCents === null ? '—' : money(d.grossProfitCents)} (margin ${pct(d.grossMarginPct)})`
+    );
+    if (d.netIncomeReliable) {
+      lines.push(`Operating expenses: ${d.opexCents === null ? '—' : money(d.opexCents)}`);
+      for (const r of d.opexRows) {
+        lines.push(`  - ${r.label}: ${money(r.cents)}${r.topVendor ? ` (top: ${r.topVendor})` : ''}`);
+      }
+      lines.push('');
+      lines.push(`NET INCOME: ${d.netIncomeCents === null ? 'Pending' : money(d.netIncomeCents)}`);
+    } else {
+      // Withhold OpEx so the unreliable net income can't be reconstructed.
+      lines.push('Operating expenses: Withheld (net income can’t be stated this month)');
+      lines.push('');
+      lines.push('NET INCOME: Pending (withheld until the flags below are resolved)');
+      for (const f of d.flags) lines.push(`  ! ${f}`);
+    }
+  }
+
+  // Income reconciliation only applies when there IS bank data for the month.
+  if (d.expenseSource !== 'none') {
+    lines.push('');
+    lines.push('Reconciliation:');
+    if (d.incomeReconciled === true) {
+      lines.push('  Income reconciles to known Stripe revenue.');
+    } else if (d.incomeReconciled === false) {
+      const gap = d.otherIncomeCents ? ` (~${money(d.otherIncomeCents)} unexplained)` : '';
+      lines.push(
+        `  Bank deposits EXCEED known Stripe revenue${gap} — operator question (loan proceeds / owner capital / transfers / unrecorded income?).`
+      );
+    }
+  }
+  lines.push('');
+  lines.push(`Dashboard: ${d.dashboardUrl}`);
+  return lines.join('\n');
+}

--- a/src/lib/finance/monthly-close-payload.ts
+++ b/src/lib/finance/monthly-close-payload.ts
@@ -1,0 +1,261 @@
+/**
+ * Monthly-close P&L payload (Finance Director Phase 5 — the recurring
+ * monthly-close email).
+ *
+ * On the 1st of each month the cron closes the PRIOR month: it reads that
+ * month's `finance_monthly_rollup` row (plus the month before, for a
+ * month-over-month delta) and shapes a P&L payload for the email template.
+ *
+ * The rollup already did the hard part — UNION of the two revenue eras, QB-vs-
+ * bank expense-source precedence, and the `dataHealth` honesty flags. This layer
+ * only reshapes it for display. **Net income is shaped through as-is; the
+ * template decides whether to render it based on `netIncomeReliable`** so the
+ * honesty gate lives in exactly one place.
+ *
+ * The bank-sourced expense numbers are CASH-BASIS: "COGS" is alcohol PURCHASED
+ * that month (cash out to distributors), not accrual cost-of-goods-SOLD — so it
+ * is lumpy (restock months spike). `cashBasis` flags this for the template.
+ */
+
+import { prisma } from '@/lib/database/client';
+
+const BASE_URL = process.env.NEXT_PUBLIC_APP_URL ?? 'https://partyondelivery.com';
+
+const MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+export interface YearMonth {
+  year: number;
+  month: number;
+}
+
+/** The month a close fired on `now` covers = the prior calendar month. */
+export function resolveCloseMonth(now: Date): YearMonth {
+  const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1));
+  return { year: d.getUTCFullYear(), month: d.getUTCMonth() + 1 };
+}
+
+function priorOf(ym: YearMonth): YearMonth {
+  const d = new Date(Date.UTC(ym.year, ym.month - 2, 1));
+  return { year: d.getUTCFullYear(), month: d.getUTCMonth() + 1 };
+}
+
+export function monthLabel(ym: YearMonth): string {
+  return `${MONTH_NAMES[ym.month - 1]} ${ym.year}`;
+}
+
+/** One OpEx category line for the P&L breakdown. */
+export interface MonthlyCloseExpenseRow {
+  label: string;
+  cents: number;
+  topVendor: string | null;
+}
+
+/** `dataHealth` block persisted on the rollup (only the fields we read). */
+interface RollupDataHealth {
+  expenseSource?: 'qb' | 'bank' | 'none' | null;
+  netIncomeReliable?: boolean;
+  incomeReconciled?: boolean | null;
+  otherIncomeCents?: number | null;
+  flags?: string[];
+}
+
+interface RollupExpenseCat {
+  category: string;
+  label: string;
+  cents: number;
+  topVendor: string | null;
+  topVendorCents: number;
+}
+
+/** Plain (BigInt-free) view of a rollup row — what the pure shaper consumes. */
+export interface RollupRow {
+  year: number;
+  month: number;
+  revenueCents: number;
+  revenueFromShopifyCents: number;
+  revenueFromOrdersCents: number;
+  orderCount: number;
+  cogsCents: number | null;
+  grossProfitCents: number | null;
+  opexCents: number | null;
+  netIncomeCents: number | null;
+  expenseCategories: RollupExpenseCat[];
+  dataHealth: RollupDataHealth;
+}
+
+export interface MonthlyClosePayload {
+  monthLabel: string;
+  period: string; // "2026-07"
+  generatedAtIso: string;
+  // Revenue
+  revenueCents: number;
+  revenueFromShopifyCents: number;
+  revenueFromOrdersCents: number;
+  orderCount: number;
+  revenueMoMPct: number | null;
+  // Expenses (cash-basis when bank-sourced)
+  expenseSource: 'qb' | 'bank' | 'none';
+  cashBasis: boolean;
+  cogsCents: number | null;
+  cogsTopVendor: string | null;
+  grossProfitCents: number | null;
+  grossMarginPct: number | null;
+  opexCents: number | null;
+  opexRows: MonthlyCloseExpenseRow[];
+  // Net (template gates rendering on netIncomeReliable)
+  netIncomeCents: number | null;
+  netIncomeReliable: boolean;
+  flags: string[];
+  // Reconciliation status
+  incomeReconciled: boolean | null;
+  otherIncomeCents: number | null;
+  dashboardUrl: string;
+}
+
+function pctChange(current: number, prior: number): number | null {
+  if (prior === 0) return null;
+  return ((current - prior) / prior) * 100;
+}
+
+/**
+ * Pure shaper — turns a rollup row (+ optional prior month) into the email
+ * payload. No DB access, so it is unit-testable in isolation.
+ */
+export function shapeMonthlyClosePayload(args: {
+  rollup: RollupRow;
+  prior: RollupRow | null;
+  generatedAt: Date;
+  baseUrl?: string;
+}): MonthlyClosePayload {
+  const { rollup, prior, generatedAt } = args;
+  const base = args.baseUrl ?? BASE_URL;
+  const ym: YearMonth = { year: rollup.year, month: rollup.month };
+  const health = rollup.dataHealth ?? {};
+  const expenseSource = (health.expenseSource ?? 'none') as 'qb' | 'bank' | 'none';
+
+  const cats = Array.isArray(rollup.expenseCategories) ? rollup.expenseCategories : [];
+  const cogsCat = cats.find((c) => c.category === 'cogs') ?? null;
+  const opexRows: MonthlyCloseExpenseRow[] = cats
+    .filter((c) => c.category !== 'cogs')
+    .map((c) => ({ label: c.label, cents: c.cents, topVendor: c.topVendor }))
+    .sort((a, b) => b.cents - a.cents);
+
+  const grossMarginPct =
+    rollup.grossProfitCents !== null && rollup.revenueCents > 0
+      ? (rollup.grossProfitCents / rollup.revenueCents) * 100
+      : null;
+
+  return {
+    monthLabel: monthLabel(ym),
+    period: `${ym.year}-${String(ym.month).padStart(2, '0')}`,
+    generatedAtIso: generatedAt.toISOString(),
+    revenueCents: rollup.revenueCents,
+    revenueFromShopifyCents: rollup.revenueFromShopifyCents,
+    revenueFromOrdersCents: rollup.revenueFromOrdersCents,
+    orderCount: rollup.orderCount,
+    revenueMoMPct: prior ? pctChange(rollup.revenueCents, prior.revenueCents) : null,
+    expenseSource,
+    cashBasis: expenseSource === 'bank',
+    cogsCents: rollup.cogsCents,
+    cogsTopVendor: cogsCat?.topVendor ?? null,
+    grossProfitCents: rollup.grossProfitCents,
+    grossMarginPct,
+    opexCents: rollup.opexCents,
+    opexRows,
+    netIncomeCents: rollup.netIncomeCents,
+    netIncomeReliable: health.netIncomeReliable === true,
+    flags: Array.isArray(health.flags) ? health.flags : [],
+    incomeReconciled: health.incomeReconciled ?? null,
+    otherIncomeCents: health.otherIncomeCents ?? null,
+    dashboardUrl: `${base}/admin/finance`,
+  };
+}
+
+/** Prisma row → plain RollupRow (BigInt → number, Json → typed). */
+function toRollupRow(r: {
+  year: number;
+  month: number;
+  revenueCents: bigint;
+  revenueFromShopifyCents: bigint;
+  revenueFromOrdersCents: bigint;
+  orderCount: number;
+  cogsCents: bigint | null;
+  grossProfitCents: bigint | null;
+  opexCents: bigint | null;
+  netIncomeCents: bigint | null;
+  expenseCategories: unknown;
+  dataHealth: unknown;
+}): RollupRow {
+  const n = (b: bigint | null): number | null => (b === null ? null : Number(b));
+  return {
+    year: r.year,
+    month: r.month,
+    revenueCents: Number(r.revenueCents),
+    revenueFromShopifyCents: Number(r.revenueFromShopifyCents),
+    revenueFromOrdersCents: Number(r.revenueFromOrdersCents),
+    orderCount: r.orderCount,
+    cogsCents: n(r.cogsCents),
+    grossProfitCents: n(r.grossProfitCents),
+    opexCents: n(r.opexCents),
+    netIncomeCents: n(r.netIncomeCents),
+    expenseCategories: Array.isArray(r.expenseCategories)
+      ? (r.expenseCategories as RollupExpenseCat[])
+      : [],
+    dataHealth: (r.dataHealth ?? {}) as RollupDataHealth,
+  };
+}
+
+/**
+ * Read the just-closed month (+ the prior month) from `finance_monthly_rollup`
+ * and shape the email payload. Returns null when the closed month has no rollup
+ * row yet (the nightly rollup cron should have built it; if not, the caller
+ * skips the email rather than inventing numbers).
+ */
+export async function buildMonthlyClosePayload(
+  now: Date,
+  baseUrl?: string
+): Promise<MonthlyClosePayload | null> {
+  const target = resolveCloseMonth(now);
+  const prevYm = priorOf(target);
+
+  // Select only the P&L fields — deliberately EXCLUDE topCustomers (name +
+  // email), topAffiliates, topSkus, segmentBreakdown so customer PII never
+  // enters this email pipeline.
+  const select = {
+    year: true,
+    month: true,
+    revenueCents: true,
+    revenueFromShopifyCents: true,
+    revenueFromOrdersCents: true,
+    orderCount: true,
+    cogsCents: true,
+    grossProfitCents: true,
+    opexCents: true,
+    netIncomeCents: true,
+    expenseCategories: true,
+    dataHealth: true,
+  } as const;
+
+  const [targetRow, priorRow] = await Promise.all([
+    prisma.financeMonthlyRollup.findUnique({
+      where: { year_month: { year: target.year, month: target.month } },
+      select,
+    }),
+    prisma.financeMonthlyRollup.findUnique({
+      where: { year_month: { year: prevYm.year, month: prevYm.month } },
+      select,
+    }),
+  ]);
+
+  if (!targetRow) return null;
+
+  return shapeMonthlyClosePayload({
+    rollup: toRollupRow(targetRow),
+    prior: priorRow ? toRollupRow(priorRow) : null,
+    generatedAt: now,
+    baseUrl,
+  });
+}

--- a/src/lib/finance/monthly-rollup.ts
+++ b/src/lib/finance/monthly-rollup.ts
@@ -533,9 +533,13 @@ function buildDataHealth(h: HealthInput): Record<string, unknown> {
     h.bankExpenseTotalCents > expensesTotalCents * 1.5 &&
     h.bankExpenseTotalCents - expensesTotalCents > QB_MATERIAL_FLOOR_CENTS
   ) {
+    // Describe the discrepancy as a RATIO, not raw dollar totals. The QB expense
+    // total is COGS+OpEx; embedding it here would let a reader reconstruct the
+    // withheld net income (Revenue − total) in the monthly-close email's
+    // honesty-gated view, so keep it qualitative.
+    const overBy = Math.round((h.bankExpenseTotalCents / expensesTotalCents - 1) * 100);
     flags.push(
-      `bank outflows ($${(h.bankExpenseTotalCents / 100).toFixed(0)}) materially exceed QB expenses ` +
-        `($${(expensesTotalCents / 100).toFixed(0)}) — QB books may be incomplete this month`
+      `bank outflows exceed QB-booked expenses by ~${overBy}% — QB books may be incomplete this month`
     );
   }
 

--- a/vercel.json
+++ b/vercel.json
@@ -97,6 +97,10 @@
       "schedule": "0 14 * * 1"
     },
     {
+      "path": "/api/cron/finance-monthly-close",
+      "schedule": "0 14 1 * *"
+    },
+    {
       "path": "/api/cron/full-moon-deadline",
       "schedule": "0 15 * * *"
     }


### PR DESCRIPTION
## What

The deferred final phase of the Finance Director buildout — a recurring **monthly-close P&L email**. On the 1st of each month a cron closes the **prior** month: reads its `finance_monthly_rollup` row, renders a P&L (Revenue → COGS → Gross Profit + margin → OpEx by category → Net income) + reconciliation status, and emails it via Resend. Mirrors the existing weekly finance-briefing pattern.

## Files
- `src/lib/finance/monthly-close-payload.ts` — pure shaper (`shapeMonthlyClosePayload`, unit-tested) + `buildMonthlyClosePayload` (reads closed + prior month; PII-minimising `select`). Returns null → skip when the month has no rollup yet.
- `src/lib/email/templates/finance-monthly-close.ts` — HTML + text renderers (cream/gold P&L aesthetic).
- `src/app/api/cron/finance-monthly-close/route.ts` — `GET`, Bearer `CRON_SECRET` (fail-closed), optional `?month=YYYY-MM` override, fail-soft on DB/email errors.
- `vercel.json` — cron `0 14 1 * *` (1st of month, 14:00 UTC).

## Honesty gate (the core requirement)
Net income renders as a **number only when `dataHealth.netIncomeReliable` is true**; otherwise "Pending" + the `dataHealth` flags.

Security review caught that hiding only the net *line* was cosmetic — `net = grossProfit − opex`, so a reader could subtract two displayed figures. **Fixed:** unreliable months now withhold **operating expenses too** (Revenue, COGS, and gross margin still shown), so net can't be reconstructed.

## Cash-basis + the deposit anomaly
Bank-sourced COGS is alcohol **purchased** that month (cash to distributors), not cost-of-goods-**sold** — labelled cash-basis so lumpy restock months aren't misread. The May/June anomaly (~$15–17K/mo of bank deposits exceeding known Stripe revenue) is surfaced in the reconciliation section as an **operator question**, never auto-resolved.

## Verified on real prod rollups
| Month | Renders |
|---|---|
| **April** (reliable) | Full P&L, **NET INCOME: $11,065** |
| **June** (flagged) | Revenue/COGS/gross-margin shown; **OpEx + Net withheld** (neither figure present in HTML); deposit-anomaly flag surfaced |
| **February** (no bank data) | "Expenses: none yet", Net Pending, no false deposit-anomaly claim |

## Reviews
- ✅ `security-reviewer`: found the honesty-gate reconstruction gap (CRITICAL) + 1 MEDIUM (cron fail-open) + 3 LOWs — **all fixed** (fail-closed auth, PII `select`, year-bound guard, single-quote escape, try/catch). Re-review requested.
- ✅ `/code-review`: 2 findings (fail-open auth, dead field) — both fixed.
- ✅ 698 tests pass (incl. an honesty-gate regression test with an internally-consistent flagged fixture), tsc 0 errors, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)