### PR TITLE
Concierge dynamic quote: services email + interactive quote page + 25% Stripe deposit

### DIFF
--- a/src/app/api/v1/concierge/lead/route.ts
+++ b/src/app/api/v1/concierge/lead/route.ts
@@ -34,7 +34,8 @@ import {
   formatCentralTimestamp,
 } from '@/lib/premier/pod-leads-sheet';
 import { sendEmail } from '@/lib/email/resend-client';
-import { conciergeWelcomeEmail } from '@/lib/email/templates/concierge-welcome';
+import { conciergeQuoteEmail } from '@/lib/email/templates/concierge-quote';
+import { buildInitialQuote, type Quote } from '@/lib/concierge/quote';
 import { EmailType } from '@prisma/client';
 
 export const runtime = 'nodejs';
@@ -114,6 +115,19 @@ export async function POST(req: NextRequest) {
       leadId = lead.id;
       const prevMeta =
         (lead.metadata as Record<string, unknown> | null) ?? {};
+
+      // Build the initial quote from the questionnaire answers so the
+      // customer sees a starting plan when they open the quote link.
+      const conciergeVariant: 'bachelor' | 'bachelorette' =
+        body.partyType === 'bachelorette' ? 'bachelorette' : 'bachelor';
+      const initialQuote: Quote = buildInitialQuote({
+        variant: conciergeVariant,
+        headcount: body.headcount,
+        arrivalDate: body.arrivalDate,
+        departureDate: body.departureDate,
+        requestedActivities: body.activities.filter((a) => a !== 'not-sure'),
+      });
+
       await prisma.lead.update({
         where: { id: lead.id },
         data: {
@@ -132,6 +146,7 @@ export async function POST(req: NextRequest) {
               notes: body.notes,
               submittedAt: new Date().toISOString(),
             },
+            quote: initialQuote,
           } as never,
         },
       });
@@ -184,45 +199,55 @@ export async function POST(req: NextRequest) {
     console.error('[concierge/lead] GHL notify failed (non-blocking)', err);
   });
 
