### PR TITLE
feat(finance): WF relink cutover — retire duplicate Plaid item after fresh 730d connect

### DIFF
--- a/src/app/api/admin/finance/plaid/cutover/route.ts
+++ b/src/app/api/admin/finance/plaid/cutover/route.ts
@@ -1,0 +1,50 @@
+/**
+ * POST /api/admin/finance/plaid/cutover
+ *
+ * Body: `{ keepId: string, apply?: boolean }`
+ *
+ * Retires duplicate production Plaid Items for the same institution as
+ * `keepId` — used after re-linking a bank as a FRESH Item (e.g. to get the
+ * 730-day history window that update mode failed to deliver). Refuses to
+ * remove any duplicate the keeper does not fully cover (date range + row
+ * count), resets Stripe-payout matches off the removed rows, deletes them,
+ * removes the Item at Plaid (stops billing), then re-categorizes and
+ * re-reconciles the keeper. Defaults to DRY-RUN; pass `apply: true` to write.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdminRole } from '@/lib/auth/ops-session';
+import { cutoverDuplicateItems } from '@/lib/finance/plaid-sync-service';
+
+export const maxDuration = 120;
+
+interface CutoverBody {
+  keepId?: string;
+  apply?: boolean;
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    // Deleting production bank history is the most destructive finance action
+    // in the codebase — admin role required, not any ops session.
+    const auth = await requireAdminRole();
+    if (auth instanceof NextResponse) return auth;
+
+    const body = (await request.json().catch(() => ({}))) as CutoverBody;
+    if (!body.keepId || typeof body.keepId !== 'string') {
+      return NextResponse.json(
+        { success: false, error: 'keepId is required' },
+        { status: 400 }
+      );
+    }
+
+    const result = await cutoverDuplicateItems(body.keepId, {
+      dryRun: body.apply !== true,
+    });
+    return NextResponse.json({ success: true, data: result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('[Plaid Cutover] Error:', message);
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/webhooks/plaid/route.ts
+++ b/src/app/api/webhooks/plaid/route.ts
@@ -59,12 +59,16 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       return NextResponse.json({ success: true, acked: true });
     }
 
+    // Same status gate as the daily cron (syncAllItems): items mid-cutover
+    // ('retiring') or awaiting a Plaid-removal retry ('removal_failed') must
+    // NOT be synced — a webhook landing in that window would resurrect the
+    // rows the cutover just deleted.
     const item = await prisma.plaidItem.findFirst({
-      where: { itemId },
+      where: { itemId, status: { in: ['active', 'error'] } },
       select: { id: true },
     });
     if (!item) {
-      console.warn('[plaid-webhook] unknown item_id', itemId);
+      console.warn('[plaid-webhook] unknown or non-syncable item_id', itemId);
       return NextResponse.json({ success: true, acked: true, unknownItem: true });
     }
 

--- a/src/lib/finance/__tests__/plaid-cutover.test.ts
+++ b/src/lib/finance/__tests__/plaid-cutover.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Relink-cutover coverage guard: the keeper Item must fully cover the old
+ * Item's history before the old one may be deleted — a keeper still waiting
+ * on its HISTORICAL_UPDATE backfill must be refused, or the cutover would
+ * throw away bank history.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { cutoverCoverageOk } from '@/lib/finance/plaid-sync-service';
+
+describe('cutoverCoverageOk', () => {
+  const old = { minDate: '2026-04-10', maxDate: '2026-07-13', txnCount: 346 };
+
+  it('accepts a keeper whose history is a superset (backfill landed)', () => {
+    const r = cutoverCoverageOk({
+      keep: { minDate: '2024-07-14', maxDate: '2026-07-13', txnCount: 2100 },
+      old,
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it('refuses a keeper still on its initial ~90d pull (backfill pending)', () => {
+    // Fresh item connected today: initial pull only reaches back ~90 days —
+    // 4 days SHORT of the old item's start. Deleting the old item now would
+    // lose those days.
+    const r = cutoverCoverageOk({
+      keep: { minDate: '2026-04-14', maxDate: '2026-07-13', txnCount: 340 },
+      old,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain('backfill not complete');
+  });
+
+  it('allows one day of slack at the recent end (sync timing skew)', () => {
+    const r = cutoverCoverageOk({
+      keep: { minDate: '2024-07-14', maxDate: '2026-07-12', txnCount: 2100 },
+      old, // old synced this morning (07-13); keeper minutes behind
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it('refuses a keeper more than a day stale at the recent end', () => {
+    const r = cutoverCoverageOk({
+      keep: { minDate: '2024-07-14', maxDate: '2026-07-10', txnCount: 2100 },
+      old,
+    });
+    expect(r.ok).toBe(false);
+  });
+
+  it('refuses a keeper with too few rows to be a superset', () => {
+    const r = cutoverCoverageOk({
+      keep: { minDate: '2024-07-14', maxDate: '2026-07-13', txnCount: 200 },
+      old,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain('too few');
+  });
+
+  it('refuses when the keeper has no transactions at all (sentinel range)', () => {
+    const r = cutoverCoverageOk({
+      keep: { minDate: '9999-12-31', maxDate: '0000-01-01', txnCount: 0 },
+      old,
+    });
+    expect(r.ok).toBe(false);
+  });
+});

--- a/src/lib/finance/plaid-client.ts
+++ b/src/lib/finance/plaid-client.ts
@@ -186,6 +186,15 @@ export async function createUpdateLinkToken(accessToken: string): Promise<string
 }
 
 /**
+ * Remove an Item at Plaid (invalidates the access token and stops billing).
+ * Used by the relink cutover after a replacement Item is verified.
+ */
+export async function removeItem(accessToken: string): Promise<void> {
+  const client = createClient();
+  await client.itemRemove({ access_token: accessToken });
+}
+
+/**
  * Update the webhook URL on an already-linked Item. Used for the one-shot
  * backfill that wires the webhook on every existing PlaidItem (which were
  * created before we passed `webhook` into link_token).

--- a/src/lib/finance/plaid-sync-service.ts
+++ b/src/lib/finance/plaid-sync-service.ts
@@ -533,3 +533,230 @@ export async function plaidReconciliationSummary(
     rows,
   };
 }
+
+// ---------------------------------------------------------------------------
+// Relink cutover (replace a duplicate Item for the same institution)
+// ---------------------------------------------------------------------------
+
+export interface CutoverCoverageInput {
+  keep: { minDate: string; maxDate: string; txnCount: number };
+  old: { minDate: string; maxDate: string; txnCount: number };
+}
+
+/**
+ * Guard for the relink cutover: the KEEP item must cover the OLD item's date
+ * range before the old one may be deleted. Used when a bank is re-linked as a
+ * fresh Item (e.g. to obtain a larger days_requested history window that
+ * update mode failed to deliver): the new Item's initial pull only reaches
+ * ~90 days, so the cutover must wait until its HISTORICAL_UPDATE backfill has
+ * at least reached the old Item's earliest transaction. maxDate gets one day
+ * of slack (the old item may have synced this morning; the new one minutes
+ * later). Count sanity: keep must have ≥90% of old's rows in the overlap era —
+ * a keeper missing whole weeks means Plaid is still backfilling.
+ */
+export function cutoverCoverageOk(c: CutoverCoverageInput): { ok: boolean; reason: string } {
+  if (c.keep.minDate > c.old.minDate) {
+    return {
+      ok: false,
+      reason: `keep item history starts ${c.keep.minDate}, after old item's ${c.old.minDate} — historical backfill not complete yet`,
+    };
+  }
+  const oldMax = new Date(c.old.maxDate);
+  oldMax.setUTCDate(oldMax.getUTCDate() - 1);
+  if (c.keep.maxDate < oldMax.toISOString().slice(0, 10)) {
+    return {
+      ok: false,
+      reason: `keep item history ends ${c.keep.maxDate}, more than a day before old item's ${c.old.maxDate}`,
+    };
+  }
+  if (c.keep.txnCount < c.old.txnCount * 0.9) {
+    return {
+      ok: false,
+      reason: `keep item has ${c.keep.txnCount} txns vs old item's ${c.old.txnCount} — too few to be a superset`,
+    };
+  }
+  return { ok: true, reason: 'keep item covers the old item' };
+}
+
+export interface CutoverResult {
+  dryRun: boolean;
+  keptId: string;
+  removed: Array<{
+    id: string;
+    institutionName: string | null;
+    txnCount: number;
+    pendingDeleted: number;
+    payoutMatchesReset: number;
+    /** Non-null = Plaid /item/remove failed. The DB row is RETAINED with
+     * status 'removal_failed' (access token kept) so removal can be retried —
+     * only its transactions/accounts/cursor were deleted. */
+    plaidRemoveError: string | null;
+  }>;
+  refused: Array<{ id: string; reason: string }>;
+  recategorized: number;
+  reconciled: { inflowsMatched: number; outflowsMatched: number } | null;
+}
+
+const CUTOVER_CHUNK = 500; // bound in-clause sizes on large histories
+
+/**
+ * Retire duplicate production Items for the same institution as `keepId`,
+ * keeping only the keeper. For each duplicate the keeper fully COVERS (see
+ * cutoverCoverageOk): flip it to 'retiring' FIRST so the daily sync/reconcile
+ * cron (status in active/error) stops touching it mid-cutover, then —
+ * atomically per item — reset StripePayout matches pointing at its rows and
+ * delete its transactions, accounts, and sync cursor. Pending rows are deleted
+ * knowingly: the keeper surfaces the same unsettled charges from its own feed.
+ * The Item is then removed at Plaid (stops billing); ONLY on success is the DB
+ * row deleted — on failure it is kept (status 'removal_failed', access token
+ * retained) so removal can be retried rather than orphaning billing at Plaid.
+ * Finally the keeper is re-categorized + re-reconciled. Dry-run reports the
+ * plan without writing.
+ */
+export async function cutoverDuplicateItems(
+  keepId: string,
+  opts: { dryRun?: boolean } = {}
+): Promise<CutoverResult> {
+  const dryRun = opts.dryRun !== false;
+  const keep = await prisma.plaidItem.findUnique({
+    where: { id: keepId },
+    select: { id: true, environment: true, institutionId: true },
+  });
+  if (!keep || keep.environment !== 'production') {
+    throw new Error('keepId must be an existing PRODUCTION PlaidItem');
+  }
+  // A null institutionId would match OTHER null-institution items below
+  // (Prisma null equality) — potentially an unrelated bank. Refuse outright.
+  if (!keep.institutionId) {
+    throw new Error(
+      'keep item has no institutionId — cannot safely identify duplicates of the same bank; refusing'
+    );
+  }
+
+  const others = await prisma.plaidItem.findMany({
+    where: {
+      id: { not: keepId },
+      environment: 'production',
+      institutionId: keep.institutionId,
+    },
+    select: { id: true, institutionName: true, accessToken: true },
+  });
+
+  const rangeOf = async (itemId: string) => {
+    const [min, max, count] = await Promise.all([
+      prisma.plaidTransaction.findFirst({ where: { plaidItemId: itemId, pending: false }, orderBy: { date: 'asc' }, select: { date: true } }),
+      prisma.plaidTransaction.findFirst({ where: { plaidItemId: itemId, pending: false }, orderBy: { date: 'desc' }, select: { date: true } }),
+      prisma.plaidTransaction.count({ where: { plaidItemId: itemId, pending: false } }),
+    ]);
+    return {
+      minDate: min?.date.toISOString().slice(0, 10) ?? '9999-12-31',
+      maxDate: max?.date.toISOString().slice(0, 10) ?? '0000-01-01',
+      txnCount: count,
+    };
+  };
+
+  const keepRange = await rangeOf(keepId);
+  const result: CutoverResult = {
+    dryRun,
+    keptId: keepId,
+    removed: [],
+    refused: [],
+    recategorized: 0,
+    reconciled: null,
+  };
+
+  for (const other of others) {
+    const oldRange = await rangeOf(other.id);
+    const coverage = cutoverCoverageOk({ keep: keepRange, old: oldRange });
+    if (!coverage.ok) {
+      result.refused.push({ id: other.id, reason: coverage.reason });
+      continue;
+    }
+
+    // Payout matches pointing at the old item's transactions must be reset so
+    // reconcileItem can re-match them against the keeper's rows.
+    const oldTxnIds = (
+      await prisma.plaidTransaction.findMany({
+        where: { plaidItemId: other.id },
+        select: { id: true },
+      })
+    ).map((t) => t.id);
+    const payoutMatches = await prisma.stripePayout.count({
+      where: { matchedPlaidTxId: { in: oldTxnIds } },
+    });
+    const pendingDeleted = await prisma.plaidTransaction.count({
+      where: { plaidItemId: other.id, pending: true },
+    });
+
+    let plaidRemoveError: string | null = null;
+    if (!dryRun) {
+      // 1. Take the item out of the cron's reach BEFORE mutating, closing the
+      // window where a concurrent sync/reconcile could re-match a payout to a
+      // row this function is about to delete.
+      await prisma.plaidItem.update({
+        where: { id: other.id },
+        data: { status: 'retiring' },
+      });
+
+      // 2. Atomic per-item cleanup: payout resets (chunked to bound the
+      // in-clause) + row deletes in ONE transaction, so a crash can't leave a
+      // payout pointing at a deleted transaction.
+      const chunkedResets = [];
+      for (let i = 0; i < oldTxnIds.length; i += CUTOVER_CHUNK) {
+        chunkedResets.push(
+          prisma.stripePayout.updateMany({
+            where: { matchedPlaidTxId: { in: oldTxnIds.slice(i, i + CUTOVER_CHUNK) } },
+            data: { matchedPlaidTxId: null },
+          })
+        );
+      }
+      await prisma.$transaction([
+        ...chunkedResets,
+        prisma.plaidTransaction.deleteMany({ where: { plaidItemId: other.id } }),
+        prisma.plaidAccount.deleteMany({ where: { plaidItemId: other.id } }),
+        prisma.plaidSyncCursor.deleteMany({ where: { plaidItemId: other.id } }),
+      ]);
+
+      // 3. Remove at Plaid; only delete the DB row on success. On failure the
+      // row (and its access token) survives as 'removal_failed' for a retry —
+      // deleting it would orphan the Item at Plaid with no way to stop billing.
+      try {
+        const { removeItem } = await import('./plaid-client');
+        await removeItem(other.accessToken);
+        await prisma.plaidItem.delete({ where: { id: other.id } });
+      } catch (err) {
+        plaidRemoveError = err instanceof Error ? err.message : String(err);
+        await prisma.plaidItem.update({
+          where: { id: other.id },
+          data: { status: 'removal_failed', lastError: plaidRemoveError },
+        });
+      }
+    }
+
+    result.removed.push({
+      id: other.id,
+      institutionName: other.institutionName,
+      txnCount: oldRange.txnCount,
+      pendingDeleted,
+      payoutMatchesReset: payoutMatches,
+      plaidRemoveError,
+    });
+  }
+
+  if (!dryRun && result.removed.length > 0) {
+    // Re-stamp categories on any keeper rows not yet categorized, then
+    // re-match payouts against the keeper's transactions.
+    for (;;) {
+      const res = await categorizeBankOutflows(keepId);
+      result.recategorized += res.categorized;
+      if (res.categorized < 1000) break;
+    }
+    const recon = await reconcileItem(keepId);
+    result.reconciled = {
+      inflowsMatched: recon.inflowsMatched,
+      outflowsMatched: recon.outflowsMatched,
+    };
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Why

The update-mode `days_requested` extension (PR #234) never took effect at Plaid — 2 days after a successful re-auth, history is still capped at the original ~90-day window and no HISTORICAL_UPDATE arrived. The guaranteed path to 24-month history is re-linking Wells Fargo as a **fresh item** (fresh link tokens request 730 days since #234), then retiring the old duplicate so nothing double-counts or double-bills.

## What

- `plaid-client`: `removeItem()` (Plaid `/item/remove` — invalidates token, stops billing)
- `plaid-sync-service`: `cutoverDuplicateItems(keepId, {dryRun})` — for each other production item of the **same institution**:
  - refuses unless the keeper **fully covers** it (pure `cutoverCoverageOk` guard: keeper minDate ≤ old minDate, maxDate within 1 day, ≥90% row count — a keeper still waiting on its historical backfill is refused, so history can never be lost)
  - flips the old item to `'retiring'` first (cron + webhook both skip non-active/error items — no mid-cutover race)
  - atomically (one `$transaction`, chunked in-clauses): resets `StripePayout.matchedPlaidTxId` off the old rows, deletes its transactions/accounts/sync-cursor
  - removes the item at Plaid; **only on success** deletes the DB row — on failure it's kept as `'removal_failed'` (token retained, visible on the health endpoint) for retry
  - then re-categorizes + re-reconciles the keeper
- New `POST /api/admin/finance/plaid/cutover` — **requireAdminRole**, dry-run by default (`apply: true` to write)
- Webhook handler now gates on `status in (active, error)` like the cron — a stray webhook can't resurrect deleted rows

## Security review (2 rounds)

Round 1: 2 HIGH (null-institutionId could match an unrelated bank; Plaid-removal failure destroyed the retry credential) + 3 MEDIUM + 2 LOW — all fixed. Round 2 independently confirmed every fix and found one residual (webhook status gate) — fixed above. Known accepted tradeoffs, documented in code: pending rows deleted knowingly (reported via `pendingDeleted`); re-reconcile is best-effort (operator spot-checks unmatched payouts after apply).

## Verification

736 tests pass (6 new guard tests), tsc 0, lint clean. Orchestration path has no mocked-DB integration test (noted gap) — mitigated by dry-run-by-default + admin gate + operator dry-run review before apply.

## Operator flow after deploy

1. Allan: connect-bank → "Link another bank" → Wells Fargo login (creates the fresh 730d item)
2. Wait for HISTORICAL_UPDATE to backfill the new item past 2026-04-10 (hours)
3. Dry-run cutover → review plan → apply → rebuild rollups → 2-year P&L

🤖 Generated with [Claude Code](https://claude.com/claude-code)