### PR TITLE
fix(finance): make connect-bank auto-open survive Plaid handler re-init

### DIFF
--- a/src/app/admin/finance/connect-bank/page.tsx
+++ b/src/app/admin/finance/connect-bank/page.tsx
@@ -109,6 +109,7 @@ export default function ConnectBankPage(): ReactElement {
 
   const onSuccess = useCallback(
     async (publicToken: string, metadata: PlaidLinkOnSuccessMetadata) => {
+      setPendingOpen(false);
       setExchanging(true);
       try {
         if (mode === 'extend') {
@@ -149,10 +150,22 @@ export default function ConnectBankPage(): ReactElement {
     setPendingOpen(false);
   }, []);
 
+  // Clear the pending-open intent only when Link actually OPENS. The auto-open
+  // effect below can fire against the PREVIOUS handler while react-plaid-link
+  // is still re-initializing for a just-swapped token — that stale open() is a
+  // silent no-op, and eagerly consuming pendingOpen there left the flow dead
+  // (button click → nothing happens). Keeping the intent until the OPEN event
+  // makes the effect self-healing: it simply fires again when the new handler's
+  // ready/open land.
+  const onEvent = useCallback((eventName: string) => {
+    if (eventName === 'OPEN') setPendingOpen(false);
+  }, []);
+
   const { open, ready } = usePlaidLink({
     token: linkToken,
     onSuccess,
     onExit,
+    onEvent,
     receivedRedirectUri,
   });
 
@@ -162,11 +175,9 @@ export default function ConnectBankPage(): ReactElement {
   }, [receivedRedirectUri, ready, open]);
 
   // Open Link once it's ready after a button click swapped in a fresh token.
+  // Deliberately does NOT clear pendingOpen — see onEvent above.
   useEffect(() => {
-    if (pendingOpen && ready) {
-      setPendingOpen(false);
-      open();
-    }
+    if (pendingOpen && ready) open();
   }, [pendingOpen, ready, open]);
 
   async function startExtendHistory(): Promise<void> {


### PR DESCRIPTION
The "Extend history to 24 months" button silently did nothing: the auto-open effect fired against the previous Plaid Link handler during re-init (stale `open()` = silent no-op) and eagerly consumed the pending-open intent. Diagnosed live on prod via in-page instrumentation (token fetch succeeded, mode flipped, no modal; server side verified fine).

Fix: hold the pending-open intent until Link actually emits `OPEN` (new `onEvent` handler; also cleared on success/exit), making the auto-open effect self-healing across handler re-initialization.

UI-only change to the admin connect page; no server/money-math code touched. tsc 0, lint clean, 712 tests pass. The extend flow itself was completed manually on prod today (WF re-auth done, historical backfill in progress) — this fix is for every future use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)