-  // ─── 4) Confirmation email — non-blocking ────────────────────────
-  // Fire-and-forget so a Resend outage or throttle can't 500 the API.
-  // Wrapped in try/catch inside the async IIFE so unhandled rejections
-  // don't crash the Node runtime.
-  (async () => {
-    try {
-      const tpl = conciergeWelcomeEmail({
-        firstName: body.firstName,
-        headcount: body.headcount,
-        arrivalDate: body.arrivalDate,
-        departureDate: body.departureDate,
-        partyType: body.partyType,
-        budgetPerPerson: body.budgetPerPerson,
-        activities: body.activities,
-        notes: body.notes,
-      });
-      await sendEmail({
-        to: body.email,
-        subject: tpl.subject,
-        html: tpl.html,
-        text: tpl.text,
-        type: EmailType.WELCOME,
-        metadata: {
-          flow: 'premier-concierge',
-          leadId,
-          partyType: body.partyType,
-          headcount: body.headcount,
-          budget: body.budgetPerPerson,
-          activities: body.activities,
-        },
-        tags: [
-          { name: 'flow', value: 'premier-concierge' },
-          { name: 'party_type', value: body.partyType },
-        ],
-      });
-    } catch (err) {
-      console.error('[concierge/lead] welcome email failed (non-blocking)', err);
-    }
-  })();
+  // ─── 4) Quote email — non-blocking ───────────────────────────────
+  // Combines the old welcome email with the summary + View Quote CTA
+  // that opens the interactive quote page. Only fires if we managed to
+  // create a Lead (need the ID for the quote URL).
+  if (leadId) {
+    const capturedLeadId = leadId;
+    const conciergeVariant: 'bachelor' | 'bachelorette' =
+      body.partyType === 'bachelorette' ? 'bachelorette' : 'bachelor';
+    const emailQuote: Quote = buildInitialQuote({
+      variant: conciergeVariant,
+      headcount: body.headcount,
+      arrivalDate: body.arrivalDate,
+      departureDate: body.departureDate,
+      requestedActivities: body.activities.filter((a) => a !== 'not-sure'),
+    });
+    const quoteUrl = `https://partyondelivery.com/concierge-quote/${capturedLeadId}`;
+    (async () => {
+      try {
+        const tpl = conciergeQuoteEmail({
+          firstName: body.firstName,
+          variant: conciergeVariant,
+          quote: emailQuote,
+          quoteUrl,
+        });
+        await sendEmail({
+          to: body.email,
+          subject: tpl.subject,
+          html: tpl.html,
+          text: tpl.text,
+          type: EmailType.WELCOME,
+          metadata: {
+            flow: 'premier-concierge',
+            leadId: capturedLeadId,
+            partyType: body.partyType,
+            headcount: body.headcount,
+            budget: body.budgetPerPerson,
+            activities: body.activities,
+            quoteUrl,
+          },
+          tags: [
+            { name: 'flow', value: 'premier-concierge' },
+            { name: 'party_type', value: body.partyType },
+          ],
+        });
+      } catch (err) {
+        console.error('[concierge/lead] quote email failed (non-blocking)', err);
+      }
+    })();
+  }
 
   // ─── 5) Google Sheet append — non-blocking ───────────────────────
   appendLeadToPodLeadsSheet({

--- a/src/app/api/v1/concierge/quote/[leadId]/checkout/route.ts
+++ b/src/app/api/v1/concierge/quote/[leadId]/checkout/route.ts
@@ -1,0 +1,139 @@
+/**
+ * POST /api/v1/concierge/quote/[leadId]/checkout
+ *
+ * Creates a Stripe Checkout session for the 25% deposit and returns
+ * the redirect URL. The success page (/concierge-quote/[leadId]/success)
+ * verifies the session was paid and marks the quote as
+ * status='deposit-paid' server-side, so we don't trust query params
+ * from the client to unlock anything.
+ *
+ * MVP: no webhook wiring yet. If Stripe's server-side confirmation
+ * matters (chargeback, dispute), we'd add a webhook handler in
+ * src/app/api/webhooks/stripe with a `concierge-deposit` event
+ * discriminator. Placeholder pricing means real money isn't moving
+ * today anyway.
+ */
+
+import { NextResponse, type NextRequest } from 'next/server';
+import { stripe } from '@/lib/stripe/client';
+import { prisma } from '@/lib/database/client';
+import { computeQuoteTotals, type Quote } from '@/lib/concierge/quote';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function isValidLeadId(id: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id);
+}
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ leadId: string }> },
+) {
+  const { leadId } = await params;
+  if (!isValidLeadId(leadId)) {
+    return NextResponse.json({ ok: false, error: 'not_found' }, { status: 404 });
+  }
+
+  const lead = await prisma.lead.findUnique({
+    where: { id: leadId },
+    select: {
+      email: true,
+      firstName: true,
+      lastName: true,
+      metadata: true,
+    },
+  });
+  if (!lead) {
+    return NextResponse.json({ ok: false, error: 'not_found' }, { status: 404 });
+  }
+
+  const meta = (lead.metadata as Record<string, unknown> | null) ?? {};
+  const quote = meta.quote as Quote | undefined;
+  if (!quote) {
+    return NextResponse.json({ ok: false, error: 'no_quote' }, { status: 404 });
+  }
+  if (quote.status === 'deposit-paid') {
+    return NextResponse.json(
+      { ok: false, error: 'already_paid' },
+      { status: 409 },
+    );
+  }
+
+  const totals = computeQuoteTotals(quote);
+  if (totals.depositAmount < 1) {
+    return NextResponse.json(
+      { ok: false, error: 'zero_deposit', detail: 'Enable at least one activity.' },
+      { status: 400 },
+    );
+  }
+
+  const partyLabel = quote.variant === 'bachelorette' ? 'Bachelorette' : 'Bachelor';
+  const displayName =
+    [lead.firstName, lead.lastName].filter(Boolean).join(' ') || 'Concierge lead';
+
+  const origin =
+    process.env.NEXT_PUBLIC_SITE_URL || 'https://partyondelivery.com';
+  const successUrl = `${origin}/concierge-quote/${leadId}/success?session_id={CHECKOUT_SESSION_ID}`;
+  const cancelUrl = `${origin}/concierge-quote/${leadId}`;
+
+  try {
+    const session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      customer_email: lead.email ?? undefined,
+      line_items: [
+        {
+          quantity: 1,
+          price_data: {
+            currency: 'usd',
+            unit_amount: Math.round(totals.depositAmount * 100),
+            product_data: {
+              name: `Premier Concierge · Austin ${partyLabel} Weekend — 25% Deposit`,
+              description: `${quote.headcount} guests · ${quote.arrivalDate} → ${quote.departureDate} · booked by ${displayName}`,
+            },
+          },
+        },
+      ],
+      success_url: successUrl,
+      cancel_url: cancelUrl,
+      metadata: {
+        source: 'concierge-quote-deposit',
+        leadId,
+        variant: quote.variant,
+        depositAmount: String(totals.depositAmount),
+        subtotal: String(totals.subtotal),
+        remaining: String(totals.remaining),
+      },
+      payment_intent_data: {
+        metadata: {
+          source: 'concierge-quote-deposit',
+          leadId,
+        },
+      },
+    });
+
+    // Save the session ID onto the quote so the success page can
+    // verify against Stripe when the customer returns.
+    await prisma.lead.update({
+      where: { id: leadId },
+      data: {
+        metadata: {
+          ...meta,
+          quote: {
+            ...quote,
+            stripeCheckoutSessionId: session.id,
+            updatedAt: new Date().toISOString(),
+          },
+        } as never,
+      },
+    });
+
+    return NextResponse.json({ ok: true, url: session.url });
+  } catch (err) {
+    console.error('[concierge/quote/checkout] Stripe failed', err);
+    return NextResponse.json(
+      { ok: false, error: 'stripe_error' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/v1/concierge/quote/[leadId]/route.ts
+++ b/src/app/api/v1/concierge/quote/[leadId]/route.ts
@@ -1,0 +1,170 @@
+/**
+ * GET  /api/v1/concierge/quote/[leadId]  → returns current quote
+ * PATCH /api/v1/concierge/quote/[leadId] → replaces the quote body
+ *
+ * Persists to Lead.metadata.quote so no schema change is required.
+ * Refuses writes once the deposit has been paid (status=deposit-paid) —
+ * once the customer commits, changes go through the concierge, not
+ * self-serve.
+ *
+ * CORS-open so the same quote page could later ship on
+ * premierconcierge.co and PATCH cross-domain.
+ */
+
+import { NextResponse, type NextRequest } from 'next/server';
+import { z } from 'zod';
+import { prisma } from '@/lib/database/client';
+import type { ActivityKey, Quote, QuoteItem } from '@/lib/concierge/quote';
+import { ACTIVITY_CATALOG } from '@/lib/concierge/quote';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, PATCH, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+};
+
+const quoteItemSchema = z.object({
+  activityKey: z.string().min(1),
+  enabled: z.boolean(),
+  headcount: z.number().int().min(1).max(500),
+  scheduledDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  scheduledTime: z.string().max(20),
+  notes: z.string().max(2000),
+});
+
+const patchSchema = z.object({
+  quote: z.object({
+    variant: z.enum(['bachelor', 'bachelorette']),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+    headcount: z.number().int().min(1).max(500),
+    arrivalDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+    departureDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+    items: z.array(quoteItemSchema).min(1).max(30),
+    status: z.enum(['draft', 'accepted', 'deposit-paid']),
+    stripeCheckoutSessionId: z.string().optional(),
+    depositPaidAt: z.string().optional(),
+  }),
+});
+
+function isValidLeadId(id: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id);
+}
+
+export async function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: CORS_HEADERS });
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ leadId: string }> },
+) {
+  const { leadId } = await params;
+  if (!isValidLeadId(leadId)) {
+    return NextResponse.json(
+      { ok: false, error: 'not_found' },
+      { status: 404, headers: CORS_HEADERS },
+    );
+  }
+  const lead = await prisma.lead.findUnique({
+    where: { id: leadId },
+    select: { metadata: true },
+  });
+  if (!lead) {
+    return NextResponse.json(
+      { ok: false, error: 'not_found' },
+      { status: 404, headers: CORS_HEADERS },
+    );
+  }
+  const meta = (lead.metadata as Record<string, unknown> | null) ?? {};
+  const quote = meta.quote as Quote | undefined;
+  if (!quote) {
+    return NextResponse.json(
+      { ok: false, error: 'no_quote' },
+      { status: 404, headers: CORS_HEADERS },
+    );
+  }
+  return NextResponse.json({ ok: true, quote }, { headers: CORS_HEADERS });
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ leadId: string }> },
+) {
+  const { leadId } = await params;
+  if (!isValidLeadId(leadId)) {
+    return NextResponse.json(
+      { ok: false, error: 'not_found' },
+      { status: 404, headers: CORS_HEADERS },
+    );
+  }
+
+  let body: z.infer<typeof patchSchema>;
+  try {
+    body = patchSchema.parse(await req.json());
+  } catch (err) {
+    return NextResponse.json(
+      { ok: false, error: 'invalid_body', detail: String(err) },
+      { status: 400, headers: CORS_HEADERS },
+    );
+  }
+
+  const lead = await prisma.lead.findUnique({
+    where: { id: leadId },
+    select: { metadata: true },
+  });
+  if (!lead) {
+    return NextResponse.json(
+      { ok: false, error: 'not_found' },
+      { status: 404, headers: CORS_HEADERS },
+    );
+  }
+  const meta = (lead.metadata as Record<string, unknown> | null) ?? {};
+  const existing = meta.quote as Quote | undefined;
+
+  // Freeze once the deposit is paid — changes go through the concierge
+  // from that point on.
+  if (existing?.status === 'deposit-paid') {
+    return NextResponse.json(
+      { ok: false, error: 'locked_after_deposit' },
+      { status: 409, headers: CORS_HEADERS },
+    );
+  }
+
+  // Drop any items with unknown activity keys — the client can't
+  // invent activities the catalog doesn't offer. Narrows the type too.
+  const validKeys = new Set(Object.keys(ACTIVITY_CATALOG));
+  const cleanedItems: QuoteItem[] = body.quote.items
+    .filter((it) => validKeys.has(it.activityKey))
+    .map((it) => ({
+      ...it,
+      activityKey: it.activityKey as ActivityKey,
+    }));
+
+  // Preserve the server-side fields (Stripe session, deposit-paid ts,
+  // status if it was upgraded) so the client can't roll them back.
+  const nextQuote: Quote = {
+    ...body.quote,
+    items: cleanedItems,
+    status: existing?.status ?? body.quote.status,
+    stripeCheckoutSessionId:
+      existing?.stripeCheckoutSessionId ?? body.quote.stripeCheckoutSessionId,
+    depositPaidAt: existing?.depositPaidAt ?? body.quote.depositPaidAt,
+    updatedAt: new Date().toISOString(),
+  };
+
+  await prisma.lead.update({
+    where: { id: leadId },
+    data: {
+      metadata: {
+        ...meta,
+        quote: nextQuote,
+      } as never,
+    },
+  });
+
+  return NextResponse.json({ ok: true, quote: nextQuote }, { headers: CORS_HEADERS });
+}

--- a/src/app/concierge-quote/[leadId]/page.tsx
+++ b/src/app/concierge-quote/[leadId]/page.tsx
@@ -1,0 +1,77 @@
+/**
+ * /concierge-quote/[leadId]
+ *
+ * Interactive quote page for Premier Concierge leads. The Lead ID
+ * doubles as the quote token — UUIDs are opaque enough for
+ * pre-launch traffic; upgrade to a signed URL later if pricing goes
+ * public.
+ *
+ * Server component: fetches the Lead + its quote, hydrates the
+ * interactive editor with the current state. All customer edits go
+ * through PATCH /api/v1/concierge/quote/[leadId] which saves to
+ * Lead.metadata.quote.
+ */
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { prisma } from '@/lib/database/client';
+import ConciergeQuoteClient from '@/components/concierge/ConciergeQuoteClient';
+import type { Quote } from '@/lib/concierge/quote';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Your Concierge Quote | Party On Delivery',
+  robots: { index: false, follow: false },
+};
+
+async function loadLead(leadId: string) {
+  // Basic UUID sanity check so we return 404 for junk paths without
+  // hitting Postgres with a malformed WHERE.
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(leadId)) {
+    return null;
+  }
+  return prisma.lead.findUnique({
+    where: { id: leadId },
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      email: true,
+      phone: true,
+      metadata: true,
+    },
+  });
+}
+
+export default async function ConciergeQuotePage({
+  params,
+}: {
+  params: Promise<{ leadId: string }>;
+}) {
+  const { leadId } = await params;
+  const lead = await loadLead(leadId);
+  if (!lead) return notFound();
+
+  const meta = (lead.metadata as Record<string, unknown> | null) ?? {};
+  const isConcierge = meta.partner === 'premier-concierge';
+  const quote = meta.quote as Quote | undefined;
+
+  if (!isConcierge || !quote) {
+    // Lead exists but was never issued a concierge quote — send them
+    // to an explanation page rather than a broken editor.
+    return notFound();
+  }
+
+  return (
+    <ConciergeQuoteClient
+      leadId={lead.id}
+      customer={{
+        firstName: lead.firstName ?? '',
+        lastName: lead.lastName ?? '',
+        email: lead.email ?? '',
+        phone: lead.phone ?? '',
+      }}
+      initialQuote={quote}
+    />
+  );
+}

