### PR TITLE
Bachelorette twin + /austin-concierge party-type gate + sheet smoke test

### DIFF
--- a/scripts/test-pod-leads-sheet.ts
+++ b/scripts/test-pod-leads-sheet.ts
@@ -1,0 +1,158 @@
+/**
+ * scripts/test-pod-leads-sheet.ts
+ *
+ * One-off smoke test for the "POD Leads" tab of the PPC Booking App
+ * Time Slots Google Sheet:
+ *
+ *   1. Read what's on row 1 to see if the header row already exists.
+ *   2. If row 1 is empty (or doesn't match our schema), write the
+ *      canonical 14-column header row.
+ *   3. Append one test lead as row N so the founder can visually
+ *      confirm the write path is live.
+ *
+ * Run:   npx tsx scripts/test-pod-leads-sheet.ts
+ *
+ * Requires the same 3 env vars the runtime API uses:
+ *   POD_LEADS_SHEET_ID
+ *   PREMIER_SHEET_SERVICE_ACCOUNT_EMAIL
+ *   PREMIER_SHEET_SERVICE_ACCOUNT_KEY
+ */
+
+// Load .env.local.tmp so the script can run outside Vercel with the
+// same env vars the API uses in prod.
+import { config as loadDotenv } from 'dotenv';
+loadDotenv({ path: '.env.local.tmp' });
+
+import { google } from 'googleapis';
+import {
+  appendLeadToPodLeadsSheet,
+  formatCentralTimestamp,
+} from '../src/lib/premier/pod-leads-sheet';
+
+const SHEETS_SCOPES = ['https://www.googleapis.com/auth/spreadsheets'];
+const TAB_NAME = 'POD Leads';
+
+const HEADER_ROW = [
+  'Submitted (CT)',
+  'Source',
+  'First',
+  'Last',
+  'Email',
+  'Phone',
+  'Headcount',
+  'Arrival',
+  'Departure',
+  'Party Type',
+  'Budget / Person',
+  'Activities',
+  'Notes',
+  'Lead URL',
+];
+
+async function main(): Promise<void> {
+  const email = process.env.PREMIER_SHEET_SERVICE_ACCOUNT_EMAIL;
+  const privateKey = process.env.PREMIER_SHEET_SERVICE_ACCOUNT_KEY;
+  const sheetId = process.env.POD_LEADS_SHEET_ID;
+
+  if (!email || !privateKey || !sheetId) {
+    console.error('Missing env vars. Need:');
+    console.error('  POD_LEADS_SHEET_ID');
+    console.error('  PREMIER_SHEET_SERVICE_ACCOUNT_EMAIL');
+    console.error('  PREMIER_SHEET_SERVICE_ACCOUNT_KEY');
+    process.exit(1);
+  }
+
+  console.log(`[test] Sheet ID: ${sheetId}`);
+  console.log(`[test] Service account: ${email}`);
+  console.log(`[test] Target tab: ${TAB_NAME}`);
+  console.log('');
+
+  // ─── Auth ─────────────────────────────────────────────────────
+  const auth = new google.auth.JWT({
+    email,
+    key: privateKey.replace(/\\n/g, '\n'),
+    scopes: SHEETS_SCOPES,
+  });
+  const sheets = google.sheets({ version: 'v4', auth });
+
+  // ─── Step 1: Read row 1 ──────────────────────────────────────
+  console.log('[test] Reading current row 1 to check for headers…');
+  let row1: string[] = [];
+  try {
+    const res = await sheets.spreadsheets.values.get({
+      spreadsheetId: sheetId,
+      range: `'${TAB_NAME}'!A1:N1`,
+      valueRenderOption: 'FORMATTED_VALUE',
+    });
+    row1 = (res.data.values?.[0] as string[]) ?? [];
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error('[test] ✗ Could not read row 1:', msg);
+    if (msg.includes('does not have permission') || msg.includes('caller does not have')) {
+      console.error(
+        '\nFIX: share the sheet with the service account email as Editor:\n' +
+          `      ${email}\n`,
+      );
+    }
+    process.exit(1);
+  }
+  console.log(`[test] Row 1 currently has ${row1.length} cells.`);
+
+  // ─── Step 2: Write headers if missing ────────────────────────
+  const looksLikeOurHeaders =
+    row1.length >= 4 &&
+    row1[0]?.toLowerCase().includes('submitted') &&
+    row1.includes('Email');
+
+  if (!looksLikeOurHeaders) {
+    console.log('[test] No header row (or non-matching). Writing canonical headers…');
+    try {
+      await sheets.spreadsheets.values.update({
+        spreadsheetId: sheetId,
+        range: `'${TAB_NAME}'!A1`,
+        valueInputOption: 'USER_ENTERED',
+        requestBody: { values: [HEADER_ROW] },
+      });
+      console.log('[test] ✓ Headers written.');
+    } catch (err) {
+      console.error('[test] ✗ Header write failed:', err);
+      process.exit(1);
+    }
+  } else {
+    console.log('[test] ✓ Header row already present — leaving it alone.');
+  }
+
+  // ─── Step 3: Append a test lead ──────────────────────────────
+  console.log('[test] Appending a test lead row…');
+  const ok = await appendLeadToPodLeadsSheet({
+    submittedAt: formatCentralTimestamp(new Date()),
+    source: 'premier-concierge-bachelor · SHEET SMOKE TEST',
+    firstName: 'Test',
+    lastName: 'Concierge',
+    email: 'test-concierge@partyondelivery.com',
+    phone: '(737) 555-0100',
+    headcount: '12',
+    arrivalDate: '2026-08-15',
+    departureDate: '2026-08-17',
+    partyType: 'bachelor',
+    budgetPerPerson: '$600/pp',
+    activities: 'boat-rental, drink-delivery, golf-brewery-tour, gun-range',
+    notes: 'Delete me — this is a smoke test row written by scripts/test-pod-leads-sheet.ts.',
+    leadUrl: 'https://partyondelivery.com/admin/brians-stuff?tab=leads',
+  });
+
+  if (ok) {
+    console.log('[test] ✓ Test lead appended. Refresh the sheet to see it.');
+    console.log(
+      `[test]   https://docs.google.com/spreadsheets/d/${sheetId}/edit?gid=114122017`,
+    );
+  } else {
+    console.error('[test] ✗ appendLeadToPodLeadsSheet returned false. See earlier logs.');
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/austin-bachelor-concierge/page.tsx
+++ b/src/app/austin-bachelor-concierge/page.tsx
@@ -36,5 +36,5 @@ export const metadata: Metadata = {
 };
 
 export default function AustinBachelorConciergePage() {
-  return <ConciergeLandingClient />;
+  return <ConciergeLandingClient variant="bachelor" />;
 }

--- a/src/app/austin-bachelorette-concierge/page.tsx
+++ b/src/app/austin-bachelorette-concierge/page.tsx
@@ -1,0 +1,33 @@
+/**
+ * /austin-bachelorette-concierge
+ *
+ * Premier Concierge · Austin Bachelorette Party Planning landing page.
+ *
+ * Twin of /austin-bachelor-concierge — shares the same ConciergeLandingClient
+ * component driven by a `variant` prop. Bachelor gets navy/gold; this one
+ * gets deep raspberry + rose. Copy, service list, and imagery all swap
+ * per-variant inside the shared component so both pages stay in sync
+ * whenever we edit shared structure.
+ */
+import type { Metadata } from 'next';
+import ConciergeLandingClient from '@/components/concierge/ConciergeLandingClient';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Premier Concierge · Austin Bachelorette Party Planning | Party On Delivery',
+  description:
+    "Full-service Austin bachelorette planning — private boats on Lake Travis, rosé + champagne delivery, brunch bars, winery tours, spa recovery, and rides. One form. Whole weekend planned before the bride's flight lands.",
+  alternates: { canonical: '/austin-bachelorette-concierge' },
+  robots: { index: false, follow: false },
+  openGraph: {
+    title: 'Premier Concierge · Austin Bachelorette Party Planning',
+    description:
+      'One form. Boats, bubbly, brunch, wineries, spa. We plan the whole weekend.',
+    type: 'website',
+  },
+};
+
+export default function AustinBacheloretteConciergePage() {
+  return <ConciergeLandingClient variant="bachelorette" />;
+}

--- a/src/app/austin-concierge/page.tsx
+++ b/src/app/austin-concierge/page.tsx
@@ -1,0 +1,37 @@
+/**
+ * /austin-concierge
+ *
+ * Party-type routing gate. Blurred hero image behind an immediate
+ * modal that asks "What kind of party are you planning?" with two
+ * buttons — Bachelor / Bachelorette — that hard-navigate to the
+ * respective planning pages.
+ *
+ * Server component: just metadata + the client shell. The gate itself
+ * is a pure client component (no data fetches, no analytics side
+ * effects beyond the standard PageViewTracker in the root layout).
+ */
+import type { Metadata } from 'next';
+import PartyTypeGateClient from '@/components/concierge/PartyTypeGateClient';
+
+export const dynamic = 'force-static';
+
+export const metadata: Metadata = {
+  title: 'Premier Concierge · Austin Party Planning | Party On Delivery',
+  description:
+    'Full-service Austin party planning — bachelor and bachelorette weekends. Pick your flavor and start planning.',
+  alternates: { canonical: '/austin-concierge' },
+  // NoIndex: this is a routing/gate page; the actual product pages
+  // (/austin-bachelor-concierge and /austin-bachelorette-concierge) are
+  // where SEO effort concentrates.
+  robots: { index: false, follow: false },
+  openGraph: {
+    title: 'Premier Concierge · Austin Party Planning',
+    description:
+      'Bachelor or bachelorette? Pick one and we plan the whole weekend.',
+    type: 'website',
+  },
+};
+
+export default function AustinConciergeGatePage() {
+  return <PartyTypeGateClient />;
+}

--- a/src/components/AgeVerification.tsx
+++ b/src/components/AgeVerification.tsx
@@ -25,6 +25,8 @@ const AGE_GATE_EXEMPT_PATHS = [
   '/event-quiz',
   '/events/4th-of-july-disco-cruise',
   '/austin-bachelor-concierge',
+  '/austin-bachelorette-concierge',
+  '/austin-concierge',
 ]
 
 /**

--- a/src/components/chat/PartyChatMount.tsx
+++ b/src/components/chat/PartyChatMount.tsx
@@ -37,8 +37,10 @@ const HIDE_PATTERNS: RegExp[] = [
   /^\/events(\/|$)/,
   // Full Moon Party lander — has its own share FAB; keep it distraction-free.
   /^\/full-moon-aug1(\/|$)/,
-  // Premier Concierge lander — own questionnaire modal; no drink-planner bubble.
+  // Premier Concierge landers — own questionnaire modal; no drink-planner bubble.
   /^\/austin-bachelor-concierge(\/|$)/,
+  /^\/austin-bachelorette-concierge(\/|$)/,
+  /^\/austin-concierge(\/|$)/,
 ];
 
 export default function PartyChatMount() {

--- a/src/components/concierge/ConciergeLandingClient.tsx
+++ b/src/components/concierge/ConciergeLandingClient.tsx
@@ -23,12 +23,129 @@ import Image from 'next/image';
 import { useState, type ReactElement } from 'react';
 import ConciergeQuestionnaireModal from './ConciergeQuestionnaireModal';
 
-// ─── Brand tokens (Premier Concierge palette) ────────────────────────
+// ─── Brand tokens ─────────────────────────────────────────────────
+// Default (bachelor) theme values kept as top-level constants so
+// existing sub-components can reference them. The main component
+// overrides these via a theme object when variant='bachelorette' by
+// passing the theme through props.
 const NAVY = '#0A1F33';
-const GOLD = '#D4AF37';        // Premium gold — Premier Concierge
+const GOLD = '#D4AF37';
 const CREAM = '#FAF6EE';
 const CHARCOAL = '#1C2A3A';
 const YELLOW = '#F2D34F';
+
+type Variant = 'bachelor' | 'bachelorette';
+
+type Theme = {
+  primary: string;   // Deep base (headings, borders)
+  accent: string;    // Chip / CTA background
+  soft: string;      // Card/backing tint
+  onAccent: string;  // Text color when placed on `accent`
+  charcoal: string;  // Trust-bar / dark section
+};
+
+const THEMES: Record<Variant, Theme> = {
+  bachelor: {
+    primary: NAVY,
+    accent: GOLD,
+    soft: CREAM,
+    onAccent: NAVY,
+    charcoal: CHARCOAL,
+  },
+  bachelorette: {
+    primary: '#7A1E4A',       // deep raspberry
+    accent: '#E8B4CE',        // rose
+    soft: '#FFF4F8',          // blush
+    onAccent: '#3F0F27',
+    charcoal: '#3F0F27',
+  },
+};
+
+type Copy = {
+  hero: {
+    eyebrow: string;
+    h1a: string;              // pre-accent line
+    h1b: string;              // accented line (uses theme accent)
+    subhead: string;
+  };
+  trustStats: { label: string; stat: string }[];
+  ctaLabels: {
+    primary: string;
+    secondary: string;
+    services: string;
+    finalCta: string;
+    stickyMobile: string;
+  };
+  servicesHeading: string;
+  servicesSub: string;
+  finalCta: { h2: string; sub: string };
+  confirmation: string;
+};
+
+const COPY_BY_VARIANT: Record<Variant, Copy> = {
+  bachelor: {
+    hero: {
+      eyebrow: '🥃 AUSTIN, TX · FULL-SERVICE PLANNING',
+      h1a: 'Premier Concierge',
+      h1b: 'Bachelor Party Planning',
+      subhead:
+        'One weekend. One concierge. Boats on Lake Travis, drinks delivered to the dock, brewery tours, ATVs, gun range, and transportation — all planned before the groom lands.',
+    },
+    trustStats: [
+      { label: 'Austin bachelor weekends served', stat: '500+' },
+      { label: 'Google rating', stat: '5.0★' },
+      { label: 'Vendors coordinated', stat: '30+' },
+      { label: 'Concierge response', stat: '<24h' },
+    ],
+    ctaLabels: {
+      primary: 'PLAN MY WEEKEND — FREE',
+      secondary: 'or call (737) 371-9700',
+      services: 'START PLANNING → 3 MIN',
+      finalCta: 'START PLANNING — FREE →',
+      stickyMobile: 'PLAN MY WEEKEND →',
+    },
+    servicesHeading: 'Everything for the weekend, in one plan',
+    servicesSub:
+      'Pick the pieces you want on the questionnaire. We book the vendors, stock the boat, and confirm every reservation before you land.',
+    finalCta: {
+      h2: 'One form. Your whole weekend, handled.',
+      sub: "Fill it out. We'll come back within 24 hours with a plan + a fixed quote. No pressure, no upsells — just the weekend the group wanted.",
+    },
+    confirmation:
+      "🎉 Got it — your concierge will reach out within 24 hours. Check your email for confirmation.",
+  },
+  bachelorette: {
+    hero: {
+      eyebrow: '🥂 AUSTIN, TX · BACHELORETTE PLANNING',
+      h1a: 'Premier Concierge',
+      h1b: 'Bachelorette Party Planning',
+      subhead:
+        "One weekend. One concierge. Rosé on Lake Travis, brunch on arrival, wineries in the Hill Country, spa recovery, and rides everywhere — all planned before the bride's flight lands.",
+    },
+    trustStats: [
+      { label: 'Austin bachelorettes hosted', stat: '400+' },
+      { label: 'Google rating', stat: '5.0★' },
+      { label: 'Vendors coordinated', stat: '30+' },
+      { label: 'Concierge response', stat: '<24h' },
+    ],
+    ctaLabels: {
+      primary: 'PLAN THE WEEKEND — FREE',
+      secondary: 'or call (737) 371-9700',
+      services: 'START PLANNING → 3 MIN',
+      finalCta: 'START PLANNING — FREE →',
+      stickyMobile: 'PLAN THE WEEKEND →',
+    },
+    servicesHeading: 'The whole weekend, planned',
+    servicesSub:
+      "Tell us what your girls are into. We book the boat, stock the champagne, and lock in every reservation before you fly.",
+    finalCta: {
+      h2: 'One form. Whole weekend. Zero group-chat chaos.',
+      sub: "Fill it out. Your concierge follows up within 24 hours with a plan + a fixed quote. No hidden fees — just the weekend the bride actually wants.",
+    },
+    confirmation:
+      "🎉 Got it — your concierge will reach out within 24 hours. Check your email for confirmation.",
+  },
+};
 
 // ─── Services ──────────────────────────────────────────────────────
 type Service = {
@@ -41,76 +158,132 @@ type Service = {
   chip: string;
 };
 
-const SERVICES: Service[] = [
-  {
-    key: 'boat-rental',
-    title: 'Private Party Boats',
-    blurb:
-      'Lake Travis captained cruises — 4 to 40 guys, from cocktail rides to overnight charters. Docked at the marina where Premier lives.',
-    emoji: '🛥️',
-    imgSrc: '/images/destinations/lake-travis-boats.webp',
-    imgAlt: 'Party boats docked on Lake Travis at sunset',
-    chip: 'Most-booked',
-  },
-  {
-    key: 'drink-delivery',
-    title: 'Drink Delivery to the Dock',
-    blurb:
-      "Beer, liquor, seltzers, cocktail kits — iced and staged at the marina before you board. We already stock the boats.",
-    emoji: '🥃',
-    imgSrc: '/images/services/bach-parties/late-night-party-supplies.webp',
-    imgAlt: 'Late-night party supplies laid out for delivery',
-    chip: 'Free · no minimum',
-  },
-  {
-    key: 'golf-brewery-tour',
-    title: 'Golf & Brewery Tours',
-    blurb:
-      'Top-nine courses, small-batch breweries in East Austin, whiskey rooms. Curated tastings + tee times booked for the group.',
-    emoji: '⛳',
-    imgSrc: '/images/destinations/east-austin-brewery.webp',
-    imgAlt: 'East Austin brewery interior with taproom bar',
-    chip: 'Guys weekend',
-  },
-  {
-    key: 'atv-tour',
-    title: 'ATV & Off-Road Tours',
-    blurb:
-      'Hill Country trails, mud tracks, sunset rides. Guided groups with equipment, coolers optional (we can send them).',
-    emoji: '🚙',
-    imgSrc: '/images/destinations/hill-country-winery.webp',
-    imgAlt: 'Texas Hill Country vista at golden hour',
-    chip: 'Adrenaline',
-  },
-  {
-    key: 'gun-range',
-    title: 'Gun Range Experience',
-    blurb:
-      'Private lane blocks at Texas premier shooting ranges. Instructor-led sessions, pistol + rifle, all skill levels welcome.',
-    emoji: '🎯',
-    imgSrc: '/images/services/bach-parties/bachelor-party-epic.webp',
-    imgAlt: 'Bachelor party group toasting at the range',
-    chip: 'Only-in-Texas',
-  },
-  {
-    key: 'transportation',
-    title: 'Group Transportation',
-    blurb:
-      'Party bus, sprinter vans, and black car service. Airport pickup, downtown → lake shuttles, and late-night rides home.',
-    emoji: '🚐',
-    imgSrc: '/images/destinations/6th-street-entertainment.webp',
-    imgAlt: '6th Street Austin nightlife strip',
-    chip: 'Airport → Airport',
-  },
-];
-
-// ─── Trust bar stats ──────────────────────────────────────────────
-const TRUST_STATS = [
-  { label: 'Austin bachelor weekends served', stat: '500+' },
-  { label: 'Google rating', stat: '5.0★' },
-  { label: 'Vendors coordinated', stat: '30+' },
-  { label: 'Concierge response', stat: '<24h' },
-];
+const SERVICES_BY_VARIANT: Record<Variant, Service[]> = {
+  bachelor: [
+    {
+      key: 'boat-rental',
+      title: 'Private Party Boats',
+      blurb:
+        'Lake Travis captained cruises — 4 to 40 guys, from cocktail rides to overnight charters. Docked at the marina where Premier lives.',
+      emoji: '🛥️',
+      imgSrc: '/images/destinations/lake-travis-boats.webp',
+      imgAlt: 'Party boats docked on Lake Travis at sunset',
+      chip: 'Most-booked',
+    },
+    {
+      key: 'drink-delivery',
+      title: 'Drink Delivery to the Dock',
+      blurb:
+        'Beer, liquor, seltzers, cocktail kits — iced and staged at the marina before you board. We already stock the boats.',
+      emoji: '🥃',
+      imgSrc: '/images/services/bach-parties/late-night-party-supplies.webp',
+      imgAlt: 'Late-night party supplies laid out for delivery',
+      chip: 'Free · no minimum',
+    },
+    {
+      key: 'golf-brewery-tour',
+      title: 'Golf & Brewery Tours',
+      blurb:
+        'Top-nine courses, small-batch breweries in East Austin, whiskey rooms. Curated tastings + tee times booked for the group.',
+      emoji: '⛳',
+      imgSrc: '/images/destinations/east-austin-brewery.webp',
+      imgAlt: 'East Austin brewery interior with taproom bar',
+      chip: 'Guys weekend',
+    },
+    {
+      key: 'atv-tour',
+      title: 'ATV & Off-Road Tours',
+      blurb:
+        'Hill Country trails, mud tracks, sunset rides. Guided groups with equipment, coolers optional (we can send them).',
+      emoji: '🚙',
+      imgSrc: '/images/destinations/hill-country-winery.webp',
+      imgAlt: 'Texas Hill Country vista at golden hour',
+      chip: 'Adrenaline',
+    },
+    {
+      key: 'gun-range',
+      title: 'Gun Range Experience',
+      blurb:
+        'Private lane blocks at Texas premier shooting ranges. Instructor-led sessions, pistol + rifle, all skill levels welcome.',
+      emoji: '🎯',
+      imgSrc: '/images/services/bach-parties/bachelor-party-epic.webp',
+      imgAlt: 'Bachelor party group toasting at the range',
+      chip: 'Only-in-Texas',
+    },
+    {
+      key: 'transportation',
+      title: 'Group Transportation',
+      blurb:
+        'Party bus, sprinter vans, and black car service. Airport pickup, downtown → lake shuttles, and late-night rides home.',
+      emoji: '🚐',
+      imgSrc: '/images/destinations/6th-street-entertainment.webp',
+      imgAlt: '6th Street Austin nightlife strip',
+      chip: 'Airport → Airport',
+    },
+  ],
+  bachelorette: [
+    {
+      key: 'boat-rental',
+      title: 'Private Party Boats',
+      blurb:
+        'Sunset cruises on Lake Travis with your girls. Captained charters, floating rosé bars, and the best sunset photos of the weekend.',
+      emoji: '🛥️',
+      imgSrc: '/images/destinations/lake-travis-boats.webp',
+      imgAlt: 'Party boats on Lake Travis at sunset',
+      chip: 'Most-booked',
+    },
+    {
+      key: 'drink-delivery',
+      title: 'Rosé, Bubbly & Cocktail Delivery',
+      blurb:
+        "Champagne towers, brunch mimosa bars, batched margaritas — iced and staged wherever you're staying. Free delivery, no minimum.",
+      emoji: '🥂',
+      imgSrc: '/images/services/bach-parties/bachelorette-champagne-tower.webp',
+      imgAlt: 'Bachelorette champagne tower ready for a toast',
+      chip: 'Free · no minimum',
+    },
+    {
+      key: 'brunch-mimosa',
+      title: 'Brunch & Mimosa Bars',
+      blurb:
+        'Private chef brunch at the Airbnb, mimosa bar set up on arrival, and reservations at the best Austin brunch spots — locked in before you fly.',
+      emoji: '🥞',
+      imgSrc: '/images/services/bach-parties/brunch-mimosa-bar.webp',
+      imgAlt: 'Bachelorette brunch mimosa bar spread',
+      chip: 'Weekend must',
+    },
+    {
+      key: 'winery-tour',
+      title: 'Wine & Winery Tours',
+      blurb:
+        'Hill Country wineries, curated tastings, and vineyard photo stops. Guided tours with rides — no designated driver needed.',
+      emoji: '🍷',
+      imgSrc: '/images/destinations/hill-country-winery.webp',
+      imgAlt: 'Hill Country winery at golden hour',
+      chip: 'Vineyard vibes',
+    },
+    {
+      key: 'spa-day',
+      title: 'Spa & Recovery Day',
+      blurb:
+        'In-Airbnb massages, blowouts on demand, mobile mani/pedi. The reset the group needs between the boat and the club.',
+      emoji: '💆‍♀️',
+      imgSrc: '/images/destinations/the-domain-upscale.webp',
+      imgAlt: 'Upscale Austin lifestyle imagery',
+      chip: 'Recovery',
+    },
+    {
+      key: 'transportation',
+      title: 'Group Transportation',
+      blurb:
+        'Sprinter vans, black cars, and party shuttles. Airport pickup, downtown → lake shuttles, and safe rides between every spot.',
+      emoji: '🚐',
+      imgSrc: '/images/destinations/rainey-street-nightlife.webp',
+      imgAlt: 'Rainey Street nightlife district',
+      chip: 'Airport → Airport',
+    },
+  ],
+};
 
 const STEPS = [
   {
@@ -130,7 +303,16 @@ const STEPS = [
   },
 ];
 
-export default function ConciergeLandingClient(): ReactElement {
+type ClientProps = {
+  variant?: Variant;
+};
+
+export default function ConciergeLandingClient({
+  variant = 'bachelor',
+}: ClientProps): ReactElement {
+  const theme = THEMES[variant];
+  const copy = COPY_BY_VARIANT[variant];
+  const services = SERVICES_BY_VARIANT[variant];
   const [open, setOpen] = useState(false);
   const [confirmed, setConfirmed] = useState(false);
 
@@ -146,24 +328,31 @@ export default function ConciergeLandingClient(): ReactElement {
   return (
     <main
       className="min-h-screen overflow-x-hidden"
-      style={{ background: CREAM, color: NAVY }}
+      style={{ background: theme.soft, color: theme.primary }}
     >
-      <TopNav onCtaClick={() => setOpen(true)} />
+      <TopNav theme={theme} copy={copy} onCtaClick={() => setOpen(true)} />
 
-      {confirmed && <ConfirmationBanner />}
+      {confirmed && (
+        <ConfirmationBanner text={copy.confirmation} />
+      )}
 
-      <Hero onCtaClick={() => setOpen(true)} />
-      <TrustBar />
-      <ServicesGrid onCtaClick={() => setOpen(true)} />
-      <HowItWorks onCtaClick={() => setOpen(true)} />
-      <FinalCta onCtaClick={() => setOpen(true)} />
+      <Hero theme={theme} copy={copy} onCtaClick={() => setOpen(true)} />
+      <TrustBar theme={theme} stats={copy.trustStats} />
+      <ServicesGrid
+        theme={theme}
+        copy={copy}
+        services={services}
+        onCtaClick={() => setOpen(true)}
+      />
+      <HowItWorks theme={theme} copy={copy} onCtaClick={() => setOpen(true)} />
+      <FinalCta theme={theme} copy={copy} onCtaClick={() => setOpen(true)} />
 
       {/* Sticky mobile CTA */}
       <div
         className="fixed bottom-0 inset-x-0 z-40 border-t-2 md:hidden"
         style={{
           background: '#FFFFFF',
-          borderColor: NAVY,
+          borderColor: theme.primary,
           boxShadow: '0 -4px 18px rgba(10,15,25,0.15)',
         }}
       >
