### PR TITLE
feat(finance): bank-as-the-book — financing classification, 24-mo history, accrual COGS

### DIFF
--- a/src/app/admin/finance/connect-bank/page.tsx
+++ b/src/app/admin/finance/connect-bank/page.tsx
@@ -41,6 +41,14 @@ export default function ConnectBankPage(): ReactElement {
   const [receivedRedirectUri, setReceivedRedirectUri] = useState<string | undefined>(
     undefined
   );
+  // 'connect' = add a new item (exchange on success); 'extend' = update-mode
+  // re-auth of the existing item to request 730 days of history (NO exchange —
+  // Plaid backfills via HISTORICAL_UPDATE webhooks). Persisted so the mode
+  // survives the OAuth redirect to the bank and back.
+  const [mode, setMode] = useState<'connect' | 'extend'>('connect');
+  // Set when the operator clicks a button before Link is ready with the new
+  // token — the effect below opens Link as soon as it is.
+  const [pendingOpen, setPendingOpen] = useState(false);
 
   async function fetchHealth(): Promise<void> {
     setLoading(true);
@@ -60,16 +68,19 @@ export default function ConnectBankPage(): ReactElement {
     }
   }
 
-  async function fetchLinkToken(): Promise<void> {
+  async function fetchLinkToken(extend = false): Promise<void> {
     try {
       const res = await fetch('/api/admin/finance/plaid/link-token', {
         method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(extend ? { extendHistory: true } : {}),
       });
-      const body = (await res.json()) as ApiResponse<{ linkToken: string }>;
+      const body = (await res.json()) as ApiResponse<{ linkToken: string; mode: string }>;
       if (body.success) {
         setLinkToken(body.data.linkToken);
-        // Persist so the SAME token survives an OAuth redirect to the bank.
+        // Persist so the SAME token + mode survive an OAuth redirect to the bank.
         window.localStorage.setItem('plaid_link_token', body.data.linkToken);
+        window.localStorage.setItem('plaid_link_mode', extend ? 'extend' : 'connect');
       } else {
         setError(body.error);
       }
@@ -82,12 +93,15 @@ export default function ConnectBankPage(): ReactElement {
     void fetchHealth();
     // OAuth banks (Wells Fargo) redirect back here with ?oauth_state_id=… . On
     // return, reuse the link_token that started the flow (Plaid requires the same
-    // one) and let the auto-open effect below resume Link.
+    // one) — and restore whether it was a connect or an extend-history flow —
+    // then let the auto-open effect below resume Link.
     if (window.location.href.includes('oauth_state_id=')) {
       setReceivedRedirectUri(window.location.href);
       const saved = window.localStorage.getItem('plaid_link_token');
+      const savedMode = window.localStorage.getItem('plaid_link_mode');
+      if (savedMode === 'extend') setMode('extend');
       if (saved) setLinkToken(saved);
-      else void fetchLinkToken();
+      else void fetchLinkToken(savedMode === 'extend');
     } else {
       void fetchLinkToken();
     }
@@ -97,30 +111,48 @@ export default function ConnectBankPage(): ReactElement {
     async (publicToken: string, metadata: PlaidLinkOnSuccessMetadata) => {
       setExchanging(true);
       try {
-        const res = await fetch('/api/admin/finance/plaid/exchange', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ publicToken, metadata }),
-        });
-        const body = (await res.json()) as ApiResponse<unknown>;
-        if (!body.success) {
-          setError(body.error);
+        if (mode === 'extend') {
+          // Update-mode re-auth: the Item is unchanged, so there is NO token
+          // exchange. Kick a sync so the first slice of deeper history lands
+          // now; the rest arrives via HISTORICAL_UPDATE webhooks.
+          const res = await fetch('/api/admin/finance/plaid/sync', { method: 'POST' });
+          const body = (await res.json()) as ApiResponse<unknown>;
+          if (!body.success) setError(body.error);
         } else {
-          window.localStorage.removeItem('plaid_link_token');
-          await fetchHealth();
+          const res = await fetch('/api/admin/finance/plaid/exchange', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ publicToken, metadata }),
+          });
+          const body = (await res.json()) as ApiResponse<unknown>;
+          if (!body.success) setError(body.error);
         }
+        window.localStorage.removeItem('plaid_link_token');
+        window.localStorage.removeItem('plaid_link_mode');
+        await fetchHealth();
       } catch (e) {
-        setError(e instanceof Error ? e.message : 'Failed to exchange token');
+        setError(e instanceof Error ? e.message : 'Failed to complete Plaid flow');
       } finally {
         setExchanging(false);
       }
     },
-    []
+    [mode]
   );
+
+  // If the operator abandons a flow (closes the Link modal), clear the saved
+  // token + mode so a later click can't silently reopen a stale update-mode
+  // flow when they meant to connect a new bank. (Does not fire during the
+  // OAuth redirect — the page unloads — so the resume path is unaffected.)
+  const onExit = useCallback(() => {
+    window.localStorage.removeItem('plaid_link_token');
+    window.localStorage.removeItem('plaid_link_mode');
+    setPendingOpen(false);
+  }, []);
 
   const { open, ready } = usePlaidLink({
     token: linkToken,
     onSuccess,
+    onExit,
     receivedRedirectUri,
   });
 
