### PR TITLE
Concierge hardening: awaited GHL, ad attribution on chat+concierge, last-touch source, deposit webhook

### DIFF
--- a/src/app/api/v1/chat/submit/route.ts
+++ b/src/app/api/v1/chat/submit/route.ts
@@ -19,6 +19,7 @@ import { z } from 'zod';
 import { sendEmail } from '@/lib/email/resend-client';
 import { eventQuizWelcomeEmail } from '@/lib/email/templates/event-quiz-welcome';
 import { upsertLead, recordEvent } from '@/lib/leads/leadCapture';
+import { attributionSchema, compactAttribution } from '@/lib/leads/attribution-schema';
 import { targetUrlFor } from '@/lib/eventQuiz/routing';
 import { recommendForChat } from '@/lib/chat/recommendation';
 import { isLastMinuteDate } from '@/lib/lastMinute/dates';
@@ -48,6 +49,10 @@ const schema = z.object({
   /** ISO YYYY-MM-DD. Drives whether the destination landing page is
    *  served the last-minute menu when the user lands there. */
   deliveryDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  /** First-touch UTM + ad click ids captured client-side. Optional so
+   *  older cached bundles never 400. Without this, chat leads could
+   *  never be tied to an ad campaign (the founder's exact question). */
+  attribution: attributionSchema,
 });
 
 export async function POST(req: NextRequest) {
@@ -77,16 +82,46 @@ export async function POST(req: NextRequest) {
       {
         sourcePage: '/chat',
         sourceWidget: 'CONTACT_FORM',
+        // UTM columns blank-fill + click ids merge into metadata.attribution.
+        utmSource: body.attribution?.utmSource,
+        utmMedium: body.attribution?.utmMedium,
+        utmCampaign: body.attribution?.utmCampaign,
+        utmContent: body.attribution?.utmContent,
+        utmTerm: body.attribution?.utmTerm,
+        gclid: body.attribution?.gclid,
+        gbraid: body.attribution?.gbraid,
+        wbraid: body.attribution?.wbraid,
+        fbclid: body.attribution?.fbclid,
+        msclkid: body.attribution?.msclkid,
       },
     );
     if (lead) {
       leadId = lead.id;
+      const prevMeta = (lead.metadata as Record<string, unknown> | null) ?? {};
+      const prevAttribution =
+        prevMeta.attribution &&
+        typeof prevMeta.attribution === 'object' &&
+        !Array.isArray(prevMeta.attribution)
+          ? (prevMeta.attribution as Record<string, unknown>)
+          : {};
       await prisma.lead.update({
         where: { id: lead.id },
         data: {
           status: 'SUBMITTED',
+          // Last-touch stamp: a fresh submit owns the source columns
+          // even when the email matched an older lead row.
+          sourcePage: '/chat',
+          sourceWidget: 'CONTACT_FORM',
           metadata: {
-            ...((lead.metadata as Record<string, unknown> | null) ?? {}),
+            ...prevMeta,
+            ...(body.attribution
+              ? {
+                  attribution: {
+                    ...prevAttribution,
+                    ...compactAttribution(body.attribution),
+                  },
+                }
+              : {}),
             chatQuiz: {
               partyType: body.partyType,
               headcount: body.headcount,
@@ -94,7 +129,7 @@ export async function POST(req: NextRequest) {
               submittedAt: new Date().toISOString(),
               resumePath,
             },
-          },
+          } as never,
         },
       });
       await recordEvent({

--- a/src/app/api/v1/concierge/lead/route.ts
+++ b/src/app/api/v1/concierge/lead/route.ts
@@ -28,6 +28,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import { prisma } from '@/lib/database/client';
 import { upsertLead, recordEvent } from '@/lib/leads/leadCapture';
+import { attributionSchema, compactAttribution } from '@/lib/leads/attribution-schema';
 import { notifyConciergeLead } from '@/lib/webhooks/ghl';
 import {
   appendLeadToPodLeadsSheet,
@@ -67,6 +68,10 @@ const bodySchema = z.object({
   /** Which page fired the form. Enables sending the same form from
    *  premierconcierge.co later. */
   source: z.string().max(80).optional().default('premier-concierge-bachelor'),
+  /** First-touch UTM + ad click ids captured client-side — same shape
+   *  every other lead surface sends. Optional so older cached bundles
+   *  never 400. */
+  attribution: attributionSchema,
 });
 
 const CORS_HEADERS = {
@@ -108,6 +113,17 @@ export async function POST(req: NextRequest) {
         // structured payload lives in metadata so admin UIs can filter
         // by `metadata.partner`.
         sourceWidget: 'PARTNER_LANDING_PAGE',
+        // UTM columns blank-fill + click ids merge into metadata.attribution.
+        utmSource: body.attribution?.utmSource,
+        utmMedium: body.attribution?.utmMedium,
+        utmCampaign: body.attribution?.utmCampaign,
+        utmContent: body.attribution?.utmContent,
+        utmTerm: body.attribution?.utmTerm,
+        gclid: body.attribution?.gclid,
+        gbraid: body.attribution?.gbraid,
+        wbraid: body.attribution?.wbraid,
+        fbclid: body.attribution?.fbclid,
+        msclkid: body.attribution?.msclkid,
       },
     );
 
@@ -128,12 +144,35 @@ export async function POST(req: NextRequest) {
         requestedActivities: body.activities.filter((a) => a !== 'not-sure'),
       });
 
+      // Merge attribution into metadata (latest ad click wins), same
+      // pattern as quote/start.
+      const prevAttribution =
+        prevMeta.attribution &&
+        typeof prevMeta.attribution === 'object' &&
+        !Array.isArray(prevMeta.attribution)
+          ? (prevMeta.attribution as Record<string, unknown>)
+          : {};
+
       await prisma.lead.update({
         where: { id: lead.id },
         data: {
           status: 'SUBMITTED',
+          // Last-touch stamp: a fresh submit should own the source
+          // columns even when the email matched an old lead row (the
+          // founder's test upserted onto a May '26 /flyer row and the
+          // admin table showed stale provenance).
+          sourcePage: `/${body.source}`,
+          sourceWidget: 'PARTNER_LANDING_PAGE',
           metadata: {
             ...prevMeta,
+            ...(body.attribution
+              ? {
+                  attribution: {
+                    ...prevAttribution,
+                    ...compactAttribution(body.attribution),
+                  },
+                }
+              : {}),
             partner: 'premier-concierge',
             conciergeQuiz: {
               source: body.source,
@@ -177,38 +216,42 @@ export async function POST(req: NextRequest) {
     ? `https://partyondelivery.com/admin/brians-stuff?tab=leads&lead=${leadId}`
     : 'https://partyondelivery.com/admin/brians-stuff?tab=leads';
 
-  // ─── 3) GHL webhook — non-blocking ───────────────────────────────
-  notifyConciergeLead({
-    event: 'concierge.lead',
-    first_name: body.firstName,
-    last_name: body.lastName,
-    email: body.email,
-    phone: body.phone,
-    source: body.source,
-    partyType: body.partyType,
-    headcount: body.headcount,
-    arrivalDate: body.arrivalDate,
-    departureDate: body.departureDate,
-    budgetPerPerson: body.budgetPerPerson,
-    activities: body.activities,
-    notes: body.notes,
-    tags,
-    leadUrl,
-    submittedAt: now.toISOString(),
-  }).catch((err) => {
-    console.error('[concierge/lead] GHL notify failed (non-blocking)', err);
-  });
-
-  // ─── 4) Quote email — AWAITED ────────────────────────────────────
-  // Combines the old welcome email with the summary + View Quote CTA
-  // that opens the interactive quote page. Only fires if we managed to
-  // create a Lead (need the ID for the quote URL).
-  //
-  // These side effects MUST be awaited before the response returns:
+  // ─── 3) Side effects — ALL AWAITED ───────────────────────────────
+  // GHL + email + sheet MUST be awaited before the response returns:
   // Vercel freezes the serverless function on return, and a
   // fire-and-forget promise gets killed mid-flight. That's exactly how
   // the founder's first bachelorette test lead vanished from the sheet.
   const sideEffects: Promise<unknown>[] = [];
+
+  // GHL webhook (no-op until GHL_CONCIERGE_LEAD_WEBHOOK_URL is set;
+  // internally never-throwing).
+  sideEffects.push(
+    notifyConciergeLead({
+      event: 'concierge.lead',
+      first_name: body.firstName,
+      last_name: body.lastName,
+      email: body.email,
+      phone: body.phone,
+      source: body.source,
+      partyType: body.partyType,
+      headcount: body.headcount,
+      arrivalDate: body.arrivalDate,
+      departureDate: body.departureDate,
+      budgetPerPerson: body.budgetPerPerson,
+      activities: body.activities,
+      notes: body.notes,
+      tags,
+      leadUrl,
+      submittedAt: now.toISOString(),
+    }).catch((err) => {
+      console.error('[concierge/lead] GHL notify failed (non-blocking)', err);
+    }),
+  );
+
+  // ─── 4) Quote email ──────────────────────────────────────────────
+  // Combines the old welcome email with the summary + View Quote CTA
+  // that opens the interactive quote page. Only fires if we managed to
+  // create a Lead (need the ID for the quote URL).
 
   if (leadId) {
     const capturedLeadId = leadId;

--- a/src/app/api/v1/event-quiz/submit/route.ts
+++ b/src/app/api/v1/event-quiz/submit/route.ts
@@ -97,6 +97,10 @@ export async function POST(req: NextRequest) {
         where: { id: lead.id },
         data: {
           status: 'SUBMITTED',
+          // Last-touch stamp: a fresh submit owns the source columns
+          // even when the email matched an older lead row.
+          sourcePage: '/event-quiz',
+          sourceWidget: 'CONTACT_FORM',
           metadata: {
             ...((lead.metadata as Record<string, unknown> | null) ?? {}),
             eventQuiz: {

--- a/src/app/api/v1/quote/start/route.ts
+++ b/src/app/api/v1/quote/start/route.ts
@@ -172,6 +172,10 @@ export async function POST(req: NextRequest) {
         where: { id: lead.id },
         data: {
           status: 'SUBMITTED',
+          // Last-touch stamp: a fresh submit owns the source columns
+          // even when the email matched an older lead row.
+          sourcePage: `/${body.source}`,
+          sourceWidget: 'CONTACT_FORM',
           metadata: nextMeta as never,
         },
       });

--- a/src/components/chat/PartyChat.tsx
+++ b/src/components/chat/PartyChat.tsx
@@ -31,6 +31,7 @@ import {
 } from '@/lib/eventQuiz/routing';
 import { sendLeadEvent } from '@/lib/leads/client';
 import { useDeliveryWindow } from '@/lib/deliveryWindow/window';
+import { getAttribution } from '@/lib/analytics/attribution';
 
 type RecommendedItem = {
   handle: string;
@@ -145,6 +146,9 @@ export default function PartyChat() {
           partyType,
           headcount,
           deliveryDate,
+          // First-touch UTM + ad click ids — lets the Lead be tied to
+          // the ad campaign that brought them in.
+          attribution: getAttribution(),
         }),
       });
       const recJson = await recRes.json();
@@ -190,6 +194,7 @@ export default function PartyChat() {
           source: 'chat',
           recommendedItems:
             recommendation?.items.map((it) => ({ handle: it.handle, qty: it.qty })) ?? [],
+          attribution: getAttribution(),
         }),
       });
       const json = await res.json();

--- a/src/components/concierge/ConciergeQuestionnaireModal.tsx
+++ b/src/components/concierge/ConciergeQuestionnaireModal.tsx
@@ -17,6 +17,7 @@
  */
 
 import { useMemo, useState, type ReactElement, type FormEvent } from 'react';
+import { getAttribution } from '@/lib/analytics/attribution';
 
 const NAVY = '#0A1F33';
 const GOLD = '#D4AF37';
@@ -165,6 +166,9 @@ export default function ConciergeQuestionnaireModal({
             variant === 'bachelorette'
               ? 'premier-concierge-bachelorette'
               : 'premier-concierge-bachelor',
+          // First-touch UTM + ad click ids — ties the lead to the ad
+          // campaign that brought them in.
+          attribution: getAttribution(),
         }),
       });
       const json = (await res.json()) as { ok: boolean; error?: string };

--- a/src/lib/stripe/webhooks.ts
+++ b/src/lib/stripe/webhooks.ts
@@ -72,6 +72,63 @@ export async function constructWebhookEvent(
  * Handle checkout.session.completed event
  * Creates an order when payment is successful
  */
+/**
+ * Premier Concierge 25% deposit paid. Marks the quote on
+ * Lead.metadata.quote as deposit-paid + promotes the Lead to CONVERTED.
+ * Idempotent — a repeat delivery (or the success page having already
+ * done it) is a no-op.
+ */
+async function handleConciergeDepositPayment(
+  session: Stripe.Checkout.Session
+): Promise<void> {
+  const leadId = session.metadata?.leadId;
+  if (!leadId) {
+    console.error('[Stripe Webhook] concierge deposit with no leadId:', session.id);
+    return;
+  }
+  if (session.payment_status !== 'paid' && session.payment_status !== 'no_payment_required') {
+    console.log('[Stripe Webhook] concierge deposit not paid yet:', session.id);
+    return;
+  }
+
+  const lead = await prisma.lead.findUnique({
+    where: { id: leadId },
+    select: { metadata: true },
+  });
+  if (!lead) {
+    console.error('[Stripe Webhook] concierge deposit lead not found:', leadId);
+    return;
+  }
+  const meta = (lead.metadata as Record<string, unknown> | null) ?? {};
+  const quote = meta.quote as Record<string, unknown> | undefined;
+  if (!quote) {
+    console.error('[Stripe Webhook] concierge deposit lead has no quote:', leadId);
+    return;
+  }
+  if (quote.status === 'deposit-paid') {
+    console.log('[Stripe Webhook] concierge deposit already recorded:', leadId);
+    return;
+  }
+
+  await prisma.lead.update({
+    where: { id: leadId },
+    data: {
+      status: 'CONVERTED',
+      metadata: {
+        ...meta,
+        quote: {
+          ...quote,
+          status: 'deposit-paid',
+          depositPaidAt: new Date().toISOString(),
+          stripeCheckoutSessionId: session.id,
+          updatedAt: new Date().toISOString(),
+        },
+      } as never,
+    },
+  });
+  console.log('[Stripe Webhook] concierge deposit recorded for lead:', leadId);
+}
+
 async function handleCheckoutSessionCompleted(
   session: Stripe.Checkout.Session
 ): Promise<void> {
@@ -99,6 +156,16 @@ async function handleCheckoutSessionCompleted(
   // Check if this is a Group V2 delivery fee payment
   if (session.metadata?.type === 'group_v2_delivery') {
     await handleGroupV2DeliveryPayment(session);
+    return;
+  }
+
+  // Check if this is a Premier Concierge quote deposit. These sessions
+  // carry no cartId, so without this branch they'd fall through to the
+  // cart path and throw. The success page also marks the quote paid
+  // when the customer returns; this webhook closes the gap for
+  // customers who pay and never come back.
+  if (session.metadata?.source === 'concierge-quote-deposit') {
+    await handleConciergeDepositPayment(session);
     return;
   }
 

--- a/src/lib/webhooks/ghl.ts
+++ b/src/lib/webhooks/ghl.ts
@@ -396,7 +396,9 @@ export async function notifyConciergeLead(payload: GhlConciergeLeadPayload): Pro
     if (!res.ok) {
       console.error('[GHL Concierge Webhook] Failed:', res.status, await res.text());
     } else {
-      console.log('[GHL Concierge Webhook] Lead synced:', payload.email);
+      // Log the lead deep-link, not the email — customer PII stays out
+      // of INFO-level production logs (project rule).
+      console.log('[GHL Concierge Webhook] Lead synced:', payload.leadUrl);
     }
   } catch (err) {
     console.error('[GHL Concierge Webhook] Error:', err);


### PR DESCRIPTION
## Summary
Closes all 4 findings from the pipeline review:
1. **GHL freeze risk** — notifyConciergeLead now awaited (same serverless-freeze bug class that ate the sheet row)
2. **Ad attribution** — chat/submit + concierge/lead accept the shared attribution payload; PartyChat + ConciergeQuestionnaireModal send getAttribution(). Chat leads can now be tied to Google Ads (gclid/UTMs).
3. **Last-touch source stamp** — submits own sourcePage/sourceWidget even when upserting onto an old lead row
4. **Stripe webhook for concierge deposits** — marks quote deposit-paid + Lead CONVERTED even if the customer never returns to the success page; idempotent; prevents "No cartId" throws for these sessions

## Test plan
- [ ] Chat bubble submit with ?utm_source=google&gclid=test on the entry URL → Lead shows utmSource + metadata.attribution.gclid
- [ ] Concierge submit → same
- [ ] Re-submit with an email that has an old lead row → Leads tab shows the new page/widget
- [ ] Pay a test deposit, close the tab before the success page → webhook still marks quote deposit-paid

🤖 Generated with [Claude Code](https://claude.com/claude-code)