@@ -172,7 +361,7 @@ export default function ConciergeLandingClient(): ReactElement {
             <div className="text-[10px] font-bold tracking-widest text-gray-500">
               FREE PLANNING
             </div>
-            <div className="text-sm font-bold" style={{ color: NAVY }}>
+            <div className="text-sm font-bold" style={{ color: theme.primary }}>
               Concierge response in 24h
             </div>
           </div>
@@ -181,19 +370,20 @@ export default function ConciergeLandingClient(): ReactElement {
             onClick={() => setOpen(true)}
             className="rounded-lg px-5 py-3 text-sm font-bold tracking-[0.08em] transition-transform hover:scale-[1.03]"
             style={{
-              background: GOLD,
-              color: NAVY,
-              border: `2px solid ${NAVY}`,
-              boxShadow: `0 3px 0 ${NAVY}`,
+              background: theme.accent,
+              color: theme.onAccent,
+              border: `2px solid ${theme.primary}`,
+              boxShadow: `0 3px 0 ${theme.primary}`,
             }}
           >
-            PLAN MY WEEKEND →
+            {copy.ctaLabels.stickyMobile}
           </button>
         </div>
       </div>
 
       {open && (
         <ConciergeQuestionnaireModal
+          variant={variant}
           onClose={() => setOpen(false)}
           onSuccess={handleSuccess}
         />
@@ -204,20 +394,28 @@ export default function ConciergeLandingClient(): ReactElement {
 
 // ─── Nav ────────────────────────────────────────────────────────────
 
-function TopNav({ onCtaClick }: { onCtaClick: () => void }) {
+function TopNav({
+  theme,
+  copy,
+  onCtaClick,
+}: {
+  theme: Theme;
+  copy: Copy;
+  onCtaClick: () => void;
+}) {
   return (
     <header
       className="sticky top-0 z-30 backdrop-blur-md"
       style={{
-        background: 'rgba(10,15,25,0.92)',
-        borderBottom: `2px solid ${GOLD}`,
+        background: `${theme.primary}EB`,
+        borderBottom: `2px solid ${theme.accent}`,
       }}
     >
       <div className="max-w-6xl mx-auto px-4 sm:px-6 py-3 flex items-center justify-between gap-3">
         <div className="flex items-baseline gap-2">
           <span
             className="font-heading text-lg sm:text-xl font-bold tracking-[0.15em]"
-            style={{ color: GOLD }}
+            style={{ color: theme.accent }}
           >
             PREMIER
           </span>
@@ -239,12 +437,12 @@ function TopNav({ onCtaClick }: { onCtaClick: () => void }) {
             onClick={onCtaClick}
             className="rounded-lg px-4 py-2.5 text-xs sm:text-sm font-bold tracking-[0.08em] transition-transform hover:scale-[1.03]"
             style={{
-              background: GOLD,
-              color: NAVY,
+              background: theme.accent,
+              color: theme.onAccent,
               border: '2px solid #1a1a1a',
             }}
           >
-            PLAN MY WEEKEND →
+            {copy.ctaLabels.stickyMobile}
           </button>
         </div>
       </div>
@@ -254,7 +452,15 @@ function TopNav({ onCtaClick }: { onCtaClick: () => void }) {
 
 // ─── Hero ───────────────────────────────────────────────────────────
 
-function Hero({ onCtaClick }: { onCtaClick: () => void }) {
+function Hero({
+  theme,
+  copy,
+  onCtaClick,
+}: {
+  theme: Theme;
+  copy: Copy;
+  onCtaClick: () => void;
+}) {
   return (
     <section className="relative overflow-hidden">
       {/* Background image */}
@@ -270,8 +476,7 @@ function Hero({ onCtaClick }: { onCtaClick: () => void }) {
         <div
           className="absolute inset-0"
           style={{
-            background:
-              'linear-gradient(180deg, rgba(10,15,25,0.6) 0%, rgba(10,15,25,0.85) 100%)',
+            background: `linear-gradient(180deg, ${theme.primary}99 0%, ${theme.primary}D9 100%)`,
           }}
         />
       </div>
@@ -279,19 +484,17 @@ function Hero({ onCtaClick }: { onCtaClick: () => void }) {
       <div className="relative max-w-4xl mx-auto px-4 sm:px-6 py-16 md:py-24 lg:py-32 text-center text-white">
         <div
           className="inline-block px-3 py-1 rounded-full text-xs font-bold tracking-widest mb-4"
-          style={{ background: GOLD, color: NAVY }}
+          style={{ background: theme.accent, color: theme.onAccent }}
         >
-          🥃 AUSTIN, TX · FULL-SERVICE PLANNING
+          {copy.hero.eyebrow}
         </div>
         <h1 className="font-heading text-4xl md:text-5xl lg:text-6xl font-bold tracking-tight leading-[1.05]">
-          Premier Concierge
+          {copy.hero.h1a}
           <br />
-          <span style={{ color: GOLD }}>Bachelor Party Planning</span>
+          <span style={{ color: theme.accent }}>{copy.hero.h1b}</span>
         </h1>
         <p className="mt-5 text-base md:text-lg opacity-90 max-w-2xl mx-auto">
-          One weekend. One concierge. Boats on Lake Travis, drinks
-          delivered to the dock, brewery tours, ATVs, gun range, and
-          transportation — all planned before the groom lands.
+          {copy.hero.subhead}
         </p>
 
         <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-3">
@@ -300,19 +503,19 @@ function Hero({ onCtaClick }: { onCtaClick: () => void }) {
             onClick={onCtaClick}
             className="rounded-lg px-6 py-4 text-base md:text-lg font-heading font-bold tracking-[0.12em] transition-transform hover:scale-[1.03]"
             style={{
-              background: GOLD,
-              color: NAVY,
-              border: `2px solid ${NAVY}`,
-              boxShadow: `0 4px 0 ${NAVY}`,
+              background: theme.accent,
+              color: theme.onAccent,
+              border: `2px solid ${theme.primary}`,
+              boxShadow: `0 4px 0 ${theme.primary}`,
             }}
           >
-            PLAN MY WEEKEND — FREE
+            {copy.ctaLabels.primary}
           </button>
           <a
             href="tel:+17373719700"
             className="text-sm sm:text-base font-bold text-white hover:opacity-80 flex items-center gap-1.5"
           >
-            <PhoneIcon /> or call (737) 371-9700
+            <PhoneIcon /> {copy.ctaLabels.secondary}
           </a>
         </div>
         <p className="mt-4 text-xs opacity-70">
@@ -325,18 +528,24 @@ function Hero({ onCtaClick }: { onCtaClick: () => void }) {
 
 // ─── Trust bar ──────────────────────────────────────────────────────
 
-function TrustBar() {
+function TrustBar({
+  theme,
+  stats,
+}: {
+  theme: Theme;
+  stats: { label: string; stat: string }[];
+}) {
   return (
     <section
       className="text-white py-6 sm:py-8"
-      style={{ background: CHARCOAL, borderBottom: `2px solid ${GOLD}` }}
+      style={{ background: theme.charcoal, borderBottom: `2px solid ${theme.accent}` }}
     >
       <div className="max-w-6xl mx-auto px-4 sm:px-6 grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
-        {TRUST_STATS.map((s) => (
+        {stats.map((s) => (
           <div key={s.label}>
             <div
               className="font-heading text-2xl md:text-4xl font-bold"
-              style={{ color: GOLD }}
+              style={{ color: theme.accent }}
             >
               {s.stat}
             </div>
@@ -352,7 +561,17 @@ function TrustBar() {
 
 // ─── Services grid ─────────────────────────────────────────────────
 
-function ServicesGrid({ onCtaClick }: { onCtaClick: () => void }) {
+function ServicesGrid({
+  theme,
+  copy,
+  services,
+  onCtaClick,
+}: {
+  theme: Theme;
+  copy: Copy;
+  services: Service[];
+  onCtaClick: () => void;
+}) {
   return (
     <section id="services" className="py-14 md:py-20">
       <div className="max-w-6xl mx-auto px-4 sm:px-6">
@@ -362,20 +581,18 @@ function ServicesGrid({ onCtaClick }: { onCtaClick: () => void }) {
           </div>
           <h2
             className="font-heading text-3xl md:text-4xl font-bold tracking-tight"
-            style={{ color: NAVY }}
+            style={{ color: theme.primary }}
           >
-            Everything for the weekend, in one plan
+            {copy.servicesHeading}
           </h2>
           <p className="mt-3 text-gray-700 max-w-2xl mx-auto">
-            Pick the pieces you want on the questionnaire. We book the
-            vendors, stock the boat, and confirm every reservation before
-            you land.
+            {copy.servicesSub}
           </p>
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {SERVICES.map((s) => (
-            <ServiceCard key={s.key} service={s} />
+          {services.map((s) => (
+            <ServiceCard key={s.key} service={s} theme={theme} />
           ))}
         </div>
 
@@ -385,13 +602,13 @@ function ServicesGrid({ onCtaClick }: { onCtaClick: () => void }) {
             onClick={onCtaClick}
             className="rounded-lg px-6 py-4 text-base font-heading font-bold tracking-[0.12em] transition-transform hover:scale-[1.03]"
             style={{
-              background: GOLD,
-              color: NAVY,
-              border: `2px solid ${NAVY}`,
-              boxShadow: `0 4px 0 ${NAVY}`,
+              background: theme.accent,
+              color: theme.onAccent,
+              border: `2px solid ${theme.primary}`,
+              boxShadow: `0 4px 0 ${theme.primary}`,
             }}
           >
-            START PLANNING → 3 MIN
+            {copy.ctaLabels.services}
           </button>
         </div>
       </div>
@@ -399,14 +616,20 @@ function ServicesGrid({ onCtaClick }: { onCtaClick: () => void }) {
   );
 }
 
-function ServiceCard({ service }: { service: Service }) {
+function ServiceCard({
+  service,
+  theme,
+}: {
+  service: Service;
+  theme: Theme;
+}) {
   return (
     <article
       className="rounded-2xl overflow-hidden flex flex-col shadow-sm transition-transform hover:scale-[1.02]"
       style={{
         background: '#FFFFFF',
-        border: `1.5px solid ${NAVY}`,
-        boxShadow: `0 3px 0 ${NAVY}18`,
+        border: `1.5px solid ${theme.primary}`,
+        boxShadow: `0 3px 0 ${theme.primary}18`,
       }}
     >
       <div className="relative aspect-[4/3] overflow-hidden">
@@ -420,13 +643,12 @@ function ServiceCard({ service }: { service: Service }) {
         <div
           className="absolute inset-0"
           style={{
-            background:
-              'linear-gradient(180deg, transparent 55%, rgba(10,15,25,0.6) 100%)',
+            background: `linear-gradient(180deg, transparent 55%, ${theme.primary}99 100%)`,
           }}
         />
         <div
           className="absolute top-3 left-3 rounded-full px-2.5 py-1 text-[10px] font-bold tracking-widest"
-          style={{ background: GOLD, color: NAVY }}
+          style={{ background: theme.accent, color: theme.onAccent }}
         >
           {service.chip}
         </div>
@@ -440,7 +662,7 @@ function ServiceCard({ service }: { service: Service }) {
       <div className="p-4 sm:p-5 flex-1">
         <h3
           className="font-heading text-lg sm:text-xl font-bold tracking-tight mb-1"
-          style={{ color: NAVY }}
+          style={{ color: theme.primary }}
         >
           {service.title}
         </h3>
@@ -454,17 +676,25 @@ function ServiceCard({ service }: { service: Service }) {
 
 // ─── How it works ──────────────────────────────────────────────────
 
-function HowItWorks({ onCtaClick }: { onCtaClick: () => void }) {
+function HowItWorks({
+  theme,
+  copy,
+  onCtaClick,
+}: {
+  theme: Theme;
+  copy: Copy;
+  onCtaClick: () => void;
+}) {
   return (
     <section
       className="py-14 md:py-20"
-      style={{ background: NAVY, color: '#FFFFFF' }}
+      style={{ background: theme.primary, color: '#FFFFFF' }}
     >
       <div className="max-w-6xl mx-auto px-4 sm:px-6">
         <div className="text-center mb-10">
           <div
             className="text-xs font-bold tracking-[0.22em] mb-2"
-            style={{ color: GOLD }}
+            style={{ color: theme.accent }}
           >
             HOW IT WORKS
           </div>
@@ -479,12 +709,12 @@ function HowItWorks({ onCtaClick }: { onCtaClick: () => void }) {
               className="rounded-2xl p-6"
               style={{
                 background: 'rgba(255,255,255,0.05)',
-                border: `1.5px solid ${GOLD}`,
+                border: `1.5px solid ${theme.accent}`,
               }}
             >
               <div
                 className="font-heading text-3xl font-bold"
-                style={{ color: GOLD }}
+                style={{ color: theme.accent }}
               >
                 {s.n}
               </div>
@@ -501,13 +731,13 @@ function HowItWorks({ onCtaClick }: { onCtaClick: () => void }) {
             onClick={onCtaClick}
             className="rounded-lg px-6 py-4 text-base font-heading font-bold tracking-[0.12em] transition-transform hover:scale-[1.03]"
             style={{
-              background: GOLD,
-              color: NAVY,
+              background: theme.accent,
+              color: theme.onAccent,
               border: `2px solid ${YELLOW}`,
               boxShadow: `0 4px 0 rgba(0,0,0,0.4)`,
             }}
           >
-            PLAN MY WEEKEND →
+            {copy.ctaLabels.stickyMobile}
           </button>
         </div>
       </div>
@@ -517,20 +747,26 @@ function HowItWorks({ onCtaClick }: { onCtaClick: () => void }) {
 
 // ─── Final CTA ────────────────────────────────────────────────────
 
-function FinalCta({ onCtaClick }: { onCtaClick: () => void }) {
+function FinalCta({
+  theme,
+  copy,
+  onCtaClick,
+}: {
+  theme: Theme;
+  copy: Copy;
+  onCtaClick: () => void;
+}) {
   return (
     <section className="py-14 md:py-20">
       <div className="max-w-3xl mx-auto px-4 sm:px-6 text-center">
         <h2
           className="font-heading text-3xl md:text-4xl font-bold tracking-tight"
-          style={{ color: NAVY }}
+          style={{ color: theme.primary }}
         >
-          One form. Your whole weekend, handled.
+          {copy.finalCta.h2}
         </h2>
         <p className="mt-3 text-gray-700 max-w-2xl mx-auto">
-          Fill it out. We&apos;ll come back within 24 hours with a plan +
-          a fixed quote. No pressure, no upsells — just the weekend the
-          group wanted.
+          {copy.finalCta.sub}
         </p>
         <div className="mt-6">
           <button
@@ -538,13 +774,13 @@ function FinalCta({ onCtaClick }: { onCtaClick: () => void }) {
             onClick={onCtaClick}
             className="rounded-lg px-8 py-4 text-lg font-heading font-bold tracking-[0.12em] transition-transform hover:scale-[1.03]"
             style={{
-              background: GOLD,
-              color: NAVY,
-              border: `2px solid ${NAVY}`,
-              boxShadow: `0 4px 0 ${NAVY}`,
+              background: theme.accent,
+              color: theme.onAccent,
+              border: `2px solid ${theme.primary}`,
+              boxShadow: `0 4px 0 ${theme.primary}`,
             }}
           >
-            START PLANNING — FREE →
+            {copy.ctaLabels.finalCta}
           </button>
         </div>
       </div>
@@ -554,14 +790,13 @@ function FinalCta({ onCtaClick }: { onCtaClick: () => void }) {
 
 // ─── Confirmation banner (post-submit) ─────────────────────────────
 
-function ConfirmationBanner() {
+function ConfirmationBanner({ text }: { text: string }) {
   return (
     <div
       className="text-white text-center py-3 px-4 text-sm font-bold"
       style={{ background: '#0F8141' }}
     >
-      🎉 Got it — your concierge will reach out within 24 hours. Check
-      your email for confirmation.
+      {text}
     </div>
   );
 }

--- a/src/components/concierge/ConciergeQuestionnaireModal.tsx
+++ b/src/components/concierge/ConciergeQuestionnaireModal.tsx
@@ -72,12 +72,19 @@ function defaultDeparture(): string {
   return d.toISOString().slice(0, 10);
 }
 
+type Variant = 'bachelor' | 'bachelorette';
+
 type Props = {
+  /** Pre-selects the party type + drives the source tag on the API call
+   *  so bachelor and bachelorette submissions are distinguishable in
+   *  the Lead metadata, GHL tags, and Google Sheet source column. */
+  variant?: Variant;
   onClose: () => void;
   onSuccess: () => void;
 };
 
 export default function ConciergeQuestionnaireModal({
+  variant = 'bachelor',
   onClose,
   onSuccess,
 }: Props): ReactElement {
@@ -88,7 +95,9 @@ export default function ConciergeQuestionnaireModal({
   const [customHead, setCustomHead] = useState<string>('');
   const [arrivalDate, setArrivalDate] = useState<string>(defaultArrival());
   const [departureDate, setDepartureDate] = useState<string>(defaultDeparture());
-  const [partyType, setPartyType] = useState<PartyType>('bachelor');
+  const [partyType, setPartyType] = useState<PartyType>(
+    variant === 'bachelorette' ? 'bachelorette' : 'bachelor',
+  );
   const [budget, setBudget] = useState<string>('$400/pp');
   const [activities, setActivities] = useState<Activity[]>([
     'boat-rental',
@@ -152,7 +161,10 @@ export default function ConciergeQuestionnaireModal({
           budgetPerPerson: budget,
           activities,
           notes: notes.trim(),
-          source: 'premier-concierge-bachelor',
+          source:
+            variant === 'bachelorette'
+              ? 'premier-concierge-bachelorette'
+              : 'premier-concierge-bachelor',
         }),
       });
       const json = (await res.json()) as { ok: boolean; error?: string };

--- a/src/components/concierge/PartyTypeGateClient.tsx
+++ b/src/components/concierge/PartyTypeGateClient.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+/**
+ * Party-type routing gate.
+ *
+ * Full-bleed blurred Lake Travis backdrop with a permanent modal
+ * asking "What kind of party are you planning?" Two big buttons —
+ * Bachelor (navy + gold) and Bachelorette (raspberry + rose) —
+ * hard-navigate to the respective planning pages.
+ *
+ * No close button, no dismiss action. The whole point of this page is
+ * to route the visitor; there's nothing behind the modal worth
+ * interacting with. If the user needs to bail they can use the browser
+ * back button.
+ *
+ * Router uses next/link with prefetch so the destination page is
+ * warmed by the time they click, and the tap-to-navigate feels
+ * instant.
+ */
+
+import Image from 'next/image';
+import Link from 'next/link';
+import type { ReactElement } from 'react';
+
+const NAVY = '#0A1F33';
+const GOLD = '#D4AF37';
+const RASPBERRY = '#7A1E4A';
+const ROSE = '#E8B4CE';
+
+export default function PartyTypeGateClient(): ReactElement {
+  return (
+    <main
+      className="relative min-h-screen w-full overflow-hidden"
+      style={{ background: NAVY }}
+    >
+      {/* Blurred background */}
+      <div className="absolute inset-0 z-0">
+        <Image
+          src="/images/destinations/lake-travis-boats.webp"
+          alt=""
+          aria-hidden
+          fill
+          priority
+          sizes="100vw"
+          className="object-cover blur-lg scale-110"
+        />
+        <div
+          className="absolute inset-0"
+          style={{
+            background:
+              'radial-gradient(ellipse at center, rgba(10,15,25,0.55) 0%, rgba(10,15,25,0.85) 60%, rgba(10,15,25,0.95) 100%)',
+          }}
+        />
+      </div>
+
+      {/* Permanent centered modal */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="gate-title"
+        className="relative z-10 min-h-screen flex items-center justify-center p-4 sm:p-6"
+      >
+        <div
+          className="w-full max-w-lg rounded-3xl overflow-hidden shadow-2xl"
+          style={{
+            background: '#FFFFFF',
+            border: `2px solid ${NAVY}`,
+            boxShadow: `0 20px 60px rgba(10,15,25,0.5)`,
+          }}
+        >
+          {/* Header */}
+          <div
+            className="px-6 py-5 text-center"
+            style={{
+              background: NAVY,
+              color: '#FFFFFF',
+              borderBottom: `3px solid ${GOLD}`,
+            }}
+          >
+            <div
+              className="text-[10px] font-bold tracking-[0.24em] mb-1"
+              style={{ color: GOLD }}
+            >
+              PREMIER CONCIERGE · AUSTIN
+            </div>
+            <h1
+              id="gate-title"
+              className="font-heading text-2xl md:text-3xl font-bold tracking-tight leading-tight"
+            >
+              What kind of party are you planning?
+            </h1>
+            <p className="text-xs opacity-80 mt-2 max-w-xs mx-auto">
+              Pick one to unlock the right planner. You can change your
+              mind on the next page.
+            </p>
+          </div>
+
+          {/* Buttons */}
+          <div className="p-5 sm:p-6 space-y-3">
+            {/* Bachelor */}
+            <Link
+              href="/austin-bachelor-concierge"
+              prefetch
+              className="block rounded-2xl overflow-hidden transition-transform hover:scale-[1.02] active:scale-[0.99]"
+              style={{
+                background: NAVY,
+                color: '#FFFFFF',
+                border: `2px solid ${NAVY}`,
+                boxShadow: `0 4px 0 ${NAVY}`,
+              }}
+            >
+              <div className="flex items-center gap-4 p-4 sm:p-5">
+                <div
+                  className="flex-shrink-0 w-14 h-14 rounded-full flex items-center justify-center text-3xl"
+                  style={{ background: GOLD }}
+                  aria-hidden
+                >
+                  🥃
+                </div>
+                <div className="flex-1 text-left">
+                  <div
+                    className="text-[10px] font-bold tracking-widest mb-0.5"
+                    style={{ color: GOLD }}
+                  >
+                    BACHELOR PARTY
+                  </div>
+                  <div className="font-heading text-lg sm:text-xl font-bold tracking-tight">
+                    Plan the guys&apos; weekend
+                  </div>
+                  <div className="text-xs opacity-80 mt-0.5">
+                    Boats, brewery tours, ATVs, gun range
+                  </div>
+                </div>
+                <div
+                  className="flex-shrink-0 text-2xl font-bold"
+                  style={{ color: GOLD }}
+                  aria-hidden
+                >
+                  →
+                </div>
+              </div>
+            </Link>
+
+            {/* Bachelorette */}
+            <Link
+              href="/austin-bachelorette-concierge"
+              prefetch
+              className="block rounded-2xl overflow-hidden transition-transform hover:scale-[1.02] active:scale-[0.99]"
+              style={{
+                background: RASPBERRY,
+                color: '#FFFFFF',
+                border: `2px solid ${RASPBERRY}`,
+                boxShadow: `0 4px 0 ${RASPBERRY}`,
+              }}
+            >
+              <div className="flex items-center gap-4 p-4 sm:p-5">
+                <div
+                  className="flex-shrink-0 w-14 h-14 rounded-full flex items-center justify-center text-3xl"
+                  style={{ background: ROSE }}
+                  aria-hidden
+                >
+                  🥂
+                </div>
+                <div className="flex-1 text-left">
+                  <div
+                    className="text-[10px] font-bold tracking-widest mb-0.5"
+                    style={{ color: ROSE }}
+                  >
+                    BACHELORETTE PARTY
+                  </div>
+                  <div className="font-heading text-lg sm:text-xl font-bold tracking-tight">
+                    Plan the girls&apos; weekend
+                  </div>
+                  <div className="text-xs opacity-90 mt-0.5">
+                    Boats, bubbly, brunch, wineries, spa
+                  </div>
+                </div>
+                <div
+                  className="flex-shrink-0 text-2xl font-bold"
+                  style={{ color: ROSE }}
+                  aria-hidden
+                >
+                  →
+                </div>
+              </div>
+            </Link>
+          </div>
+
+          {/* Footer */}
+          <div
+            className="px-6 pb-5 text-center text-xs text-gray-500"
+          >
+            Corporate or something else? Call{' '}
+            <a
+              href="tel:+17373719700"
+              className="font-bold underline"
+              style={{ color: NAVY }}
+            >
+              (737) 371-9700
+            </a>
+            .
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- Google Sheet integration **VERIFIED WORKING** — header row + test row landed after founder shared the sheet with the Premier service account. Smoke-test script retained for future ops use.
- New /austin-bachelorette-concierge — twin of the bachelor page, raspberry/rose palette, bachelorette-tailored service list (brunch, wineries, spa), source tag \`premier-concierge-bachelorette\`
- New /austin-concierge — blurred backdrop + permanent modal asking "What kind of party are you planning?" with Bachelor / Bachelorette buttons that hard-navigate

## Backend
- Both new pages POST to /api/v1/concierge/lead — same endpoint, same Lead / GHL / Sheet / email pipeline. \`source\` field distinguishes bachelor vs bachelorette.

## Test plan
- [ ] After deploy: https://partyondelivery.com/austin-concierge renders blurred hero + modal
- [ ] Click Bachelor → routes to /austin-bachelor-concierge (navy/gold)
- [ ] Click Bachelorette → routes to /austin-bachelorette-concierge (raspberry/rose)
- [ ] Submit bachelorette form → Lead created with \`source: premier-concierge-bachelorette\`, appears in Sheet with \`Source\` column showing that value, welcome email sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)