@@ -128,6 +160,38 @@ export default function ConnectBankPage(): ReactElement {
   useEffect(() => {
     if (receivedRedirectUri && ready) open();
   }, [receivedRedirectUri, ready, open]);
+
+  // Open Link once it's ready after a button click swapped in a fresh token.
+  useEffect(() => {
+    if (pendingOpen && ready) {
+      setPendingOpen(false);
+      open();
+    }
+  }, [pendingOpen, ready, open]);
+
+  async function startExtendHistory(): Promise<void> {
+    setError(null);
+    setMode('extend');
+    setLinkToken(null); // force usePlaidLink to re-init with the update-mode token
+    await fetchLinkToken(true);
+    setPendingOpen(true);
+  }
+
+  // The primary connect button always runs the CONNECT flow — if a prior
+  // extend attempt left update-mode state behind, fetch a fresh connect token
+  // instead of trusting ambient state.
+  async function startConnect(): Promise<void> {
+    setError(null);
+    if (mode !== 'connect') {
+      setMode('connect');
+      setLinkToken(null);
+      await fetchLinkToken(false);
+      setPendingOpen(true);
+      return;
+    }
+    if (ready) open();
+    else setPendingOpen(true);
+  }
 
   return (
     <div className="p-4 md:p-8 max-w-3xl">
@@ -205,18 +269,37 @@ export default function ConnectBankPage(): ReactElement {
               </ul>
             )}
 
-            <button
-              type="button"
-              onClick={() => open()}
-              disabled={!ready || exchanging}
-              className="px-4 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50"
-            >
-              {exchanging
-                ? 'Exchanging…'
-                : health.items.length > 0
-                  ? 'Link another bank'
-                  : 'Connect bank with Plaid'}
-            </button>
+            <div className="flex flex-wrap gap-3">
+              <button
+                type="button"
+                onClick={() => void startConnect()}
+                disabled={exchanging || pendingOpen}
+                className="px-4 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50"
+              >
+                {exchanging
+                  ? 'Working…'
+                  : health.items.length > 0
+                    ? 'Link another bank'
+                    : 'Connect bank with Plaid'}
+              </button>
+              {health.items.some((i) => i.environment === 'production') && (
+                <button
+                  type="button"
+                  onClick={() => void startExtendHistory()}
+                  disabled={exchanging || pendingOpen}
+                  className="px-4 py-2 text-sm bg-white text-blue-700 border-2 border-blue-600 rounded-md hover:bg-blue-50 disabled:opacity-50"
+                >
+                  {pendingOpen ? 'Opening…' : 'Extend history to 24 months'}
+                </button>
+              )}
+            </div>
+            {health.items.some((i) => i.environment === 'production') && (
+              <p className="text-gray-500 text-xs">
+                Extend history: quick re-login with the bank so Plaid can pull up
+                to 24 months of transactions (the initial connection only fetched
+                ~90 days). History fills in over the following hours.
+              </p>
+            )}
             {!linkToken && !error && (
               <p className="text-gray-500 text-xs">Loading Plaid link token…</p>
             )}

--- a/src/app/api/admin/finance/plaid/link-token/route.ts
+++ b/src/app/api/admin/finance/plaid/link-token/route.ts
@@ -4,19 +4,56 @@
  * Returns a Plaid link_token the browser-side Plaid Link SDK uses to launch
  * the institution-picker UI. Per Plaid recs, link_tokens are short-lived
  * (30 min) so the connect page fetches a fresh one on mount.
+ *
+ * Body (optional): `{ extendHistory: true }` — returns an UPDATE-MODE token
+ * for the existing production Item instead, requesting the full 730 days of
+ * transaction history (the fresh-connect default was Plaid's 90 days). The
+ * operator re-auths through Link; no token exchange follows — Plaid backfills
+ * deeper history via HISTORICAL_UPDATE webhooks.
  */
 
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { requireOpsAuth } from '@/lib/auth/ops-session';
-import { createLinkToken } from '@/lib/finance/plaid-client';
+import { createLinkToken, createUpdateLinkToken } from '@/lib/finance/plaid-client';
+import { prisma } from '@/lib/database/client';
 
-export async function POST(): Promise<NextResponse> {
+interface LinkTokenBody {
+  extendHistory?: boolean;
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
   try {
     const auth = await requireOpsAuth();
     if (auth instanceof NextResponse) return auth;
 
+    // Body is optional (the connect flow sends none).
+    const body = (await request.json().catch(() => ({}))) as LinkTokenBody;
+
+    if (body.extendHistory) {
+      // Single-item assumption: the business operates ONE production bank
+      // account (operator-confirmed 2026-07-10), so "extend" targets the most
+      // recent production item. If a second bank is ever linked, this needs an
+      // item picker — the response's `institution` field says which one it hit.
+      const item = await prisma.plaidItem.findFirst({
+        where: { environment: 'production', status: { in: ['active', 'error'] } },
+        orderBy: { createdAt: 'desc' },
+        select: { accessToken: true, institutionName: true },
+      });
+      if (!item) {
+        return NextResponse.json(
+          { success: false, error: 'No production bank item to extend — connect one first' },
+          { status: 400 }
+        );
+      }
+      const linkToken = await createUpdateLinkToken(item.accessToken);
+      return NextResponse.json({
+        success: true,
+        data: { linkToken, mode: 'extend', institution: item.institutionName },
+      });
+    }
+
     const linkToken = await createLinkToken(`ops-${auth.role}`);
-    return NextResponse.json({ success: true, data: { linkToken } });
+    return NextResponse.json({ success: true, data: { linkToken, mode: 'connect' } });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error('[Plaid Link Token] Error:', message);

--- a/src/app/api/admin/finance/plaid/sync/route.ts
+++ b/src/app/api/admin/finance/plaid/sync/route.ts
@@ -1,0 +1,32 @@
+/**
+ * POST /api/admin/finance/plaid/sync
+ *
+ * Manually kick a transaction sync across all linked Plaid items — the same
+ * `syncAllItems()` the daily cron runs. Used by the connect-bank page right
+ * after an extend-history re-auth so the first slice of deeper history lands
+ * immediately (the rest arrives via HISTORICAL_UPDATE webhooks over the
+ * following hours), and handy as a general "sync now" for the operator.
+ */
+
+import { NextResponse } from 'next/server';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
+import { syncAllItems } from '@/lib/finance/plaid-sync-service';
+
+export const maxDuration = 120;
+
+export async function POST(): Promise<NextResponse> {
+  try {
+    const auth = await requireOpsAuth();
+    if (auth instanceof NextResponse) return auth;
+
+    const results = await syncAllItems();
+    return NextResponse.json({ success: true, data: { results } });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('[Plaid Sync] Error:', message);
+    return NextResponse.json(
+      { success: false, error: message },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/email/templates/__tests__/finance-monthly-close.test.ts
+++ b/src/lib/email/templates/__tests__/finance-monthly-close.test.ts
@@ -209,6 +209,62 @@ describe('renderFinanceMonthlyCloseEmail', () => {
     expect(html).not.toContain('Barrett Distributing');
   });
 
+  it('renders the accrual product-margin line over the COVERED basket only', () => {
+    // covered revenue $150 − accrual cogs $90 → 40% margin (NOT 9k into full revenue)
+    const html = renderFinanceMonthlyCloseEmail(
+      shapeMonthlyClosePayload({
+        rollup: reliableRollup({
+          dataHealth: {
+            expenseSource: 'bank',
+            netIncomeReliable: true,
+            incomeReconciled: true,
+            otherIncomeCents: 0,
+            accrual: { cogsCents: 9_000, coveredRevenueCents: 15_000, coveragePct: 75 },
+            flags: [],
+          },
+        }),
+        prior: null,
+        generatedAt: GEN,
+      })
+    );
+    expect(html).toContain('Product margin (accrual est.)');
+    expect(html).toContain('40.0%');
+    expect(html).toContain('75% of item revenue');
+    // …and absent when there is no accrual block.
+    const none = renderFinanceMonthlyCloseEmail(
+      shapeMonthlyClosePayload({ rollup: reliableRollup(), prior: null, generatedAt: GEN })
+    );
+    expect(none).not.toContain('accrual est.');
+  });
+
+  it('itemizes owner-capital transfers in the reconciliation section (audit trail)', () => {
+    const html = renderFinanceMonthlyCloseEmail(
+      shapeMonthlyClosePayload({
+        rollup: reliableRollup({
+          dataHealth: {
+            expenseSource: 'bank',
+            netIncomeReliable: true,
+            incomeReconciled: true,
+            otherIncomeCents: 0,
+            ownerCapitalCents: 1_000_000,
+            ownerCapitalTxns: [
+              { name: 'ZELLE FROM B HILL ENTERTAINMENT LLC ON 05/15', cents: 500_000 },
+              { name: 'ONLINE TRANSFER FROM HILL B EVERYDAY CHECKIN', cents: 500_000 },
+            ],
+            flags: [],
+          },
+        }),
+        prior: null,
+        generatedAt: GEN,
+      })
+    );
+    expect(html).toContain('Owner capital');
+    expect(html).toContain('$10,000');
+    // Per-transfer audit trail visible, so a misclassified deposit is spot-checkable.
+    expect(html).toContain('ZELLE FROM B HILL ENTERTAINMENT LLC ON 05/15');
+    expect(html).toContain('financing');
+  });
+
   it('does not leak net income via a QB-discrepancy flag (reconstruction chain closed)', () => {
     const html = renderFinanceMonthlyCloseEmail(
       shapeMonthlyClosePayload({ rollup: qbDiscrepancyRollup(), prior: null, generatedAt: GEN })

--- a/src/lib/email/templates/finance-monthly-close.ts
+++ b/src/lib/email/templates/finance-monthly-close.ts
@@ -127,6 +127,25 @@ function reconciliationBlock(d: MonthlyClosePayload): string {
     `Expense source: <strong>${d.expenseSource === 'bank' ? 'bank feed (cash-basis)' : 'QuickBooks'}</strong>`
   );
 
+  if (d.ownerCapitalCents !== null && d.ownerCapitalCents > 0) {
+    // Itemize the transfers — the audit trail that makes a misclassified
+    // deposit visible instead of hidden inside an aggregate.
+    const txns = d.ownerCapitalTxns
+      .map((t) => `${money(t.cents)} — ${esc(t.name)}`)
+      .join('<br>&nbsp;&nbsp;');
+    rows.push(
+      `Owner capital: <strong>${money(d.ownerCapitalCents)}</strong> received this month — ` +
+        `classified as financing (equity injection), excluded from income.` +
+        (txns ? `<br>&nbsp;&nbsp;${txns}` : '')
+    );
+  }
+
+  if (d.vendorRefundCents !== null && d.vendorRefundCents > 0) {
+    rows.push(
+      `Vendor refunds: ${money(d.vendorRefundCents)} in distributor credits — excluded from income.`
+    );
+  }
+
   if (d.incomeReconciled === true) {
     rows.push(`Income: ✅ bank deposits reconcile to known Stripe revenue.`);
   } else if (d.incomeReconciled === false) {
@@ -188,6 +207,16 @@ export function renderFinanceMonthlyCloseEmail(d: MonthlyClosePayload): string {
     d.grossProfitCents === null ? '—' : money(d.grossProfitCents),
     { strong: true, sub: `gross margin ${pct(d.grossMarginPct)}` }
   );
+  // Accrual view: true product margin (cost of what SOLD), over the covered
+  // basket only. Supplements the lumpy cash-basis line above; safe to show even
+  // on withheld months (independent of OpEx, so it can't reconstruct net).
+  const accrualLine =
+    d.accrualGrossMarginPct !== null && d.accrualCoveragePct !== null
+      ? plLine('Product margin (accrual est.)', pct(d.accrualGrossMarginPct), {
+          indent: true,
+          sub: `cost of goods sold this month · based on ${d.accrualCoveragePct.toFixed(0)}% of item revenue with known cost`,
+        })
+      : '';
 
   if (!hasExpenses) {
     plRows.push(
@@ -200,6 +229,7 @@ export function renderFinanceMonthlyCloseEmail(d: MonthlyClosePayload): string {
     plRows.push(
       cogsLine,
       grossProfitLine,
+      accrualLine,
       plLine('Operating expenses', d.opexCents === null ? '—' : money(d.opexCents), { strong: true }),
       opexRowsHtml(d.opexRows)
     );
@@ -211,6 +241,7 @@ export function renderFinanceMonthlyCloseEmail(d: MonthlyClosePayload): string {
     plRows.push(
       cogsLine,
       grossProfitLine,
+      accrualLine,
       plLine('Operating expenses', 'Withheld', {
         strong: true,
         sub: 'withheld until the flags below are resolved — net income can’t be stated',
@@ -305,6 +336,12 @@ export function renderFinanceMonthlyCloseText(d: MonthlyClosePayload): string {
     lines.push(
       `Gross profit: ${d.grossProfitCents === null ? '—' : money(d.grossProfitCents)} (margin ${pct(d.grossMarginPct)})`
     );
+    if (d.accrualGrossMarginPct !== null && d.accrualCoveragePct !== null) {
+      lines.push(
+        `Product margin (accrual est.): ${pct(d.accrualGrossMarginPct)} ` +
+          `(cost of goods SOLD; ${d.accrualCoveragePct.toFixed(0)}% of item revenue has known cost)`
+      );
+    }
     if (d.netIncomeReliable) {
       lines.push(`Operating expenses: ${d.opexCents === null ? '—' : money(d.opexCents)}`);
       for (const r of d.opexRows) {
@@ -325,6 +362,19 @@ export function renderFinanceMonthlyCloseText(d: MonthlyClosePayload): string {
   if (d.expenseSource !== 'none') {
     lines.push('');
     lines.push('Reconciliation:');
+    if (d.ownerCapitalCents !== null && d.ownerCapitalCents > 0) {
+      lines.push(
+        `  Owner capital: ${money(d.ownerCapitalCents)} received — financing (equity), excluded from income.`
+      );
+      for (const t of d.ownerCapitalTxns) {
+        lines.push(`    ${money(t.cents)} — ${t.name}`);
+      }
+    }
+    if (d.vendorRefundCents !== null && d.vendorRefundCents > 0) {
+      lines.push(
+        `  Vendor refunds: ${money(d.vendorRefundCents)} in distributor credits — excluded from income.`
+      );
+    }
     if (d.incomeReconciled === true) {
       lines.push('  Income reconciles to known Stripe revenue.');
     } else if (d.incomeReconciled === false) {

--- a/src/lib/finance/__tests__/bank-income-recon.test.ts
+++ b/src/lib/finance/__tests__/bank-income-recon.test.ts
@@ -6,7 +6,76 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { explainDeposits } from '@/lib/finance/bank-income-recon';
+import { explainDeposits, classifyBankInflow } from '@/lib/finance/bank-income-recon';
+
+describe('classifyBankInflow', () => {
+  it('classifies Brian owner-capital transfers by real WF descriptors (financing, not income)', () => {
+    // Real descriptors from the first production sync — Plaid mislabels these
+    // INCOME_CONTRACTOR, so classification is by descriptor.
+    expect(
+      classifyBankInflow({ name: 'ZELLE FROM B HILL ENTERTAINMENT LLC ON 05/15', merchantName: null })
+    ).toBe('owner_capital');
+    expect(
+      classifyBankInflow({ name: 'ONLINE TRANSFER FROM HILL B EVERYDAY CHECKIN', merchantName: null })
+    ).toBe('owner_capital');
+    expect(
+      classifyBankInflow({ name: 'ONLINE TRANSFER FROM B HILL ENTERTAINMENT LL', merchantName: null })
+    ).toBe('owner_capital');
+    expect(
+      classifyBankInflow({ name: 'ONLINE TRANSFER FROM HILL B REF #IB0Y2NKXHG', merchantName: null })
+    ).toBe('owner_capital');
+  });
+
+  it('classifies credits from COGS merchants as vendor refunds (not sales)', () => {
+    expect(
+      classifyBankInflow({ name: "Southern Glazer' FINTECHEFT 051826 XXXXX6635", merchantName: null })
+    ).toBe('vendor_refund');
+    expect(
+      classifyBankInflow({ name: 'Capital Reyes Di FINTECHEFT 061626 XXXXX6635', merchantName: null })
+    ).toBe('vendor_refund');
+  });
+
+  it('leaves Stripe payouts and ordinary deposits as sales_or_other', () => {
+    expect(
+      classifyBankInflow({ name: 'STRIPE TRANSFER ST-A9T6H2F5F3O9 PREMIER WORL', merchantName: null })
+    ).toBe('sales_or_other');
+    expect(
+      classifyBankInflow({ name: 'MOBILE DEPOSIT : REF NUMBER :308100443081', merchantName: null })
+    ).toBe('sales_or_other');
+    // A customer named Hillberg must NOT be swept into owner capital (word
+    // boundaries required around the B/HILL pairing).
+    expect(classifyBankInflow({ name: 'ZELLE FROM HILLBERG SARAH', merchantName: null })).toBe(
+      'sales_or_other'
+    );
+  });
+
+  it('does NOT classify a real customer whose name contains "B Hill" as owner capital', () => {
+    // The recon exists to catch unrecorded off-platform sales — a payment from
+    // a real person with a colliding name must stay IN the income check. The
+    // rules therefore require the LLC name or WF's online-transfer form, not a
+    // bare name match. (Security review, bank-truth round 1.)
+    expect(classifyBankInflow({ name: 'PAYMENT FROM SARAH B HILL', merchantName: null })).toBe(
+      'sales_or_other'
+    );
+    expect(classifyBankInflow({ name: 'ZELLE FROM ROBERT B HILL JR', merchantName: null })).toBe(
+      'sales_or_other'
+    );
+    expect(classifyBankInflow({ name: 'ZELLE FROM HILL BRANDON', merchantName: null })).toBe(
+      'sales_or_other'
+    );
+  });
+
+  it('requires the vendor processor stamp for a refund — a person named like a distributor stays in the check', () => {
+    // Real distributor credits carry the FINTECH/FINTECHEFT processor stamp;
+    // a Zelle from a coincidentally-named person does not.
+    expect(classifyBankInflow({ name: 'ZELLE FROM JOHN SPECS', merchantName: null })).toBe(
+      'sales_or_other'
+    );
+    expect(
+      classifyBankInflow({ name: 'WIRE FROM BROWN DISTRIBUTING EVENTS CO', merchantName: null })
+    ).toBe('sales_or_other');
+  });
+});
 
 describe('explainDeposits', () => {
   it('explains deposits via the revenue proxy when NO payouts matched (payout gap)', () => {

--- a/src/lib/finance/__tests__/monthly-rollup.test.ts
+++ b/src/lib/finance/__tests__/monthly-rollup.test.ts
@@ -6,7 +6,39 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { isQbMaterial } from '@/lib/finance/monthly-rollup';
+import { isQbMaterial, computeAccrualBlock } from '@/lib/finance/monthly-rollup';
+
+describe('computeAccrualBlock', () => {
+  it('sums cost of SOLD items and reports coverage over item revenue', () => {
+    const r = computeAccrualBlock([
+      { priceCents: 10_000, costCents: 6_000 }, // covered
+      { priceCents: 5_000, costCents: 3_000 }, // covered
+      { priceCents: 5_000, costCents: null }, // no cost — uncovered
+    ]);
+    expect(r).toEqual({
+      cogsCents: 9_000,
+      coveredRevenueCents: 15_000,
+      coveragePct: 75, // 15k of 20k item revenue carries a cost
+    });
+    // Margin over the COVERED basket: (15k − 9k) / 15k = 40% — consumers must
+    // divide by coveredRevenueCents, never full revenue.
+    expect(((r!.coveredRevenueCents - r!.cogsCents) / r!.coveredRevenueCents) * 100).toBe(40);
+  });
+
+  it('returns null when no item carries a cost (nothing to estimate from)', () => {
+    expect(computeAccrualBlock([{ priceCents: 10_000, costCents: null }])).toBeNull();
+    expect(computeAccrualBlock([{ priceCents: 10_000, costCents: 0 }])).toBeNull();
+    expect(computeAccrualBlock([])).toBeNull();
+  });
+
+  it('rounds coverage to one decimal', () => {
+    const r = computeAccrualBlock([
+      { priceCents: 3_333, costCents: 1_000 },
+      { priceCents: 6_667, costCents: null },
+    ]);
+    expect(r!.coveragePct).toBe(33.3);
+  });
+});
 
 describe('isQbMaterial', () => {
   it('is FALSE when QB has only auto-posted payment_fees (2026 dormant month)', () => {

--- a/src/lib/finance/bank-income-recon.ts
+++ b/src/lib/finance/bank-income-recon.ts
@@ -7,8 +7,17 @@
  * do the month's production bank deposits line up with known Stripe revenue?
  *
  * It splits production bank inflows into:
+ *   - FINANCING (owner capital — Brian's injections) and vendor refunds, which
+ *     are excluded from the income check entirely (they are not sales), then
  *   - matched to a StripePayout (via the existing reconciliation), and
  *   - everything else, "explained" by the month's aggregate Stripe revenue.
+ *
+ * Owner capital: the operator confirmed (2026-07-10) that the recurring
+ * ~$15–17K/mo of non-sales deposits are equity injections from the co-owner
+ * (B Hill Entertainment LLC / Hill B transfers). Plaid mislabels these
+ * INCOME_CONTRACTOR, so classification is by descriptor, not PFC. They are
+ * financing — never income — and must not trip the "deposits exceed revenue"
+ * flag once recognized.
  *
  * ⚠️ StripePayout gap: there are no StripePayout rows before 2026-05-26, so
  * Jan–May 2026 deposits would look non-Stripe purely from the sync gap. The
@@ -22,6 +31,67 @@
 
 import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/database/client';
+import {
+  COGS_MERCHANT_RULES,
+  COGS_GROCERY_MERCHANT_RULES,
+} from './plaid-category-map';
+
+/**
+ * Owner-capital (financing) inflow descriptors, ANCHORED to the exact shapes
+ * observed on the real Wells Fargo feed (operator-confirmed 2026-07-10):
+ *
+ *   "ZELLE FROM B HILL ENTERTAINMENT LLC ON 05/15"
+ *   "ONLINE TRANSFER FROM B HILL ENTERTAINMENT LL"   (WF truncation)
+ *   "ONLINE TRANSFER FROM HILL B EVERYDAY CHECKIN"
+ *   "ONLINE TRANSFER FROM HILL B REF #IB0Y2NKXHG"
+ *
+ * Deliberately NOT a bare name match: a customer payment from a real person
+ * whose name happens to contain "B Hill" (e.g. "PAYMENT FROM SARAH B HILL")
+ * must stay in the income check — this recon exists to catch unrecorded
+ * off-platform sales, and a loose rule would silently launder one as
+ * financing. So each rule requires the funding-source context: either the
+ * LLC name, or WF's own online-transfer form of Brian's account ("HILL B" +
+ * word boundary). If Brian's descriptor drifts, the month re-flags as excess
+ * deposits (see the drift hint in the flag text) rather than misclassifying.
+ */
+export const OWNER_CAPITAL_RULES: readonly RegExp[] = [
+  /from\s+b\.?\s+hill\s+entertainment/i, // Zelle / transfer from the LLC
+  /online\s+transfer\s+from\s+hill\s+b\b/i, // WF transfer from Brian's checking ("HILL B EVERYDAY…", "HILL B REF #…")
+];
+
+/**
+ * The distributors' payment-processor stamp that appears on their ACH debits
+ * AND their refund credits ("Southern Glazer' FINTECHEFT 051826 …"). A vendor
+ * refund must carry it — a Zelle from a person whose name merely contains a
+ * distributor-like word (e.g. "ZELLE FROM JOHN SPECS") must NOT be excluded
+ * from the income check.
+ */
+const VENDOR_PROCESSOR_STAMP = /fintech/i;
+
+export type BankInflowClass = 'owner_capital' | 'vendor_refund' | 'sales_or_other';
+
+/**
+ * Classify a production bank INFLOW by descriptor. Owner capital and vendor
+ * refunds (credits back from a COGS merchant, e.g. a distributor rebate) are
+ * excluded from the income reconciliation — neither is sales revenue.
+ */
+export function classifyBankInflow(txn: {
+  name: string;
+  merchantName?: string | null;
+}): BankInflowClass {
+  const text = `${txn.merchantName ?? ''} ${txn.name ?? ''}`.trim();
+  for (const re of OWNER_CAPITAL_RULES) {
+    if (re.test(text)) return 'owner_capital';
+  }
+  // Vendor refund = COGS-merchant descriptor AND the processor stamp their
+  // real credits carry — never a bare name match.
+  if (VENDOR_PROCESSOR_STAMP.test(text)) {
+    for (const re of [...COGS_MERCHANT_RULES, ...COGS_GROCERY_MERCHANT_RULES]) {
+      if (re.test(text)) return 'vendor_refund';
+    }
+  }
+  return 'sales_or_other';
+}
 
 /** Share of deposits allowed to be unexplained before the month is "unreconciled". */
 const OTHER_INCOME_TOLERANCE = 0.15;
@@ -39,7 +109,18 @@ export interface BankIncomeReconInput {
 
 export interface BankIncomeRecon {
   hasProductionBank: boolean;
+  /** ALL production inflows for the month (incl. financing + refunds). */
   totalDepositsCents: number;
+  /** Owner-capital injections (financing) — excluded from the income check. */
+  ownerCapitalCents: number;
+  /**
+   * Per-transfer audit trail of what was classified owner capital, so a
+   * misclassified deposit is spot-checkable in the monthly email instead of
+   * disappearing into an aggregate.
+   */
+  ownerCapitalTxns: Array<{ name: string; cents: number }>;
+  /** Credits back from COGS merchants (distributor refunds) — excluded too. */
+  vendorRefundCents: number;
   matchedToStripeCents: number;
   stripeExplainedCents: number;
   otherIncomeCents: number;
@@ -108,6 +189,9 @@ export async function reconcileBankIncome(
     return {
       hasProductionBank: false,
       totalDepositsCents: 0,
+      ownerCapitalCents: 0,
+      ownerCapitalTxns: [],
+      vendorRefundCents: 0,
       matchedToStripeCents: 0,
       stripeExplainedCents: 0,
       otherIncomeCents: 0,
@@ -124,41 +208,72 @@ export async function reconcileBankIncome(
     amount: { lt: 0 },
   } satisfies Prisma.PlaidTransactionWhereInput;
 
-  const [allInflows, matchedInflows] = await Promise.all([
-    prisma.plaidTransaction.aggregate({ where: inflowWhere, _sum: { amount: true } }),
-    prisma.plaidTransaction.aggregate({
-      where: { ...inflowWhere, matchedStripePayoutId: { not: null } },
-      _sum: { amount: true },
-    }),
-  ]);
+  const inflows = await prisma.plaidTransaction.findMany({
+    where: inflowWhere,
+    select: { name: true, merchantName: true, amount: true, matchedStripePayoutId: true },
+  });
 
-  const totalDepositsCents = Math.abs(decToCents(allInflows._sum.amount));
-  const matchedToStripeCents = Math.abs(decToCents(matchedInflows._sum.amount));
+  // Classify each inflow; financing (owner capital) and vendor refunds are not
+  // sales, so they're removed BEFORE the deposits-vs-revenue check. The matched
+  // sum is computed over sales-class rows only, so a coincidental payout match
+  // on a financing row can't inflate the explainable amount.
+  let totalDepositsCents = 0;
+  let ownerCapitalCents = 0;
+  const ownerCapitalTxns: Array<{ name: string; cents: number }> = [];
+  let vendorRefundCents = 0;
+  let salesDepositsCents = 0;
+  let matchedToStripeCents = 0;
+  for (const t of inflows) {
+    const cents = Math.abs(decToCents(t.amount));
+    totalDepositsCents += cents;
+    const cls = classifyBankInflow(t);
+    if (cls === 'owner_capital') {
+      ownerCapitalCents += cents;
+      ownerCapitalTxns.push({ name: t.merchantName ?? t.name, cents });
+    } else if (cls === 'vendor_refund') {
+      vendorRefundCents += cents;
+    } else {
+      salesDepositsCents += cents;
+      if (t.matchedStripePayoutId) matchedToStripeCents += cents;
+    }
+  }
 
-  // Deposits up to known Stripe revenue are Stripe-explained even without a
-  // payout match (covers the Jan–May payout-sync gap).
+  // Sales-class deposits up to known Stripe revenue are Stripe-explained even
+  // without a payout match (covers the Jan–May payout-sync gap).
   const { stripeExplainedCents, otherIncomeCents, reconciled } = explainDeposits({
-    totalDepositsCents,
+    totalDepositsCents: salesDepositsCents,
     matchedToStripeCents,
     stripeRevenueProxyCents,
   });
 
-  if (totalDepositsCents > 0 && matchedToStripeCents === 0) {
+  if (salesDepositsCents > 0 && matchedToStripeCents === 0) {
     flags.push(
       'no deposits matched to Stripe payouts (payout-sync gap before 2026-05-26) — ' +
         'explained via aggregate Stripe revenue'
     );
   }
-  if (otherIncomeCents > totalDepositsCents * OTHER_INCOME_TOLERANCE) {
+  if (otherIncomeCents > salesDepositsCents * OTHER_INCOME_TOLERANCE) {
+    // Drift hint: if a month shows a large excess AND no owner-capital rows
+    // were recognized, the most likely cause is a changed transfer descriptor
+    // (a classifier miss), not a new anomaly — say so, so the operator checks
+    // OWNER_CAPITAL_RULES before hunting for missing orders.
+    const driftHint =
+      ownerCapitalCents === 0
+        ? ' (no owner-capital transfers recognized this month — if Brian did inject capital, the bank descriptor may have drifted; check OWNER_CAPITAL_RULES)'
+        : '';
     flags.push(
       `$${(otherIncomeCents / 100).toFixed(0)} of bank deposits exceed known Stripe ` +
-        'revenue — possible other income (owner injection / loan) or missing orders'
+        'revenue — possible other income (owner injection / loan) or missing orders' +
+        driftHint
     );
   }
 
   return {
     hasProductionBank: true,
     totalDepositsCents,
+    ownerCapitalCents,
+    ownerCapitalTxns,
+    vendorRefundCents,
     matchedToStripeCents,
     stripeExplainedCents,
     otherIncomeCents,

--- a/src/lib/finance/monthly-close-payload.ts
+++ b/src/lib/finance/monthly-close-payload.ts
@@ -59,6 +59,14 @@ interface RollupDataHealth {
   netIncomeReliable?: boolean;
   incomeReconciled?: boolean | null;
   otherIncomeCents?: number | null;
+  /** Owner-capital injections recognized as financing this month. */
+  ownerCapitalCents?: number | null;
+  /** Per-transfer audit trail of the owner-capital classification. */
+  ownerCapitalTxns?: Array<{ name: string; cents: number }>;
+  /** Distributor refund credits excluded from the income check. */
+  vendorRefundCents?: number | null;
+  /** Accrual-COGS estimate (cost of what SOLD) + revenue coverage. */
+  accrual?: { cogsCents: number; coveredRevenueCents: number; coveragePct: number } | null;
   flags?: string[];
 }
 
@@ -112,6 +120,16 @@ export interface MonthlyClosePayload {
   // Reconciliation status
   incomeReconciled: boolean | null;
   otherIncomeCents: number | null;
+  /** Owner-capital injections (financing) recognized this month. */
+  ownerCapitalCents: number | null;
+  /** Per-transfer audit trail (descriptor + amount) of the owner-capital rows. */
+  ownerCapitalTxns: Array<{ name: string; cents: number }>;
+  /** Distributor refund credits excluded from the income check. */
+  vendorRefundCents: number | null;
+  // Accrual view (estimate) — cost of what SOLD, vs the cash-basis COGS above.
+  accrualCogsCents: number | null;
+  accrualCoveragePct: number | null;
+  accrualGrossMarginPct: number | null;
   dashboardUrl: string;
 }
 
@@ -170,6 +188,19 @@ export function shapeMonthlyClosePayload(args: {
     flags: Array.isArray(health.flags) ? health.flags : [],
     incomeReconciled: health.incomeReconciled ?? null,
     otherIncomeCents: health.otherIncomeCents ?? null,
+    ownerCapitalCents: health.ownerCapitalCents ?? null,
+    ownerCapitalTxns: Array.isArray(health.ownerCapitalTxns) ? health.ownerCapitalTxns : [],
+    vendorRefundCents: health.vendorRefundCents ?? null,
+    accrualCogsCents: health.accrual?.cogsCents ?? null,
+    accrualCoveragePct: health.accrual?.coveragePct ?? null,
+    // Margin over the COVERED basket only — dividing a partial COGS into full
+    // revenue would overstate the margin.
+    accrualGrossMarginPct:
+      health.accrual && health.accrual.coveredRevenueCents > 0
+        ? ((health.accrual.coveredRevenueCents - health.accrual.cogsCents) /
+            health.accrual.coveredRevenueCents) *
+          100
+        : null,
     dashboardUrl: `${base}/admin/finance`,
   };
 }

--- a/src/lib/finance/monthly-rollup.ts
+++ b/src/lib/finance/monthly-rollup.ts
@@ -154,6 +154,32 @@ function decToCents(d: Prisma.Decimal | null | undefined): number {
   return Math.round(Number(d) * 100);
 }
 
+/**
+ * Pure accrual-COGS aggregation over a month's order items. Returns the cost
+ * of what SOLD (cents), the revenue of the items that carry a cost
+ * (`coveredRevenueCents` — consumers must compute margin over THIS, not full
+ * revenue, or partial coverage overstates the margin), and the coverage share.
+ * Null when no item carries a cost (nothing to estimate from).
+ */
+export function computeAccrualBlock(
+  rows: Array<{ priceCents: number; costCents: number | null }>
+): { cogsCents: number; coveredRevenueCents: number; coveragePct: number } | null {
+  let cogsCents = 0;
+  let itemRevenueCents = 0;
+  let coveredRevenueCents = 0;
+  for (const r of rows) {
+    itemRevenueCents += r.priceCents;
+    if (r.costCents !== null && r.costCents > 0) {
+      cogsCents += r.costCents;
+      coveredRevenueCents += r.priceCents;
+    }
+  }
+  if (cogsCents <= 0) return null;
+  const coveragePct =
+    itemRevenueCents > 0 ? (coveredRevenueCents / itemRevenueCents) * 100 : 0;
+  return { cogsCents, coveredRevenueCents, coveragePct: Math.round(coveragePct * 10) / 10 };
+}
+
 function emptySegments(): Record<Segment, SegmentStat> {
   const out = {} as Record<Segment, SegmentStat>;
   for (const s of SEGMENTS) out[s] = { revenueCents: 0, orderCount: 0 };
@@ -271,12 +297,20 @@ export async function computeMonthlyRollup(
     stripeRevenueProxyCents: revenueCents,
   });
 
-  // Per-order COGS from OrderItem cost (sparse, ~4% coverage) — only used as a
-  // fallback signal; QB inventory cogs is the primary cost source.
-  const orderItemCostCents = orders.reduce(
-    (s, o) => s + o.items.reduce((is, it) => is + decToCents(it.totalCost), 0),
-    0
+  // ACCRUAL COGS: cost of what actually SOLD this month, from per-item cost
+  // snapshots (OrderItem.totalCost ← ProductVariant.costPerUnit at order time,
+  // or the margins backfill). Unlike the bank/QB cash-basis COGS (alcohol
+  // PURCHASED this month), this matches cost to revenue — the true product
+  // margin. Order-table era only (Shopify archive line items carry no cost).
+  const accrual = computeAccrualBlock(
+    orders.flatMap((o) =>
+      o.items.map((it) => ({
+        priceCents: decToCents(it.totalPrice),
+        costCents: it.totalCost === null ? null : decToCents(it.totalCost),
+      }))
+    )
   );
+  const orderItemCostCents = accrual?.cogsCents ?? 0;
 
   const effectiveCogs = cogsCents ?? (orderItemCostCents > 0 ? orderItemCostCents : null);
   const grossProfitCents = effectiveCogs !== null ? revenueCents - effectiveCogs : null;
@@ -295,6 +329,7 @@ export async function computeMonthlyRollup(
     bankExpenseTotalCents,
     bankIncome,
     orderItemCostCents,
+    accrual,
     orderCount: orders.length,
     archiveCount: archiveDeduped.length,
   });
@@ -477,6 +512,8 @@ interface HealthInput {
   bankExpenseTotalCents: number;
   bankIncome: BankIncomeRecon;
   orderItemCostCents: number;
+  /** Accrual-COGS estimate (cost of what SOLD) + its revenue coverage, or null. */
+  accrual: { cogsCents: number; coveredRevenueCents: number; coveragePct: number } | null;
   orderCount: number;
   archiveCount: number;
 }
@@ -558,6 +595,16 @@ function buildDataHealth(h: HealthInput): Record<string, unknown> {
     netIncomeReliable,
     incomeReconciled: h.bankIncome.hasProductionBank ? h.bankIncome.reconciled : null,
     otherIncomeCents: h.bankIncome.hasProductionBank ? h.bankIncome.otherIncomeCents : null,
+    // Owner-capital injections (financing) recognized this month — surfaced so
+    // the monthly close can report them as financing, never as income. The
+    // per-transfer list is the audit trail: a misclassified deposit shows up
+    // in the email instead of vanishing into an aggregate.
+    ownerCapitalCents: h.bankIncome.hasProductionBank ? h.bankIncome.ownerCapitalCents : null,
+    ownerCapitalTxns: h.bankIncome.hasProductionBank ? h.bankIncome.ownerCapitalTxns : [],
+    vendorRefundCents: h.bankIncome.hasProductionBank ? h.bankIncome.vendorRefundCents : null,
+    // Accrual-COGS estimate (cost of what SOLD, from per-item cost snapshots) —
+    // the true product-margin view alongside the lumpy cash-basis COGS.
+    accrual: h.accrual,
     flags,
   };
 }

--- a/src/lib/finance/plaid-client.ts
+++ b/src/lib/finance/plaid-client.ts
@@ -130,6 +130,15 @@ function getRedirectUri(): string | undefined {
 }
 
 /**
+ * How much transaction history to request from the institution. Plaid's
+ * default is 90 days — which is why the first Wells Fargo sync only reached
+ * back ~3 months. 730 days (the maximum) gives the 2-year picture the
+ * bank-as-source-of-truth P&L needs. Fixed per-Item at link time, so existing
+ * items need the update-mode flow below to extend.
+ */
+const DAYS_REQUESTED = 730;
+
+/**
  * Create a link_token the browser SDK exchanges for a public_token.
  * Only requests `Transactions` since that's all the sync path uses.
  */
@@ -143,8 +152,34 @@ export async function createLinkToken(userId: string): Promise<string> {
     country_codes: [CountryCode.Us],
     language: 'en',
     webhook: getWebhookUrl(),
+    transactions: { days_requested: DAYS_REQUESTED },
     // OAuth banks (Wells Fargo) require a registered redirect_uri; omit it
     // entirely for the non-OAuth sandbox bank so that flow is unchanged.
+    ...(redirectUri ? { redirect_uri: redirectUri } : {}),
+  });
+  return response.data.link_token;
+}
+
+/**
+ * Create an UPDATE-MODE link_token for an already-linked Item, requesting the
+ * full 730 days of history. The operator re-authenticates through Link (quick
+ * OAuth round-trip for Wells Fargo); Plaid then backfills the deeper history
+ * and fires HISTORICAL_UPDATE webhooks, which the webhook handler turns into
+ * syncs. No token exchange happens on success — the Item is unchanged.
+ *
+ * Update-mode rule: pass `access_token`, do NOT pass `products`.
+ */
+export async function createUpdateLinkToken(accessToken: string): Promise<string> {
+  const client = createClient();
+  const redirectUri = getRedirectUri();
+  const response = await client.linkTokenCreate({
+    user: { client_user_id: 'ops-extend-history' },
+    client_name: 'Party On Delivery',
+    country_codes: [CountryCode.Us],
+    language: 'en',
+    access_token: accessToken,
+    webhook: getWebhookUrl(),
+    transactions: { days_requested: DAYS_REQUESTED },
     ...(redirectUri ? { redirect_uri: redirectUri } : {}),
   });
   return response.data.link_token;


### PR DESCRIPTION
## What

Operator confirmed the Wells Fargo account is the company's single source of truth ("the bank is the book"), QB is PartyOn-only, Brian's injections are owner capital, and PeopleFund is loan repayment. Three changes:

### 1. Financing classification (`bank-income-recon.ts`)
New `classifyBankInflow()`: **owner capital** (anchored to the real funding-source descriptors — `FROM B HILL ENTERTAINMENT…` / `ONLINE TRANSFER FROM HILL B…`), **vendor refunds** (COGS-merchant match AND the `FINTECH` processor stamp), and **sales/other**. Financing + refunds are excluded from the deposits-vs-revenue check → owner-funded months (May/June 2026, ~$15–17K/mo from Brian) stop tripping the deposit-anomaly flag and flip `netIncomeReliable`. Includes a **per-transfer audit trail** in the monthly email (itemized owner-capital transfers), a **descriptor-drift hint** when a deposit excess appears with zero recognized transfers, and payout-match sums computed over sales-class rows only.

### 2. 24-month bank history (Plaid)
Link tokens now request `days_requested: 730` (Plaid's default 90d is why history only reaches 2026-04). New **update-mode** token + "Extend history to 24 months" button on `/admin/finance/connect-bank`; success skips token exchange and kicks the new `POST /api/admin/finance/plaid/sync` (requireOpsAuth). Deeper history backfills automatically via the existing HISTORICAL_UPDATE webhook. Mode survives the WF OAuth redirect; abandoned flows can't hijack a later connect (explicit mode reset + `onExit` cleanup).

### 3. Accrual COGS (true product margin)
Pure `computeAccrualBlock()` in the rollup: cost of what **sold** (from per-item cost snapshots) + covered revenue + coverage %. The monthly-close email shows "Product margin (accrual est.)" computed **over the covered basket only**, so partial coverage can't overstate margin. Independent of OpEx → honesty gate intact.

## Security review (2 rounds)
Round 1 found 1 HIGH (owner-capital regex could sweep a real customer named "…B Hill…" into financing — silently laundering an unrecorded off-platform sale) + 3 MEDIUMs (loose vendor-refund match, descriptor-drift blindness, stale extend-mode hijack). **All fixed**; re-review independently verified every fix, re-ran all gates, and returned **SAFE TO MERGE**.

## Verification
- 712 tests pass (incl. adversarial name-collision cases, fintech-stamp requirement, accrual covered-basket math, email itemization), tsc 0 errors, lint clean
- Owner-capital regexes probed against all 4 real WF descriptors (match) and 7 collision variants (no match)

## After merge
Prod: rebuild rollups (May/June flip reliable), then Allan clicks "Extend history" once (quick WF re-login) → 24 months of bank history backfills over the following hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)