### PR TITLE
Premier Concierge bachelor-party landing + POD lead capture + Google Sheets mirror

### DIFF
--- a/src/app/admin/brians-stuff/BriansStuffTabs.tsx
+++ b/src/app/admin/brians-stuff/BriansStuffTabs.tsx
@@ -68,7 +68,12 @@ export default function BriansStuffTabs({
   return (
     <div className="-m-6 md:-m-8 lg:-m-10">
       <div className="sticky top-[var(--pod-appbar-h,0px)] z-20 bg-white border-b border-gray-200">
-        <div className="max-w-5xl mx-auto px-6 md:px-10 flex gap-1 overflow-x-auto">
+        {/* Wrap onto multiple rows when the label count exceeds one row's
+            width. The old `overflow-x-auto` clipped labels behind a
+            silent scrollbar so half the tabs were invisible on 13"
+            laptops. flex-wrap + generous vertical padding gives every
+            tab a real touch target. */}
+        <div className="max-w-6xl mx-auto px-4 md:px-8 flex flex-wrap gap-x-1 gap-y-0.5 py-1">
           <TabButton active={tab === 'playbook'} onClick={() => setTab('playbook')}>
             📘 Landing Page Playbook
           </TabButton>
@@ -152,10 +157,11 @@ function TabButton({
     <button
       type="button"
       onClick={onClick}
-      className="px-4 py-3 text-sm font-bold border-b-2 transition-colors whitespace-nowrap"
+      className="px-3 py-2.5 text-[13px] sm:text-sm font-bold border-b-2 transition-colors whitespace-nowrap rounded-t-md hover:bg-purple-50/50"
       style={{
         borderColor: active ? '#7C3AED' : 'transparent',
-        color: active ? '#5B21B6' : '#6B7280',
+        color: active ? '#5B21B6' : '#4B5563',
+        background: active ? 'rgba(124,58,237,0.06)' : 'transparent',
       }}
     >
       {children}

--- a/src/app/api/v1/concierge/lead/route.ts
+++ b/src/app/api/v1/concierge/lead/route.ts
@@ -1,0 +1,230 @@
+/**
+ * POST /api/v1/concierge/lead
+ *
+ * Premier Concierge bachelor-party planning lead capture.
+ *
+ * Pipeline (all fire-and-forget except the Lead upsert, which we await
+ * because the caller needs the leadId back):
+ *
+ *   1. Validate payload with Zod.
+ *   2. upsertLead() — creates or updates the Postgres Lead row, promotes
+ *      status to SUBMITTED, stamps metadata.conciergeQuiz with the full
+ *      questionnaire.
+ *   3. recordEvent(FORM_SUBMIT) — atomic audit trail.
+ *   4. notifyConciergeLead() — fires the GHL concierge webhook with the
+ *      tags array (premier-concierge, bachelor-party, activity tags,
+ *      budget bucket, headcount bucket). No-ops silently if
+ *      GHL_CONCIERGE_LEAD_WEBHOOK_URL is not set.
+ *   5. appendLeadToPodLeadsSheet() — writes a row to the "POD Leads"
+ *      tab of the PPC Booking App Time Slots Google Sheet. Best-effort;
+ *      never blocks the response.
+ *
+ * CORS: this endpoint is intentionally OPEN (no origin check) so the
+ * same page can eventually be hosted on premierconcierge.co and POST
+ * cross-domain. If we ever need to lock it down we'd add an allowlist
+ * here.
+ */
+import { NextResponse, type NextRequest } from 'next/server';
+import { z } from 'zod';
+import { prisma } from '@/lib/database/client';
+import { upsertLead, recordEvent } from '@/lib/leads/leadCapture';
+import { notifyConciergeLead } from '@/lib/webhooks/ghl';
+import {
+  appendLeadToPodLeadsSheet,
+  formatCentralTimestamp,
+} from '@/lib/premier/pod-leads-sheet';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const ACTIVITIES = [
+  'drink-delivery',
+  'boat-rental',
+  'golf-brewery-tour',
+  'atv-tour',
+  'gun-range',
+  'transportation',
+  'not-sure',
+] as const;
+
+const bodySchema = z.object({
+  firstName: z.string().min(1).max(80),
+  lastName: z.string().max(80).optional().default(''),
+  email: z.string().email().max(200),
+  phone: z.string().max(40).optional().default(''),
+  headcount: z.number().int().min(1).max(500),
+  arrivalDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  departureDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  partyType: z.enum(['bachelor', 'bachelorette', 'weekend', 'corporate', 'other']),
+  /** Selected budget tier per person, dollars — sent as a chip label from the UI. */
+  budgetPerPerson: z.string().max(24),
+  activities: z.array(z.enum(ACTIVITIES)).min(1).max(ACTIVITIES.length),
+  notes: z.string().max(2000).optional().default(''),
+  /** Which page fired the form. Enables sending the same form from
+   *  premierconcierge.co later. */
+  source: z.string().max(80).optional().default('premier-concierge-bachelor'),
+});
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+};
+
+// Preflight for cross-domain form submits (once premierconcierge.co ships).
+export async function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: CORS_HEADERS });
+}
+
+export async function POST(req: NextRequest) {
+  let body: z.infer<typeof bodySchema>;
+  try {
+    body = bodySchema.parse(await req.json());
+  } catch (err) {
+    return NextResponse.json(
+      { ok: false, error: 'invalid_body', detail: String(err) },
+      { status: 400, headers: CORS_HEADERS },
+    );
+  }
+
+  // ─── 1) Lead upsert + metadata stamp ────────────────────────────
+  let leadId: string | null = null;
+  try {
+    const lead = await upsertLead(
+      {
+        firstName: body.firstName,
+        lastName: body.lastName || null,
+        email: body.email,
+        phone: body.phone || null,
+      },
+      {
+        sourcePage: `/${body.source}`,
+        // No specific enum for concierge yet — the existing
+        // PARTNER_LANDING_PAGE value semantically covers it, and the
+        // structured payload lives in metadata so admin UIs can filter
+        // by `metadata.partner`.
+        sourceWidget: 'PARTNER_LANDING_PAGE',
+      },
+    );
+
+    if (lead) {
+      leadId = lead.id;
+      const prevMeta =
+        (lead.metadata as Record<string, unknown> | null) ?? {};
+      await prisma.lead.update({
+        where: { id: lead.id },
+        data: {
+          status: 'SUBMITTED',
+          metadata: {
+            ...prevMeta,
+            partner: 'premier-concierge',
+            conciergeQuiz: {
+              source: body.source,
+              partyType: body.partyType,
+              headcount: body.headcount,
+              arrivalDate: body.arrivalDate,
+              departureDate: body.departureDate,
+              budgetPerPerson: body.budgetPerPerson,
+              activities: body.activities,
+              notes: body.notes,
+              submittedAt: new Date().toISOString(),
+            },
+          } as never,
+        },
+      });
+
+      await recordEvent({
+        type: 'FORM_SUBMIT',
+        leadId: lead.id,
+        page: `/${body.source}`,
+        widget: 'PARTNER_LANDING_PAGE',
+        fieldName: 'concierge-submit',
+        metadata: {
+          flow: 'premier-concierge',
+          partyType: body.partyType,
+          headcount: body.headcount,
+          budget: body.budgetPerPerson,
+          activities: body.activities,
+        },
+      });
+    }
+  } catch (err) {
+    console.error('[concierge/lead] upsertLead failed', err);
+  }
+
+  // ─── 2) Compose the tag array for GHL ────────────────────────────
+  const tags = buildTags(body);
+  const now = new Date();
+  const leadUrl = leadId
+    ? `https://partyondelivery.com/admin/brians-stuff?tab=leads&lead=${leadId}`
+    : 'https://partyondelivery.com/admin/brians-stuff?tab=leads';
+
+  // ─── 3) GHL webhook — non-blocking ───────────────────────────────
+  notifyConciergeLead({
+    event: 'concierge.lead',
+    first_name: body.firstName,
+    last_name: body.lastName,
+    email: body.email,
+    phone: body.phone,
+    source: body.source,
+    partyType: body.partyType,
+    headcount: body.headcount,
+    arrivalDate: body.arrivalDate,
+    departureDate: body.departureDate,
+    budgetPerPerson: body.budgetPerPerson,
+    activities: body.activities,
+    notes: body.notes,
+    tags,
+    leadUrl,
+    submittedAt: now.toISOString(),
+  }).catch((err) => {
+    console.error('[concierge/lead] GHL notify failed (non-blocking)', err);
+  });
+
+  // ─── 4) Google Sheet append — non-blocking ───────────────────────
+  appendLeadToPodLeadsSheet({
+    submittedAt: formatCentralTimestamp(now),
+    source: body.source,
+    firstName: body.firstName,
+    lastName: body.lastName,
+    email: body.email,
+    phone: body.phone,
+    headcount: String(body.headcount),
+    arrivalDate: body.arrivalDate,
+    departureDate: body.departureDate,
+    partyType: body.partyType,
+    budgetPerPerson: body.budgetPerPerson,
+    activities: body.activities.join(', '),
+    notes: body.notes,
+    leadUrl,
+  }).catch((err) => {
+    console.error('[concierge/lead] sheet append failed (non-blocking)', err);
+  });
+
+  return NextResponse.json(
+    { ok: true, leadId },
+    { status: 200, headers: CORS_HEADERS },
+  );
+}
+
+/**
+ * Build the GHL tag array from the questionnaire answers. Every tag
+ * here is a signal the receiving GHL workflow can route on (assign
+ * pipeline stage, route to a specific rep, trigger different follow-up
+ * sequences, etc.).
+ */
+function buildTags(body: z.infer<typeof bodySchema>): string[] {
+  const tags: string[] = ['premier-concierge', 'bachelor-party-inquiry'];
+  tags.push(`party-type:${body.partyType}`);
+  tags.push(`budget:${body.budgetPerPerson.replace(/\s+/g, '').toLowerCase()}`);
+  tags.push(`headcount:${headcountBucket(body.headcount)}`);
+  for (const a of body.activities) tags.push(`activity:${a}`);
+  return tags;
+}
+
+function headcountBucket(n: number): string {
+  if (n <= 6) return '2-6';
+  if (n <= 12) return '7-12';
+  if (n <= 20) return '13-20';
+  return '20-plus';
+}

--- a/src/app/austin-bachelor-concierge/page.tsx
+++ b/src/app/austin-bachelor-concierge/page.tsx
@@ -1,0 +1,40 @@
+/**
+ * /austin-bachelor-concierge
+ *
+ * Premier Concierge · Austin Bachelor Party Planning landing page.
+ *
+ * Built ON the POD infrastructure per founder spec (leads land in POD's
+ * Brian's Stuff → Leads; product catalog references POD; GHL webhook
+ * fires from POD; Google Sheet mirror writes from POD). This page is
+ * intentionally not indexed yet — canonical URL flips to
+ * premierconcierge.co once that repo mirrors this component.
+ *
+ * The interactive pieces (services grid + 6-step questionnaire modal)
+ * live in ConciergeLandingClient. This file is a thin server wrapper
+ * for SEO metadata + first-paint HTML.
+ */
+import type { Metadata } from 'next';
+import ConciergeLandingClient from '@/components/concierge/ConciergeLandingClient';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Premier Concierge · Austin Bachelor Party Planning | Party On Delivery',
+  description:
+    'Full-service Austin bachelor-party planning — party boat rentals on Lake Travis, drink delivery to the dock, golf & brewery tours, ATV rides, gun range, and transportation. One questionnaire, one concierge, one weekend planned.',
+  alternates: { canonical: '/austin-bachelor-concierge' },
+  // NoIndex during Phase 1 while the component is co-hosted on POD.
+  // Flip to indexed after we migrate the canonical URL to
+  // premierconcierge.co.
+  robots: { index: false, follow: false },
+  openGraph: {
+    title: 'Premier Concierge · Austin Bachelor Party Planning',
+    description:
+      'One form. Boats, drinks, golf, ATVs, gun range, transportation. We plan the whole weekend.',
+    type: 'website',
+  },
+};
+
+export default function AustinBachelorConciergePage() {
+  return <ConciergeLandingClient />;
+}