--- a/src/app/concierge-quote/[leadId]/success/page.tsx
+++ b/src/app/concierge-quote/[leadId]/success/page.tsx
@@ -1,0 +1,222 @@
+/**
+ * /concierge-quote/[leadId]/success
+ *
+ * Post-Stripe-checkout landing page. Verifies the session_id query
+ * param against Stripe SERVER-SIDE and, if paid, promotes the quote's
+ * status to `deposit-paid` on Lead.metadata.quote. We never trust the
+ * URL alone to unlock anything.
+ */
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { prisma } from '@/lib/database/client';
+import { stripe } from '@/lib/stripe/client';
+import { computeQuoteTotals, type Quote } from '@/lib/concierge/quote';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Deposit paid — Premier Concierge | Party On Delivery',
+  robots: { index: false, follow: false },
+};
+
+const NAVY = '#0A1F33';
+const GOLD = '#D4AF37';
+const RASPBERRY = '#7A1E4A';
+const ROSE = '#E8B4CE';
+const CREAM = '#FAF6EE';
+
+function isValidLeadId(id: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id);
+}
+
+function fmt$(n: number): string {
+  return `$${Math.round(n).toLocaleString('en-US')}`;
+}
+
+export default async function ConciergeDepositSuccessPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ leadId: string }>;
+  searchParams: Promise<{ session_id?: string }>;
+}) {
+  const { leadId } = await params;
+  const { session_id: sessionId } = await searchParams;
+  if (!isValidLeadId(leadId)) return notFound();
+
+  const lead = await prisma.lead.findUnique({
+    where: { id: leadId },
+    select: { firstName: true, metadata: true },
+  });
+  if (!lead) return notFound();
+
+  const meta = (lead.metadata as Record<string, unknown> | null) ?? {};
+  const quote = meta.quote as Quote | undefined;
+  if (!quote) return notFound();
+
+  const theme = quote.variant === 'bachelorette'
+    ? { primary: RASPBERRY, accent: ROSE, onAccent: '#3F0F27', soft: '#FFF4F8' }
+    : { primary: NAVY, accent: GOLD, onAccent: NAVY, soft: CREAM };
+
+  const totals = computeQuoteTotals(quote);
+
+  // ─── Verify with Stripe ──────────────────────────────────────
+  // Two ways to end up here:
+  //   1. Fresh redirect from Stripe with a session_id in the URL — verify it.
+  //   2. Direct hit after we already marked it paid — trust the flag.
+  let verified = quote.status === 'deposit-paid';
+  let verifiedError: string | null = null;
+
+  if (!verified && sessionId) {
+    try {
+      const session = await stripe.checkout.sessions.retrieve(sessionId);
+      const matchesLead = session.metadata?.leadId === leadId;
+      const paid =
+        session.payment_status === 'paid' || session.payment_status === 'no_payment_required';
+      if (matchesLead && paid) {
+        verified = true;
+        await prisma.lead.update({
+          where: { id: leadId },
+          data: {
+            status: 'CONVERTED',
+            metadata: {
+              ...meta,
+              quote: {
+                ...quote,
+                status: 'deposit-paid',
+                depositPaidAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+              },
+            } as never,
+          },
+        });
+      } else if (!matchesLead) {
+        verifiedError = 'session_lead_mismatch';
+      } else {
+        verifiedError = 'not_paid_yet';
+      }
+    } catch (err) {
+      console.error('[concierge success] Stripe retrieve failed', err);
+      verifiedError = 'stripe_verify_failed';
+    }
+  }
+
+  return (
+    <main
+      className="min-h-screen"
+      style={{ background: theme.soft, color: theme.primary }}
+    >
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 py-14 text-center">
+        {verified ? (
+          <>
+            <div
+              className="inline-block px-4 py-2 rounded-full text-xs font-bold tracking-widest mb-6"
+              style={{ background: theme.primary, color: theme.accent }}
+            >
+              ✓ DEPOSIT CONFIRMED
+            </div>
+            <h1
+              className="font-heading text-4xl md:text-5xl font-bold tracking-tight leading-tight"
+              style={{ color: theme.primary }}
+            >
+              You&rsquo;re booked.
+            </h1>
+            <p className="mt-4 text-base text-gray-700 max-w-xl mx-auto">
+              {lead.firstName || 'Your concierge'} — thanks for locking in
+              your weekend. Your dedicated concierge will confirm every
+              vendor within 24 hours and send you the final itinerary.
+            </p>
+
+            <div
+              className="mt-8 mx-auto max-w-md rounded-lg p-5 text-left"
+              style={{
+                background: '#FFFFFF',
+                border: `2px solid ${theme.primary}`,
+              }}
+            >
+              <div
+                className="text-[10px] font-bold tracking-widest mb-3"
+                style={{ color: theme.primary }}
+              >
+                RECEIPT
+              </div>
+              <div className="flex justify-between text-sm mb-1">
+                <span>Subtotal</span>
+                <span className="font-mono">{fmt$(totals.subtotal)}</span>
+              </div>
+              <div
+                className="flex justify-between text-sm font-bold mt-2 pt-2"
+                style={{ borderTop: `1px solid #E5E7EB` }}
+              >
+                <span>Deposit paid today</span>
+                <span className="font-mono" style={{ color: '#0F8141' }}>
+                  {fmt$(totals.depositAmount)}
+                </span>
+              </div>
+              <div className="flex justify-between text-xs text-gray-500 mt-2">
+                <span>Remaining (due 7d before)</span>
+                <span className="font-mono">{fmt$(totals.remaining)}</span>
+              </div>
+            </div>
+
+            <p className="text-xs text-gray-500 mt-6">
+              Stripe emailed you a receipt. Save this page — your quote link
+              stays live until the event.
+            </p>
+
+            <div className="mt-8">
+              <Link
+                href={`/concierge-quote/${leadId}`}
+                className="inline-block rounded-lg px-6 py-3 text-sm font-heading font-bold tracking-[0.10em] transition-transform hover:scale-[1.03]"
+                style={{
+                  background: theme.accent,
+                  color: theme.onAccent,
+                  border: `2px solid ${theme.primary}`,
+                  boxShadow: `0 3px 0 ${theme.primary}`,
+                }}
+              >
+                VIEW YOUR QUOTE
+              </Link>
+            </div>
+          </>
+        ) : (
+          <>
+            <h1
+              className="font-heading text-3xl md:text-4xl font-bold tracking-tight leading-tight"
+              style={{ color: theme.primary }}
+            >
+              We couldn&rsquo;t verify your deposit.
+            </h1>
+            <p className="mt-4 text-base text-gray-700 max-w-xl mx-auto">
+              {verifiedError === 'not_paid_yet'
+                ? "Stripe hasn't marked the payment as complete yet. Give it a minute and refresh — or hit the button below to try again."
+                : "Something went sideways verifying your session. This doesn't mean the deposit failed — hit the button below to reopen your quote, or reply to your quote email and a concierge will confirm manually."}
+            </p>
+            <div className="mt-6 flex flex-col sm:flex-row items-center justify-center gap-3">
+              <Link
+                href={`/concierge-quote/${leadId}`}
+                className="rounded-lg px-6 py-3 text-sm font-heading font-bold tracking-[0.10em] transition-transform hover:scale-[1.03]"
+                style={{
+                  background: theme.accent,
+                  color: theme.onAccent,
+                  border: `2px solid ${theme.primary}`,
+                  boxShadow: `0 3px 0 ${theme.primary}`,
+                }}
+              >
+                BACK TO QUOTE
+              </Link>
+              <a
+                href="tel:+17373719700"
+                className="text-sm font-bold underline"
+                style={{ color: theme.primary }}
+              >
+                Or call (737) 371-9700
+              </a>
+            </div>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/components/AgeVerification.tsx
+++ b/src/components/AgeVerification.tsx
@@ -27,6 +27,7 @@ const AGE_GATE_EXEMPT_PATHS = [
   '/austin-bachelor-concierge',
   '/austin-bachelorette-concierge',
   '/austin-concierge',
+  '/concierge-quote',
 ]
 
 /**
@@ -93,7 +94,11 @@ export default function AgeVerification() {
     if (
       pathname &&
       (AGE_GATE_EXEMPT_PATHS.includes(pathname) ||
-        AGE_GATE_EXEMPT_INVITE_PATHS.includes(pathname))
+        AGE_GATE_EXEMPT_INVITE_PATHS.includes(pathname) ||
+        // Concierge quote pages are dynamic (/concierge-quote/[leadId]
+        // and /success). Prefix-match them so every sub-route is
+        // exempted without listing each UUID.
+        pathname.startsWith('/concierge-quote/'))
     ) {
       setIsVisible(false)
       return

--- a/src/components/chat/PartyChatMount.tsx
+++ b/src/components/chat/PartyChatMount.tsx
@@ -41,6 +41,7 @@ const HIDE_PATTERNS: RegExp[] = [
   /^\/austin-bachelor-concierge(\/|$)/,
   /^\/austin-bachelorette-concierge(\/|$)/,
   /^\/austin-concierge(\/|$)/,
+  /^\/concierge-quote(\/|$)/,
 ];
 
 export default function PartyChatMount() {

--- a/src/components/concierge/ConciergeQuoteClient.tsx
+++ b/src/components/concierge/ConciergeQuoteClient.tsx
@@ -1,0 +1,715 @@
+'use client';
+
+/**
+ * Interactive Concierge Quote editor.
+ *
+ * Customer can:
+ *   - Toggle activities on/off
+ *   - Adjust headcount per activity (defaults to top-level headcount)
+ *   - Pick date + time per activity
+ *   - Leave notes per activity
+ *   - See live subtotal + 25% deposit + remaining balance
+ *   - Accept & pay deposit via Stripe Checkout
+ *
+ * Persistence: every edit debounces a PATCH to
+ *   /api/v1/concierge/quote/[leadId]
+ * which writes back to Lead.metadata.quote so the state survives
+ * refresh / email re-clicks / late-night revisits.
+ *
+ * Placeholder pricing per founder spec — real vendor rates get plugged
+ * into ACTIVITY_CATALOG later without touching this component.
+ */
+
+import { useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
+import Link from 'next/link';
+import {
+  ACTIVITY_CATALOG,
+  DEPOSIT_PERCENT,
+  computeQuoteTotals,
+  type ActivityKey,
+  type Quote,
+  type QuoteItem,
+} from '@/lib/concierge/quote';
+
+// ─── Brand tokens (mirror ConciergeLandingClient) ────────────────
+const NAVY = '#0A1F33';
+const GOLD = '#D4AF37';
+const RASPBERRY = '#7A1E4A';
+const ROSE = '#E8B4CE';
+const CREAM = '#FAF6EE';
+const BLUSH = '#FFF4F8';
+
+type Theme = {
+  primary: string;
+  accent: string;
+  soft: string;
+  onAccent: string;
+};
+
+const THEMES: Record<'bachelor' | 'bachelorette', Theme> = {
+  bachelor: { primary: NAVY, accent: GOLD, soft: CREAM, onAccent: NAVY },
+  bachelorette: { primary: RASPBERRY, accent: ROSE, soft: BLUSH, onAccent: '#3F0F27' },
+};
+
+type Customer = {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+};
+
+type Props = {
+  leadId: string;
+  customer: Customer;
+  initialQuote: Quote;
+};
+
+const TIME_SLOTS = [
+  '8:00 AM',
+  '9:00 AM',
+  '10:00 AM',
+  '11:00 AM',
+  '12:00 PM',
+  '1:00 PM',
+  '2:00 PM',
+  '3:00 PM',
+  '4:00 PM',
+  '5:00 PM',
+  '6:00 PM',
+  '7:00 PM',
+  '8:00 PM',
+];
+
+function fmt$(n: number): string {
+  return `$${Math.round(n).toLocaleString('en-US')}`;
+}
+
+export default function ConciergeQuoteClient({
+  leadId,
+  customer,
+  initialQuote,
+}: Props): ReactElement {
+  const theme = THEMES[initialQuote.variant];
+  const [quote, setQuote] = useState<Quote>(initialQuote);
+  const [saveState, setSaveState] = useState<'idle' | 'saving' | 'saved' | 'error'>(
+    'idle',
+  );
+  const [checkingOut, setCheckingOut] = useState(false);
+  const [checkoutError, setCheckoutError] = useState<string | null>(null);
+
+  // ─── Autosave (debounced) ─────────────────────────────────────
+  const savedOnceRef = useRef(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    // Skip the very first render — the quote came from the server.
+    if (!savedOnceRef.current) {
+      savedOnceRef.current = true;
+      return;
+    }
+    setSaveState('saving');
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/v1/concierge/quote/${leadId}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ quote }),
+        });
+        if (!res.ok) {
+          setSaveState('error');
+          return;
+        }
+        setSaveState('saved');
+        setTimeout(() => setSaveState('idle'), 1200);
+      } catch (err) {
+        console.error('[concierge quote] autosave failed', err);
+        setSaveState('error');
+      }
+    }, 600);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [quote, leadId]);
+
+  const totals = useMemo(() => computeQuoteTotals(quote), [quote]);
+  const enabledCount = quote.items.filter((it) => it.enabled).length;
+
+  function updateItem(key: ActivityKey, patch: Partial<QuoteItem>) {
+    setQuote((prev) => ({
+      ...prev,
+      items: prev.items.map((it) =>
+        it.activityKey === key ? { ...it, ...patch } : it,
+      ),
+      updatedAt: new Date().toISOString(),
+    }));
+  }
+
+  function updateTopLevel(patch: Partial<Pick<Quote, 'headcount' | 'arrivalDate' | 'departureDate'>>) {
+    setQuote((prev) => ({
+      ...prev,
+      ...patch,
+      updatedAt: new Date().toISOString(),
+    }));
+  }
+
+  async function payDeposit() {
+    if (checkingOut) return;
+    if (totals.subtotal <= 0) {
+      setCheckoutError('Turn on at least one activity before paying the deposit.');
+      return;
+    }
+    setCheckoutError(null);
+    setCheckingOut(true);
+    try {
+      const res = await fetch(`/api/v1/concierge/quote/${leadId}/checkout`, {
+        method: 'POST',
+      });
+      const json = (await res.json()) as { ok: boolean; url?: string; error?: string };
+      if (!res.ok || !json.ok || !json.url) {
+        setCheckoutError(json.error || 'Could not start checkout — try again.');
+        setCheckingOut(false);
+        return;
+      }
+      window.location.href = json.url;
+    } catch (err) {
+      console.error('[concierge quote] checkout failed', err);
+      setCheckoutError('Network blip — try again.');
+      setCheckingOut(false);
+    }
+  }
+
+  const isPaid = quote.status === 'deposit-paid';
+
+  return (
+    <main
+      className="min-h-screen"
+      style={{ background: theme.soft, color: theme.primary }}
+    >
+      {/* Header */}
+      <header
+        className="text-white"
+        style={{
+          background: theme.primary,
+          borderBottom: `3px solid ${theme.accent}`,
+        }}
+      >
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 py-6">
+          <div
+            className="text-[10px] font-bold tracking-[0.24em] mb-1"
+            style={{ color: theme.accent }}
+          >
+            PREMIER CONCIERGE · AUSTIN
+          </div>
+          <h1 className="font-heading text-2xl sm:text-3xl font-bold tracking-tight leading-tight">
+            {customer.firstName
+              ? `${customer.firstName}'s`
+              : 'Your'} Austin{' '}
+            {quote.variant} weekend quote
+          </h1>
+          <p className="mt-2 text-sm opacity-85">
+            Tweak activities, headcount, and dates below. Your total updates
+            live. Pay the 25% deposit to lock in your vendors.
+          </p>
+        </div>
+      </header>
+
+      {isPaid && <DepositPaidBanner />}
+
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 py-6 pb-32 lg:pb-8 grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-6">
+        {/* ── Left column — trip + activities ─────────────────── */}
+        <section>
+          <TripCard
+            theme={theme}
+            headcount={quote.headcount}
+            arrivalDate={quote.arrivalDate}
+            departureDate={quote.departureDate}
+            onUpdate={updateTopLevel}
+          />
+
+          <div className="mt-6 mb-3 flex items-baseline justify-between">
+            <h2
+              className="font-heading text-xl font-bold tracking-tight"
+              style={{ color: theme.primary }}
+            >
+              Activities & services
+            </h2>
+            <div className="text-xs text-gray-500">
+              {enabledCount} of {quote.items.length} on
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            {quote.items.map((it) => (
+              <ActivityCard
+                key={it.activityKey}
+                theme={theme}
+                item={it}
+                onUpdate={(patch) => updateItem(it.activityKey, patch)}
+                onToggle={() =>
+                  updateItem(it.activityKey, { enabled: !it.enabled })
+                }
+              />
+            ))}
+          </div>
+
+          <div className="mt-6 rounded-lg p-4 text-sm bg-white" style={{ border: `1.5px solid ${theme.accent}` }}>
+            <div className="text-[10px] font-bold tracking-widest mb-1" style={{ color: theme.primary }}>
+              💧 RECOMMENDED DRINKS
+            </div>
+            <p className="text-gray-700 text-sm">
+              Drink delivery is priced per person above ({fmt$(ACTIVITY_CATALOG['drink-delivery'].pricePerPerson)}/head).
+              After you pay the deposit, your concierge will send a follow-up with the recommended drinks list from
+              our engine — quantities auto-scale to your final headcount + party type. You can edit that list
+              before delivery.
+            </p>
+          </div>
+
+          {saveState !== 'idle' && (
+            <div className="mt-4 text-xs text-gray-500 flex items-center gap-2">
+              {saveState === 'saving' && '💾 Saving…'}
+              {saveState === 'saved' && (
+                <span style={{ color: '#0F8141' }}>✓ Saved</span>
+              )}
+              {saveState === 'error' && (
+                <span style={{ color: '#C0392B' }}>⚠ Save failed — retry on next edit</span>
+              )}
+            </div>
+          )}
+        </section>
+
+        {/* ── Right column — totals + deposit ─────────────────── */}
+        <aside>
+          <TotalsCard
+            theme={theme}
+            subtotal={totals.subtotal}
+            depositAmount={totals.depositAmount}
+            remaining={totals.remaining}
+            isPaid={isPaid}
+            checkingOut={checkingOut}
+            checkoutError={checkoutError}
+            onPay={payDeposit}
+          />
+
+          <ContactCard theme={theme} customer={customer} />
+        </aside>
+      </div>
+
+      {/* Mobile sticky deposit bar */}
+      {!isPaid && (
+        <div
+          className="fixed bottom-0 inset-x-0 z-40 border-t-2 lg:hidden"
+          style={{
+            background: '#FFFFFF',
+            borderColor: theme.primary,
+            boxShadow: '0 -4px 18px rgba(10,15,25,0.15)',
+          }}
+        >
+          <div className="px-4 py-3 flex items-center justify-between gap-3">
+            <div>
+              <div className="text-[10px] font-bold tracking-widest text-gray-500">
+                DEPOSIT DUE TODAY
+              </div>
+              <div className="text-lg font-bold" style={{ color: theme.primary }}>
+                {fmt$(totals.depositAmount)}
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={payDeposit}
+              disabled={checkingOut || totals.subtotal <= 0}
+              className="rounded-lg px-5 py-3 text-sm font-heading font-bold tracking-[0.10em] transition-transform hover:scale-[1.03] disabled:opacity-50 disabled:cursor-not-allowed"
+              style={{
+                background: theme.accent,
+                color: theme.onAccent,
+                border: `2px solid ${theme.primary}`,
+                boxShadow: `0 3px 0 ${theme.primary}`,
+              }}
+            >
+              {checkingOut ? 'STARTING…' : 'PAY DEPOSIT →'}
+            </button>
+          </div>
+        </div>
+      )}
+    </main>
+  );
+}
+
+// ─── Sub-components ─────────────────────────────────────────────
+
+function TripCard({
+  theme,
+  headcount,
+  arrivalDate,
+  departureDate,
+  onUpdate,
+}: {
+  theme: Theme;
+  headcount: number;
+  arrivalDate: string;
+  departureDate: string;
+  onUpdate: (patch: Partial<Pick<Quote, 'headcount' | 'arrivalDate' | 'departureDate'>>) => void;
+}) {
+  return (
+    <div
+      className="rounded-lg p-4 bg-white"
+      style={{ border: `1.5px solid ${theme.primary}` }}
+    >
+      <div
+        className="text-[10px] font-bold tracking-widest mb-2"
+        style={{ color: theme.primary }}
+      >
+        TRIP DETAILS
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <Field label="Default headcount">
+          <input
+            type="number"
+            min={1}
+            max={500}
+            value={headcount}
+            onChange={(e) => {
+              const n = Math.max(1, Math.min(500, Number(e.target.value) || 1));
+              onUpdate({ headcount: n });
+            }}
+            className="w-full rounded-md border-2 border-gray-200 px-3 py-2 text-base focus:outline-none focus:border-current"
+            style={{ color: theme.primary }}
+          />
+        </Field>
+        <Field label="Arrival">
+          <input
+            type="date"
+            value={arrivalDate}
+            onChange={(e) => onUpdate({ arrivalDate: e.target.value })}
+            className="w-full rounded-md border-2 border-gray-200 px-3 py-2 text-base focus:outline-none focus:border-current"
+            style={{ color: theme.primary }}
+          />
+        </Field>
+        <Field label="Departure">
+          <input
+            type="date"
+            value={departureDate}
+            onChange={(e) => onUpdate({ departureDate: e.target.value })}
+            className="w-full rounded-md border-2 border-gray-200 px-3 py-2 text-base focus:outline-none focus:border-current"
+            style={{ color: theme.primary }}
+          />
+        </Field>
+      </div>
+    </div>
+  );
+}
+
+function ActivityCard({
+  theme,
+  item,
+  onUpdate,
+  onToggle,
+}: {
+  theme: Theme;
+  item: QuoteItem;
+  onUpdate: (patch: Partial<QuoteItem>) => void;
+  onToggle: () => void;
+}) {
+  const entry = ACTIVITY_CATALOG[item.activityKey];
+  if (!entry) return null;
+  const lineTotal = item.enabled ? entry.pricePerPerson * item.headcount : 0;
+  const on = item.enabled;
+
+  return (
+    <div
+      className="rounded-lg overflow-hidden bg-white transition-all"
+      style={{
+        border: `${on ? 2 : 1.5}px solid ${on ? theme.primary : '#E5E7EB'}`,
+        boxShadow: on ? `0 3px 0 ${theme.primary}18` : 'none',
+        opacity: on ? 1 : 0.72,
+      }}
+    >
+      {/* Header row */}
+      <button
+        type="button"
+        onClick={onToggle}
+        className="w-full flex items-center gap-3 p-4 text-left hover:bg-gray-50 transition-colors"
+      >
+        <div
+          className="w-6 h-6 rounded flex-shrink-0 flex items-center justify-center"
+          style={{
+            background: on ? theme.accent : '#FFFFFF',
+            border: `2px solid ${on ? theme.accent : '#D1D5DB'}`,
+          }}
+          aria-hidden
+        >
+          {on && (
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke={theme.onAccent}
+              strokeWidth={4}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+          )}
+        </div>
+        <div className="text-2xl flex-shrink-0" aria-hidden>
+          {entry.emoji}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div
+            className="font-bold text-base leading-tight truncate"
+            style={{ color: theme.primary }}
+          >
+            {entry.label}
+          </div>
+          <div className="text-xs text-gray-600 truncate">{entry.blurb}</div>
+        </div>
+        <div className="text-right flex-shrink-0">
+          <div
+            className="font-mono text-sm font-bold"
+            style={{ color: theme.primary }}
+          >
+            {fmt$(lineTotal)}
+          </div>
+          <div className="text-[10px] text-gray-500">
+            {fmt$(entry.pricePerPerson)}/pp · {entry.durationHours}h
+          </div>
+        </div>
+      </button>
+
+      {/* Details editor (only visible when enabled) */}
+      {on && (
+        <div
+          className="grid grid-cols-1 sm:grid-cols-3 gap-3 px-4 pb-4 pt-1"
+          style={{ background: '#FAFAFA', borderTop: '1px solid #F0F0F0' }}
+        >
+          <Field label="People">
+            <input
+              type="number"
+              min={1}
+              max={500}
+              value={item.headcount}
+              onChange={(e) =>
+                onUpdate({
+                  headcount: Math.max(1, Math.min(500, Number(e.target.value) || 1)),
+                })
+              }
+              className="w-full rounded-md border-2 border-gray-200 px-3 py-2 text-sm focus:outline-none focus:border-current"
+              style={{ color: theme.primary }}
+            />
+          </Field>
+          <Field label="Date">
+            <input
+              type="date"
+              value={item.scheduledDate}
+              onChange={(e) => onUpdate({ scheduledDate: e.target.value })}
+              className="w-full rounded-md border-2 border-gray-200 px-3 py-2 text-sm focus:outline-none focus:border-current"
+              style={{ color: theme.primary }}
+            />
+          </Field>
+          <Field label="Time">
+            <select
+              value={item.scheduledTime}
+              onChange={(e) => onUpdate({ scheduledTime: e.target.value })}
+              className="w-full rounded-md border-2 border-gray-200 px-3 py-2 text-sm focus:outline-none focus:border-current"
+              style={{ color: theme.primary }}
+            >
+              {TIME_SLOTS.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <div className="sm:col-span-3">
+            <Field label="Notes (optional)">
+              <input
+                type="text"
+                value={item.notes}
+                onChange={(e) => onUpdate({ notes: e.target.value })}
+                placeholder="e.g. best boat for 12 guys, avoid country music"
+                className="w-full rounded-md border-2 border-gray-200 px-3 py-2 text-sm focus:outline-none focus:border-current"
+                style={{ color: theme.primary }}
+              />
+            </Field>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TotalsCard({
+  theme,
+  subtotal,
+  depositAmount,
+  remaining,
+  isPaid,
+  checkingOut,
+  checkoutError,
+  onPay,
+}: {
+  theme: Theme;
+  subtotal: number;
+  depositAmount: number;
+  remaining: number;
+  isPaid: boolean;
+  checkingOut: boolean;
+  checkoutError: string | null;
+  onPay: () => void;
+}) {
+  return (
+    <div
+      className="rounded-lg p-5 sticky top-4"
+      style={{
+        background: theme.primary,
+        color: '#FFFFFF',
+        border: `2px solid ${theme.accent}`,
+      }}
+    >
+      <div
+        className="text-[10px] font-bold tracking-[0.24em] mb-3"
+        style={{ color: theme.accent }}
+      >
+        {isPaid ? 'DEPOSIT PAID' : 'YOUR TOTAL'}
+      </div>
+      <div className="space-y-2 text-sm">
+        <Row label="Subtotal" value={fmt$(subtotal)} />
+        <Row
+          label={`Deposit today (${Math.round(DEPOSIT_PERCENT * 100)}%)`}
+          value={fmt$(depositAmount)}
+          bold
+          accent={theme.accent}
+        />
+        <Row
+          label="Remaining (due 7d before)"
+          value={fmt$(remaining)}
+          small
+        />
+      </div>
+
+      {!isPaid && (
+        <>
+          <button
+            type="button"
+            onClick={onPay}
+            disabled={checkingOut || subtotal <= 0}
+            className="w-full mt-5 rounded-lg py-4 text-base font-heading font-bold tracking-[0.10em] transition-transform hover:scale-[1.02] disabled:opacity-50 disabled:cursor-not-allowed hidden lg:block"
+            style={{
+              background: theme.accent,
+              color: theme.onAccent,
+              border: `2px solid ${theme.accent}`,
+              boxShadow: `0 3px 0 rgba(0,0,0,0.35)`,
+            }}
+          >
+            {checkingOut ? 'STARTING CHECKOUT…' : 'ACCEPT & PAY DEPOSIT →'}
+          </button>
+          <p className="text-xs opacity-70 mt-3">
+            Secured by Stripe. Deposit locks in your vendors. Remaining balance
+            is due 7 days before the first activity.
+          </p>
+          {checkoutError && (
+            <div
+              className="mt-3 rounded p-2 text-xs"
+              style={{ background: 'rgba(255,255,255,0.15)', color: '#FFCFCF' }}
+            >
+              {checkoutError}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function ContactCard({ theme, customer }: { theme: Theme; customer: Customer }) {
+  return (
+    <div
+      className="mt-4 rounded-lg p-4 bg-white text-sm"
+      style={{ border: `1.5px solid #E5E7EB` }}
+    >
+      <div
+        className="text-[10px] font-bold tracking-widest mb-2"
+        style={{ color: theme.primary }}
+      >
+        YOU
+      </div>
+      <div style={{ color: theme.primary }}>
+        {[customer.firstName, customer.lastName].filter(Boolean).join(' ') || 'Concierge lead'}
+      </div>
+      <div className="text-xs text-gray-600 truncate">{customer.email}</div>
+      {customer.phone && (
+        <div className="text-xs text-gray-600">{customer.phone}</div>
+      )}
+      <div className="text-[10px] text-gray-500 mt-3">
+        Wrong info?{' '}
+        <a
+          href="mailto:concierge@partyondelivery.com"
+          className="underline"
+          style={{ color: theme.primary }}
+        >
+          Reply to your quote email
+        </a>{' '}
+        and we&rsquo;ll update it.
+      </div>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label className="block text-[10px] font-bold tracking-widest text-gray-500 mb-1">
+        {label.toUpperCase()}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+function Row({
+  label,
+  value,
+  bold,
+  small,
+  accent,
+}: {
+  label: string;
+  value: string;
+  bold?: boolean;
+  small?: boolean;
+  accent?: string;
+}) {
+  return (
+    <div
+      className={`flex justify-between items-baseline ${small ? 'text-xs opacity-80' : 'text-sm'}`}
+      style={accent ? { color: accent } : undefined}
+    >
+      <span className={bold ? 'font-bold' : ''}>{label}</span>
+      <span className={`font-mono ${bold ? 'font-bold' : ''}`}>{value}</span>
+    </div>
+  );
+}
+
+function DepositPaidBanner() {
+  return (
+    <div
+      className="text-white text-center py-3 px-4 text-sm font-bold"
+      style={{ background: '#0F8141' }}
+    >
+      🎉 Deposit paid — your concierge will confirm every vendor within 24
+      hours. Check your email for the receipt.
+      <span className="ml-2 opacity-90">
+        <Link href="/" className="underline">
+          Back to POD
+        </Link>
+      </span>
+    </div>
+  );
+}

--- a/src/lib/concierge/quote.ts
+++ b/src/lib/concierge/quote.ts
@@ -1,0 +1,248 @@
+/**
+ * Concierge Quote — shared types + placeholder pricing + quote builder.
+ *
+ * The quote lives on `Lead.metadata.quote` (JSON blob) so no schema
+ * change is needed for MVP. The Lead ID doubles as the quote token in
+ * the URL (UUIDs are opaque enough for pre-launch traffic; we can add
+ * a signed token later if pricing goes public).
+ *
+ * All pricing here is PLACEHOLDER per founder spec — the point is to
+ * validate the interactive flow (customer edits, deposit checkout,
+ * post-payment confirmation) before we plug in real vendor rates.
+ */
+
+export type ActivityKey =
+  | 'boat-rental'
+  | 'drink-delivery'
+  | 'golf-brewery-tour'
+  | 'atv-tour'
+  | 'gun-range'
+  | 'transportation'
+  | 'brunch-mimosa'
+  | 'winery-tour'
+  | 'spa-day';
+
+export type ActivityCatalogEntry = {
+  key: ActivityKey;
+  label: string;
+  /** One-line description shown on the quote page. */
+  blurb: string;
+  emoji: string;
+  /** Placeholder rate. Real rate lives in a per-vendor config later. */
+  pricePerPerson: number;
+  /** Duration in hours — informational; drives the default time-slot
+   *  suggestion but doesn't affect price today. */
+  durationHours: number;
+  /** Which variants offer this activity. */
+  variants: Array<'bachelor' | 'bachelorette'>;
+};
+
+export const ACTIVITY_CATALOG: Record<ActivityKey, ActivityCatalogEntry> = {
+  'boat-rental': {
+    key: 'boat-rental',
+    label: 'Private Party Boat',
+    blurb: 'Captained cruise on Lake Travis with your group.',
+    emoji: '🛥️',
+    pricePerPerson: 165,
+    durationHours: 4,
+    variants: ['bachelor', 'bachelorette'],
+  },
+  'drink-delivery': {
+    key: 'drink-delivery',
+    label: 'Drink Delivery to the Dock',
+    blurb:
+      'Beer, liquor, seltzers + cocktail kits iced and staged before you board.',
+    emoji: '🥃',
+    pricePerPerson: 85,
+    durationHours: 0,
+    variants: ['bachelor', 'bachelorette'],
+  },
+  'golf-brewery-tour': {
+    key: 'golf-brewery-tour',
+    label: 'Golf & Brewery Tour',
+    blurb: 'Tee times + East Austin brewery tasting flight, transportation included.',
+    emoji: '⛳',
+    pricePerPerson: 195,
+    durationHours: 6,
+    variants: ['bachelor'],
+  },
+  'atv-tour': {
+    key: 'atv-tour',
+    label: 'ATV / Off-Road Tour',
+    blurb: 'Guided Hill Country ATV ride with all equipment.',
+    emoji: '🚙',
+    pricePerPerson: 175,
+    durationHours: 3,
+    variants: ['bachelor'],
+  },
+  'gun-range': {
+    key: 'gun-range',
+    label: 'Gun Range Experience',
+    blurb: 'Private lane block, instructor-led. Pistol + rifle. All levels.',
+    emoji: '🎯',
+    pricePerPerson: 125,
+    durationHours: 2,
+    variants: ['bachelor'],
+  },
+  transportation: {
+    key: 'transportation',
+    label: 'Group Transportation',
+    blurb: 'Party bus or sprinter van, airport → hotel → lake → home.',
+    emoji: '🚐',
+    pricePerPerson: 55,
+    durationHours: 8,
+    variants: ['bachelor', 'bachelorette'],
+  },
+  'brunch-mimosa': {
+    key: 'brunch-mimosa',
+    label: 'Brunch & Mimosa Bar',
+    blurb: "Private chef brunch or reservations at Austin's best brunch spots.",
+    emoji: '🥞',
+    pricePerPerson: 75,
+    durationHours: 3,
+    variants: ['bachelorette'],
+  },
+  'winery-tour': {
+    key: 'winery-tour',
+    label: 'Hill Country Winery Tour',
+    blurb: 'Curated tastings + vineyard photo stops. Rides included.',
+    emoji: '🍷',
+    pricePerPerson: 185,
+    durationHours: 5,
+    variants: ['bachelorette'],
+  },
+  'spa-day': {
+    key: 'spa-day',
+    label: 'Spa & Recovery Day',
+    blurb: 'In-Airbnb massages, blowouts, mobile mani/pedi.',
+    emoji: '💆‍♀️',
+    pricePerPerson: 220,
+    durationHours: 3,
+    variants: ['bachelorette'],
+  },
+};
+
+export const DEPOSIT_PERCENT = 0.25;
+
+export type QuoteItem = {
+  activityKey: ActivityKey;
+  /** True → included in the total. False → line stays visible but is
+   *  greyed out and excluded. */
+  enabled: boolean;
+  headcount: number;
+  scheduledDate: string; // YYYY-MM-DD
+  scheduledTime: string; // "1:00 PM"
+  notes: string;
+};
+
+export type QuoteStatus = 'draft' | 'accepted' | 'deposit-paid';
+
+export type Quote = {
+  variant: 'bachelor' | 'bachelorette';
+  createdAt: string;
+  updatedAt: string;
+  /** Defaults the customer entered on the intake form; per-item
+   *  headcount can override on the quote page. */
+  headcount: number;
+  arrivalDate: string;
+  departureDate: string;
+  items: QuoteItem[];
+  status: QuoteStatus;
+  /** Set when the customer starts a Stripe deposit checkout. */
+  stripeCheckoutSessionId?: string;
+  /** Set when Stripe confirms the deposit was paid. */
+  depositPaidAt?: string;
+};
+
+export type QuoteTotals = {
+  lineTotals: Record<ActivityKey, number>;
+  subtotal: number;
+  depositAmount: number;
+  remaining: number;
+};
+
+/**
+ * Build the initial quote from questionnaire answers. Auto-enables the
+ * activities the customer picked; leaves everything else present but
+ * disabled so they can toggle it on later.
+ */
+export function buildInitialQuote(opts: {
+  variant: 'bachelor' | 'bachelorette';
+  headcount: number;
+  arrivalDate: string;
+  departureDate: string;
+  requestedActivities: string[];
+}): Quote {
+  const now = new Date().toISOString();
+  const requested = new Set(opts.requestedActivities);
+
+  const items: QuoteItem[] = Object.values(ACTIVITY_CATALOG)
+    .filter((a) => a.variants.includes(opts.variant))
+    .map((a) => ({
+      activityKey: a.key,
+      enabled: requested.has(a.key),
+      headcount: opts.headcount,
+      scheduledDate: opts.arrivalDate,
+      scheduledTime: defaultTimeFor(a.key),
+      notes: '',
+    }));
+
+  return {
+    variant: opts.variant,
+    createdAt: now,
+    updatedAt: now,
+    headcount: opts.headcount,
+    arrivalDate: opts.arrivalDate,
+    departureDate: opts.departureDate,
+    items,
+    status: 'draft',
+  };
+}
+
+function defaultTimeFor(key: ActivityKey): string {
+  switch (key) {
+    case 'boat-rental':
+      return '1:00 PM';
+    case 'drink-delivery':
+      return '12:00 PM';
+    case 'golf-brewery-tour':
+      return '10:00 AM';
+    case 'atv-tour':
+      return '2:00 PM';
+    case 'gun-range':
+      return '4:00 PM';
+    case 'transportation':
+      return '11:00 AM';
+    case 'brunch-mimosa':
+      return '11:00 AM';
+    case 'winery-tour':
+      return '1:00 PM';
+    case 'spa-day':
+      return '10:00 AM';
+  }
+}
+
+/**
+ * Compute subtotal + deposit + per-line totals from a Quote. Pure
+ * function; no side effects.
+ */
+export function computeQuoteTotals(quote: Quote): QuoteTotals {
+  const lineTotals: Record<ActivityKey, number> = {} as Record<ActivityKey, number>;
+  let subtotal = 0;
+  for (const item of quote.items) {
+    const entry = ACTIVITY_CATALOG[item.activityKey];
+    if (!entry) continue;
+    const lineTotal = item.enabled
+      ? entry.pricePerPerson * Math.max(0, item.headcount)
+      : 0;
+    lineTotals[item.activityKey] = lineTotal;
+    subtotal += lineTotal;
+  }
+  const depositAmount = Math.round(subtotal * DEPOSIT_PERCENT);
+  return {
+    lineTotals,
+    subtotal,
+    depositAmount,
+    remaining: subtotal - depositAmount,
+  };
+}

--- a/src/lib/email/templates/concierge-quote.ts
+++ b/src/lib/email/templates/concierge-quote.ts
@@ -1,0 +1,240 @@
+/**
+ * Premier Concierge — quote email.
+ *
+ * Sent immediately after the customer submits the concierge planner.
+ * Replaces the standalone welcome email — this one both (a) confirms
+ * we got their info and (b) includes the summary of services + a big
+ * "View Your Quote" button that opens the interactive quote page.
+ *
+ * The quote page lets them toggle activities, adjust per-service
+ * headcount / date / time, edit recommended drinks, and pay a 25%
+ * deposit to lock in vendors.
+ */
+
+import {
+  ACTIVITY_CATALOG,
+  DEPOSIT_PERCENT,
+  computeQuoteTotals,
+  type Quote,
+} from '@/lib/concierge/quote';
+
+const NAVY = '#0A1F33';
+const GOLD = '#D4AF37';
+const RASPBERRY = '#7A1E4A';
+const ROSE = '#E8B4CE';
+const CREAM = '#FAF6EE';
+
+function escape(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function fmt$(n: number): string {
+  return `$${Math.round(n).toLocaleString('en-US')}`;
+}
+
+function longDate(iso: string): string {
+  try {
+    const d = new Date(`${iso}T12:00:00Z`);
+    return d.toLocaleDateString('en-US', {
+      weekday: 'short',
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+      timeZone: 'UTC',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export type ConciergeQuoteEmailInput = {
+  firstName: string;
+  variant: 'bachelor' | 'bachelorette';
+  quote: Quote;
+  /** Absolute URL to the interactive quote page. */
+  quoteUrl: string;
+};
+
+export function conciergeQuoteEmail(input: ConciergeQuoteEmailInput): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const isBachelorette = input.variant === 'bachelorette';
+  const primary = isBachelorette ? RASPBERRY : NAVY;
+  const accent = isBachelorette ? ROSE : GOLD;
+  const partyLabel = isBachelorette ? 'bachelorette' : 'bachelor';
+
+  const totals = computeQuoteTotals(input.quote);
+  const enabledItems = input.quote.items.filter((it) => it.enabled);
+
+  const subject = `${escape(input.firstName)}, your Austin ${partyLabel} quote is ready`;
+
+  // ─── Services HTML bullets ────────────────────────────────────
+  const bulletsHtml = enabledItems
+    .map((it) => {
+      const entry = ACTIVITY_CATALOG[it.activityKey];
+      if (!entry) return '';
+      const lineTotal = entry.pricePerPerson * it.headcount;
+      return `
+        <tr>
+          <td style="padding:12px 8px 12px 0;vertical-align:top;width:36px;font-size:22px;line-height:1;">${entry.emoji}</td>
+          <td style="padding:12px 12px 12px 4px;vertical-align:top;">
+            <div style="font-weight:700;color:${primary};font-size:14px;">${escape(entry.label)}</div>
+            <div style="color:#6b7280;font-size:12px;margin-top:2px;">${escape(entry.blurb)}</div>
+          </td>
+          <td style="padding:12px 4px 12px 12px;vertical-align:top;text-align:right;white-space:nowrap;">
+            <div style="font-family:ui-monospace,monospace;font-size:13px;color:${primary};font-weight:700;">${fmt$(lineTotal)}</div>
+            <div style="color:#9ca3af;font-size:11px;">${it.headcount} × ${fmt$(entry.pricePerPerson)}</div>
+          </td>
+        </tr>`;
+    })
+    .join('');
+
+  // ─── Services plain-text bullets ──────────────────────────────
+  const bulletsText = enabledItems
+    .map((it) => {
+      const entry = ACTIVITY_CATALOG[it.activityKey];
+      if (!entry) return '';
+      const lineTotal = entry.pricePerPerson * it.headcount;
+      return `  • ${entry.label}: ${it.headcount} × ${fmt$(entry.pricePerPerson)} = ${fmt$(lineTotal)}`;
+    })
+    .join('\n');
+
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>${escape(subject)}</title>
+</head>
+<body style="margin:0;padding:0;background:#f4f4f4;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:${primary};">
+  <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background:#f4f4f4;padding:24px 12px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="max-width:640px;background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 2px 12px rgba(10,15,25,0.08);">
+          <!-- Header -->
+          <tr>
+            <td style="background:${primary};color:#ffffff;padding:24px 24px 20px 24px;border-bottom:3px solid ${accent};">
+              <div style="font-size:11px;font-weight:700;letter-spacing:0.24em;color:${accent};margin-bottom:6px;">PREMIER CONCIERGE · AUSTIN</div>
+              <h1 style="margin:0;font-size:24px;font-weight:700;line-height:1.15;letter-spacing:0.01em;">
+                Your Austin ${partyLabel} quote is ready.
+              </h1>
+              <p style="margin:8px 0 0 0;font-size:14px;color:#ffffff;opacity:0.88;line-height:1.5;">
+                Hi ${escape(input.firstName)} — here&rsquo;s a starting plan based on what you told us. Tweak anything on the quote page, then pay a 25% deposit to lock it in.
+              </p>
+            </td>
+          </tr>
+
+          <!-- Trip summary -->
+          <tr>
+            <td style="padding:20px 24px 8px 24px;">
+              <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background:${CREAM};border-radius:8px;padding:12px 16px;">
+                <tr>
+                  <td style="padding:6px 8px;font-size:12px;color:${primary};">
+                    <strong>Trip:</strong>&nbsp;${input.quote.headcount} people · ${longDate(input.quote.arrivalDate)} → ${longDate(input.quote.departureDate)}
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- Services header -->
+          <tr>
+            <td style="padding:20px 24px 4px 24px;">
+              <div style="font-size:11px;font-weight:700;letter-spacing:0.22em;color:${primary};">WHAT&rsquo;S IN THE QUOTE</div>
+            </td>
+          </tr>
+
+          <!-- Services bullets -->
+          <tr>
+            <td style="padding:0 24px 8px 24px;">
+              <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="border-collapse:collapse;">
+                ${bulletsHtml || '<tr><td style="padding:12px 4px;color:#6b7280;font-size:13px;">No activities selected yet — pick some on the quote page.</td></tr>'}
+              </table>
+            </td>
+          </tr>
+
+          <!-- Totals -->
+          <tr>
+            <td style="padding:8px 24px 8px 24px;">
+              <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="border-top:1.5px solid ${primary};padding-top:8px;">
+                <tr>
+                  <td style="padding:8px 4px;font-size:14px;color:${primary};">Subtotal</td>
+                  <td style="padding:8px 4px;font-size:14px;color:${primary};text-align:right;font-family:ui-monospace,monospace;">${fmt$(totals.subtotal)}</td>
+                </tr>
+                <tr>
+                  <td style="padding:8px 4px;font-size:14px;color:${primary};font-weight:700;">Deposit today (${Math.round(DEPOSIT_PERCENT * 100)}%)</td>
+                  <td style="padding:8px 4px;font-size:14px;color:${primary};text-align:right;font-family:ui-monospace,monospace;font-weight:700;">${fmt$(totals.depositAmount)}</td>
+                </tr>
+                <tr>
+                  <td style="padding:8px 4px;font-size:12px;color:#6b7280;">Remaining (due 7 days before event)</td>
+                  <td style="padding:8px 4px;font-size:12px;color:#6b7280;text-align:right;font-family:ui-monospace,monospace;">${fmt$(totals.remaining)}</td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- CTA -->
+          <tr>
+            <td style="padding:8px 24px 24px 24px;text-align:center;">
+              <a href="${escape(input.quoteUrl)}" style="display:inline-block;background:${accent};color:${isBachelorette ? '#3F0F27' : NAVY};text-decoration:none;padding:16px 36px;border-radius:10px;font-weight:700;letter-spacing:0.12em;border:2px solid ${primary};box-shadow:0 3px 0 ${primary};font-size:15px;">
+                VIEW YOUR QUOTE →
+              </a>
+              <div style="font-size:12px;color:#6b7280;margin-top:10px;">
+                Toggle activities · adjust headcount · pick dates · pay deposit
+              </div>
+            </td>
+          </tr>
+
+          <!-- Fine print -->
+          <tr>
+            <td style="padding:0 24px 20px 24px;">
+              <div style="font-size:12px;color:#6b7280;line-height:1.6;background:#F9FAFB;border-radius:6px;padding:12px 14px;">
+                <strong style="color:${primary};">How it works:</strong> Everything above is a starting plan based on what you told us. On the quote page you can toggle activities on/off, adjust the number of people per service, pick dates/times, and edit the drinks package. Your total updates live. Pay 25% to lock in the vendors — remaining balance is due 7 days before the first activity.
+                <br /><br />
+                Prices are placeholders during our launch — a concierge will confirm the final numbers within 24h. Questions? Reply to this email or call <a href="tel:+17373719700" style="color:${primary};font-weight:700;">(737) 371-9700</a>.
+              </div>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="background:${CREAM};padding:16px 24px;font-size:11px;color:#6b7280;text-align:center;">
+              Party On Delivery · Premier Concierge · Austin, TX
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+
+  const text = [
+    `${input.firstName}, your Austin ${partyLabel} quote is ready.`,
+    '',
+    'Here\'s a starting plan based on what you told us. Tweak anything on the quote page, then pay a 25% deposit to lock it in.',
+    '',
+    `Trip: ${input.quote.headcount} people · ${longDate(input.quote.arrivalDate)} → ${longDate(input.quote.departureDate)}`,
+    '',
+    "WHAT'S IN THE QUOTE",
+    bulletsText || '  (no activities selected — pick some on the quote page)',
+    '',
+    `Subtotal:      ${fmt$(totals.subtotal)}`,
+    `Deposit (25%): ${fmt$(totals.depositAmount)}`,
+    `Remaining:     ${fmt$(totals.remaining)}`,
+    '',
+    `View your quote → ${input.quoteUrl}`,
+    '',
+    'Prices are placeholders during launch — a concierge will confirm the final numbers within 24h.',
+    '',
+    'Party On Delivery · Premier Concierge · (737) 371-9700',
+  ].join('\n');
+
+  return { subject, html, text };
+}


### PR DESCRIPTION
## Summary
Purely additive — no existing POD funnel changes.

1. Concierge lead submit → sends a **services-summary email** with a **View Your Quote** CTA
2. Quote page \`/concierge-quote/[leadId]\` — dynamic editor:
   - Trip header (headcount / arrival / departure editable)
   - Per-activity cards: toggle on/off, adjust headcount + date + time + notes, live line total
   - Recommended drinks section
   - Sticky totals sidebar w/ subtotal + 25% deposit + remaining balance
   - Autosave (debounced PATCH) so state survives refresh
3. **Accept & Pay Deposit** → Stripe Checkout for the 25% deposit only → success page verifies via \`stripe.checkout.sessions.retrieve\` server-side and locks the quote

## Placeholder pricing (per founder spec)
All 9 activities have per-person placeholder rates in \`src/lib/concierge/quote.ts\`. Real rates plug in later without touching UI.

## Test plan
- [ ] Submit concierge form → email arrives with bullets + View Quote button
- [ ] Click button → editor loads with your questionnaire selections pre-enabled
- [ ] Toggle / adjust anything → total updates live, "Saving..." → "Saved" chip appears
- [ ] Click Accept & Pay Deposit → Stripe Checkout for 25% of subtotal
- [ ] Complete test payment → success page shows receipt + marks quote as deposit-paid
- [ ] Refresh success page → shows same confirmation (no double-processing)
- [ ] Go back to /concierge-quote/[leadId] after paying → banner says "Deposit paid", no re-checkout button

🤖 Generated with [Claude Code](https://claude.com/claude-code)