### PR TITLE
fix(refunds): net amendment refund prefill against refunds recorded since amendment creation

### DIFF
--- a/src/app/api/v1/admin/orders/[id]/route.ts
+++ b/src/app/api/v1/admin/orders/[id]/route.ts
@@ -79,7 +79,7 @@ export async function GET(
           },
         },
         refunds: {
-          select: { amount: true, createdAt: true },
+          select: { id: true, amount: true, createdAt: true },
         },
       },
     });
@@ -369,8 +369,10 @@ export async function GET(
             ? await getStripeCapturedAmount(order.stripePaymentIntentId).catch(() => null)
             : null,
           // Per-refund rows so the client can net an amendment's refund prefill
-          // against refunds recorded after the amendment was created.
+          // against refunds recorded after the amendment was created. The id
+          // lets the client skip refunds an amendment already claims.
           items: order.refunds.map((r) => ({
+            id: r.id,
             amount: Number(r.amount),
             createdAt: r.createdAt.toISOString(),
           })),

--- a/src/app/api/v1/admin/orders/[id]/route.ts
+++ b/src/app/api/v1/admin/orders/[id]/route.ts
@@ -79,7 +79,7 @@ export async function GET(
           },
         },
         refunds: {
-          select: { amount: true },
+          select: { amount: true, createdAt: true },
         },
       },
     });
@@ -368,6 +368,12 @@ export async function GET(
           stripeCapturedAmount: order.stripePaymentIntentId
             ? await getStripeCapturedAmount(order.stripePaymentIntentId).catch(() => null)
             : null,
+          // Per-refund rows so the client can net an amendment's refund prefill
+          // against refunds recorded after the amendment was created.
+          items: order.refunds.map((r) => ({
+            amount: Number(r.amount),
+            createdAt: r.createdAt.toISOString(),
+          })),
         },
       },
     });

--- a/src/app/ops/orders/[id]/page.tsx
+++ b/src/app/ops/orders/[id]/page.tsx
@@ -10,6 +10,7 @@ import ItemsCard from '@/components/ops/orders/detail/ItemsCard';
 import PaymentCard from '@/components/ops/orders/detail/PaymentCard';
 import DetailStickyBar, { nextTransition } from '@/components/ops/orders/detail/DetailStickyBar';
 import OrderActionSheet from '@/components/ops/orders/detail/OrderActionSheet';
+import { computeAmendmentRefundPrefill } from '@/components/ops/orders/detail/refund-prefill';
 import { getStatusColor, formatDateTime, SectionHeader } from '@/components/ops/orders/detail/shared';
 import type { OrderDetail } from '@/components/ops/orders/detail/types';
 
@@ -1255,22 +1256,30 @@ export default function OrderDetailPage(): ReactElement {
                             Send Invoice (${amendment.amountDelta.toFixed(2)})
                           </button>
                         )}
-                        {amendment.resolution === 'PENDING' && amendment.amountDelta < 0 && (
-                          <button
-                            onClick={() => {
-                              setPendingAmendmentId(amendment.id);
-                              setRefundAmount(Math.abs(amendment.amountDelta));
-                              setRefundReason('Order amendment');
-                              setRefundType('custom');
-                              setShowActionSheet(true);
-                            }}
-                            disabled={refundProcessing || !order.payment.stripePaymentIntentId}
-                            className="mt-2 px-3 py-1.5 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed"
-                            title={!order.payment.stripePaymentIntentId ? 'No Stripe payment found for this order' : ''}
-                          >
-                            Process Refund (${Math.abs(amendment.amountDelta).toFixed(2)})
-                          </button>
-                        )}
+                        {amendment.resolution === 'PENDING' && amendment.amountDelta < 0 && (() => {
+                          // Seed the netted remainder, not the full |amountDelta| —
+                          // refunds recorded since the amendment was created must not
+                          // be offered again on a retry (PR #225 security review).
+                          const prefill = computeAmendmentRefundPrefill(amendment, order.refunds?.items ?? []);
+                          return (
+                            <button
+                              onClick={() => {
+                                setPendingAmendmentId(amendment.id);
+                                setRefundAmount(prefill.suggestedAmount);
+                                setRefundReason('Order amendment');
+                                setRefundType('custom');
+                                setShowActionSheet(true);
+                              }}
+                              disabled={refundProcessing || !order.payment.stripePaymentIntentId}
+                              className="mt-2 px-3 py-1.5 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                              title={!order.payment.stripePaymentIntentId ? 'No Stripe payment found for this order' : ''}
+                            >
+                              {prefill.fullyCovered
+                                ? 'Review Refund (already covered)'
+                                : `Process Refund ($${prefill.suggestedAmount.toFixed(2)})`}
+                            </button>
+                          );
+                        })()}
                       </div>
                     ))}
                   </div>