--- a/src/components/AgeVerification.tsx
+++ b/src/components/AgeVerification.tsx
@@ -24,6 +24,7 @@ const AGE_GATE_EXEMPT_PATHS = [
   '/austin-4th-of-july-delivery',
   '/event-quiz',
   '/events/4th-of-july-disco-cruise',
+  '/austin-bachelor-concierge',
 ]
 
 /**

--- a/src/components/admin/LeadsView.tsx
+++ b/src/components/admin/LeadsView.tsx
@@ -43,7 +43,7 @@ function fmtDate(d: Date) {
 }
 
 export default async function LeadsView() {
-  const [leads, totalLeads, anonSessions, partialCount, submittedCount, convertedCount] =
+  const [leads, totalLeads, anonSessions, partialCount, submittedCount, convertedCount, conciergeCount] =
     await Promise.all([
       prisma.lead.findMany({
         orderBy: { updatedAt: 'desc' },
@@ -58,17 +58,24 @@ export default async function LeadsView() {
       prisma.lead.count({ where: { status: 'PARTIAL' } }),
       prisma.lead.count({ where: { status: 'SUBMITTED' } }),
       prisma.lead.count({ where: { status: 'CONVERTED' } }),
+      // Premier Concierge leads — stored in metadata.partner so we don't
+      // need a schema migration for a new enum value. If we ever start
+      // seeing dozens per day we'll promote this to its own column.
+      prisma.lead.count({
+        where: { metadata: { path: ['partner'], equals: 'premier-concierge' } },
+      }),
     ]);
 
   return (
     <div className="space-y-6">
       {/* Top-line counters */}
-      <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
+      <div className="grid grid-cols-2 md:grid-cols-6 gap-3">
         <Stat label="Total leads" value={totalLeads} />
         <Stat label="Anonymous sessions" value={anonSessions} />
         <Stat label="Partial" value={partialCount} color="#92400E" />
         <Stat label="Submitted" value={submittedCount} color="#1E40AF" />
         <Stat label="Converted" value={convertedCount} color="#166534" />
+        <Stat label="🥃 Concierge" value={conciergeCount} color="#5B21B6" />
       </div>
 
       <div className="rounded-md border border-gray-200 overflow-hidden bg-white">