@@ -1717,6 +1726,7 @@ export default function OrderDetailPage(): ReactElement {
         refundReason={refundReason}
         refundType={refundType}
         refundProcessing={refundProcessing}
+        pendingAmendmentId={pendingAmendmentId}
         onRefundAmount={(amount) => {
           setRefundAmount(amount);
           // Any preset/manual amount change inside the sheet detaches the

--- a/src/app/ops/orders/[id]/page.tsx
+++ b/src/app/ops/orders/[id]/page.tsx
@@ -10,7 +10,7 @@ import ItemsCard from '@/components/ops/orders/detail/ItemsCard';
 import PaymentCard from '@/components/ops/orders/detail/PaymentCard';
 import DetailStickyBar, { nextTransition } from '@/components/ops/orders/detail/DetailStickyBar';
 import OrderActionSheet from '@/components/ops/orders/detail/OrderActionSheet';
-import { computeAmendmentRefundPrefill } from '@/components/ops/orders/detail/refund-prefill';
+import { computeAmendmentRefundPrefill, claimedRefundIds } from '@/components/ops/orders/detail/refund-prefill';
 import { getStatusColor, formatDateTime, SectionHeader } from '@/components/ops/orders/detail/shared';
 import type { OrderDetail } from '@/components/ops/orders/detail/types';
 
@@ -1260,7 +1260,10 @@ export default function OrderDetailPage(): ReactElement {
                           // Seed the netted remainder, not the full |amountDelta| —
                           // refunds recorded since the amendment was created must not
                           // be offered again on a retry (PR #225 security review).
-                          const prefill = computeAmendmentRefundPrefill(amendment, order.refunds?.items ?? []);
+                          // Refunds that resolved a different amendment don't count.
+                          const prefill = computeAmendmentRefundPrefill(amendment, order.refunds?.items ?? [], {
+                            excludeRefundIds: claimedRefundIds(order.amendments ?? []),
+                          });
                           return (
                             <button
                               onClick={() => {

--- a/src/components/ops/orders/detail/OrderActionSheet.tsx
+++ b/src/components/ops/orders/detail/OrderActionSheet.tsx
@@ -3,6 +3,7 @@
 import { ReactElement, ReactNode } from 'react';
 import BottomSheet from '@/components/backend/kit/BottomSheet';
 import SlideToConfirm from './SlideToConfirm';
+import { computeAmendmentRefundPrefill } from './refund-prefill';
 import type { OrderDetail } from './types';
 
 function ActionRow({
@@ -39,6 +40,9 @@ function ActionRow({
  * refund zone. Refunds are exact-amount, preset-chipped, and confirmed by a
  * slide gesture — never a bare tap. All money state and the processRefund
  * call live in the page; the server enforces the Stripe-authoritative cap.
+ * When the refund is attached to a PENDING amendment, a callout nets the
+ * amendment's amount against refunds recorded since it was created, so a
+ * retry never silently re-offers money that already went back.
  */
 export default function OrderActionSheet({
   open,
@@ -52,6 +56,7 @@ export default function OrderActionSheet({
   refundReason,
   refundType,
   refundProcessing,
+  pendingAmendmentId,
   onRefundAmount,
   onRefundReason,
   onRefundType,
@@ -73,6 +78,7 @@ export default function OrderActionSheet({
   refundReason: string;
   refundType: string;
   refundProcessing: boolean;
+  pendingAmendmentId: string | null;
   onRefundAmount: (amount: number) => void;
   onRefundReason: (reason: string) => void;
   onRefundType: (type: string) => void;
@@ -89,6 +95,17 @@ export default function OrderActionSheet({
     0,
     (order.refunds?.stripeCapturedAmount ?? order.pricing.total) - (order.refunds?.totalRefunded || 0),
   );
+
+  // While the refund is attached to a PENDING refund-direction amendment,
+  // net its amount against refunds recorded since the amendment was created.
+  // Lifecycle rides on pendingAmendmentId: the page clears it when the
+  // operator edits the amount, on a fresh sheet open, and after a refund.
+  const pendingAmendment = pendingAmendmentId
+    ? order.amendments?.find((a) => a.id === pendingAmendmentId && a.amountDelta < 0)
+    : undefined;
+  const amendmentPrefill = pendingAmendment
+    ? computeAmendmentRefundPrefill(pendingAmendment, order.refunds?.items ?? [])
+    : null;
 
   const chip = (active: boolean): string =>
     `min-h-[44px] px-3 text-sm font-semibold rounded-lg border transition-colors touch-manipulation ${
@@ -281,6 +298,32 @@ export default function OrderActionSheet({
               <p className="text-sm text-red-800 mb-3">
                 Previously refunded ${order.refunds.totalRefunded.toFixed(2)} across {order.refunds.count} refund{order.refunds.count === 1 ? '' : 's'}.
               </p>
+            )}
+
+            {amendmentPrefill && amendmentPrefill.refundedSinceAmendment > 0 && (
+              <div className="mb-3 flex gap-2 rounded-lg border border-red-300 bg-white p-3">
+                <svg className="w-5 h-5 text-red-600 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+                </svg>
+                <p className="text-sm text-red-900">
+                  {amendmentPrefill.fullyCovered ? (
+                    <>
+                      This amendment&apos;s <strong>${amendmentPrefill.amendmentAmount.toFixed(2)}</strong> looks
+                      fully covered — ${amendmentPrefill.refundedSinceAmendment.toFixed(2)} was refunded after it
+                      was created, leaving nothing to refund. Entering an amount processes a manual refund and
+                      the amendment stays pending.
+                    </>
+                  ) : (
+                    <>
+                      ${amendmentPrefill.refundedSinceAmendment.toFixed(2)} of this amendment&apos;s{' '}
+                      <strong>${amendmentPrefill.amendmentAmount.toFixed(2)}</strong> was already refunded after it
+                      was created, leaving <strong>${amendmentPrefill.suggestedAmount.toFixed(2)}</strong> to
+                      refund. The amendment will stay pending (only an exact full-amount refund marks it
+                      refunded).
+                    </>
+                  )}
+                </p>
+              </div>
             )}
 
             <SlideToConfirm

--- a/src/components/ops/orders/detail/OrderActionSheet.tsx
+++ b/src/components/ops/orders/detail/OrderActionSheet.tsx
@@ -3,7 +3,7 @@
 import { ReactElement, ReactNode } from 'react';
 import BottomSheet from '@/components/backend/kit/BottomSheet';
 import SlideToConfirm from './SlideToConfirm';
-import { computeAmendmentRefundPrefill } from './refund-prefill';
+import { computeAmendmentRefundPrefill, claimedRefundIds } from './refund-prefill';
 import type { OrderDetail } from './types';
 
 function ActionRow({
@@ -101,10 +101,14 @@ export default function OrderActionSheet({
   // Lifecycle rides on pendingAmendmentId: the page clears it when the
   // operator edits the amount, on a fresh sheet open, and after a refund.
   const pendingAmendment = pendingAmendmentId
-    ? order.amendments?.find((a) => a.id === pendingAmendmentId && a.amountDelta < 0)
+    ? order.amendments?.find(
+        (a) => a.id === pendingAmendmentId && a.amountDelta < 0 && a.resolution === 'PENDING',
+      )
     : undefined;
   const amendmentPrefill = pendingAmendment
-    ? computeAmendmentRefundPrefill(pendingAmendment, order.refunds?.items ?? [])
+    ? computeAmendmentRefundPrefill(pendingAmendment, order.refunds?.items ?? [], {
+        excludeRefundIds: claimedRefundIds(order.amendments ?? []),
+      })
     : null;
 
   const chip = (active: boolean): string =>

--- a/src/components/ops/orders/detail/__tests__/refund-prefill.test.ts
+++ b/src/components/ops/orders/detail/__tests__/refund-prefill.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import { computeAmendmentRefundPrefill } from '../refund-prefill';
+
+const AMENDED_AT = '2026-07-10T12:00:00.000Z';
+const BEFORE = '2026-07-10T11:59:59.000Z';
+const AFTER = '2026-07-10T12:00:01.000Z';
+
+function amendment(amountDelta: number, createdAt = AMENDED_AT) {
+  return { amountDelta, createdAt };
+}
+
+describe('computeAmendmentRefundPrefill', () => {
+  it('prefills the full |amountDelta| when no refunds exist', () => {
+    const result = computeAmendmentRefundPrefill(amendment(-57), []);
+    expect(result).toEqual({
+      amendmentAmount: 57,
+      refundedSinceAmendment: 0,
+      suggestedAmount: 57,
+      fullyCovered: false,
+    });
+  });
+
+  it('ignores refunds recorded before the amendment was created', () => {
+    const result = computeAmendmentRefundPrefill(amendment(-57), [
+      { amount: 20, createdAt: BEFORE },
+    ]);
+    expect(result.refundedSinceAmendment).toBe(0);
+    expect(result.suggestedAmount).toBe(57);
+    expect(result.fullyCovered).toBe(false);
+  });
+
+  it('nets a refund recorded at exactly the amendment timestamp', () => {
+    const result = computeAmendmentRefundPrefill(amendment(-57), [
+      { amount: 20, createdAt: AMENDED_AT },
+    ]);
+    expect(result.refundedSinceAmendment).toBe(20);
+    expect(result.suggestedAmount).toBe(37);
+  });
+
+  it('nets partial refunds recorded after the amendment', () => {
+    const result = computeAmendmentRefundPrefill(amendment(-57), [
+      { amount: 20, createdAt: AFTER },
+    ]);
+    expect(result).toEqual({
+      amendmentAmount: 57,
+      refundedSinceAmendment: 20,
+      suggestedAmount: 37,
+      fullyCovered: false,
+    });
+  });
+
+  it('nets only the refunds recorded after when the history is mixed', () => {
+    const result = computeAmendmentRefundPrefill(amendment(-57), [
+      { amount: 15, createdAt: BEFORE },
+      { amount: 10, createdAt: AFTER },
+      { amount: 5, createdAt: AFTER },
+    ]);
+    expect(result.refundedSinceAmendment).toBe(15);
+    expect(result.suggestedAmount).toBe(42);
+  });
+
+  it('suggests zero and reports fullyCovered when refunds meet the amount', () => {
+    const result = computeAmendmentRefundPrefill(amendment(-57), [
+      { amount: 57, createdAt: AFTER },
+    ]);
+    expect(result.suggestedAmount).toBe(0);
+    expect(result.fullyCovered).toBe(true);
+  });
+
+  it('never suggests a negative amount when refunds exceed the amendment', () => {
+    const result = computeAmendmentRefundPrefill(amendment(-57), [
+      { amount: 60, createdAt: AFTER },
+    ]);
+    expect(result.suggestedAmount).toBe(0);
+    expect(result.fullyCovered).toBe(true);
+    expect(result.refundedSinceAmendment).toBe(60);
+  });
+
+  it('rounds in cents so float dust cannot leave a phantom remainder', () => {
+    // 10.03 + 20.07 !== 30.10 in binary floats; cents math must net to 0.
+    const result = computeAmendmentRefundPrefill(amendment(-30.1), [
+      { amount: 10.03, createdAt: AFTER },
+      { amount: 20.07, createdAt: AFTER },
+    ]);
+    expect(result.suggestedAmount).toBe(0);
+    expect(result.fullyCovered).toBe(true);
+  });
+
+  it('nets every refund when the amendment timestamp is unparseable (safe direction)', () => {
+    const result = computeAmendmentRefundPrefill(amendment(-57, 'not-a-date'), [
+      { amount: 20, createdAt: BEFORE },
+    ]);
+    expect(result.refundedSinceAmendment).toBe(20);
+    expect(result.suggestedAmount).toBe(37);
+  });
+
+  it('nets a refund whose timestamp is unparseable (safe direction)', () => {
+    const result = computeAmendmentRefundPrefill(amendment(-57), [
+      { amount: 20, createdAt: 'not-a-date' },
+    ]);
+    expect(result.refundedSinceAmendment).toBe(20);
+    expect(result.suggestedAmount).toBe(37);
+  });
+
+  it('treats a zero-delta amendment as nothing to refund, not fully covered', () => {
+    const result = computeAmendmentRefundPrefill(amendment(0), []);
+    expect(result.suggestedAmount).toBe(0);
+    expect(result.fullyCovered).toBe(false);
+  });
+
+  it('uses the magnitude of the (negative) refund delta', () => {
+    const result = computeAmendmentRefundPrefill(amendment(-19.99), []);
+    expect(result.amendmentAmount).toBe(19.99);
+    expect(result.suggestedAmount).toBe(19.99);
+  });
+});

--- a/src/components/ops/orders/detail/__tests__/refund-prefill.test.ts
+++ b/src/components/ops/orders/detail/__tests__/refund-prefill.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeAmendmentRefundPrefill } from '../refund-prefill';
+import { computeAmendmentRefundPrefill, claimedRefundIds } from '../refund-prefill';
 
 const AMENDED_AT = '2026-07-10T12:00:00.000Z';
 const BEFORE = '2026-07-10T11:59:59.000Z';
@@ -112,5 +112,65 @@ describe('computeAmendmentRefundPrefill', () => {
     const result = computeAmendmentRefundPrefill(amendment(-19.99), []);
     expect(result.amendmentAmount).toBe(19.99);
     expect(result.suggestedAmount).toBe(19.99);
+  });
+
+  it('ignores negative refund amounts instead of inflating the offer', () => {
+    const result = computeAmendmentRefundPrefill(amendment(-57), [
+      { amount: -20, createdAt: AFTER },
+    ]);
+    expect(result.refundedSinceAmendment).toBe(0);
+    expect(result.suggestedAmount).toBe(57);
+  });
+
+  it('does not net a refund that resolved a different amendment', () => {
+    // Amendment A (-$30, earlier) was refunded in full at AFTER and stamped
+    // with refund "ref-a". Amendment B (-$20) must not treat A's money as
+    // covering it — B is still owed in full.
+    const result = computeAmendmentRefundPrefill(
+      amendment(-20),
+      [{ id: 'ref-a', amount: 30, createdAt: AFTER }],
+      { excludeRefundIds: new Set(['ref-a']) }
+    );
+    expect(result.refundedSinceAmendment).toBe(0);
+    expect(result.suggestedAmount).toBe(20);
+    expect(result.fullyCovered).toBe(false);
+  });
+
+  it('still nets unclaimed refunds when an exclusion set is provided', () => {
+    const result = computeAmendmentRefundPrefill(
+      amendment(-57),
+      [
+        { id: 'ref-a', amount: 30, createdAt: AFTER },
+        { id: 'ref-b', amount: 20, createdAt: AFTER },
+      ],
+      { excludeRefundIds: new Set(['ref-a']) }
+    );
+    expect(result.refundedSinceAmendment).toBe(20);
+    expect(result.suggestedAmount).toBe(37);
+  });
+
+  it('nets refunds without an id even when an exclusion set is provided', () => {
+    const result = computeAmendmentRefundPrefill(
+      amendment(-57),
+      [{ amount: 20, createdAt: AFTER }],
+      { excludeRefundIds: new Set(['ref-a']) }
+    );
+    expect(result.refundedSinceAmendment).toBe(20);
+    expect(result.suggestedAmount).toBe(37);
+  });
+});
+
+describe('claimedRefundIds', () => {
+  it('collects stamped refund ids and skips unresolved amendments', () => {
+    const ids = claimedRefundIds([
+      { refundId: 'ref-a' },
+      { refundId: null },
+      { refundId: 'ref-b' },
+    ]);
+    expect(ids).toEqual(new Set(['ref-a', 'ref-b']));
+  });
+
+  it('returns an empty set for no amendments', () => {
+    expect(claimedRefundIds([]).size).toBe(0);
   });
 });

--- a/src/components/ops/orders/detail/refund-prefill.ts
+++ b/src/components/ops/orders/detail/refund-prefill.ts
@@ -18,7 +18,9 @@ export interface AmendmentForPrefill {
 
 /** The slice of a recorded refund the netting math needs. */
 export interface RefundForPrefill {
-  /** Refunded dollars (positive). */
+  /** Refund row id — lets netting skip rows already claimed by an amendment. */
+  id?: string;
+  /** Refunded dollars (expected positive; negative values are ignored). */
   amount: number;
   /** ISO timestamp the refund row was recorded. */
   createdAt: string;
@@ -51,22 +53,32 @@ function toCents(dollars: number): number {
  * - Unparseable timestamps (either side) count as "since".
  * - All refund rows count regardless of status/origin, matching how
  *   `totalRefunded` and the refund route's prior-refund sum are computed.
+ * - Negative refund amounts are ignored (they would inflate the offer).
+ *
+ * The one exception to "count everything since": a refund that RESOLVED a
+ * different amendment (its id is in `excludeRefundIds`, built from
+ * `OrderAmendment.refundId`) is attributed money — netting it here too
+ * would tell the operator a second, unrelated amendment is already covered
+ * and a legitimately-owed refund would be skipped.
  *
  * Callers gate on amountDelta < 0 (refund-direction amendments); the math
  * uses |amountDelta| either way.
  */
 export function computeAmendmentRefundPrefill(
   amendment: AmendmentForPrefill,
-  refunds: RefundForPrefill[]
+  refunds: RefundForPrefill[],
+  options?: { excludeRefundIds?: ReadonlySet<string> }
 ): AmendmentRefundPrefill {
   const amendmentTs = Date.parse(amendment.createdAt);
   const amendmentCents = toCents(Math.abs(amendment.amountDelta));
+  const excluded = options?.excludeRefundIds;
 
   const refundedSinceCents = refunds.reduce((sum, refund) => {
+    if (refund.id && excluded?.has(refund.id)) return sum;
     const refundTs = Date.parse(refund.createdAt);
     const since =
       Number.isNaN(amendmentTs) || Number.isNaN(refundTs) || refundTs >= amendmentTs;
-    return since ? sum + toCents(refund.amount) : sum;
+    return since ? sum + Math.max(0, toCents(refund.amount)) : sum;
   }, 0);
 
   const suggestedCents = Math.max(0, amendmentCents - refundedSinceCents);
@@ -77,4 +89,20 @@ export function computeAmendmentRefundPrefill(
     suggestedAmount: suggestedCents / 100,
     fullyCovered: amendmentCents > 0 && suggestedCents === 0,
   };
+}
+
+/**
+ * Refund row ids already claimed by an amendment — `OrderAmendment.refundId`
+ * is stamped when a refund resolves that amendment. Pass the result as
+ * `excludeRefundIds` so money that answered one amendment never nets against
+ * another amendment on the same order.
+ */
+export function claimedRefundIds(
+  amendments: { refundId: string | null }[]
+): Set<string> {
+  const ids = new Set<string>();
+  for (const amendment of amendments) {
+    if (amendment.refundId) ids.add(amendment.refundId);
+  }
+  return ids;
 }

--- a/src/components/ops/orders/detail/refund-prefill.ts
+++ b/src/components/ops/orders/detail/refund-prefill.ts
@@ -1,0 +1,80 @@
+/**
+ * Netting logic for the amendment-driven refund prefill in the order action
+ * sheet. A PENDING refund amendment calls for |amountDelta|, but refunds may
+ * already have been recorded against the order after the amendment was
+ * created (a retry after a mismatch, a manual partial, another session).
+ * Prefilling the full |amountDelta| in that state over-refunds, bounded only
+ * by the order-level Stripe cap — so the prefill offers the remainder instead
+ * (security review of PR #225, LOW).
+ */
+
+/** The slice of an amendment the netting math needs. */
+export interface AmendmentForPrefill {
+  /** Signed dollar delta; refund amendments are negative. */
+  amountDelta: number;
+  /** ISO timestamp the amendment was created. */
+  createdAt: string;
+}
+
+/** The slice of a recorded refund the netting math needs. */
+export interface RefundForPrefill {
+  /** Refunded dollars (positive). */
+  amount: number;
+  /** ISO timestamp the refund row was recorded. */
+  createdAt: string;
+}
+
+export interface AmendmentRefundPrefill {
+  /** What the amendment calls for: |amountDelta|, in dollars. */
+  amendmentAmount: number;
+  /** Dollars refunded at or after the amendment was created. */
+  refundedSinceAmendment: number;
+  /** Amount the refund form should be seeded with (never negative). */
+  suggestedAmount: number;
+  /** True when refunds since creation already cover the full amendment. */
+  fullyCovered: boolean;
+}
+
+function toCents(dollars: number): number {
+  return Math.round(dollars * 100);
+}
+
+/**
+ * Nets an amendment's refund amount against refunds recorded at or after the
+ * amendment's createdAt. Refunds recorded BEFORE the amendment are untouched:
+ * they compensated earlier events and are already reflected in the totals the
+ * amendment's delta was computed from.
+ *
+ * Safety posture (this seeds a money-out form, so every ambiguity resolves
+ * toward offering LESS):
+ * - A refund with a timestamp equal to the amendment's counts as "since".
+ * - Unparseable timestamps (either side) count as "since".
+ * - All refund rows count regardless of status/origin, matching how
+ *   `totalRefunded` and the refund route's prior-refund sum are computed.
+ *
+ * Callers gate on amountDelta < 0 (refund-direction amendments); the math
+ * uses |amountDelta| either way.
+ */
+export function computeAmendmentRefundPrefill(
+  amendment: AmendmentForPrefill,
+  refunds: RefundForPrefill[]
+): AmendmentRefundPrefill {
+  const amendmentTs = Date.parse(amendment.createdAt);
+  const amendmentCents = toCents(Math.abs(amendment.amountDelta));
+
+  const refundedSinceCents = refunds.reduce((sum, refund) => {
+    const refundTs = Date.parse(refund.createdAt);
+    const since =
+      Number.isNaN(amendmentTs) || Number.isNaN(refundTs) || refundTs >= amendmentTs;
+    return since ? sum + toCents(refund.amount) : sum;
+  }, 0);
+
+  const suggestedCents = Math.max(0, amendmentCents - refundedSinceCents);
+
+  return {
+    amendmentAmount: amendmentCents / 100,
+    refundedSinceAmendment: refundedSinceCents / 100,
+    suggestedAmount: suggestedCents / 100,
+    fullyCovered: amendmentCents > 0 && suggestedCents === 0,
+  };
+}

--- a/src/components/ops/orders/detail/types.ts
+++ b/src/components/ops/orders/detail/types.ts
@@ -144,5 +144,6 @@ export interface OrderDetail {
     totalRefunded: number;
     count: number;
     stripeCapturedAmount: number | null;
+    items: { amount: number; createdAt: string }[];
   };
 }

--- a/src/components/ops/orders/detail/types.ts
+++ b/src/components/ops/orders/detail/types.ts
@@ -144,6 +144,6 @@ export interface OrderDetail {
     totalRefunded: number;
     count: number;
     stripeCapturedAmount: number | null;
-    items: { amount: number; createdAt: string }[];
+    items: { id: string; amount: number; createdAt: string }[];
   };
 }


### PR DESCRIPTION
## What

Closes the LOW flagged by PR #225's security review (chip `task_548a6f77`): the HQ order action sheet's refund prefill offered the **full** `|amountDelta|` of a PENDING OrderAmendment even when partial refunds had already been recorded against the order after the amendment was created. An operator retrying after a mismatch/partial could over-refund, bounded only by the order-level Stripe cap.

## How

- **New pure helper** `src/components/ops/orders/detail/refund-prefill.ts` — `computeAmendmentRefundPrefill(amendment, refunds, {excludeRefundIds})` nets `|amountDelta|` against refund rows with `createdAt >= amendment.createdAt`. Cents-space math; unparseable timestamps count toward netting; negative amounts ignored — every ambiguity offers **less**.
- **Attribution guard**: refunds that resolved a *different* amendment (`OrderAmendment.refundId`, via `claimedRefundIds()`) are excluded, so amendment B never shows "already covered" because amendment A's refund landed after B was created (security review round 2, MEDIUM).
- **History "Process Refund" button** seeds the netted remainder; label shows it (`Review Refund (already covered)` at $0, where slide-to-confirm stays disabled).
- **Action sheet callout** (partial + fully-covered variants) explains the discrepancy whenever refunds were recorded since the pending amendment's creation, and that the amendment stays pending unless the refund exactly matches.
- **`GET /api/v1/admin/orders/[id]`** now serializes `refunds.items = [{id, amount, createdAt}]` (rows were already loaded; behind ops auth middleware; no reason/processedBy/stripeRefundId exposure).
- The `confirmAmendment` seed site is deliberately unchanged — a just-created amendment can have no refunds "since" it.

## Kept invariants (verified untouched)

- `POST /api/v1/admin/orders/[id]/refund` byte-identical: Stripe-authoritative cap, idempotency key, amendment-stamping guard + top-level `warning`.
- `processRefund()` still alerts the server `warning`.
- Editing the amount still detaches the amendment (mismatch can't stamp it REFUNDED).

## Verification

- `npx tsc --noEmit` clean · `npm run lint` 0 errors · `npm run test:run` **720/720** (18 helper tests, incl. the multi-amendment repro, float dust, timestamp edges)
- **security-reviewer: 2 rounds, CLEARED** — round 1 found 1 MEDIUM (multi-pending-amendment conflation) + 2 LOW (negative-amount clamp, stale-resolution guard), all fixed in the second commit and independently re-verified (reviewer re-ran the repro and all gates)
- Webpack dev-server smoke: unauthenticated `GET /api/v1/admin/orders/:id` → 401 via middleware
- NOT verified: authenticated payload in a live browser / on-device sheet visuals — left for the preview gate per HQ workstream convention

## QA script (preview)

1. Open an order that has a PENDING negative amendment AND a refund recorded after that amendment was created → Amendment History button shows the netted amount, not the full delta.
2. Tap it → sheet opens, red callout explains `$X of $Y already refunded, leaving $Z`; amount field seeds $Z.
3. Fully-covered case → button reads "Review Refund (already covered)", amount seeds $0, slide disabled, callout explains.
4. Type any amount → callout disappears (amendment detached), manual refund path unchanged.
5. Normal case (no refunds since amendment) → behavior identical to before, no callout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