@@ -106,8 +113,14 @@ export default async function LeadsView() {
               {leads.map((l) => {
                 const sc = STATUS_COLOR[l.status] ?? STATUS_COLOR.PARTIAL;
                 const lastEvent = l.events[0];
+                const meta = (l.metadata as Record<string, unknown> | null) ?? {};
+                const isConcierge = meta.partner === 'premier-concierge';
                 return (
-                  <tr key={l.id} className="border-t border-gray-100 align-top">
+                  <tr
+                    key={l.id}
+                    className="border-t border-gray-100 align-top"
+                    style={isConcierge ? { background: '#FAF5FF' } : undefined}
+                  >
                     <Td>{fmtDate(l.updatedAt)}</Td>
                     <Td>
                       <span
@@ -127,6 +140,14 @@ export default async function LeadsView() {
                       <div className="text-gray-500 text-xs">{l.phone || ''}</div>
                     </Td>
                     <Td>
+                      {isConcierge && (
+                        <span
+                          className="inline-block px-1.5 py-0.5 rounded text-[10px] font-bold tracking-wider mr-1"
+                          style={{ background: '#5B21B6', color: '#F2D34F' }}
+                        >
+                          🥃 CONCIERGE
+                        </span>
+                      )}
                       {l.sourceWidget ? (
                         <span className="text-xs font-semibold text-purple-700">
                           {WIDGET_LABELS[l.sourceWidget] ?? l.sourceWidget}

--- a/src/components/chat/PartyChatMount.tsx
+++ b/src/components/chat/PartyChatMount.tsx
@@ -37,6 +37,8 @@ const HIDE_PATTERNS: RegExp[] = [
   /^\/events(\/|$)/,
   // Full Moon Party lander — has its own share FAB; keep it distraction-free.
   /^\/full-moon-aug1(\/|$)/,
+  // Premier Concierge lander — own questionnaire modal; no drink-planner bubble.
+  /^\/austin-bachelor-concierge(\/|$)/,
 ];
 
 export default function PartyChatMount() {

--- a/src/components/concierge/ConciergeLandingClient.tsx
+++ b/src/components/concierge/ConciergeLandingClient.tsx
@@ -1,0 +1,587 @@
+'use client';
+
+/**
+ * Client shell for the Austin Bachelor Concierge landing page.
+ *
+ * Structure:
+ *   - Sticky nav (Premier Concierge wordmark + Plan CTA + phone)
+ *   - Hero (headline + subhead + primary CTA)
+ *   - Trust bar (stats)
+ *   - Services grid (6 tiles — drinks, boats, golf/brewery, ATVs,
+ *     gun range, transportation)
+ *   - How-it-works strip
+ *   - Testimonials placeholder
+ *   - Final CTA
+ *   - Sticky mobile CTA
+ *
+ * The multi-step questionnaire opens on CTA click and posts to
+ * /api/v1/concierge/lead which handles Lead upsert + GHL fire + Google
+ * Sheet append. See ConciergeQuestionnaireModal for the form.
+ */
+
+import Image from 'next/image';
+import { useState, type ReactElement } from 'react';
+import ConciergeQuestionnaireModal from './ConciergeQuestionnaireModal';
+
+// ─── Brand tokens (Premier Concierge palette) ────────────────────────
+const NAVY = '#0A1F33';
+const GOLD = '#D4AF37';        // Premium gold — Premier Concierge
+const CREAM = '#FAF6EE';
+const CHARCOAL = '#1C2A3A';
+const YELLOW = '#F2D34F';
+
+// ─── Services ──────────────────────────────────────────────────────
+type Service = {
+  key: string;
+  title: string;
+  blurb: string;
+  emoji: string;
+  imgSrc: string;
+  imgAlt: string;
+  chip: string;
+};
+
+const SERVICES: Service[] = [
+  {
+    key: 'boat-rental',
+    title: 'Private Party Boats',
+    blurb:
+      'Lake Travis captained cruises — 4 to 40 guys, from cocktail rides to overnight charters. Docked at the marina where Premier lives.',
+    emoji: '🛥️',
+    imgSrc: '/images/destinations/lake-travis-boats.webp',
+    imgAlt: 'Party boats docked on Lake Travis at sunset',
+    chip: 'Most-booked',
+  },
+  {
+    key: 'drink-delivery',
+    title: 'Drink Delivery to the Dock',
+    blurb:
+      "Beer, liquor, seltzers, cocktail kits — iced and staged at the marina before you board. We already stock the boats.",
+    emoji: '🥃',
+    imgSrc: '/images/services/bach-parties/late-night-party-supplies.webp',
+    imgAlt: 'Late-night party supplies laid out for delivery',
+    chip: 'Free · no minimum',
+  },
+  {
+    key: 'golf-brewery-tour',
+    title: 'Golf & Brewery Tours',
+    blurb:
+      'Top-nine courses, small-batch breweries in East Austin, whiskey rooms. Curated tastings + tee times booked for the group.',
+    emoji: '⛳',
+    imgSrc: '/images/destinations/east-austin-brewery.webp',
+    imgAlt: 'East Austin brewery interior with taproom bar',
+    chip: 'Guys weekend',
+  },
+  {
+    key: 'atv-tour',
+    title: 'ATV & Off-Road Tours',
+    blurb:
+      'Hill Country trails, mud tracks, sunset rides. Guided groups with equipment, coolers optional (we can send them).',
+    emoji: '🚙',
+    imgSrc: '/images/destinations/hill-country-winery.webp',
+    imgAlt: 'Texas Hill Country vista at golden hour',
+    chip: 'Adrenaline',
+  },
+  {
+    key: 'gun-range',
+    title: 'Gun Range Experience',
+    blurb:
+      'Private lane blocks at Texas premier shooting ranges. Instructor-led sessions, pistol + rifle, all skill levels welcome.',
+    emoji: '🎯',
+    imgSrc: '/images/services/bach-parties/bachelor-party-epic.webp',
+    imgAlt: 'Bachelor party group toasting at the range',
+    chip: 'Only-in-Texas',
+  },
+  {
+    key: 'transportation',
+    title: 'Group Transportation',
+    blurb:
+      'Party bus, sprinter vans, and black car service. Airport pickup, downtown → lake shuttles, and late-night rides home.',
+    emoji: '🚐',
+    imgSrc: '/images/destinations/6th-street-entertainment.webp',
+    imgAlt: '6th Street Austin nightlife strip',
+    chip: 'Airport → Airport',
+  },
+];
+
+// ─── Trust bar stats ──────────────────────────────────────────────
+const TRUST_STATS = [
+  { label: 'Austin bachelor weekends served', stat: '500+' },
+  { label: 'Google rating', stat: '5.0★' },
+  { label: 'Vendors coordinated', stat: '30+' },
+  { label: 'Concierge response', stat: '<24h' },
+];
+
+const STEPS = [
+  {
+    n: '01',
+    title: 'Tell us the vibe',
+    body: '3-minute questionnaire — who, when, how much, what you like.',
+  },
+  {
+    n: '02',
+    title: 'We plan the weekend',
+    body: 'Our concierge stitches boat, drinks, activities, and rides into one plan.',
+  },
+  {
+    n: '03',
+    title: 'You show up',
+    body: 'Everything is booked, iced, and staged before the groom lands.',
+  },
+];
+
+export default function ConciergeLandingClient(): ReactElement {
+  const [open, setOpen] = useState(false);
+  const [confirmed, setConfirmed] = useState(false);
+
+  function handleSuccess() {
+    setOpen(false);
+    setConfirmed(true);
+    // Scroll to top so the confirmation banner is immediately visible.
+    if (typeof window !== 'undefined') {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }
+
+  return (
+    <main
+      className="min-h-screen overflow-x-hidden"
+      style={{ background: CREAM, color: NAVY }}
+    >
+      <TopNav onCtaClick={() => setOpen(true)} />
+
+      {confirmed && <ConfirmationBanner />}
+
+      <Hero onCtaClick={() => setOpen(true)} />
+      <TrustBar />
+      <ServicesGrid onCtaClick={() => setOpen(true)} />
+      <HowItWorks onCtaClick={() => setOpen(true)} />
+      <FinalCta onCtaClick={() => setOpen(true)} />
+
+      {/* Sticky mobile CTA */}
+      <div
+        className="fixed bottom-0 inset-x-0 z-40 border-t-2 md:hidden"
+        style={{
+          background: '#FFFFFF',
+          borderColor: NAVY,
+          boxShadow: '0 -4px 18px rgba(10,15,25,0.15)',
+        }}
+      >
+        <div className="px-4 py-3 flex items-center justify-between gap-3">
+          <div>
+            <div className="text-[10px] font-bold tracking-widest text-gray-500">
+              FREE PLANNING
+            </div>
+            <div className="text-sm font-bold" style={{ color: NAVY }}>
+              Concierge response in 24h
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => setOpen(true)}
+            className="rounded-lg px-5 py-3 text-sm font-bold tracking-[0.08em] transition-transform hover:scale-[1.03]"
+            style={{
+              background: GOLD,
+              color: NAVY,
+              border: `2px solid ${NAVY}`,
+              boxShadow: `0 3px 0 ${NAVY}`,
+            }}
+          >
+            PLAN MY WEEKEND →
+          </button>
+        </div>
+      </div>
+
+      {open && (
+        <ConciergeQuestionnaireModal
+          onClose={() => setOpen(false)}
+          onSuccess={handleSuccess}
+        />
+      )}
+    </main>
+  );
+}
+
+// ─── Nav ────────────────────────────────────────────────────────────
+
+function TopNav({ onCtaClick }: { onCtaClick: () => void }) {
+  return (
+    <header
+      className="sticky top-0 z-30 backdrop-blur-md"
+      style={{
+        background: 'rgba(10,15,25,0.92)',
+        borderBottom: `2px solid ${GOLD}`,
+      }}
+    >
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 py-3 flex items-center justify-between gap-3">
+        <div className="flex items-baseline gap-2">
+          <span
+            className="font-heading text-lg sm:text-xl font-bold tracking-[0.15em]"
+            style={{ color: GOLD }}
+          >
+            PREMIER
+          </span>
+          <span
+            className="font-heading text-lg sm:text-xl font-bold tracking-[0.15em] text-white"
+          >
+            CONCIERGE
+          </span>
+        </div>
+        <div className="flex items-center gap-2 sm:gap-3">
+          <a
+            href="tel:+17373719700"
+            className="hidden sm:inline-flex items-center gap-1 text-white text-sm font-bold hover:opacity-80"
+          >
+            <PhoneIcon /> (737) 371-9700
+          </a>
+          <button
+            type="button"
+            onClick={onCtaClick}
+            className="rounded-lg px-4 py-2.5 text-xs sm:text-sm font-bold tracking-[0.08em] transition-transform hover:scale-[1.03]"
+            style={{
+              background: GOLD,
+              color: NAVY,
+              border: '2px solid #1a1a1a',
+            }}
+          >
+            PLAN MY WEEKEND →
+          </button>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+// ─── Hero ───────────────────────────────────────────────────────────
+
+function Hero({ onCtaClick }: { onCtaClick: () => void }) {
+  return (
+    <section className="relative overflow-hidden">
+      {/* Background image */}
+      <div className="absolute inset-0">
+        <Image
+          src="/images/destinations/lake-travis-boats.webp"
+          alt="Lake Travis party boats at golden hour"
+          fill
+          priority
+          sizes="100vw"
+          className="object-cover"
+        />
+        <div
+          className="absolute inset-0"
+          style={{
+            background:
+              'linear-gradient(180deg, rgba(10,15,25,0.6) 0%, rgba(10,15,25,0.85) 100%)',
+          }}
+        />
+      </div>
+
+      <div className="relative max-w-4xl mx-auto px-4 sm:px-6 py-16 md:py-24 lg:py-32 text-center text-white">
+        <div
+          className="inline-block px-3 py-1 rounded-full text-xs font-bold tracking-widest mb-4"
+          style={{ background: GOLD, color: NAVY }}
+        >
+          🥃 AUSTIN, TX · FULL-SERVICE PLANNING
+        </div>
+        <h1 className="font-heading text-4xl md:text-5xl lg:text-6xl font-bold tracking-tight leading-[1.05]">
+          Premier Concierge
+          <br />
+          <span style={{ color: GOLD }}>Bachelor Party Planning</span>
+        </h1>
+        <p className="mt-5 text-base md:text-lg opacity-90 max-w-2xl mx-auto">
+          One weekend. One concierge. Boats on Lake Travis, drinks
+          delivered to the dock, brewery tours, ATVs, gun range, and
+          transportation — all planned before the groom lands.
+        </p>
+
+        <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-3">
+          <button
+            type="button"
+            onClick={onCtaClick}
+            className="rounded-lg px-6 py-4 text-base md:text-lg font-heading font-bold tracking-[0.12em] transition-transform hover:scale-[1.03]"
+            style={{
+              background: GOLD,
+              color: NAVY,
+              border: `2px solid ${NAVY}`,
+              boxShadow: `0 4px 0 ${NAVY}`,
+            }}
+          >
+            PLAN MY WEEKEND — FREE
+          </button>
+          <a
+            href="tel:+17373719700"
+            className="text-sm sm:text-base font-bold text-white hover:opacity-80 flex items-center gap-1.5"
+          >
+            <PhoneIcon /> or call (737) 371-9700
+          </a>
+        </div>
+        <p className="mt-4 text-xs opacity-70">
+          3-minute questionnaire · concierge follows up within 24 hours
+        </p>
+      </div>
+    </section>
+  );
+}
+
+// ─── Trust bar ──────────────────────────────────────────────────────
+
+function TrustBar() {
+  return (
+    <section
+      className="text-white py-6 sm:py-8"
+      style={{ background: CHARCOAL, borderBottom: `2px solid ${GOLD}` }}
+    >
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
+        {TRUST_STATS.map((s) => (
+          <div key={s.label}>
+            <div
+              className="font-heading text-2xl md:text-4xl font-bold"
+              style={{ color: GOLD }}
+            >
+              {s.stat}
+            </div>
+            <div className="text-xs sm:text-sm uppercase tracking-widest opacity-80 mt-1">
+              {s.label}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ─── Services grid ─────────────────────────────────────────────────
+
+function ServicesGrid({ onCtaClick }: { onCtaClick: () => void }) {
+  return (
+    <section id="services" className="py-14 md:py-20">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6">
+        <div className="text-center mb-10">
+          <div className="text-xs font-bold tracking-[0.22em] text-gray-500 mb-2">
+            WHAT WE COORDINATE
+          </div>
+          <h2
+            className="font-heading text-3xl md:text-4xl font-bold tracking-tight"
+            style={{ color: NAVY }}
+          >
+            Everything for the weekend, in one plan
+          </h2>
+          <p className="mt-3 text-gray-700 max-w-2xl mx-auto">
+            Pick the pieces you want on the questionnaire. We book the
+            vendors, stock the boat, and confirm every reservation before
+            you land.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {SERVICES.map((s) => (
+            <ServiceCard key={s.key} service={s} />
+          ))}
+        </div>
+
+        <div className="mt-10 text-center">
+          <button
+            type="button"
+            onClick={onCtaClick}
+            className="rounded-lg px-6 py-4 text-base font-heading font-bold tracking-[0.12em] transition-transform hover:scale-[1.03]"
+            style={{
+              background: GOLD,
+              color: NAVY,
+              border: `2px solid ${NAVY}`,
+              boxShadow: `0 4px 0 ${NAVY}`,
+            }}
+          >
+            START PLANNING → 3 MIN
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ServiceCard({ service }: { service: Service }) {
+  return (
+    <article
+      className="rounded-2xl overflow-hidden flex flex-col shadow-sm transition-transform hover:scale-[1.02]"
+      style={{
+        background: '#FFFFFF',
+        border: `1.5px solid ${NAVY}`,
+        boxShadow: `0 3px 0 ${NAVY}18`,
+      }}
+    >
+      <div className="relative aspect-[4/3] overflow-hidden">
+        <Image
+          src={service.imgSrc}
+          alt={service.imgAlt}
+          fill
+          sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
+          className="object-cover"
+        />
+        <div
+          className="absolute inset-0"
+          style={{
+            background:
+              'linear-gradient(180deg, transparent 55%, rgba(10,15,25,0.6) 100%)',
+          }}
+        />
+        <div
+          className="absolute top-3 left-3 rounded-full px-2.5 py-1 text-[10px] font-bold tracking-widest"
+          style={{ background: GOLD, color: NAVY }}
+        >
+          {service.chip}
+        </div>
+        <div
+          className="absolute bottom-3 left-3 text-3xl leading-none"
+          aria-hidden
+        >
+          {service.emoji}
+        </div>
+      </div>
+      <div className="p-4 sm:p-5 flex-1">
+        <h3
+          className="font-heading text-lg sm:text-xl font-bold tracking-tight mb-1"
+          style={{ color: NAVY }}
+        >
+          {service.title}
+        </h3>
+        <p className="text-sm text-gray-700 leading-relaxed">
+          {service.blurb}
+        </p>
+      </div>
+    </article>
+  );
+}
+
+// ─── How it works ──────────────────────────────────────────────────
+
+function HowItWorks({ onCtaClick }: { onCtaClick: () => void }) {
+  return (
+    <section
+      className="py-14 md:py-20"
+      style={{ background: NAVY, color: '#FFFFFF' }}
+    >
+      <div className="max-w-6xl mx-auto px-4 sm:px-6">
+        <div className="text-center mb-10">
+          <div
+            className="text-xs font-bold tracking-[0.22em] mb-2"
+            style={{ color: GOLD }}
+          >
+            HOW IT WORKS
+          </div>
+          <h2 className="font-heading text-3xl md:text-4xl font-bold tracking-tight">
+            Three moves. Then the weekend runs itself.
+          </h2>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+          {STEPS.map((s) => (
+            <div
+              key={s.n}
+              className="rounded-2xl p-6"
+              style={{
+                background: 'rgba(255,255,255,0.05)',
+                border: `1.5px solid ${GOLD}`,
+              }}
+            >
+              <div
+                className="font-heading text-3xl font-bold"
+                style={{ color: GOLD }}
+              >
+                {s.n}
+              </div>
+              <div className="font-heading text-xl font-bold tracking-wide mt-2">
+                {s.title}
+              </div>
+              <div className="text-sm opacity-90 mt-2">{s.body}</div>
+            </div>
+          ))}
+        </div>
+        <div className="mt-10 text-center">
+          <button
+            type="button"
+            onClick={onCtaClick}
+            className="rounded-lg px-6 py-4 text-base font-heading font-bold tracking-[0.12em] transition-transform hover:scale-[1.03]"
+            style={{
+              background: GOLD,
+              color: NAVY,
+              border: `2px solid ${YELLOW}`,
+              boxShadow: `0 4px 0 rgba(0,0,0,0.4)`,
+            }}
+          >
+            PLAN MY WEEKEND →
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── Final CTA ────────────────────────────────────────────────────
+
+function FinalCta({ onCtaClick }: { onCtaClick: () => void }) {
+  return (
+    <section className="py-14 md:py-20">
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 text-center">
+        <h2
+          className="font-heading text-3xl md:text-4xl font-bold tracking-tight"
+          style={{ color: NAVY }}
+        >
+          One form. Your whole weekend, handled.
+        </h2>
+        <p className="mt-3 text-gray-700 max-w-2xl mx-auto">
+          Fill it out. We&apos;ll come back within 24 hours with a plan +
+          a fixed quote. No pressure, no upsells — just the weekend the
+          group wanted.
+        </p>
+        <div className="mt-6">
+          <button
+            type="button"
+            onClick={onCtaClick}
+            className="rounded-lg px-8 py-4 text-lg font-heading font-bold tracking-[0.12em] transition-transform hover:scale-[1.03]"
+            style={{
+              background: GOLD,
+              color: NAVY,
+              border: `2px solid ${NAVY}`,
+              boxShadow: `0 4px 0 ${NAVY}`,
+            }}
+          >
+            START PLANNING — FREE →
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── Confirmation banner (post-submit) ─────────────────────────────
+
+function ConfirmationBanner() {
+  return (
+    <div
+      className="text-white text-center py-3 px-4 text-sm font-bold"
+      style={{ background: '#0F8141' }}
+    >
+      🎉 Got it — your concierge will reach out within 24 hours. Check
+      your email for confirmation.
+    </div>
+  );
+}
+
+// ─── SVG icons ────────────────────────────────────────────────────
+
+function PhoneIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.13 1 .37 1.98.72 2.92a2 2 0 0 1-.45 2.11L8.09 10.09a16 16 0 0 0 6 6l1.34-1.34a2 2 0 0 1 2.11-.45c.94.35 1.92.59 2.92.72A2 2 0 0 1 22 16.92z" />
+    </svg>
+  );
+}

--- a/src/components/concierge/ConciergeQuestionnaireModal.tsx
+++ b/src/components/concierge/ConciergeQuestionnaireModal.tsx
@@ -1,0 +1,594 @@
+'use client';
+
+/**
+ * Premier Concierge — 6-step planning questionnaire.
+ *
+ * Step order (contact LAST per founder spec so the customer commits
+ * before they type their email):
+ *   1. Headcount
+ *   2. Arrival + departure dates
+ *   3. Party type (bachelor / bachelorette / weekend / corporate / other)
+ *   4. Budget per person (chip picker)
+ *   5. Activities & services checkboxes (multi-select)
+ *   6. Contact info + notes
+ *
+ * Submit → POST /api/v1/concierge/lead which handles Lead upsert +
+ * GHL fire + Google Sheet append.
+ */
+
+import { useMemo, useState, type ReactElement, type FormEvent } from 'react';
+
+const NAVY = '#0A1F33';
+const GOLD = '#D4AF37';
+const CREAM = '#FAF6EE';
+
+type PartyType = 'bachelor' | 'bachelorette' | 'weekend' | 'corporate' | 'other';
+type Activity =
+  | 'drink-delivery'
+  | 'boat-rental'
+  | 'golf-brewery-tour'
+  | 'atv-tour'
+  | 'gun-range'
+  | 'transportation'
+  | 'not-sure';
+
+const HEADCOUNT_CHIPS = [4, 6, 8, 10, 12, 15, 20, 25];
+
+const PARTY_TYPES: { key: PartyType; label: string; emoji: string }[] = [
+  { key: 'bachelor', label: 'Bachelor', emoji: '🥃' },
+  { key: 'bachelorette', label: 'Bachelorette', emoji: '🥂' },
+  { key: 'weekend', label: 'Guys weekend', emoji: '🎣' },
+  { key: 'corporate', label: 'Corporate offsite', emoji: '💼' },
+  { key: 'other', label: 'Something else', emoji: '✨' },
+];
+
+const BUDGET_TIERS = [
+  { key: '$200/pp', label: '$200/person', sub: 'Boat + drinks basics' },
+  { key: '$400/pp', label: '$400/person', sub: 'Boat + drinks + 1 activity' },
+  { key: '$600/pp', label: '$600/person', sub: 'Multi-day, 2+ activities' },
+  { key: '$800/pp', label: '$800/person', sub: 'Premium boats + tours + rides' },
+  { key: '$1000+/pp', label: '$1,000+/person', sub: 'Full concierge, no limits' },
+];
+
+const ACTIVITIES: { key: Activity; label: string; emoji: string }[] = [
+  { key: 'boat-rental', label: 'Private party boat rental', emoji: '🛥️' },
+  { key: 'drink-delivery', label: 'Drink delivery to the dock', emoji: '🥃' },
+  { key: 'golf-brewery-tour', label: 'Golf & brewery tour', emoji: '⛳' },
+  { key: 'atv-tour', label: 'ATV / off-road tour', emoji: '🚙' },
+  { key: 'gun-range', label: 'Gun range experience', emoji: '🎯' },
+  { key: 'transportation', label: 'Group transportation', emoji: '🚐' },
+  { key: 'not-sure', label: "Not sure yet — recommend for me", emoji: '💡' },
+];
+
+// Default arrival date = ~30 days out. Weekend rendezvous is the modal norm.
+function defaultArrival(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 30);
+  return d.toISOString().slice(0, 10);
+}
+function defaultDeparture(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 32);
+  return d.toISOString().slice(0, 10);
+}
+
+type Props = {
+  onClose: () => void;
+  onSuccess: () => void;
+};
+
+export default function ConciergeQuestionnaireModal({
+  onClose,
+  onSuccess,
+}: Props): ReactElement {
+  const [step, setStep] = useState<1 | 2 | 3 | 4 | 5 | 6>(1);
+
+  // ─── Form state ───────────────────────────────────────────────
+  const [headcount, setHeadcount] = useState<number>(10);
+  const [customHead, setCustomHead] = useState<string>('');
+  const [arrivalDate, setArrivalDate] = useState<string>(defaultArrival());
+  const [departureDate, setDepartureDate] = useState<string>(defaultDeparture());
+  const [partyType, setPartyType] = useState<PartyType>('bachelor');
+  const [budget, setBudget] = useState<string>('$400/pp');
+  const [activities, setActivities] = useState<Activity[]>([
+    'boat-rental',
+    'drink-delivery',
+  ]);
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [notes, setNotes] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string>('');
+
+  function toggleActivity(a: Activity) {
+    setActivities((prev) =>
+      prev.includes(a) ? prev.filter((x) => x !== a) : [...prev, a],
+    );
+  }
+
+  const effectiveHead = useMemo(() => {
+    if (customHead.trim()) {
+      const n = Number(customHead);
+      if (Number.isFinite(n) && n > 0) return Math.min(500, Math.round(n));
+    }
+    return headcount;
+  }, [customHead, headcount]);
+
+  function canAdvanceFrom(s: number): boolean {
+    if (s === 1) return effectiveHead >= 1;
+    if (s === 2) return !!arrivalDate && !!departureDate && arrivalDate <= departureDate;
+    if (s === 3) return !!partyType;
+    if (s === 4) return !!budget;
+    if (s === 5) return activities.length > 0;
+    if (s === 6)
+      return (
+        firstName.trim().length > 0 &&
+        /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())
+      );
+    return true;
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!canAdvanceFrom(6) || submitting) return;
+    setError('');
+    setSubmitting(true);
+
+    try {
+      const res = await fetch('/api/v1/concierge/lead', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          firstName: firstName.trim(),
+          lastName: lastName.trim(),
+          email: email.trim(),
+          phone: phone.trim(),
+          headcount: effectiveHead,
+          arrivalDate,
+          departureDate,
+          partyType,
+          budgetPerPerson: budget,
+          activities,
+          notes: notes.trim(),
+          source: 'premier-concierge-bachelor',
+        }),
+      });
+      const json = (await res.json()) as { ok: boolean; error?: string };
+      if (!res.ok || !json.ok) {
+        setError(json.error || 'Something went wrong. Try again?');
+        setSubmitting(false);
+        return;
+      }
+      onSuccess();
+    } catch (err) {
+      console.error('[concierge modal] submit failed', err);
+      setError('Network blip — try again.');
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4"
+      style={{ background: 'rgba(5,10,20,0.75)' }}
+    >
+      <div
+        className="w-full max-w-lg rounded-t-2xl sm:rounded-2xl overflow-hidden shadow-2xl max-h-[95vh] flex flex-col"
+        style={{ background: CREAM }}
+      >
+        {/* Header */}
+        <div
+          className="px-5 py-4 flex items-center justify-between"
+          style={{
+            background: NAVY,
+            color: '#FFFFFF',
+            borderBottom: `3px solid ${GOLD}`,
+          }}
+        >
+          <div>
+            <div
+              className="text-[10px] font-bold tracking-widest"
+              style={{ color: GOLD }}
+            >
+              STEP {step} OF 6
+            </div>
+            <div className="font-heading text-lg font-bold tracking-wide">
+              Premier Concierge
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="w-8 h-8 rounded-full flex items-center justify-center text-white/80 hover:text-white text-xl"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Progress bar */}
+        <div className="h-1 w-full bg-gray-200">
+          <div
+            className="h-full transition-all duration-300"
+            style={{ width: `${(step / 6) * 100}%`, background: GOLD }}
+          />
+        </div>
+
+        {/* Body — scrollable */}
+        <div className="flex-1 overflow-y-auto px-5 py-5">
+          {step === 1 && (
+            <Step
+              title="How many guys?"
+              subtitle="Approximate is fine — you can adjust later."
+            >
+              <div className="flex flex-wrap gap-2 mb-3">
+                {HEADCOUNT_CHIPS.map((n) => (
+                  <ChipButton
+                    key={n}
+                    active={headcount === n && !customHead}
+                    onClick={() => {
+                      setHeadcount(n);
+                      setCustomHead('');
+                    }}
+                  >
+                    {n} {n === 25 ? '+' : ''}
+                  </ChipButton>
+                ))}
+              </div>
+              <label className="text-xs font-bold tracking-widest text-gray-500">
+                OR ENTER A NUMBER
+              </label>
+              <input
+                type="number"
+                min={1}
+                max={500}
+                value={customHead}
+                onChange={(e) => setCustomHead(e.target.value)}
+                placeholder="e.g. 14"
+                className="mt-1 w-full rounded-lg border-2 border-gray-200 px-3 py-2.5 text-base focus:border-brand-blue focus:outline-none"
+                style={{ color: NAVY }}
+              />
+            </Step>
+          )}
+
+          {step === 2 && (
+            <Step
+              title="When's the weekend?"
+              subtitle="Arrival and departure — approximate is fine."
+            >
+              <label className="text-xs font-bold tracking-widest text-gray-500">
+                ARRIVAL
+              </label>
+              <input
+                type="date"
+                required
+                value={arrivalDate}
+                onChange={(e) => setArrivalDate(e.target.value)}
+                className="mt-1 mb-4 w-full rounded-lg border-2 border-gray-200 px-3 py-2.5 text-base focus:border-brand-blue focus:outline-none"
+                style={{ color: NAVY }}
+              />
+              <label className="text-xs font-bold tracking-widest text-gray-500">
+                DEPARTURE
+              </label>
+              <input
+                type="date"
+                required
+                value={departureDate}
+                onChange={(e) => setDepartureDate(e.target.value)}
+                className="mt-1 w-full rounded-lg border-2 border-gray-200 px-3 py-2.5 text-base focus:border-brand-blue focus:outline-none"
+                style={{ color: NAVY }}
+              />
+              {arrivalDate > departureDate && (
+                <p className="mt-2 text-xs text-red-600">
+                  Departure must be after arrival.
+                </p>
+              )}
+            </Step>
+          )}
+
+          {step === 3 && (
+            <Step title="What kind of weekend?" subtitle="Pick one.">
+              <div className="grid grid-cols-1 gap-2">
+                {PARTY_TYPES.map((p) => (
+                  <BigCard
+                    key={p.key}
+                    active={partyType === p.key}
+                    onClick={() => setPartyType(p.key)}
+                  >
+                    <div className="flex items-center gap-3">
+                      <span className="text-2xl">{p.emoji}</span>
+                      <span className="font-heading font-bold text-base tracking-wide">
+                        {p.label}
+                      </span>
+                    </div>
+                  </BigCard>
+                ))}
+              </div>
+            </Step>
+          )}
+
+          {step === 4 && (
+            <Step
+              title="Ballpark budget?"
+              subtitle="Per person, all-in. We stay under it — no surprise line items."
+            >
+              <div className="grid grid-cols-1 gap-2">
+                {BUDGET_TIERS.map((b) => (
+                  <BigCard
+                    key={b.key}
+                    active={budget === b.key}
+                    onClick={() => setBudget(b.key)}
+                  >
+                    <div>
+                      <div className="font-heading font-bold text-lg tracking-tight">
+                        {b.label}
+                      </div>
+                      <div className="text-xs opacity-80">{b.sub}</div>
+                    </div>
+                  </BigCard>
+                ))}
+              </div>
+            </Step>
+          )}
+
+          {step === 5 && (
+            <Step
+              title="What are you into?"
+              subtitle="Pick everything that interests the group — we'll price it all."
+            >
+              <div className="grid grid-cols-1 gap-2">
+                {ACTIVITIES.map((a) => {
+                  const on = activities.includes(a.key);
+                  return (
+                    <button
+                      key={a.key}
+                      type="button"
+                      onClick={() => toggleActivity(a.key)}
+                      className="rounded-lg px-3 py-3 text-left transition-transform hover:scale-[1.01] flex items-center gap-3"
+                      style={{
+                        background: on ? NAVY : '#FFFFFF',
+                        color: on ? '#FFFFFF' : NAVY,
+                        border: `2px solid ${NAVY}`,
+                        boxShadow: on ? `0 3px 0 ${NAVY}` : 'none',
+                      }}
+                    >
+                      <div
+                        className="w-5 h-5 rounded flex-shrink-0 flex items-center justify-center"
+                        style={{
+                          background: on ? GOLD : '#FFFFFF',
+                          border: `2px solid ${on ? GOLD : NAVY}`,
+                        }}
+                      >
+                        {on && (
+                          <svg
+                            width="12"
+                            height="12"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke={NAVY}
+                            strokeWidth={4}
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            aria-hidden
+                          >
+                            <polyline points="20 6 9 17 4 12" />
+                          </svg>
+                        )}
+                      </div>
+                      <span className="text-xl">{a.emoji}</span>
+                      <span className="font-bold text-sm sm:text-base">
+                        {a.label}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </Step>
+          )}
+
+          {step === 6 && (
+            <Step
+              title="Where can we reach you?"
+              subtitle="One quick follow-up email within 24 hours — no spam."
+            >
+              <div className="grid grid-cols-2 gap-2">
+                <input
+                  type="text"
+                  required
+                  placeholder="First name"
+                  value={firstName}
+                  onChange={(e) => setFirstName(e.target.value)}
+                  className="rounded-lg border-2 border-gray-200 px-3 py-2.5 text-base focus:border-brand-blue focus:outline-none"
+                  style={{ color: NAVY }}
+                />
+                <input
+                  type="text"
+                  placeholder="Last name"
+                  value={lastName}
+                  onChange={(e) => setLastName(e.target.value)}
+                  className="rounded-lg border-2 border-gray-200 px-3 py-2.5 text-base focus:border-brand-blue focus:outline-none"
+                  style={{ color: NAVY }}
+                />
+              </div>
+              <input
+                type="email"
+                required
+                placeholder="Email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="mt-2 w-full rounded-lg border-2 border-gray-200 px-3 py-2.5 text-base focus:border-brand-blue focus:outline-none"
+                style={{ color: NAVY }}
+              />
+              <input
+                type="tel"
+                placeholder="Phone (optional — for faster follow-up)"
+                value={phone}
+                onChange={(e) => setPhone(e.target.value)}
+                className="mt-2 w-full rounded-lg border-2 border-gray-200 px-3 py-2.5 text-base focus:border-brand-blue focus:outline-none"
+                style={{ color: NAVY }}
+              />
+              <textarea
+                placeholder="Anything else we should know? (venue preferences, groom's picky about drinks, etc.)"
+                rows={3}
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                className="mt-2 w-full rounded-lg border-2 border-gray-200 px-3 py-2.5 text-base focus:border-brand-blue focus:outline-none resize-none"
+                style={{ color: NAVY }}
+              />
+              {error && (
+                <div
+                  className="mt-3 rounded-lg px-3 py-2 text-sm"
+                  style={{
+                    background: '#FFE6E6',
+                    color: '#7A1F1F',
+                    border: '1.5px solid #E58A8A',
+                  }}
+                >
+                  {error}
+                </div>
+              )}
+            </Step>
+          )}
+        </div>
+
+        {/* Footer nav */}
+        <div
+          className="px-5 py-3 flex items-center justify-between gap-3"
+          style={{
+            background: '#FFFFFF',
+            borderTop: `1.5px solid #E5E7EB`,
+          }}
+        >
+          <button
+            type="button"
+            onClick={() => setStep((s) => (s > 1 ? ((s - 1) as 1 | 2 | 3 | 4 | 5 | 6) : s))}
+            disabled={step === 1}
+            className="rounded-lg px-4 py-2.5 text-sm font-bold tracking-[0.08em] transition-transform hover:scale-[1.02] disabled:opacity-30 disabled:cursor-not-allowed"
+            style={{
+              background: '#FFFFFF',
+              color: NAVY,
+              border: `2px solid ${NAVY}`,
+            }}
+          >
+            ← Back
+          </button>
+          {step < 6 ? (
+            <button
+              type="button"
+              onClick={() =>
+                canAdvanceFrom(step) &&
+                setStep((s) => (s < 6 ? ((s + 1) as 1 | 2 | 3 | 4 | 5 | 6) : s))
+              }
+              disabled={!canAdvanceFrom(step)}
+              className="rounded-lg px-5 py-2.5 text-sm font-bold tracking-[0.08em] transition-transform hover:scale-[1.03] disabled:opacity-50 disabled:cursor-not-allowed"
+              style={{
+                background: GOLD,
+                color: NAVY,
+                border: `2px solid ${NAVY}`,
+                boxShadow: `0 3px 0 ${NAVY}`,
+              }}
+            >
+              Continue →
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={submitting || !canAdvanceFrom(6)}
+              className="rounded-lg px-5 py-3 text-sm font-heading font-bold tracking-[0.12em] transition-transform hover:scale-[1.03] disabled:opacity-50 disabled:cursor-not-allowed"
+              style={{
+                background: GOLD,
+                color: NAVY,
+                border: `2px solid ${NAVY}`,
+                boxShadow: `0 3px 0 ${NAVY}`,
+              }}
+            >
+              {submitting ? 'SENDING…' : 'SEND MY PLAN →'}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Primitives ─────────────────────────────────────────────────────
+
+function Step({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <h3
+        className="font-heading text-xl font-bold tracking-tight mb-1"
+        style={{ color: NAVY }}
+      >
+        {title}
+      </h3>
+      {subtitle && <p className="text-sm text-gray-700 mb-4">{subtitle}</p>}
+      {children}
+    </div>
+  );
+}
+
+function ChipButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="rounded-full px-4 py-2 text-sm font-bold transition-transform hover:scale-[1.03]"
+      style={{
+        background: active ? NAVY : '#FFFFFF',
+        color: active ? GOLD : NAVY,
+        border: `2px solid ${NAVY}`,
+        boxShadow: active ? `0 2px 0 ${NAVY}` : 'none',
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+function BigCard({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="w-full text-left rounded-lg px-4 py-3 transition-transform hover:scale-[1.01]"
+      style={{
+        background: active ? NAVY : '#FFFFFF',
+        color: active ? '#FFFFFF' : NAVY,
+        border: `2px solid ${NAVY}`,
+        boxShadow: active ? `0 3px 0 ${NAVY}` : 'none',
+      }}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/lib/premier/pod-leads-sheet.ts
+++ b/src/lib/premier/pod-leads-sheet.ts
@@ -1,0 +1,125 @@
+/**
+ * Append a POD lead to the "POD Leads" tab of the PPC Booking App Time
+ * Slots Google Sheet.
+ *
+ * Sheet: https://docs.google.com/spreadsheets/d/13VHEq3Aqv46oSt0tGiF5ZBOxs1WxBU0SqEIwG6QUsxI/edit?gid=114122017
+ * Tab: "POD Leads" (gid=114122017)
+ *
+ * Auth reuses the existing Premier Sheets service account
+ * (PREMIER_SHEET_SERVICE_ACCOUNT_EMAIL / _KEY) — that account just
+ * needs to be shared with the target sheet as Editor. Sheet ID is in a
+ * new env var so it can be swapped without touching code.
+ *
+ * Writes are best-effort: if credentials are missing, the sheet is
+ * unreachable, or the API errors, we log and return false — we never
+ * throw and never block the caller's request. The Postgres Lead row is
+ * always the source of truth; the sheet is a convenience mirror for
+ * ops.
+ */
+
+import { google } from 'googleapis';
+
+const SHEETS_SCOPES = ['https://www.googleapis.com/auth/spreadsheets'];
+const TAB_NAME = 'POD Leads';
+
+/** Every field we append. Kept flat so the row is trivially readable in-sheet. */
+export interface PodLeadSheetRow {
+  /** ISO timestamp in America/Chicago, e.g. "2026-07-10 15:03 CT". */
+  submittedAt: string;
+  /** Marketing surface — e.g. "premier-concierge-bachelor". */
+  source: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  headcount: string;
+  arrivalDate: string;
+  departureDate: string;
+  partyType: string;
+  budgetPerPerson: string;
+  activities: string;
+  notes: string;
+  /** Deep link back to the Lead row in Brian's Stuff. */
+  leadUrl: string;
+}
+
+/**
+ * Append one row to the POD Leads tab. Returns true on success, false
+ * on any failure (missing env vars, API error, etc.). Never throws.
+ */
+export async function appendLeadToPodLeadsSheet(
+  row: PodLeadSheetRow,
+): Promise<boolean> {
+  const email = process.env.PREMIER_SHEET_SERVICE_ACCOUNT_EMAIL;
+  const privateKey = process.env.PREMIER_SHEET_SERVICE_ACCOUNT_KEY;
+  const sheetId = process.env.POD_LEADS_SHEET_ID;
+
+  if (!email || !privateKey || !sheetId) {
+    console.warn(
+      '[pod-leads-sheet] Missing env vars — skipping sheet append. ' +
+        'Required: PREMIER_SHEET_SERVICE_ACCOUNT_EMAIL, PREMIER_SHEET_SERVICE_ACCOUNT_KEY, POD_LEADS_SHEET_ID',
+    );
+    return false;
+  }
+
+  try {
+    // Handle escaped newlines in the private key (common env-var pattern).
+    const formattedKey = privateKey.replace(/\\n/g, '\n');
+
+    const auth = new google.auth.JWT({
+      email,
+      key: formattedKey,
+      scopes: SHEETS_SCOPES,
+    });
+
+    const sheets = google.sheets({ version: 'v4', auth });
+
+    // Append at the end of the tab. USER_ENTERED interpretation lets
+    // date strings render as dates in-sheet when they parse.
+    await sheets.spreadsheets.values.append({
+      spreadsheetId: sheetId,
+      range: `'${TAB_NAME}'!A:Z`,
+      valueInputOption: 'USER_ENTERED',
+      insertDataOption: 'INSERT_ROWS',
+      requestBody: {
+        values: [
+          [
+            row.submittedAt,
+            row.source,
+            row.firstName,
+            row.lastName,
+            row.email,
+            row.phone,
+            row.headcount,
+            row.arrivalDate,
+            row.departureDate,
+            row.partyType,
+            row.budgetPerPerson,
+            row.activities,
+            row.notes,
+            row.leadUrl,
+          ],
+        ],
+      },
+    });
+    return true;
+  } catch (err) {
+    console.error('[pod-leads-sheet] Append failed:', err);
+    return false;
+  }
+}
+
+/** Format a Date as "YYYY-MM-DD HH:mm CT" for the sheet. */
+export function formatCentralTimestamp(date: Date): string {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Chicago',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).formatToParts(date);
+  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? '';
+  return `${get('year')}-${get('month')}-${get('day')} ${get('hour')}:${get('minute')} CT`;
+}

--- a/src/lib/webhooks/ghl.ts
+++ b/src/lib/webhooks/ghl.ts
@@ -9,6 +9,7 @@ const GHL_WEBHOOK_URL = process.env.GHL_ORDER_WEBHOOK_URL;
 const GHL_REVIEW_WEBHOOK_URL = process.env.GHL_REVIEW_WEBHOOK_URL;
 const GHL_DASHBOARD_WEBHOOK_URL = process.env.GHL_DASHBOARD_WEBHOOK_URL;
 const GHL_NEWSLETTER_WEBHOOK_URL = process.env.GHL_NEWSLETTER_WEBHOOK_URL;
+const GHL_CONCIERGE_LEAD_WEBHOOK_URL = process.env.GHL_CONCIERGE_LEAD_WEBHOOK_URL;
 const CORELINQ_INGEST_URL = process.env.CORELINQ_INGEST_URL;
 
 // ──────────────────────────────────────────────
@@ -338,5 +339,66 @@ export async function notifyNewsletterSignup(payload: GhlNewsletterPayload): Pro
     }
   } catch (err) {
     console.error('[GHL Newsletter Webhook] Error:', err);
+  }
+}
+
+// ──────────────────────────────────────────────
+// Premier Concierge — bachelor / weekend planning lead
+// ──────────────────────────────────────────────
+
+export interface GhlConciergeLeadPayload {
+  event: 'concierge.lead';
+  /** GHL-standard contact fields */
+  first_name: string;
+  last_name: string;
+  email: string;
+  phone: string;
+  /** Structured questionnaire answers so the receiving workflow can
+   *  route to the right pipeline stage. */
+  source: string;                  // e.g. 'premier-concierge-bachelor'
+  partyType: string;               // 'bachelor' | 'bachelorette' | 'weekend' | ...
+  headcount: number;
+  arrivalDate: string;             // ISO YYYY-MM-DD
+  departureDate: string;
+  budgetPerPerson: string;         // '$400' etc.
+  activities: string[];            // ['drink-delivery', 'boat', 'atv', ...]
+  notes: string;
+  /** Array of tags the receiving GHL workflow should apply to the
+   *  contact. Everything after 'premier-concierge' + 'bachelor-party'
+   *  is dynamic based on the questionnaire (activity tags, budget tag,
+   *  headcount bucket, etc.). */
+  tags: string[];
+  /** Deep link back to the Lead row in Brian's Stuff. */
+  leadUrl: string;
+  submittedAt: string;
+}
+
+/**
+ * POST a Premier Concierge lead to the GHL concierge webhook so the
+ * receiving GHL workflow can create/update the contact and apply the
+ * appropriate tags for pipeline routing.
+ *
+ * Fire-and-forget: logs errors, never throws. No-ops silently when
+ * GHL_CONCIERGE_LEAD_WEBHOOK_URL is not set — so this is inert until
+ * the founder creates the GHL inbound webhook/workflow and sets the
+ * env var. In the meantime the CoreLinq mirror still fires.
+ */
+export async function notifyConciergeLead(payload: GhlConciergeLeadPayload): Promise<void> {
+  await postToCoreLinq(payload);
+  if (!GHL_CONCIERGE_LEAD_WEBHOOK_URL) return;
+
+  try {
+    const res = await fetch(GHL_CONCIERGE_LEAD_WEBHOOK_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      console.error('[GHL Concierge Webhook] Failed:', res.status, await res.text());
+    } else {
+      console.log('[GHL Concierge Webhook] Lead synced:', payload.email);
+    }
+  } catch (err) {
+    console.error('[GHL Concierge Webhook] Error:', err);
   }
 }


### PR DESCRIPTION
## Summary
- New landing page at \`/austin-bachelor-concierge\` (noindex during Phase 1)
- 6-service tile grid + 6-step planning questionnaire modal
- New endpoint \`POST /api/v1/concierge/lead\` (CORS-open for future premierconcierge.co)
- Every submission: Postgres Lead row → GHL webhook fires with tags → row appended to "POD Leads" tab of the PPC Booking App Time Slots sheet
- Brian's Stuff: new "🥃 Concierge" counter on Leads tab; concierge rows highlighted purple
- Tab bar readability fix — was clipping labels behind a silent scrollbar

## Env vars needed in Vercel
- \`POD_LEADS_SHEET_ID = 13VHEq3Aqv46oSt0tGiF5ZBOxs1WxBU0SqEIwG6QUsxI\`
- \`GHL_CONCIERGE_LEAD_WEBHOOK_URL = <inbound webhook URL from GHL>\`

## Sheet sharing
Share the sheet with the existing Premier service account (email in \`PREMIER_SHEET_SERVICE_ACCOUNT_EMAIL\`) as Editor.

## Test plan
- [ ] After deploy: https://partyondelivery.com/austin-bachelor-concierge loads (no chat bubble, no age gate)
- [ ] Click "PLAN MY WEEKEND →" → 6-step modal opens
- [ ] Complete all steps → SUCCESS banner shows on landing page
- [ ] /admin/brians-stuff?tab=leads → new lead appears with "🥃 CONCIERGE" tag + purple row
- [ ] Once env vars set: row appears in the "POD Leads" tab of the Google Sheet
- [ ] Once GHL webhook URL configured: new contact + tags in GHL

🤖 Generated with [Claude Code](https://claude.com/claude-code)