### PR TITLE
feat(leads): Lead Flow pipeline foundation — stages, scoring, sweeps, cron

### DIFF
--- a/prisma/migrations/manual/2026-07-13-lead-activity-backfill.sql
+++ b/prisma/migrations/manual/2026-07-13-lead-activity-backfill.sql
@@ -1,0 +1,22 @@
+-- Lead Flow board — backfill last_activity_at from real event history.
+--
+-- Companion to 2026-07-13-lead-pipeline.sql (already applied — never edit an
+-- applied file, hence this separate migration). Without this, leads that
+-- predate the pipeline have last_activity_at NULL and scoring would fall
+-- back to updated_at — but the daily rescore itself bumps updated_at (it
+-- writes the row), so recency would never decay (code-review finding #2).
+-- The code-side fix drops the updated_at fallback entirely (createdAt only);
+-- this backfill gives historical leads their honest activity timestamp.
+--
+-- Idempotent: only touches rows still NULL.
+
+BEGIN;
+
+UPDATE leads
+SET last_activity_at = COALESCE(
+  (SELECT MAX(e.occurred_at) FROM lead_events e WHERE e.lead_id = leads.id),
+  created_at
+)
+WHERE last_activity_at IS NULL;
+
+COMMIT;

--- a/prisma/migrations/manual/2026-07-13-lead-pipeline.sql
+++ b/prisma/migrations/manual/2026-07-13-lead-pipeline.sql
@@ -1,0 +1,117 @@
+-- Lead Flow board — pipeline columns on leads.
+--
+-- Backs the /admin/leads Kanban (src/lib/leads/pipeline.ts + scoring.ts):
+-- every submitted lead enters a sales pipeline (NEW → CONTACTED → QUALIFIED →
+-- QUOTE_SENT → WON → LOST) with a rule-based 0–100 temperature score.
+--
+-- Design rules (from the 2026-07-13 plan risk review):
+--   - pipeline_stage is a NEW column; the existing LeadStatus enum is
+--     untouched — the follow-ups engine reads Lead.status in shouldCancel
+--     and must keep its semantics.
+--   - pipeline_stage is TEXT + CHECK, not a Postgres enum (precedent:
+--     follow_up_jobs.status) so adding a stage later is a code-only change.
+--   - Backfill is selective: 243/263 prod leads are pixel fragments; only
+--     SUBMITTED leads with contact info that aren't newsletter-only signups
+--     enter the board. Fragments keep pipeline_stage NULL (= off board).
+--
+-- Per prisma/migrations/manual/README.md: additive + idempotent, applied
+-- automatically on prod deploys via the _manual_migrations ledger.
+-- The LEAD_REPLY EmailType value lives in its own solo file
+-- (2026-07-13-lead-reply-emailtype.sql) — ALTER TYPE can't share a transaction.
+
+BEGIN;
+
+-- =========================================================================
+-- Pipeline columns
+-- =========================================================================
+ALTER TABLE leads ADD COLUMN IF NOT EXISTS pipeline_stage    TEXT;
+ALTER TABLE leads ADD COLUMN IF NOT EXISTS stage_changed_at  TIMESTAMP(3);
+-- Fractional ranking within a column: lower sorts first (top). Enroll code
+-- writes -epoch-seconds so newest lands on top; drags write midpoints.
+ALTER TABLE leads ADD COLUMN IF NOT EXISTS board_sort_order  DOUBLE PRECISION NOT NULL DEFAULT 0;
+-- Stored rule-based temperature (0–100), recomputed on pipeline writes +
+-- daily cron decay. Hot/warm/cold labels are derived in code from
+-- SCORE_THRESHOLDS — never stored.
+ALTER TABLE leads ADD COLUMN IF NOT EXISTS lead_score        INTEGER;
+ALTER TABLE leads ADD COLUMN IF NOT EXISTS score_breakdown   JSONB;
+-- Stamped when staff reply from the board (email v1; SMS post-CoreLinq).
+ALTER TABLE leads ADD COLUMN IF NOT EXISTS last_contacted_at TIMESTAMP(3);
+-- Bumped by recordEvent so board reads never scan lead_events.
+ALTER TABLE leads ADD COLUMN IF NOT EXISTS last_activity_at  TIMESTAMP(3);
+-- Stamped when a WON/LOST lead submits a fresh inquiry and re-enters NEW;
+-- the won-order matcher uses max(created_at, reopened_at) as its floor.
+ALTER TABLE leads ADD COLUMN IF NOT EXISTS reopened_at       TIMESTAMP(3);
+ALTER TABLE leads ADD COLUMN IF NOT EXISTS owner             TEXT;
+ALTER TABLE leads ADD COLUMN IF NOT EXISTS snoozed_until     TIMESTAMP(3);
+ALTER TABLE leads ADD COLUMN IF NOT EXISTS lost_reason       TEXT;
+ALTER TABLE leads ADD COLUMN IF NOT EXISTS won_at            TIMESTAMP(3);
+ALTER TABLE leads ADD COLUMN IF NOT EXISTS lost_at           TIMESTAMP(3);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'leads_pipeline_stage_check'
+  ) THEN
+    ALTER TABLE leads ADD CONSTRAINT leads_pipeline_stage_check CHECK (
+      pipeline_stage IS NULL OR pipeline_stage IN
+        ('NEW','CONTACTED','QUALIFIED','QUOTE_SENT','WON','LOST')
+    );
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'leads_lead_score_check'
+  ) THEN
+    ALTER TABLE leads ADD CONSTRAINT leads_lead_score_check CHECK (
+      lead_score IS NULL OR (lead_score >= 0 AND lead_score <= 100)
+    );
+  END IF;
+END $$;
+
+-- Board column reads: WHERE pipeline_stage = X ORDER BY board_sort_order.
+CREATE INDEX IF NOT EXISTS leads_pipeline_stage_sort_idx
+  ON leads (pipeline_stage, board_sort_order)
+  WHERE pipeline_stage IS NOT NULL;
+-- Needs-response / hot-badge queries.
+CREATE INDEX IF NOT EXISTS leads_last_contacted_idx
+  ON leads (last_contacted_at);
+
+-- =========================================================================
+-- Selective backfill (idempotent: only rows still NULL are touched).
+-- "Newsletter-only" = EMAIL_SIGNUP widget whose metadata never gained a
+-- quiz/quote payload — subscribers, not party inquiries.
+-- =========================================================================
+UPDATE leads
+SET pipeline_stage = 'WON',
+    won_at = updated_at,
+    stage_changed_at = NOW(),
+    board_sort_order = -EXTRACT(EPOCH FROM updated_at)
+WHERE pipeline_stage IS NULL AND status = 'CONVERTED';
+
+UPDATE leads
+SET pipeline_stage = 'NEW',
+    stage_changed_at = NOW(),
+    board_sort_order = -EXTRACT(EPOCH FROM updated_at)
+WHERE pipeline_stage IS NULL
+  AND status = 'SUBMITTED'
+  AND (email IS NOT NULL OR phone IS NOT NULL)
+  AND updated_at > NOW() - INTERVAL '90 days'
+  AND NOT (
+    source_widget = 'EMAIL_SIGNUP'
+    AND NOT (metadata ?| ARRAY['conciergeQuiz','chatQuiz','eventQuiz','contactForm','unifiedQuote','quote'])
+  );
+
+UPDATE leads
+SET pipeline_stage = 'LOST',
+    lost_at = NOW(),
+    lost_reason = 'stale_backfill',
+    stage_changed_at = NOW(),
+    board_sort_order = -EXTRACT(EPOCH FROM updated_at)
+WHERE pipeline_stage IS NULL
+  AND status = 'SUBMITTED'
+  AND (email IS NOT NULL OR phone IS NOT NULL)
+  AND updated_at <= NOW() - INTERVAL '90 days'
+  AND NOT (
+    source_widget = 'EMAIL_SIGNUP'
+    AND NOT (metadata ?| ARRAY['conciergeQuiz','chatQuiz','eventQuiz','contactForm','unifiedQuote','quote'])
+  );
+
+COMMIT;

--- a/prisma/migrations/manual/2026-07-13-lead-reply-emailtype.sql
+++ b/prisma/migrations/manual/2026-07-13-lead-reply-emailtype.sql
@@ -1,0 +1,10 @@
+-- Lead Flow board — LEAD_REPLY EmailType enum value.
+--
+-- Deliberately its own file with NO BEGIN/COMMIT: ALTER TYPE ... ADD VALUE
+-- cannot share a transaction with statements that use the new value, and the
+-- migration runner executes each file as a single query. Keep this file to
+-- exactly this one statement. (Precedent: 2026-07-06-followups-emailtype.sql.)
+--
+-- Companion DDL (leads pipeline columns) lives in 2026-07-13-lead-pipeline.sql.
+
+ALTER TYPE "EmailType" ADD VALUE IF NOT EXISTS 'LEAD_REPLY';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1377,6 +1377,7 @@ enum EmailType {
   ORDER_CANCELLED
   RECEIPT
   FOLLOW_UP
+  LEAD_REPLY
 }
 
 enum EmailStatus {
@@ -3345,6 +3346,31 @@ model Lead {
   /// in a later PR. Kept here so `prisma db push` doesn't drop the column.
   affiliateId     String?         @map("affiliate_id")
 
+  /// ---- Lead Flow board (2026-07-13-lead-pipeline.sql) -------------------
+  /// Kanban stage. NULL = not on the board. TEXT + DB CHECK, not an enum —
+  /// values in src/lib/leads/pipeline-types.ts (NEW/CONTACTED/QUALIFIED/
+  /// QUOTE_SENT/WON/LOST). Deliberately separate from `status`: the
+  /// follow-ups engine reads `status` and must keep its semantics.
+  pipelineStage   String?         @map("pipeline_stage")
+  stageChangedAt  DateTime?       @map("stage_changed_at")
+  /// Fractional rank within a column — lower sorts first (top).
+  boardSortOrder  Float           @default(0) @map("board_sort_order")
+  /// Stored rule-based temperature 0–100 (hot/warm/cold derived in code).
+  leadScore       Int?            @map("lead_score")
+  scoreBreakdown  Json?           @map("score_breakdown")
+  /// Last staff outreach from the board (email reply v1).
+  lastContactedAt DateTime?       @map("last_contacted_at")
+  /// Bumped by recordEvent — board reads never scan lead_events.
+  lastActivityAt  DateTime?       @map("last_activity_at")
+  /// Set when a WON/LOST lead re-submits and re-enters NEW.
+  reopenedAt      DateTime?       @map("reopened_at")
+  /// Freeform staff owner ('Allan' | 'Brian' by convention).
+  owner           String?
+  snoozedUntil    DateTime?       @map("snoozed_until")
+  lostReason      String?         @map("lost_reason")
+  wonAt           DateTime?       @map("won_at")
+  lostAt          DateTime?       @map("lost_at")
+
   events          LeadEvent[]
   sessions        VisitorSession[]
 
@@ -3356,6 +3382,8 @@ model Lead {
   @@index([status])
   @@index([createdAt])
   @@index([draftOrderId])
+  @@index([pipelineStage, boardSortOrder])
+  @@index([lastContactedAt])
   @@map("leads")
 }
 

--- a/src/app/api/cron/lead-pipeline/route.ts
+++ b/src/app/api/cron/lead-pipeline/route.ts
@@ -1,7 +1,8 @@
 /**
  * GET /api/cron/lead-pipeline
  *
- * Daily Lead Flow board tick (vercel.json: 30 11 * * * = 6:30am CT), the
+ * Daily Lead Flow board tick (vercel.json: 30 11 * * * = 6:30am CDT /
+ * 5:30am CST), the
  * backstop behind the realtime hooks in leadCapture/enqueue:
  *   1. enroll  — SUBMITTED leads that never got a board card
  *   2. reopen  — WON/LOST leads with a fresh submit re-enter NEW
@@ -21,8 +22,11 @@ export const maxDuration = 300;
 const CRON_SECRET = process.env.CRON_SECRET;
 
 export async function GET(req: NextRequest) {
+  // Fail CLOSED when CRON_SECRET is unset (follow-up-engine precedent): this
+  // route mass-mutates board state, so a misconfigured environment must not
+  // leave it publicly triggerable.
   const auth = req.headers.get('authorization');
-  if (CRON_SECRET && auth !== `Bearer ${CRON_SECRET}`) {
+  if (!CRON_SECRET || auth !== `Bearer ${CRON_SECRET}`) {
     return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 });
   }
 

--- a/src/app/api/cron/lead-pipeline/route.ts
+++ b/src/app/api/cron/lead-pipeline/route.ts
@@ -1,0 +1,37 @@
+/**
+ * GET /api/cron/lead-pipeline
+ *
+ * Daily Lead Flow board tick (vercel.json: 30 11 * * * = 6:30am CT), the
+ * backstop behind the realtime hooks in leadCapture/enqueue:
+ *   1. enroll  — SUBMITTED leads that never got a board card
+ *   2. reopen  — WON/LOST leads with a fresh submit re-enter NEW
+ *   3. quote   — outstanding drafts move cards to QUOTE_SENT
+ *   4. won     — verified paid-order matches move cards to WON
+ *   5. rescore — daily recency/proximity decay for every open card
+ *
+ * Auth: CRON_SECRET bearer (same pattern as event-abandoned-rsvps).
+ */
+import { NextResponse, type NextRequest } from 'next/server';
+import { runLeadPipelineTick } from '@/lib/leads/pipeline';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+export const maxDuration = 300;
+
+const CRON_SECRET = process.env.CRON_SECRET;
+
+export async function GET(req: NextRequest) {
+  const auth = req.headers.get('authorization');
+  if (CRON_SECRET && auth !== `Bearer ${CRON_SECRET}`) {
+    return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const result = await runLeadPipelineTick();
+    console.log('[lead-pipeline cron]', JSON.stringify(result));
+    return NextResponse.json({ ok: true, ...result, at: new Date().toISOString() });
+  } catch (err) {
+    console.error('[lead-pipeline cron] tick failed', err);
+    return NextResponse.json({ ok: false, error: 'tick-failed' }, { status: 500 });
+  }
+}

--- a/src/app/api/v1/chat/submit/route.ts
+++ b/src/app/api/v1/chat/submit/route.ts
@@ -134,6 +134,7 @@ export async function POST(req: NextRequest) {
       });
       await recordEvent({
         type: 'FORM_SUBMIT',
+        trustedSubmit: true, // server-validated form (zod) — may reopen closed board cards
         leadId: lead.id,
         page: '/chat',
         widget: 'CONTACT_FORM',

--- a/src/app/api/v1/concierge/lead/route.ts
+++ b/src/app/api/v1/concierge/lead/route.ts
@@ -192,6 +192,7 @@ export async function POST(req: NextRequest) {
 
       await recordEvent({
         type: 'FORM_SUBMIT',
+        trustedSubmit: true, // server-validated form (zod) — may reopen closed board cards
         leadId: lead.id,
         page: `/${body.source}`,
         widget: 'PARTNER_LANDING_PAGE',

--- a/src/app/api/v1/event-quiz/submit/route.ts
+++ b/src/app/api/v1/event-quiz/submit/route.ts
@@ -117,6 +117,7 @@ export async function POST(req: NextRequest) {
       // Record an explicit FORM_SUBMIT event for the funnel/tracker.
       await recordEvent({
         type: 'FORM_SUBMIT',
+        trustedSubmit: true, // server-validated form (zod) — may reopen closed board cards
         leadId: lead.id,
         page: '/event-quiz',
         widget: 'CONTACT_FORM',

--- a/src/app/api/v1/landing/lead-event/route.ts
+++ b/src/app/api/v1/landing/lead-event/route.ts
@@ -61,13 +61,11 @@ const eventTypeEnum = z.enum([
   'CUSTOM',
 ]);
 
-const statusEnum = z.enum([
-  'ANONYMOUS',
-  'PARTIAL',
-  'SUBMITTED',
-  'CONVERTED',
-  'ARCHIVED',
-]);
+// Public browser input may only promote a lead to SUBMITTED — never
+// CONVERTED/ARCHIVED (those are server-side facts: Stripe webhooks + the won
+// matcher). The legitimate client (src/lib/leads/client.ts) only ever sends
+// SUBMITTED; anything wider lets curl vandalize the Lead Flow board.
+const statusEnum = z.enum(['PARTIAL', 'SUBMITTED']);
 
 const bodySchema = z.object({
   type: eventTypeEnum,

--- a/src/app/api/v1/landing/lead-event/route.ts
+++ b/src/app/api/v1/landing/lead-event/route.ts
@@ -26,6 +26,7 @@ import {
 import { ensureVisitorCookie, COOKIE_NAME } from '@/lib/leads/cookie';
 import { normalizeEmail } from '@/lib/leads/email-validation';
 import { enqueueJourney } from '@/lib/followups/enqueue';
+import { checkRateLimit } from '@/lib/security/rate-limit';
 import type {
   LeadEventType,
   LeadSourceWidget,
@@ -104,6 +105,17 @@ const bodySchema = z.object({
 });
 
 export async function POST(req: NextRequest) {
+  // Public + unauthenticated + does real DB writes per request — throttle
+  // (same helper/pattern as /api/contact). Generous: the pixel legitimately
+  // fires on page views + field blurs during a real form session.
+  const ip =
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    req.headers.get('x-real-ip') ||
+    'unknown';
+  if (!(await checkRateLimit('lead-event', ip, 30, 60))) {
+    return NextResponse.json({ error: 'rate_limited' }, { status: 429 });
+  }
+
   let parsed: z.infer<typeof bodySchema>;
   try {
     parsed = bodySchema.parse(await req.json());

--- a/src/app/api/v1/quote/start/route.ts
+++ b/src/app/api/v1/quote/start/route.ts
@@ -181,6 +181,7 @@ export async function POST(req: NextRequest) {
       });
       await recordEvent({
         type: 'CHECKOUT_START',
+        trustedSubmit: true, // server-validated quote request — may reopen closed board cards
         leadId: lead.id,
         page: `/${body.source}`,
         widget: 'CONTACT_FORM',

--- a/src/app/concierge-quote/[leadId]/success/page.tsx
+++ b/src/app/concierge-quote/[leadId]/success/page.tsx
@@ -11,6 +11,7 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { prisma } from '@/lib/database/client';
 import { stripe } from '@/lib/stripe/client';
+import { syncStageFromConversion } from '@/lib/leads/pipeline';
 import { computeQuoteTotals, type Quote } from '@/lib/concierge/quote';
 
 export const dynamic = 'force-dynamic';
@@ -91,6 +92,8 @@ export default async function ConciergeDepositSuccessPage({
             } as never,
           },
         });
+        // Lead Flow board: keep stage in sync (webhook may have already done it).
+        await syncStageFromConversion(leadId);
       } else if (!matchesLead) {
         verifiedError = 'session_lead_mismatch';
       } else {

--- a/src/lib/followups/__tests__/engine.test.ts
+++ b/src/lib/followups/__tests__/engine.test.ts
@@ -25,8 +25,9 @@ const mockDb: {
   suppressions: Array<{ email: string }>;
   paidOrders: Array<{ customerEmail: string; createdAt: Date }>;
   emailLogs: Array<{ id: string; metadata: Record<string, unknown>; status: string }>;
+  leads: Array<{ id: string; pipelineStage: string | null }>;
   seq: number;
-} = { jobs: [], suppressions: [], paidOrders: [], emailLogs: [], seq: 0 };
+} = { jobs: [], suppressions: [], paidOrders: [], emailLogs: [], leads: [], seq: 0 };
 
 const flagState: Record<string, boolean> = {};
 
@@ -68,6 +69,11 @@ vi.mock('@/lib/database/client', () => ({
     emailSuppression: {
       findUnique: vi.fn(async ({ where }: any) =>
         mockDb.suppressions.find((s) => s.email === where.email) ?? null
+      ),
+    },
+    lead: {
+      findUnique: vi.fn(async ({ where }: any) =>
+        mockDb.leads.find((l) => l.id === where.id) ?? null
       ),
     },
     order: {
@@ -167,6 +173,7 @@ beforeEach(() => {
   mockDb.suppressions = [];
   mockDb.paidOrders = [];
   mockDb.emailLogs = [];
+  mockDb.leads = [];
   mockDb.seq = 0;
   for (const key of Object.keys(flagState)) delete flagState[key];
   process.env.UNSUBSCRIBE_SECRET = 'engine-test-secret';
@@ -219,6 +226,30 @@ describe('processJob pipeline', () => {
     expect(outcome).toBe('suppressed');
     expect(mockDb.jobs[0].status).toBe('suppressed');
     expect(sendEmailDetailed).not.toHaveBeenCalled();
+  });
+
+  it('a lead moved to LOST on the Lead Flow board cancels the job', async () => {
+    mockDb.leads.push({ id: 'lead-1', pipelineStage: 'LOST' });
+    const job = makeJob();
+    const outcome = await processJob(job, makeJourney());
+    expect(outcome).toBe('canceled');
+    expect(mockDb.jobs[0].cancelReason).toBe('pipeline-lost');
+    expect(sendEmailDetailed).not.toHaveBeenCalled();
+  });
+
+  it('a lead moved to WON on the Lead Flow board cancels the job', async () => {
+    mockDb.leads.push({ id: 'lead-1', pipelineStage: 'WON' });
+    const job = makeJob();
+    const outcome = await processJob(job, makeJourney());
+    expect(outcome).toBe('canceled');
+    expect(mockDb.jobs[0].cancelReason).toBe('pipeline-won');
+  });
+
+  it('an active-stage lead does NOT cancel the job', async () => {
+    mockDb.leads.push({ id: 'lead-1', pipelineStage: 'CONTACTED' });
+    const job = makeJob();
+    const outcome = await processJob(job, makeJourney());
+    expect(outcome).toBe('sent');
   });
 
   it('journey shouldCancel cancels with its reason', async () => {

--- a/src/lib/followups/engine.ts
+++ b/src/lib/followups/engine.ts
@@ -249,6 +249,25 @@ export async function processJob(
     return 'canceled';
   }
 
+  // 2b. Lead Flow board guard: a lead explicitly closed on the board (WON or
+  // LOST) is a finished conversation — a board-Lost lead must never get a
+  // follow-up email when the flags flip on. Only jobs anchored to a lead are
+  // affected (B2B journeys carry no leadId).
+  if (job.leadId) {
+    const boardLead = await prisma.lead.findUnique({
+      where: { id: job.leadId },
+      select: { pipelineStage: true },
+    });
+    if (boardLead?.pipelineStage === 'LOST') {
+      await markCanceled(job, 'pipeline-lost');
+      return 'canceled';
+    }
+    if (boardLead?.pipelineStage === 'WON') {
+      await markCanceled(job, 'pipeline-won');
+      return 'canceled';
+    }
+  }
+
   // 3. Global guard: they became a paying customer since this was queued.
   if (!journey.skipGlobalPaidGuard && (await hasPaidOrderSince(job.email, job.createdAt))) {
     await markCanceled(job, 'converted-order');

--- a/src/lib/followups/enqueue.ts
+++ b/src/lib/followups/enqueue.ts
@@ -13,6 +13,7 @@
 import { Prisma, type FollowUpJob } from '@prisma/client';
 import { prisma } from '@/lib/database/client';
 import { getJourney } from './journeys';
+import { isFeatureEnabled } from '@/lib/features/feature-flags';
 import { normalizeEmail } from './suppression';
 import { isCompleteEmail } from '@/lib/leads/email-validation';
 import { enrollLeadIfEligible } from '@/lib/leads/pipeline';
@@ -134,8 +135,11 @@ export async function enqueueJourney(
     });
     // Lead Flow board: anything flagged for a follow-up belongs on the board
     // (Allan's rule) — this is how abandoned-quote PARTIAL leads surface.
-    // Best-effort; a board hiccup must not fail the enqueue.
-    if (opts.leadId) {
+    // Gated on the journey's feature flag so an anonymous pixel POST can't
+    // push PARTIAL leads onto the board while follow-ups are switched off
+    // (security review HIGH-1); best-effort — a board hiccup must not fail
+    // the enqueue.
+    if (opts.leadId && (await isFeatureEnabled(journey.featureFlag))) {
       await enrollLeadIfEligible(opts.leadId, { allowPartial: true }).catch(() => undefined);
     }
     return { enqueued: true, jobId: job.id };

--- a/src/lib/followups/enqueue.ts
+++ b/src/lib/followups/enqueue.ts
@@ -15,6 +15,7 @@ import { prisma } from '@/lib/database/client';
 import { getJourney } from './journeys';
 import { normalizeEmail } from './suppression';
 import { isCompleteEmail } from '@/lib/leads/email-validation';
+import { enrollLeadIfEligible } from '@/lib/leads/pipeline';
 import { entityIdFromDedupeKey, type JourneyKey } from './types';
 
 const MAX_JITTER_MS = 45 * 60 * 1000;
@@ -131,6 +132,12 @@ export async function enqueueJourney(
         scheduledFor,
       },
     });
+    // Lead Flow board: anything flagged for a follow-up belongs on the board
+    // (Allan's rule) — this is how abandoned-quote PARTIAL leads surface.
+    // Best-effort; a board hiccup must not fail the enqueue.
+    if (opts.leadId) {
+      await enrollLeadIfEligible(opts.leadId, { allowPartial: true }).catch(() => undefined);
+    }
     return { enqueued: true, jobId: job.id };
   } catch (error) {
     if (

--- a/src/lib/leads/__tests__/pipeline.test.ts
+++ b/src/lib/leads/__tests__/pipeline.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Lead Flow pipeline service: transition matrix + side effects, board
+ * eligibility, enroll/reopen semantics, and the guarded won matcher.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+interface MockLead {
+  id: string;
+  email: string | null;
+  phone: string | null;
+  status: string;
+  sourceWidget: string | null;
+  metadata: unknown;
+  resumeCart: unknown;
+  pipelineStage: string | null;
+  stageChangedAt: Date | null;
+  boardSortOrder: number;
+  leadScore: number | null;
+  scoreBreakdown: unknown;
+  lastContactedAt: Date | null;
+  lastActivityAt: Date | null;
+  reopenedAt: Date | null;
+  owner: string | null;
+  snoozedUntil: Date | null;
+  lostReason: string | null;
+  wonAt: Date | null;
+  lostAt: Date | null;
+  orderId: string | null;
+  draftOrderId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const db: {
+  leads: MockLead[];
+  events: Array<Record<string, unknown>>;
+  drafts: Array<{ id: string; customerEmail: string; status: string; createdAt: Date }>;
+  wonOrderRows: Array<{ id: string }>;
+} = { leads: [], events: [], drafts: [], wonOrderRows: [] };
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function matchesWhere(lead: MockLead, where: Record<string, any>): boolean {
+  for (const [key, cond] of Object.entries(where)) {
+    if (key === 'OR') {
+      const ors = cond as Array<Record<string, any>>;
+      if (!ors.some((o) => matchesWhere(lead, o))) return false;
+      continue;
+    }
+    const value = (lead as unknown as Record<string, unknown>)[key];
+    if (cond && typeof cond === 'object' && !Array.isArray(cond) && !(cond instanceof Date)) {
+      if ('in' in cond && !cond.in.includes(value)) return false;
+      if ('not' in cond && value === cond.not) return false;
+      if ('gte' in cond && !((value as Date) >= cond.gte)) return false;
+      if ('gt' in cond && !((value as Date) > cond.gt)) return false;
+    } else if (value !== cond) {
+      return false;
+    }
+  }
+  return true;
+}
+
+vi.mock('@/lib/database/client', () => ({
+  prisma: {
+    lead: {
+      findUnique: vi.fn(async ({ where }: any) => db.leads.find((l) => l.id === where.id) ?? null),
+      findMany: vi.fn(async ({ where, take }: any) =>
+        db.leads.filter((l) => matchesWhere(l, where ?? {})).slice(0, take ?? 100)
+      ),
+      update: vi.fn(async ({ where, data }: any) => {
+        const lead = db.leads.find((l) => l.id === where.id);
+        if (lead) Object.assign(lead, data);
+        return lead;
+      }),
+      updateMany: vi.fn(async ({ where, data }: any) => {
+        let count = 0;
+        for (const lead of db.leads) {
+          if (!matchesWhere(lead, where)) continue;
+          Object.assign(lead, data);
+          count++;
+        }
+        return { count };
+      }),
+    },
+    leadEvent: {
+      create: vi.fn(async ({ data }: any) => {
+        db.events.push(data);
+        return data;
+      }),
+      count: vi.fn(async () => 0),
+      findFirst: vi.fn(async ({ where }: any) => {
+        const hit = db.events.find(
+          (e) =>
+            e.leadId === where.leadId &&
+            (!where.type?.in || where.type.in.includes(e.type))
+        );
+        return hit ?? null;
+      }),
+    },
+    draftOrder: {
+      findFirst: vi.fn(async ({ where }: any) => {
+        const email = String(where.customerEmail.equals).toLowerCase();
+        const hit = db.drafts.find(
+          (d) =>
+            d.customerEmail.toLowerCase() === email &&
+            where.status.in.includes(d.status) &&
+            d.createdAt >= where.createdAt.gte
+        );
+        return hit ? { id: hit.id } : null;
+      }),
+    },
+    $queryRaw: vi.fn(async () => db.wonOrderRows),
+  },
+}));
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+import {
+  enrollLeadIfEligible,
+  handleSubmitSignal,
+  isBoardEligible,
+  isNewsletterOnly,
+  sweepQuoteSent,
+  sweepWonMatches,
+  syncStageFromConversion,
+  transitionStage,
+} from '../pipeline';
+import { validateTransition } from '../pipeline-types';
+
+let seq = 0;
+function makeLead(overrides: Partial<MockLead> = {}): MockLead {
+  const lead: MockLead = {
+    id: `lead-${++seq}`,
+    email: 'guest@example.com',
+    phone: null,
+    status: 'SUBMITTED',
+    sourceWidget: 'CONTACT_FORM',
+    metadata: { contactForm: { eventType: 'party' } },
+    resumeCart: null,
+    pipelineStage: null,
+    stageChangedAt: null,
+    boardSortOrder: 0,
+    leadScore: null,
+    scoreBreakdown: null,
+    lastContactedAt: null,
+    lastActivityAt: null,
+    reopenedAt: null,
+    owner: null,
+    snoozedUntil: null,
+    lostReason: null,
+    wonAt: null,
+    lostAt: null,
+    orderId: null,
+    draftOrderId: null,
+    createdAt: new Date('2026-07-01T12:00:00Z'),
+    updatedAt: new Date('2026-07-01T12:00:00Z'),
+    ...overrides,
+  };
+  db.leads.push(lead);
+  return lead;
+}
+
+beforeEach(() => {
+  db.leads = [];
+  db.events = [];
+  db.drafts = [];
+  db.wonOrderRows = [];
+  seq = 0;
+});
+
+describe('validateTransition', () => {
+  it('rejects unknown stages and same-stage moves, allows the rest', () => {
+    expect(validateTransition('NEW', 'BANANA')).toBe('unknown-stage');
+    expect(validateTransition('NEW', 'NEW')).toBe('same-stage');
+    expect(validateTransition('NEW', 'WON')).toBeNull();
+    expect(validateTransition('LOST', 'CONTACTED')).toBeNull();
+    expect(validateTransition(null, 'NEW')).toBeNull();
+  });
+});
+
+describe('board eligibility', () => {
+  it('newsletter-only signups are excluded until they submit an inquiry', () => {
+    expect(
+      isNewsletterOnly({ sourceWidget: 'EMAIL_SIGNUP', metadata: { newsletter: {} } })
+    ).toBe(true);
+    expect(
+      isNewsletterOnly({
+        sourceWidget: 'EMAIL_SIGNUP',
+        metadata: { newsletter: {}, chatQuiz: { headcount: 5 } },
+      })
+    ).toBe(false);
+    expect(isNewsletterOnly({ sourceWidget: 'CONTACT_FORM', metadata: {} })).toBe(false);
+  });
+
+  it('requires contact info and SUBMITTED (or PARTIAL only when allowed)', () => {
+    const asLite = (l: MockLead) => l as unknown as Parameters<typeof isBoardEligible>[0];
+    const base = makeLead({ email: null, phone: null });
+    expect(isBoardEligible(asLite(base))).toBe(false);
+    const partial = makeLead({ status: 'PARTIAL' });
+    expect(isBoardEligible(asLite(partial))).toBe(false);
+    expect(isBoardEligible(asLite(partial), { allowPartial: true })).toBe(true);
+    const submitted = makeLead();
+    expect(isBoardEligible(asLite(submitted))).toBe(true);
+  });
+});
+
+describe('transitionStage', () => {
+  it('WON stamps wonAt; leaving WON clears it and sets reopenedAt', async () => {
+    const lead = makeLead({ pipelineStage: 'QUOTE_SENT', stageChangedAt: new Date() });
+    const toWon = await transitionStage(lead.id, 'WON', { via: 'drag' });
+    expect(toWon.moved).toBe(true);
+    expect(lead.pipelineStage).toBe('WON');
+    expect(lead.wonAt).toBeInstanceOf(Date);
+
+    const back = await transitionStage(lead.id, 'QUALIFIED', { via: 'drag' });
+    expect(back.moved).toBe(true);
+    expect(lead.wonAt).toBeNull();
+    expect(lead.reopenedAt).toBeInstanceOf(Date);
+  });
+
+  it('LOST stores the reason; reopening clears lost fields', async () => {
+    const lead = makeLead({ pipelineStage: 'NEW', stageChangedAt: new Date() });
+    await transitionStage(lead.id, 'LOST', { via: 'drag', lostReason: 'ghosted' });
+    expect(lead.pipelineStage).toBe('LOST');
+    expect(lead.lostReason).toBe('ghosted');
+
+    await transitionStage(lead.id, 'NEW', { via: 'drag' });
+    expect(lead.lostReason).toBeNull();
+    expect(lead.lostAt).toBeNull();
+    expect(lead.reopenedAt).toBeInstanceOf(Date);
+  });
+
+  it('same-stage is a no-op; onlyFrom blocks auto-moves from other stages', async () => {
+    const lead = makeLead({ pipelineStage: 'QUOTE_SENT', stageChangedAt: new Date() });
+    const same = await transitionStage(lead.id, 'QUOTE_SENT', { via: 'drag' });
+    expect(same.moved).toBe(false);
+    expect(same.reason).toBe('same-stage');
+
+    const blocked = await transitionStage(lead.id, 'CONTACTED', {
+      via: 'reply',
+      onlyFrom: ['NEW'],
+    });
+    expect(blocked.moved).toBe(false);
+    expect(blocked.reason).toBe('not-in-from-stage');
+    expect(lead.pipelineStage).toBe('QUOTE_SENT');
+  });
+
+  it('appends a stage.changed audit event', async () => {
+    const lead = makeLead({ pipelineStage: 'NEW', stageChangedAt: new Date() });
+    await transitionStage(lead.id, 'CONTACTED', { via: 'drag' });
+    const evt = db.events.find(
+      (e) => (e.metadata as Record<string, unknown>)?.kind === 'stage.changed'
+    );
+    expect(evt).toBeTruthy();
+    expect((evt!.metadata as Record<string, unknown>).from).toBe('NEW');
+    expect((evt!.metadata as Record<string, unknown>).to).toBe('CONTACTED');
+  });
+});
+
+describe('enroll + reopen', () => {
+  it('enrolls an eligible SUBMITTED lead as NEW exactly once', async () => {
+    const lead = makeLead();
+    expect(await enrollLeadIfEligible(lead.id)).toBe(true);
+    expect(lead.pipelineStage).toBe('NEW');
+    expect(await enrollLeadIfEligible(lead.id)).toBe(false); // already boarded
+  });
+
+  it('does not enroll PARTIAL leads unless allowPartial (follow-up hook path)', async () => {
+    const lead = makeLead({ status: 'PARTIAL' });
+    expect(await enrollLeadIfEligible(lead.id)).toBe(false);
+    expect(await enrollLeadIfEligible(lead.id, { allowPartial: true })).toBe(true);
+  });
+
+  it('does not enroll newsletter-only signups', async () => {
+    const lead = makeLead({
+      sourceWidget: 'EMAIL_SIGNUP',
+      metadata: { newsletter: { status: 'confirmed' } },
+    });
+    expect(await enrollLeadIfEligible(lead.id)).toBe(false);
+  });
+
+  it('handleSubmitSignal re-opens WON/LOST leads as NEW', async () => {
+    const lead = makeLead({
+      pipelineStage: 'LOST',
+      stageChangedAt: new Date(),
+      lostAt: new Date(),
+      lostReason: 'stale',
+    });
+    await handleSubmitSignal(lead.id);
+    expect(lead.pipelineStage).toBe('NEW');
+    expect(lead.lostReason).toBeNull();
+    expect(lead.reopenedAt).toBeInstanceOf(Date);
+  });
+
+  it('handleSubmitSignal enrolls off-board leads', async () => {
+    const lead = makeLead();
+    await handleSubmitSignal(lead.id);
+    expect(lead.pipelineStage).toBe('NEW');
+  });
+
+  it('handleSubmitSignal leaves working-stage leads alone', async () => {
+    const lead = makeLead({ pipelineStage: 'QUALIFIED', stageChangedAt: new Date() });
+    await handleSubmitSignal(lead.id);
+    expect(lead.pipelineStage).toBe('QUALIFIED');
+  });
+});
+
+describe('conversion sync + sweeps', () => {
+  it('syncStageFromConversion moves CONVERTED leads to WON, forward-only', async () => {
+    const lead = makeLead({
+      status: 'CONVERTED',
+      pipelineStage: 'QUOTE_SENT',
+      stageChangedAt: new Date(),
+    });
+    await syncStageFromConversion(lead.id);
+    expect(lead.pipelineStage).toBe('WON');
+
+    // Already WON → no second event.
+    const eventsBefore = db.events.length;
+    await syncStageFromConversion(lead.id);
+    expect(db.events.length).toBe(eventsBefore);
+  });
+
+  it('syncStageFromConversion ignores non-converted leads', async () => {
+    const lead = makeLead({ pipelineStage: 'NEW', stageChangedAt: new Date() });
+    await syncStageFromConversion(lead.id);
+    expect(lead.pipelineStage).toBe('NEW');
+  });
+
+  it('sweepQuoteSent moves working leads with an outstanding draft', async () => {
+    const lead = makeLead({ pipelineStage: 'CONTACTED', stageChangedAt: new Date() });
+    db.drafts.push({
+      id: 'draft-1',
+      customerEmail: 'GUEST@example.com',
+      status: 'SENT',
+      createdAt: new Date('2026-07-05T12:00:00Z'),
+    });
+    const moved = await sweepQuoteSent();
+    expect(moved).toBe(1);
+    expect(lead.pipelineStage).toBe('QUOTE_SENT');
+    expect(lead.draftOrderId).toBe('draft-1');
+  });
+
+  it('sweepQuoteSent ignores drafts older than the lead (or its reopen)', async () => {
+    makeLead({
+      pipelineStage: 'NEW',
+      stageChangedAt: new Date(),
+      createdAt: new Date('2026-07-10T12:00:00Z'),
+    });
+    db.drafts.push({
+      id: 'draft-old',
+      customerEmail: 'guest@example.com',
+      status: 'SENT',
+      createdAt: new Date('2026-06-01T12:00:00Z'),
+    });
+    expect(await sweepQuoteSent()).toBe(0);
+  });
+
+  it('sweepWonMatches sets WON + orderId + CONVERTED on a verified match', async () => {
+    const lead = makeLead({ pipelineStage: 'QUOTE_SENT', stageChangedAt: new Date() });
+    db.wonOrderRows = [{ id: 'order-9' }];
+    const won = await sweepWonMatches();
+    expect(won).toBe(1);
+    expect(lead.pipelineStage).toBe('WON');
+    expect(lead.orderId).toBe('order-9');
+    expect(lead.status).toBe('CONVERTED');
+  });
+
+  it('sweepWonMatches skips leads with no identity and no match', async () => {
+    makeLead({ pipelineStage: 'NEW', stageChangedAt: new Date(), email: null, phone: null });
+    db.wonOrderRows = [];
+    expect(await sweepWonMatches()).toBe(0);
+  });
+});

--- a/src/lib/leads/__tests__/pipeline.test.ts
+++ b/src/lib/leads/__tests__/pipeline.test.ts
@@ -37,7 +37,8 @@ const db: {
   events: Array<Record<string, unknown>>;
   drafts: Array<{ id: string; customerEmail: string; status: string; createdAt: Date }>;
   wonOrderRows: Array<{ id: string }>;
-} = { leads: [], events: [], drafts: [], wonOrderRows: [] };
+  reopenRows: Array<{ id: string }>;
+} = { leads: [], events: [], drafts: [], wonOrderRows: [], reopenRows: [] };
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 function matchesWhere(lead: MockLead, where: Record<string, any>): boolean {
@@ -89,11 +90,16 @@ vi.mock('@/lib/database/client', () => ({
       }),
       count: vi.fn(async () => 0),
       findFirst: vi.fn(async ({ where }: any) => {
-        const hit = db.events.find(
-          (e) =>
-            e.leadId === where.leadId &&
-            (!where.type?.in || where.type.in.includes(e.type))
-        );
+        const hit = db.events.find((e) => {
+          if (e.leadId !== where.leadId) return false;
+          if (where.type?.in && !where.type.in.includes(e.type)) return false;
+          if (where.occurredAt?.gt && !((e.occurredAt as Date) > where.occurredAt.gt)) return false;
+          if (where.metadata?.path) {
+            const meta = (e.metadata ?? {}) as Record<string, unknown>;
+            if (meta[where.metadata.path[0]] !== where.metadata.equals) return false;
+          }
+          return true;
+        });
         return hit ?? null;
       }),
     },
@@ -109,7 +115,12 @@ vi.mock('@/lib/database/client', () => ({
         return hit ? { id: hit.id } : null;
       }),
     },
-    $queryRaw: vi.fn(async () => db.wonOrderRows),
+    $queryRaw: vi.fn(async (strings: TemplateStringsArray) => {
+      const sql = Array.isArray(strings) ? strings.join('?') : String(strings);
+      // sweepReopens' candidate query vs findWonOrder's order match.
+      if (sql.includes('last_activity_at')) return db.reopenRows;
+      return db.wonOrderRows;
+    }),
   },
 }));
 /* eslint-enable @typescript-eslint/no-explicit-any */
@@ -119,7 +130,9 @@ import {
   handleSubmitSignal,
   isBoardEligible,
   isNewsletterOnly,
+  matchFloor,
   sweepQuoteSent,
+  sweepReopens,
   sweepWonMatches,
   syncStageFromConversion,
   transitionStage,
@@ -164,6 +177,7 @@ beforeEach(() => {
   db.events = [];
   db.drafts = [];
   db.wonOrderRows = [];
+  db.reopenRows = [];
   seq = 0;
 });
 
@@ -369,5 +383,54 @@ describe('conversion sync + sweeps', () => {
     makeLead({ pipelineStage: 'NEW', stageChangedAt: new Date(), email: null, phone: null });
     db.wonOrderRows = [];
     expect(await sweepWonMatches()).toBe(0);
+  });
+
+  it('sweepReopens reopens only on trusted (server-originated) submits', async () => {
+    const staleStage = new Date('2026-07-01T12:00:00Z');
+    const untrusted = makeLead({
+      pipelineStage: 'WON',
+      stageChangedAt: staleStage,
+      wonAt: staleStage,
+      lastActivityAt: new Date('2026-07-10T12:00:00Z'),
+    });
+    const trusted = makeLead({
+      pipelineStage: 'LOST',
+      stageChangedAt: staleStage,
+      lostAt: staleStage,
+      lastActivityAt: new Date('2026-07-10T12:00:00Z'),
+    });
+    db.reopenRows = [{ id: untrusted.id }, { id: trusted.id }];
+    // Untrusted lead has only a client-claimed pixel FORM_SUBMIT.
+    db.events.push({
+      leadId: untrusted.id,
+      type: 'FORM_SUBMIT',
+      occurredAt: new Date('2026-07-10T12:00:00Z'),
+      metadata: {},
+    });
+    // Trusted lead has a server-validated submit (trustedSubmit stamp).
+    db.events.push({
+      leadId: trusted.id,
+      type: 'FORM_SUBMIT',
+      occurredAt: new Date('2026-07-10T12:00:00Z'),
+      metadata: { trustedSubmit: true },
+    });
+
+    const reopened = await sweepReopens();
+    expect(reopened).toBe(1);
+    expect(untrusted.pipelineStage).toBe('WON');
+    expect(trusted.pipelineStage).toBe('NEW');
+    expect(trusted.lostAt).toBeNull();
+  });
+});
+
+describe('matchFloor', () => {
+  it('uses the reopen date when newer than creation (old orders cannot re-win)', () => {
+    const createdAt = new Date('2026-06-01T00:00:00Z');
+    const reopenedAt = new Date('2026-07-01T00:00:00Z');
+    expect(matchFloor({ createdAt, reopenedAt })).toEqual(reopenedAt);
+    expect(matchFloor({ createdAt, reopenedAt: null })).toEqual(createdAt);
+    expect(
+      matchFloor({ createdAt: reopenedAt, reopenedAt: createdAt })
+    ).toEqual(reopenedAt); // stale reopen older than creation is ignored
   });
 });

--- a/src/lib/leads/__tests__/scoring.test.ts
+++ b/src/lib/leads/__tests__/scoring.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Rule-based temperature scoring: per-surface fixtures, threshold boundaries,
+ * CT-safe date math, past-event zeroing, missing-metadata leniency, clamping.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  computeLeadScore,
+  daysUntilCT,
+  dateStrCT,
+  temperatureFor,
+  SCORE_THRESHOLDS,
+} from '../scoring';
+
+/** Fixed clock: 2026-07-13 18:00 UTC = 1pm CT. */
+const NOW = new Date('2026-07-13T18:00:00Z');
+
+function isoDaysFromNow(days: number): string {
+  const d = new Date(NOW.getTime() + days * 86_400_000);
+  return dateStrCT(d);
+}
+
+describe('temperatureFor', () => {
+  it('maps thresholds exactly (fork-compatible: hot ≥70, warm ≥40)', () => {
+    expect(temperatureFor(100)).toBe('hot');
+    expect(temperatureFor(SCORE_THRESHOLDS.hot)).toBe('hot');
+    expect(temperatureFor(SCORE_THRESHOLDS.hot - 1)).toBe('warm');
+    expect(temperatureFor(SCORE_THRESHOLDS.warm)).toBe('warm');
+    expect(temperatureFor(SCORE_THRESHOLDS.warm - 1)).toBe('cold');
+    expect(temperatureFor(0)).toBe('cold');
+    expect(temperatureFor(null)).toBeNull();
+    expect(temperatureFor(undefined)).toBeNull();
+  });
+});
+
+describe('daysUntilCT', () => {
+  it('is CT-safe: an evening in CT does not shift the day', () => {
+    // 2026-07-14 03:00 UTC is still 2026-07-13 10pm in CT.
+    const lateEvening = new Date('2026-07-14T03:00:00Z');
+    expect(daysUntilCT('2026-07-14', lateEvening)).toBe(1);
+    expect(daysUntilCT('2026-07-13', lateEvening)).toBe(0);
+  });
+
+  it('handles same-day, future, past, and garbage', () => {
+    expect(daysUntilCT('2026-07-13', NOW)).toBe(0);
+    expect(daysUntilCT('2026-07-20', NOW)).toBe(7);
+    expect(daysUntilCT('2026-07-01', NOW)).toBe(-12);
+    expect(daysUntilCT('not a date', NOW)).toBeNull();
+    expect(daysUntilCT('', NOW)).toBeNull();
+  });
+});
+
+describe('computeLeadScore — per-surface fixtures', () => {
+  it('concierge lead with near event, big group, high budget is hot', () => {
+    const { score, breakdown } = computeLeadScore({
+      sourceWidget: 'PARTNER_LANDING_PAGE',
+      metadata: {
+        conciergeQuiz: {
+          arrivalDate: isoDaysFromNow(5),
+          headcount: 25,
+          budgetPerPerson: '$300+',
+          partyType: 'bachelor',
+        },
+      },
+      createdAt: NOW,
+      lastActivityAt: NOW,
+      now: NOW,
+    });
+    expect(breakdown.eventProximity).toBe(30);
+    expect(breakdown.dealSize).toBe(22); // 12 headcount + 10 budget
+    expect(breakdown.sourceQuality).toBe(20);
+    expect(breakdown.recency).toBe(15);
+    expect(score).toBeGreaterThanOrEqual(SCORE_THRESHOLDS.hot);
+    expect(temperatureFor(score)).toBe('hot');
+  });
+
+  it('chat lead with a mid-range date scores warm', () => {
+    const { score, breakdown } = computeLeadScore({
+      sourceWidget: 'CONTACT_FORM',
+      metadata: {
+        chatQuiz: {
+          partyType: 'boat',
+          headcount: 8,
+          deliveryDate: isoDaysFromNow(45),
+        },
+      },
+      createdAt: new Date(NOW.getTime() - 2 * 86_400_000),
+      lastActivityAt: new Date(NOW.getTime() - 2 * 86_400_000),
+      now: NOW,
+    });
+    expect(breakdown.eventProximity).toBe(12); // ≤60d
+    expect(breakdown.dealSize).toBe(4); // headcount ≥5
+    expect(breakdown.sourceQuality).toBe(14); // chatQuiz
+    expect(breakdown.recency).toBe(12); // ≤3d
+    expect(temperatureFor(score)).toBe('warm'); // 42 — decays to cold if they go quiet
+  });
+
+  it('event-quiz today/tomorrow timing counts as imminent', () => {
+    const { breakdown } = computeLeadScore({
+      sourceWidget: 'CONTACT_FORM',
+      metadata: { eventQuiz: { partyType: 'birthday', timing: 'today' } },
+      createdAt: NOW,
+      now: NOW,
+    });
+    expect(breakdown.eventProximity).toBe(30);
+    expect(breakdown.sourceQuality).toBe(12);
+  });
+
+  it('contact form parses stringified guest counts', () => {
+    const { breakdown } = computeLeadScore({
+      sourceWidget: 'CONTACT_FORM',
+      metadata: {
+        contactForm: {
+          eventType: 'wedding',
+          eventDate: isoDaysFromNow(20),
+          guestCount: '120',
+        },
+      },
+      createdAt: NOW,
+      now: NOW,
+    });
+    expect(breakdown.eventProximity).toBe(20); // ≤30d
+    expect(breakdown.dealSize).toBe(15); // ≥50 heads
+    expect(breakdown.sourceQuality).toBe(10);
+  });
+
+  it('a past event zeroes proximity', () => {
+    const { breakdown } = computeLeadScore({
+      sourceWidget: 'CONTACT_FORM',
+      metadata: { unifiedQuote: { deliveryDate: isoDaysFromNow(-3), headcount: 10 } },
+      createdAt: NOW,
+      now: NOW,
+    });
+    expect(breakdown.eventProximity).toBe(0);
+  });
+
+  it('newsletter-only signup scores cold', () => {
+    const { score, breakdown } = computeLeadScore({
+      sourceWidget: 'EMAIL_SIGNUP',
+      metadata: { newsletter: { status: 'confirmed' } },
+      createdAt: new Date(NOW.getTime() - 40 * 86_400_000),
+      lastActivityAt: new Date(NOW.getTime() - 40 * 86_400_000),
+      now: NOW,
+    });
+    expect(breakdown.sourceQuality).toBe(2);
+    expect(temperatureFor(score)).toBe('cold');
+  });
+
+  it('tolerates missing/garbage metadata without throwing', () => {
+    for (const metadata of [null, undefined, [], 'junk', { conciergeQuiz: 'oops' }]) {
+      const { score } = computeLeadScore({
+        sourceWidget: null,
+        metadata,
+        createdAt: NOW,
+        now: NOW,
+      });
+      expect(score).toBeGreaterThanOrEqual(0);
+      expect(score).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it('engagement adds checkout/resume/submit points, capped at 10', () => {
+    const base = {
+      sourceWidget: 'CONTACT_FORM',
+      metadata: {},
+      createdAt: NOW,
+      now: NOW,
+    } as const;
+    const none = computeLeadScore({ ...base });
+    const all = computeLeadScore({
+      ...base,
+      resumeCart: { items: [] },
+      engagement: { hasCheckoutStart: true, formSubmitCount: 3 },
+    });
+    expect(all.breakdown.engagement).toBe(10);
+    expect(none.breakdown.engagement).toBe(0);
+  });
+
+  it('never exceeds 100 or drops below 0', () => {
+    const maxed = computeLeadScore({
+      sourceWidget: 'PARTNER_LANDING_PAGE',
+      metadata: {
+        conciergeQuiz: {
+          arrivalDate: isoDaysFromNow(2),
+          headcount: 100,
+          budgetPerPerson: '$500',
+        },
+      },
+      resumeCart: {},
+      engagement: { hasCheckoutStart: true, formSubmitCount: 5 },
+      createdAt: NOW,
+      lastActivityAt: NOW,
+      now: NOW,
+    });
+    expect(maxed.score).toBe(100);
+  });
+});

--- a/src/lib/leads/leadCapture.ts
+++ b/src/lib/leads/leadCapture.ts
@@ -20,6 +20,8 @@ import type {
   VisitorSession,
 } from '@prisma/client';
 import { normalizeEmail } from './email-validation';
+import { normPhone } from './phone';
+import { enrollLeadIfEligible, handleSubmitSignal } from './pipeline';
 
 export type IdentifyInput = {
   email?: string | null;
@@ -87,11 +89,7 @@ const MAX_FIELD_VALUE_LEN = 1000;
 // mid-typing fragments like `an@` / `@gmail.com`, so a Lead is only ever
 // keyed/created on a syntactically complete address.
 
-function normPhone(v?: string | null) {
-  if (!v) return null;
-  const digits = v.replace(/[^\d+]/g, '');
-  return digits.length >= 7 ? digits : null;
-}
+// normPhone lives in ./phone (shared with the Lead Flow pipeline + order matching).
 
 function nonEmpty(v?: string | null) {
   if (v == null) return null;
@@ -269,7 +267,7 @@ export async function recordEvent(opts: {
   metadata?: Record<string, unknown> | null;
 }) {
   if (!opts.sessionId && !opts.leadId) return null;
-  return prisma.leadEvent.create({
+  const event = await prisma.leadEvent.create({
     data: {
       type: opts.type,
       sessionId: opts.sessionId ?? null,
@@ -281,6 +279,24 @@ export async function recordEvent(opts: {
       metadata: (opts.metadata ?? null) as never,
     },
   });
+  // Lead Flow board bookkeeping — must never break capture (module contract:
+  // intentionally tolerant).
+  if (opts.leadId) {
+    try {
+      // Board cards + scoring read this instead of scanning lead_events.
+      await prisma.lead.update({
+        where: { id: opts.leadId },
+        data: { lastActivityAt: new Date() },
+      });
+      // A real submit enrolls a new card / re-opens a WON-LOST one as NEW.
+      if (opts.type === 'FORM_SUBMIT' || opts.type === 'CHECKOUT_START') {
+        await handleSubmitSignal(opts.leadId);
+      }
+    } catch (err) {
+      console.warn('[leadCapture] pipeline bookkeeping failed', err);
+    }
+  }
+  return event;
 }
 
 /**
@@ -297,7 +313,7 @@ export async function markLeadStatus(
     orderId?: string | null;
   },
 ) {
-  return prisma.lead.update({
+  const lead = await prisma.lead.update({
     where: { id: leadId },
     data: {
       status,
@@ -307,4 +323,15 @@ export async function markLeadStatus(
       orderId: extras?.orderId ?? undefined,
     },
   });
+  // Lead Flow board: a pixel-driven SUBMITTED promotion happens AFTER its
+  // recordEvent call (see landing/lead-event), so enroll here too. Idempotent;
+  // never breaks the caller.
+  if (status === 'SUBMITTED') {
+    try {
+      await enrollLeadIfEligible(leadId);
+    } catch (err) {
+      console.warn('[leadCapture] board enroll failed', err);
+    }
+  }
+  return lead;
 }

--- a/src/lib/leads/leadCapture.ts
+++ b/src/lib/leads/leadCapture.ts
@@ -265,8 +265,18 @@ export async function recordEvent(opts: {
   fieldName?: string | null;
   fieldValue?: string | null;
   metadata?: Record<string, unknown> | null;
+  /**
+   * Set ONLY by server-validated submit routes (chat, concierge, event-quiz,
+   * quote/start). The public pixel route must never set this: event `type`
+   * is client-chosen there, and a trusted submit is what re-opens WON/LOST
+   * board cards — an anonymous caller must not be able to do that with a
+   * victim's email (security review HIGH-1, 2026-07-13).
+   */
+  trustedSubmit?: boolean;
 }) {
   if (!opts.sessionId && !opts.leadId) return null;
+  const isSubmitType = opts.type === 'FORM_SUBMIT' || opts.type === 'CHECKOUT_START';
+  const trusted = opts.trustedSubmit === true && isSubmitType;
   const event = await prisma.leadEvent.create({
     data: {
       type: opts.type,
@@ -276,7 +286,11 @@ export async function recordEvent(opts: {
       widget: nonEmpty(opts.widget),
       fieldName: nonEmpty(opts.fieldName),
       fieldValue: opts.fieldValue ? truncate(opts.fieldValue) : null,
-      metadata: (opts.metadata ?? null) as never,
+      // Trusted submits are stamped so the reopen cron sweep can require
+      // server-originated proof, not just a client-claimed FORM_SUBMIT.
+      metadata: (trusted
+        ? { ...(opts.metadata ?? {}), trustedSubmit: true }
+        : (opts.metadata ?? null)) as never,
     },
   });
   // Lead Flow board bookkeeping — must never break capture (module contract:
@@ -288,8 +302,9 @@ export async function recordEvent(opts: {
         where: { id: opts.leadId },
         data: { lastActivityAt: new Date() },
       });
-      // A real submit enrolls a new card / re-opens a WON-LOST one as NEW.
-      if (opts.type === 'FORM_SUBMIT' || opts.type === 'CHECKOUT_START') {
+      // A real (server-validated) submit enrolls a new card / re-opens a
+      // WON-LOST one as NEW.
+      if (trusted) {
         await handleSubmitSignal(opts.leadId);
       }
     } catch (err) {

--- a/src/lib/leads/phone.ts
+++ b/src/lib/leads/phone.ts
@@ -1,0 +1,26 @@
+/**
+ * Phone normalization shared by lead capture, the Lead Flow pipeline, and
+ * order matching. Prisma-free so client bundles can import it.
+ */
+
+/**
+ * Normalize a phone to its digits (keeps a leading +). Returns null when the
+ * value has fewer than 7 digits — too short to be a real phone.
+ */
+export function normPhone(v?: string | null): string | null {
+  if (!v) return null;
+  const digits = v.replace(/[^\d+]/g, '');
+  return digits.length >= 7 ? digits : null;
+}
+
+/**
+ * Last 10 digits of a phone, for matching Order.customerPhone (stored
+ * as-typed). Mirrors the `idx_orders_customer_phone_last10` expression index
+ * (2026-07-04-crm-lookup-phone-indexes.sql) so lookups stay indexed.
+ */
+export function phoneLast10(v?: string | null): string | null {
+  if (!v) return null;
+  const digits = v.replace(/\D/g, '');
+  if (digits.length < 7) return null;
+  return digits.slice(-10);
+}

--- a/src/lib/leads/pipeline-types.ts
+++ b/src/lib/leads/pipeline-types.ts
@@ -1,0 +1,58 @@
+/**
+ * Lead Flow board — stage vocabulary + transition rules.
+ *
+ * `pipelineStage` is deliberately a plain string column (TEXT + DB CHECK, see
+ * 2026-07-13-lead-pipeline.sql), NOT a Postgres/Prisma enum — adding a stage
+ * later is a code-only change. This module is the single source of truth for
+ * the allowed values. Prisma-free so board client components can import it.
+ */
+
+export const PIPELINE_STAGES = [
+  'NEW',
+  'CONTACTED',
+  'QUALIFIED',
+  'QUOTE_SENT',
+  'WON',
+  'LOST',
+] as const;
+
+export type PipelineStage = (typeof PIPELINE_STAGES)[number];
+
+/** Stages that mean "still being worked" — sweeps and auto-moves only touch these. */
+export const ACTIVE_STAGES = ['NEW', 'CONTACTED', 'QUALIFIED', 'QUOTE_SENT'] as const;
+export type ActiveStage = (typeof ACTIVE_STAGES)[number];
+
+/** How a stage change happened — stored on the stage.changed LeadEvent. */
+export type StageChangeVia =
+  | 'drag' // staff moved the card on the board
+  | 'auto' // sweep (draft detected → QUOTE_SENT)
+  | 'reply' // email reply sent from the board (NEW → CONTACTED)
+  | 'order' // paid order / deposit matched (→ WON)
+  | 'reopen' // WON/LOST lead submitted a fresh inquiry (→ NEW)
+  | 'enroll' // lead entered the board (→ NEW)
+  | 'backfill'; // migration backfill
+
+export function isPipelineStage(v: unknown): v is PipelineStage {
+  return typeof v === 'string' && (PIPELINE_STAGES as readonly string[]).includes(v);
+}
+
+export function isActiveStage(v: unknown): v is ActiveStage {
+  return typeof v === 'string' && (ACTIVE_STAGES as readonly string[]).includes(v);
+}
+
+/**
+ * Server-side transition validation. The board UI adds confirm dialogs for
+ * the destructive-feeling moves (into/out of WON, into LOST); the server
+ * accepts any move between distinct known stages — staff are trusted, and
+ * every change is audit-logged as a LeadEvent.
+ *
+ * Returns null when allowed, or a short kebab-case error string.
+ */
+export function validateTransition(
+  from: PipelineStage | null,
+  to: unknown,
+): string | null {
+  if (!isPipelineStage(to)) return 'unknown-stage';
+  if (from === to) return 'same-stage';
+  return null;
+}

--- a/src/lib/leads/pipeline-types.ts
+++ b/src/lib/leads/pipeline-types.ts
@@ -29,15 +29,10 @@ export type StageChangeVia =
   | 'reply' // email reply sent from the board (NEW → CONTACTED)
   | 'order' // paid order / deposit matched (→ WON)
   | 'reopen' // WON/LOST lead submitted a fresh inquiry (→ NEW)
-  | 'enroll' // lead entered the board (→ NEW)
-  | 'backfill'; // migration backfill
+  | 'enroll'; // lead entered the board (→ NEW)
 
 export function isPipelineStage(v: unknown): v is PipelineStage {
   return typeof v === 'string' && (PIPELINE_STAGES as readonly string[]).includes(v);
-}
-
-export function isActiveStage(v: unknown): v is ActiveStage {
-  return typeof v === 'string' && (ACTIVE_STAGES as readonly string[]).includes(v);
 }
 
 /**

--- a/src/lib/leads/pipeline.ts
+++ b/src/lib/leads/pipeline.ts
@@ -1,0 +1,484 @@
+/**
+ * Lead Flow board — pipeline service (single writer for stage changes).
+ *
+ * Design rules (2026-07-13 plan):
+ *   - `pipelineStage` never touches `Lead.status` EXCEPT the verified won
+ *     matcher, which sets CONVERTED (the semantically-correct existing
+ *     meaning — it also cancels abandoned-quote follow-ups).
+ *   - Won detection is a sweep with a guarded updateMany, NOT order-creation
+ *     hooks (orders are created in 5 places; a hook would miss one).
+ *   - Auto-moves are forward-only and never demote.
+ *   - Every stage change appends a LeadEvent (kind: stage.changed) so the
+ *     card timeline is a full audit trail.
+ *
+ * This module must not import leadCapture.ts (leadCapture imports us).
+ */
+
+import { Prisma, type Lead } from '@prisma/client';
+import { prisma } from '@/lib/database/client';
+import { computeLeadScore } from './scoring';
+import {
+  ACTIVE_STAGES,
+  isPipelineStage,
+  validateTransition,
+  type PipelineStage,
+  type StageChangeVia,
+} from './pipeline-types';
+import { phoneLast10 } from './phone';
+
+/** Metadata keys that mark a lead as a real party inquiry (vs newsletter). */
+const INQUIRY_META_KEYS = [
+  'conciergeQuiz',
+  'chatQuiz',
+  'eventQuiz',
+  'contactForm',
+  'unifiedQuote',
+  'quote',
+] as const;
+
+const SWEEP_BATCH = 200;
+
+type LeadLite = Pick<Lead, 'status' | 'email' | 'phone' | 'sourceWidget' | 'metadata'>;
+
+function hasInquiryMetadata(metadata: unknown): boolean {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return false;
+  const m = metadata as Record<string, unknown>;
+  return INQUIRY_META_KEYS.some((k) => m[k] != null);
+}
+
+/** Newsletter subscribers are not party inquiries — they stay off the board. */
+export function isNewsletterOnly(lead: Pick<LeadLite, 'sourceWidget' | 'metadata'>): boolean {
+  return lead.sourceWidget === 'EMAIL_SIGNUP' && !hasInquiryMetadata(lead.metadata);
+}
+
+/**
+ * Should this lead get a board card? Contactable + a real inquiry.
+ * PARTIAL leads only enter via explicit paths (follow-up enqueue hook,
+ * tray promotion) — `allowPartial` gates that.
+ */
+export function isBoardEligible(
+  lead: LeadLite,
+  opts: { allowPartial?: boolean } = {},
+): boolean {
+  if (!lead.email && !lead.phone) return false;
+  if (isNewsletterOnly(lead)) return false;
+  if (lead.status === 'SUBMITTED' || lead.status === 'CONVERTED') return true;
+  return opts.allowPartial === true && lead.status === 'PARTIAL';
+}
+
+/** Fractional rank: newest on top (lower sorts first). Drags write midpoints. */
+export function topSortOrder(now: Date = new Date()): number {
+  return -Math.floor(now.getTime() / 1000);
+}
+
+async function appendStageEvent(
+  leadId: string,
+  from: PipelineStage | null,
+  to: PipelineStage,
+  via: StageChangeVia,
+  extra?: Record<string, unknown>,
+): Promise<void> {
+  await prisma.leadEvent.create({
+    data: {
+      leadId,
+      type: 'CUSTOM',
+      metadata: { kind: 'stage.changed', from, to, via, ...extra } as never,
+    },
+  });
+}
+
+/**
+ * Recompute + store the temperature score for one lead. Engagement counts
+ * come from lead_events here (bounded per-lead), never at board read time.
+ */
+export async function recomputeLeadScore(leadId: string): Promise<number | null> {
+  const lead = await prisma.lead.findUnique({ where: { id: leadId } });
+  if (!lead) return null;
+  const [checkoutStarts, formSubmits] = await Promise.all([
+    prisma.leadEvent.count({ where: { leadId, type: 'CHECKOUT_START' } }),
+    prisma.leadEvent.count({ where: { leadId, type: 'FORM_SUBMIT' } }),
+  ]);
+  const { score, breakdown } = computeLeadScore({
+    sourceWidget: lead.sourceWidget,
+    metadata: lead.metadata,
+    resumeCart: lead.resumeCart,
+    createdAt: lead.createdAt,
+    updatedAt: lead.updatedAt,
+    lastActivityAt: lead.lastActivityAt,
+    engagement: {
+      hasCheckoutStart: checkoutStarts > 0,
+      formSubmitCount: formSubmits,
+    },
+  });
+  await prisma.lead.update({
+    where: { id: leadId },
+    data: { leadScore: score, scoreBreakdown: breakdown as never },
+  });
+  return score;
+}
+
+export interface TransitionOptions {
+  via: StageChangeVia;
+  /** Auto-moves pass the stages they may move FROM — anything else no-ops. */
+  onlyFrom?: readonly PipelineStage[];
+  lostReason?: string | null;
+  /** Board drags pass an explicit rank; defaults to top of the column. */
+  sortOrder?: number;
+  /** Extra audit payload for the stage.changed event. */
+  eventExtra?: Record<string, unknown>;
+  now?: Date;
+}
+
+export interface TransitionResult {
+  ok: boolean;
+  moved: boolean;
+  reason?: string;
+  lead?: Lead;
+}
+
+/** Field updates that entering/leaving a stage implies. */
+function stageSideEffects(
+  from: PipelineStage | null,
+  to: PipelineStage,
+  opts: TransitionOptions,
+  now: Date,
+): Prisma.LeadUpdateManyMutationInput {
+  const data: Prisma.LeadUpdateManyMutationInput = {
+    pipelineStage: to,
+    stageChangedAt: now,
+    boardSortOrder: opts.sortOrder ?? topSortOrder(now),
+  };
+  if (to === 'WON') data.wonAt = now;
+  if (to === 'LOST') {
+    data.lostAt = now;
+    data.lostReason = opts.lostReason ?? null;
+  }
+  if (from === 'WON' && to !== 'WON') {
+    data.wonAt = null;
+    data.reopenedAt = now; // floor for the won matcher — old orders can't re-win
+  }
+  if (from === 'LOST' && to !== 'LOST') {
+    data.lostAt = null;
+    data.lostReason = null;
+    data.reopenedAt = now;
+  }
+  return data;
+}
+
+/**
+ * Move a lead to a stage. Race-safe: the UPDATE is guarded on the stage we
+ * read, so a concurrent move wins cleanly and this returns moved:false.
+ */
+export async function transitionStage(
+  leadId: string,
+  to: PipelineStage,
+  opts: TransitionOptions,
+): Promise<TransitionResult> {
+  const now = opts.now ?? new Date();
+  const lead = await prisma.lead.findUnique({ where: { id: leadId } });
+  if (!lead) return { ok: false, moved: false, reason: 'lead-not-found' };
+
+  const from = isPipelineStage(lead.pipelineStage) ? lead.pipelineStage : null;
+  const invalid = validateTransition(from, to);
+  if (invalid === 'same-stage') return { ok: true, moved: false, reason: invalid, lead };
+  if (invalid) return { ok: false, moved: false, reason: invalid };
+  if (opts.onlyFrom && (!from || !opts.onlyFrom.includes(from))) {
+    return { ok: true, moved: false, reason: 'not-in-from-stage', lead };
+  }
+
+  const updated = await prisma.lead.updateMany({
+    where: { id: leadId, pipelineStage: lead.pipelineStage },
+    data: stageSideEffects(from, to, opts, now),
+  });
+  if (updated.count === 0) {
+    return { ok: true, moved: false, reason: 'concurrent-change' };
+  }
+
+  await appendStageEvent(leadId, from, to, opts.via, opts.eventExtra);
+  await recomputeLeadScore(leadId).catch(() => undefined);
+  const fresh = await prisma.lead.findUnique({ where: { id: leadId } });
+  return { ok: true, moved: true, lead: fresh ?? undefined };
+}
+
+/**
+ * Put an off-board lead onto the board as NEW (no-op if already on it).
+ * Used by the submit-signal hook, the follow-up enqueue hook, and sweeps.
+ */
+export async function enrollLeadIfEligible(
+  leadId: string,
+  opts: { allowPartial?: boolean; via?: StageChangeVia; now?: Date } = {},
+): Promise<boolean> {
+  const now = opts.now ?? new Date();
+  const lead = await prisma.lead.findUnique({ where: { id: leadId } });
+  if (!lead || lead.pipelineStage !== null) return false;
+  if (!isBoardEligible(lead, { allowPartial: opts.allowPartial })) return false;
+
+  const updated = await prisma.lead.updateMany({
+    where: { id: leadId, pipelineStage: null },
+    data: {
+      pipelineStage: 'NEW',
+      stageChangedAt: now,
+      boardSortOrder: topSortOrder(now),
+    },
+  });
+  if (updated.count === 0) return false;
+  await appendStageEvent(leadId, null, 'NEW', opts.via ?? 'enroll');
+  await recomputeLeadScore(leadId).catch(() => undefined);
+  return true;
+}
+
+/**
+ * Called by recordEvent on FORM_SUBMIT / CHECKOUT_START: a fresh inquiry
+ * re-opens a closed (WON/LOST) card as NEW, or enrolls a new lead.
+ * Never throws — capture paths must not break on board bookkeeping.
+ */
+export async function handleSubmitSignal(leadId: string): Promise<void> {
+  try {
+    const lead = await prisma.lead.findUnique({
+      where: { id: leadId },
+      select: { pipelineStage: true },
+    });
+    if (!lead) return;
+    if (lead.pipelineStage === 'WON' || lead.pipelineStage === 'LOST') {
+      await transitionStage(leadId, 'NEW', { via: 'reopen' });
+      return;
+    }
+    if (lead.pipelineStage === null) {
+      await enrollLeadIfEligible(leadId);
+    }
+  } catch (err) {
+    console.warn('[lead-pipeline] submit signal failed', err);
+  }
+}
+
+/**
+ * Stage↔status sync for the existing conversion writers (concierge deposit
+ * webhook + success page): a CONVERTED lead must show as WON on the board.
+ * Forward-only; never throws.
+ */
+export async function syncStageFromConversion(leadId: string): Promise<void> {
+  try {
+    const lead = await prisma.lead.findUnique({
+      where: { id: leadId },
+      select: { pipelineStage: true, status: true, orderId: true },
+    });
+    if (!lead || lead.pipelineStage === 'WON') return;
+    if (lead.status !== 'CONVERTED' && !lead.orderId) return;
+    await transitionStage(leadId, 'WON', { via: 'order' });
+  } catch (err) {
+    console.warn('[lead-pipeline] conversion sync failed', err);
+  }
+}
+
+/** Cron sweep: board-eligible SUBMITTED leads that never got a card. */
+export async function sweepEnrollSubmitted(): Promise<number> {
+  const candidates = await prisma.lead.findMany({
+    where: {
+      pipelineStage: null,
+      status: 'SUBMITTED',
+      OR: [{ email: { not: null } }, { phone: { not: null } }],
+    },
+    select: { id: true },
+    orderBy: { updatedAt: 'desc' },
+    take: SWEEP_BATCH,
+  });
+  let enrolled = 0;
+  for (const { id } of candidates) {
+    if (await enrollLeadIfEligible(id)) enrolled++;
+  }
+  return enrolled;
+}
+
+/**
+ * Cron sweep: an outstanding (SENT/VIEWED) non-group, non-amendment draft
+ * for the lead's email moves NEW/CONTACTED/QUALIFIED → QUOTE_SENT.
+ * Same draft filters as the follow-up engine's sweepUnpaidInvoices.
+ */
+export async function sweepQuoteSent(): Promise<number> {
+  const leads = await prisma.lead.findMany({
+    where: {
+      pipelineStage: { in: ['NEW', 'CONTACTED', 'QUALIFIED'] },
+      email: { not: null },
+    },
+    select: { id: true, email: true, createdAt: true, reopenedAt: true, draftOrderId: true },
+    take: SWEEP_BATCH,
+  });
+  let moved = 0;
+  for (const lead of leads) {
+    const floor = lead.reopenedAt && lead.reopenedAt > lead.createdAt ? lead.reopenedAt : lead.createdAt;
+    const draft = await prisma.draftOrder.findFirst({
+      where: {
+        customerEmail: { equals: lead.email as string, mode: 'insensitive' },
+        status: { in: ['SENT', 'VIEWED'] },
+        createdAt: { gte: floor },
+        groupOrderId: null,
+        amendmentForOrderId: null,
+      },
+      select: { id: true },
+      orderBy: { createdAt: 'desc' },
+    });
+    if (!draft) continue;
+    const result = await transitionStage(lead.id, 'QUOTE_SENT', {
+      via: 'auto',
+      onlyFrom: ['NEW', 'CONTACTED', 'QUALIFIED'],
+      eventExtra: { draftOrderId: draft.id },
+    });
+    if (result.moved) {
+      moved++;
+      if (!lead.draftOrderId) {
+        await prisma.lead.update({ where: { id: lead.id }, data: { draftOrderId: draft.id } });
+      }
+    }
+  }
+  return moved;
+}
+
+/**
+ * High-confidence paid-order match for one lead: email (case-insensitive) or
+ * last-10-digit phone, created on/after the lead (or its reopen), and NOT a
+ * GroupOrderV2 participant payment (a $40 guest chip-in is not a won party —
+ * risk R1). Uses the idx_orders_customer_phone_last10 expression index.
+ */
+async function findWonOrder(lead: {
+  email: string | null;
+  phone: string | null;
+  createdAt: Date;
+  reopenedAt: Date | null;
+}): Promise<{ id: string } | null> {
+  const floor =
+    lead.reopenedAt && lead.reopenedAt > lead.createdAt ? lead.reopenedAt : lead.createdAt;
+  const last10 = phoneLast10(lead.phone);
+  const identity: Prisma.Sql[] = [];
+  if (lead.email) identity.push(Prisma.sql`LOWER(customer_email) = LOWER(${lead.email})`);
+  if (last10) {
+    identity.push(
+      Prisma.sql`RIGHT(REGEXP_REPLACE(COALESCE(customer_phone, ''), '\\D', '', 'g'), 10) = ${last10}`,
+    );
+  }
+  if (identity.length === 0) return null;
+  const rows = await prisma.$queryRaw<Array<{ id: string }>>`
+    SELECT id FROM orders
+    WHERE financial_status IN ('PAID', 'PARTIALLY_REFUNDED')
+      AND group_order_v2_id IS NULL
+      AND created_at >= ${floor}
+      AND (${Prisma.join(identity, ' OR ')})
+    ORDER BY created_at ASC
+    LIMIT 1
+  `;
+  return rows[0] ?? null;
+}
+
+/**
+ * Cron sweep: move active-stage leads with a verified paid order to WON.
+ * Also back-links Lead.orderId and sets status CONVERTED (the one sanctioned
+ * status write — cancels abandoned-quote follow-ups correctly).
+ */
+export async function sweepWonMatches(): Promise<number> {
+  const leads = await prisma.lead.findMany({
+    where: { pipelineStage: { in: [...ACTIVE_STAGES] } },
+    select: {
+      id: true,
+      email: true,
+      phone: true,
+      createdAt: true,
+      reopenedAt: true,
+      pipelineStage: true,
+    },
+    take: SWEEP_BATCH,
+  });
+  let won = 0;
+  const now = new Date();
+  for (const lead of leads) {
+    const order = await findWonOrder(lead);
+    if (!order) continue;
+    // Guarded update — concurrent sweeps / a staff drag serialize on the row
+    // and the loser's WHERE no longer matches (READ COMMITTED re-check).
+    const updated = await prisma.lead.updateMany({
+      where: { id: lead.id, pipelineStage: { in: [...ACTIVE_STAGES] } },
+      data: {
+        pipelineStage: 'WON',
+        stageChangedAt: now,
+        wonAt: now,
+        orderId: order.id,
+        status: 'CONVERTED',
+        boardSortOrder: topSortOrder(now),
+      },
+    });
+    if (updated.count === 0) continue;
+    won++;
+    const from = isPipelineStage(lead.pipelineStage) ? lead.pipelineStage : null;
+    await appendStageEvent(lead.id, from, 'WON', 'order', { orderId: order.id });
+    await recomputeLeadScore(lead.id).catch(() => undefined);
+  }
+  return won;
+}
+
+/**
+ * Cron backstop for handleSubmitSignal: a WON/LOST lead whose activity
+ * timestamp moved after the stage change AND has a fresh FORM_SUBMIT /
+ * CHECKOUT_START event re-opens as NEW.
+ */
+export async function sweepReopens(): Promise<number> {
+  const rows = await prisma.$queryRaw<Array<{ id: string }>>`
+    SELECT id FROM leads
+    WHERE pipeline_stage IN ('WON', 'LOST')
+      AND last_activity_at IS NOT NULL
+      AND stage_changed_at IS NOT NULL
+      AND last_activity_at > stage_changed_at
+    LIMIT 100
+  `;
+  let reopened = 0;
+  for (const { id } of rows) {
+    const lead = await prisma.lead.findUnique({
+      where: { id },
+      select: { stageChangedAt: true },
+    });
+    if (!lead?.stageChangedAt) continue;
+    const freshSubmit = await prisma.leadEvent.findFirst({
+      where: {
+        leadId: id,
+        type: { in: ['FORM_SUBMIT', 'CHECKOUT_START'] },
+        occurredAt: { gt: lead.stageChangedAt },
+      },
+      select: { id: true },
+    });
+    if (!freshSubmit) continue;
+    const result = await transitionStage(id, 'NEW', {
+      via: 'reopen',
+      onlyFrom: ['WON', 'LOST'],
+    });
+    if (result.moved) reopened++;
+  }
+  return reopened;
+}
+
+/** Rescore every boarded, still-open lead (daily decay). */
+export async function sweepRescoreActive(): Promise<number> {
+  const leads = await prisma.lead.findMany({
+    where: { pipelineStage: { in: [...ACTIVE_STAGES] } },
+    select: { id: true },
+    take: 500,
+  });
+  for (const { id } of leads) {
+    await recomputeLeadScore(id).catch(() => undefined);
+  }
+  return leads.length;
+}
+
+export interface PipelineTickResult {
+  enrolled: number;
+  reopened: number;
+  quoteSent: number;
+  won: number;
+  rescored: number;
+}
+
+/** One daily-cron tick. Order matters: enroll → reopen → quote → won → score. */
+export async function runLeadPipelineTick(): Promise<PipelineTickResult> {
+  const enrolled = await sweepEnrollSubmitted();
+  const reopened = await sweepReopens();
+  const quoteSent = await sweepQuoteSent();
+  const won = await sweepWonMatches();
+  const rescored = await sweepRescoreActive();
+  return { enrolled, reopened, quoteSent, won, rescored };
+}

--- a/src/lib/leads/pipeline.ts
+++ b/src/lib/leads/pipeline.ts
@@ -71,6 +71,18 @@ export function topSortOrder(now: Date = new Date()): number {
   return -Math.floor(now.getTime() / 1000);
 }
 
+/**
+ * Earliest order/draft date that may count toward this lead's current
+ * inquiry: the lead's creation, or its most recent reopen — a reopened
+ * card's OLD order must not re-win it. Shared by the won matcher and the
+ * quote-sent sweep.
+ */
+export function matchFloor(lead: { createdAt: Date; reopenedAt: Date | null }): Date {
+  return lead.reopenedAt && lead.reopenedAt > lead.createdAt
+    ? lead.reopenedAt
+    : lead.createdAt;
+}
+
 async function appendStageEvent(
   leadId: string,
   from: PipelineStage | null,
@@ -103,7 +115,6 @@ export async function recomputeLeadScore(leadId: string): Promise<number | null>
     metadata: lead.metadata,
     resumeCart: lead.resumeCart,
     createdAt: lead.createdAt,
-    updatedAt: lead.updatedAt,
     lastActivityAt: lead.lastActivityAt,
     engagement: {
       hasCheckoutStart: checkoutStarts > 0,
@@ -277,6 +288,10 @@ export async function sweepEnrollSubmitted(): Promise<number> {
       pipelineStage: null,
       status: 'SUBMITTED',
       OR: [{ email: { not: null } }, { phone: { not: null } }],
+      // Newsletter signups stay off-board and would otherwise accumulate as
+      // permanent rejects that starve the batch (review #5). A signup that
+      // later submits a real inquiry enrolls via the realtime hooks.
+      NOT: { sourceWidget: 'EMAIL_SIGNUP' },
     },
     select: { id: true },
     orderBy: { updatedAt: 'desc' },
@@ -305,12 +320,11 @@ export async function sweepQuoteSent(): Promise<number> {
   });
   let moved = 0;
   for (const lead of leads) {
-    const floor = lead.reopenedAt && lead.reopenedAt > lead.createdAt ? lead.reopenedAt : lead.createdAt;
     const draft = await prisma.draftOrder.findFirst({
       where: {
         customerEmail: { equals: lead.email as string, mode: 'insensitive' },
         status: { in: ['SENT', 'VIEWED'] },
-        createdAt: { gte: floor },
+        createdAt: { gte: matchFloor(lead) },
         groupOrderId: null,
         amendmentForOrderId: null,
       },
@@ -345,8 +359,7 @@ async function findWonOrder(lead: {
   createdAt: Date;
   reopenedAt: Date | null;
 }): Promise<{ id: string } | null> {
-  const floor =
-    lead.reopenedAt && lead.reopenedAt > lead.createdAt ? lead.reopenedAt : lead.createdAt;
+  const floor = matchFloor(lead);
   const last10 = phoneLast10(lead.phone);
   const identity: Prisma.Sql[] = [];
   if (lead.email) identity.push(Prisma.sql`LOWER(customer_email) = LOWER(${lead.email})`);
@@ -439,6 +452,9 @@ export async function sweepReopens(): Promise<number> {
         leadId: id,
         type: { in: ['FORM_SUBMIT', 'CHECKOUT_START'] },
         occurredAt: { gt: lead.stageChangedAt },
+        // Server-originated submits only — a client-claimed pixel
+        // FORM_SUBMIT must not be able to reopen a closed card.
+        metadata: { path: ['trustedSubmit'], equals: true },
       },
       select: { id: true },
     });

--- a/src/lib/leads/scoring.ts
+++ b/src/lib/leads/scoring.ts
@@ -1,0 +1,241 @@
+/**
+ * Lead Flow board — rule-based temperature scoring.
+ *
+ * Pure module (no Prisma): the caller gathers the inputs, this computes a
+ * 0–100 score + per-factor breakdown. The score is STORED on the lead
+ * (recomputed on pipeline writes + the daily cron so recency/proximity
+ * decay); the hot/warm/cold label is always DERIVED here so thresholds stay
+ * tweakable without a backfill.
+ *
+ * Thresholds intentionally match the CoreLinq CRM fork (hot ≥70, warm ≥40 —
+ * fork apps/web/app/api/analytics/contacts/route.ts) so scores port at
+ * cutover.
+ *
+ * Factor budget (sums to 100):
+ *   event-date proximity 30 · deal size 25 · source quality 20 ·
+ *   activity recency 15 · engagement depth 10
+ */
+
+export const SCORE_THRESHOLDS = { hot: 70, warm: 40 } as const;
+
+export type Temperature = 'hot' | 'warm' | 'cold';
+
+/** Label for a stored score; null when the lead has never been scored. */
+export function temperatureFor(score: number | null | undefined): Temperature | null {
+  if (score == null) return null;
+  if (score >= SCORE_THRESHOLDS.hot) return 'hot';
+  if (score >= SCORE_THRESHOLDS.warm) return 'warm';
+  return 'cold';
+}
+
+export interface ScoreBreakdown {
+  eventProximity: number;
+  dealSize: number;
+  sourceQuality: number;
+  recency: number;
+  engagement: number;
+}
+
+export interface LeadScoringInput {
+  sourceWidget?: string | null;
+  /** Lead.metadata — surface payloads live under conciergeQuiz / chatQuiz /
+      eventQuiz / contactForm / unifiedQuote. */
+  metadata?: unknown;
+  resumeCart?: unknown;
+  createdAt: Date;
+  updatedAt?: Date | null;
+  /** Bumped by recordEvent; preferred recency signal. */
+  lastActivityAt?: Date | null;
+  /** Aggregated from lead_events by the caller (never scanned here). */
+  engagement?: {
+    hasCheckoutStart?: boolean;
+    formSubmitCount?: number;
+  };
+  /** Injectable clock for tests. */
+  now?: Date;
+}
+
+type Meta = Record<string, unknown>;
+
+function asObject(v: unknown): Meta | null {
+  return v && typeof v === 'object' && !Array.isArray(v) ? (v as Meta) : null;
+}
+
+function metaSection(meta: unknown, key: string): Meta | null {
+  const m = asObject(meta);
+  return m ? asObject(m[key]) : null;
+}
+
+/** America/Chicago YYYY-MM-DD for a Date (same convention as ops cooler-grouping). */
+export function dateStrCT(d: Date): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Chicago',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(d);
+}
+
+/**
+ * Whole days from "today in CT" to a YYYY-MM-DD event date. String-compare
+ * safe: both sides become UTC-noon instants so `new Date('YYYY-MM-DD')`'s
+ * UTC-midnight off-by-one (a real bug for CT evenings) can't happen.
+ * Null when the value isn't a parseable date.
+ */
+export function daysUntilCT(dateStr: string, now: Date): number | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(dateStr.trim());
+  if (!m) return null;
+  const event = Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]), 12);
+  const t = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStrCT(now));
+  if (!t) return null;
+  const today = Date.UTC(Number(t[1]), Number(t[2]) - 1, Number(t[3]), 12);
+  return Math.round((event - today) / 86_400_000);
+}
+
+/** First surface payload that carries an event date, in intent order. */
+function extractEventDate(meta: unknown): string | null {
+  const candidates = [
+    metaSection(meta, 'conciergeQuiz')?.arrivalDate,
+    metaSection(meta, 'chatQuiz')?.deliveryDate,
+    metaSection(meta, 'unifiedQuote')?.deliveryDate,
+    metaSection(meta, 'contactForm')?.eventDate,
+  ];
+  for (const c of candidates) {
+    if (typeof c === 'string' && c.trim()) return c;
+  }
+  return null;
+}
+
+function extractHeadcount(meta: unknown): number | null {
+  const candidates = [
+    metaSection(meta, 'conciergeQuiz')?.headcount,
+    metaSection(meta, 'chatQuiz')?.headcount,
+    metaSection(meta, 'unifiedQuote')?.headcount,
+    metaSection(meta, 'contactForm')?.guestCount,
+  ];
+  for (const c of candidates) {
+    const n = typeof c === 'number' ? c : parseInt(String(c ?? ''), 10);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
+  return null;
+}
+
+/** Dollars per person parsed from the concierge budget chip ("$150–300", "300+"). */
+function extractBudgetPerPerson(meta: unknown): number | null {
+  const raw = metaSection(meta, 'conciergeQuiz')?.budgetPerPerson;
+  if (typeof raw !== 'string') return null;
+  const m = /(\d{2,5})/.exec(raw.replace(/[,\s]/g, ''));
+  return m ? Number(m[1]) : null;
+}
+
+function eventProximityPoints(meta: unknown, now: Date): number {
+  // event-quiz has no date — only a today/tomorrow/future chip.
+  const timing = metaSection(meta, 'eventQuiz')?.timing;
+  if (timing === 'today' || timing === 'tomorrow') return 30;
+
+  const dateStr = extractEventDate(meta);
+  if (!dateStr) return 4; // no date known — mild default, not zero
+  const days = daysUntilCT(dateStr, now);
+  if (days == null) return 4;
+  if (days < 0) return 0; // event already happened
+  if (days <= 7) return 30;
+  if (days <= 14) return 26;
+  if (days <= 30) return 20;
+  if (days <= 60) return 12;
+  if (days <= 90) return 6;
+  return 4;
+}
+
+function dealSizePoints(meta: unknown): number {
+  const headcount = extractHeadcount(meta);
+  let pts = 0;
+  if (headcount != null) {
+    if (headcount >= 50) pts += 15;
+    else if (headcount >= 20) pts += 12;
+    else if (headcount >= 10) pts += 8;
+    else if (headcount >= 5) pts += 4;
+  }
+  const budget = extractBudgetPerPerson(meta);
+  if (budget != null) {
+    if (budget >= 300) pts += 10;
+    else if (budget >= 150) pts += 6;
+    else if (budget > 0) pts += 3;
+  }
+  return Math.min(pts, 25);
+}
+
+function sourceQualityPoints(sourceWidget: string | null | undefined, meta: unknown): number {
+  const m = asObject(meta) ?? {};
+  if (m.conciergeQuiz) return 20; // full questionnaire w/ budget + dates
+  if (m.unifiedQuote) return 16; // asked for a real quote
+  if (m.chatQuiz) return 14;
+  if (m.eventQuiz) return 12;
+  if (m.contactForm) return 10;
+  switch (sourceWidget) {
+    case 'QUICK_BUY':
+    case 'PACKAGE_BUILDER':
+    case 'CALL_BOOKING':
+      return 16;
+    case 'PARTNER_LANDING_PAGE':
+    case 'PARTNER_FAREHARBOR_WEBHOOK':
+    case 'PARTNER_EMAIL_OPTIN':
+      return 14;
+    case 'DRINK_CALCULATOR':
+      return 12;
+    case 'A_LA_CARTE':
+    case 'CONTACT_FORM':
+      return 10;
+    case 'EMAIL_SIGNUP':
+      return 2; // newsletter subscriber, not a party inquiry
+    default:
+      return 8;
+  }
+}
+
+function recencyPoints(input: LeadScoringInput, now: Date): number {
+  const last = input.lastActivityAt ?? input.updatedAt ?? input.createdAt;
+  const hours = (now.getTime() - last.getTime()) / 3_600_000;
+  if (hours < 0) return 15; // clock skew — treat as fresh
+  if (hours <= 24) return 15;
+  if (hours <= 72) return 12;
+  if (hours <= 168) return 8; // 7 days
+  if (hours <= 336) return 5; // 14 days
+  if (hours <= 720) return 2; // 30 days
+  return 0;
+}
+
+function engagementPoints(input: LeadScoringInput): number {
+  let pts = 0;
+  if (input.engagement?.hasCheckoutStart) pts += 4;
+  if (input.resumeCart != null) pts += 3;
+  if ((input.engagement?.formSubmitCount ?? 0) >= 2) pts += 3;
+  return Math.min(pts, 10);
+}
+
+const clamp = (n: number) => Math.max(0, Math.min(100, Math.round(n)));
+
+/**
+ * Compute the rule-based temperature score for a lead. Pure — pass `now` in
+ * tests.
+ */
+export function computeLeadScore(input: LeadScoringInput): {
+  score: number;
+  breakdown: ScoreBreakdown;
+} {
+  const now = input.now ?? new Date();
+  const breakdown: ScoreBreakdown = {
+    eventProximity: eventProximityPoints(input.metadata, now),
+    dealSize: dealSizePoints(input.metadata),
+    sourceQuality: sourceQualityPoints(input.sourceWidget, input.metadata),
+    recency: recencyPoints(input, now),
+    engagement: engagementPoints(input),
+  };
+  const score = clamp(
+    breakdown.eventProximity +
+      breakdown.dealSize +
+      breakdown.sourceQuality +
+      breakdown.recency +
+      breakdown.engagement,
+  );
+  return { score, breakdown };
+}

--- a/src/lib/leads/scoring.ts
+++ b/src/lib/leads/scoring.ts
@@ -43,8 +43,7 @@ export interface LeadScoringInput {
   metadata?: unknown;
   resumeCart?: unknown;
   createdAt: Date;
-  updatedAt?: Date | null;
-  /** Bumped by recordEvent; preferred recency signal. */
+  /** Bumped by recordEvent; the only recency signal besides createdAt. */
   lastActivityAt?: Date | null;
   /** Aggregated from lead_events by the caller (never scanned here). */
   engagement?: {
@@ -193,7 +192,9 @@ function sourceQualityPoints(sourceWidget: string | null | undefined, meta: unkn
 }
 
 function recencyPoints(input: LeadScoringInput, now: Date): number {
-  const last = input.lastActivityAt ?? input.updatedAt ?? input.createdAt;
+  // NEVER fall back to updatedAt: the daily rescore writes the lead row and
+  // bumps @updatedAt, which would pin recency fresh forever (review #2).
+  const last = input.lastActivityAt ?? input.createdAt;
   const hours = (now.getTime() - last.getTime()) / 3_600_000;
   if (hours < 0) return 15; // clock skew — treat as fresh
   if (hours <= 24) return 15;

--- a/src/lib/stripe/webhooks.ts
+++ b/src/lib/stripe/webhooks.ts
@@ -16,6 +16,7 @@ import {
   sendRefundProcessedEmail,
 } from '@/lib/email';
 import { notifyNewOrder, buildGhlPayload } from '@/lib/webhooks/ghl';
+import { syncStageFromConversion } from '@/lib/leads/pipeline';
 import { recordDiscountUsage } from '@/lib/discounts/discount-engine';
 import {
   handleGroupV2PaymentCompleted,
@@ -126,6 +127,8 @@ async function handleConciergeDepositPayment(
       } as never,
     },
   });
+  // Lead Flow board: a paid deposit is a win — keep stage in sync with status.
+  await syncStageFromConversion(leadId);
   console.log('[Stripe Webhook] concierge deposit recorded for lead:', leadId);
 }
 

--- a/vercel.json
+++ b/vercel.json
@@ -103,6 +103,10 @@
     {
       "path": "/api/cron/full-moon-deadline",
       "schedule": "0 15 * * *"
+    },
+    {
+      "path": "/api/cron/lead-pipeline",
+      "schedule": "30 11 * * *"
     }
   ]
 }


### PR DESCRIPTION
Part 1 of 3 of the Lead Flow Kanban build. No UI in this PR — data model, scoring, transitions, sweeps, cron, and follow-ups integration.

## What
- Manual migrations (ledger-applied; selective backfill enrolls submitted leads with contact info, pixel fragments and newsletter-only signups stay off the board):
  - `2026-07-13-lead-pipeline.sql` — `pipeline_stage` (TEXT + CHECK, NULL = off board), stage/score/sort/contact/activity/reopen columns, partial indexes
  - `2026-07-13-lead-reply-emailtype.sql` — `LEAD_REPLY` enum value (solo file, ALTER TYPE rule)
  - `2026-07-13-lead-activity-backfill.sql` — `last_activity_at` from event history (prevents a rescore/updatedAt feedback loop)
- `src/lib/leads/scoring.ts` — rule-based 0–100 temperature with a documented factor budget, CT-safe date math, thresholds shared with the CRM fork
- `src/lib/leads/pipeline.ts` — `transitionStage` single writer (audit LeadEvents, race-safe guarded updates), enroll/reopen semantics, sweeps: enroll → reopen → quote-sent → won matcher (email/last-10-phone paid-order match, group-participant orders excluded, `matchFloor` blocks stale orders from re-winning reopened cards) → daily rescore
- The won matcher is the ONLY new LeadStatus writer (sets CONVERTED); board actions never touch `status` (the follow-ups engine reads it)
- Follow-ups engine: `pipeline-lost`/`pipeline-won` cancel guard so a board-Lost lead can never receive a follow-up email when flags flip on (tested)
- `/api/cron/lead-pipeline` daily (fail-closed CRON_SECRET auth) + vercel.json entry

## Security hardening (security-reviewer findings fixed in-branch)
- Trusted-submit gating: only server-zod-validated routes may enroll/reopen board cards via `recordEvent(trustedSubmit)`; the public pixel route cannot reopen closed cards with a client-claimed FORM_SUBMIT (the reopen sweep requires the trusted LeadEvent stamp); rate limit on `/api/v1/landing/lead-event`; public `setStatus` tightened to `PARTIAL|SUBMITTED`; enqueue-time enrollment gated on the journey feature flag
- Cron fails closed without CRON_SECRET

## Verified
- `npx tsc --noEmit` clean · `npm run lint` 0 errors · `npm run test:run` all green (new: scoring fixtures + threshold boundaries, transition matrix, reopen semantics, trusted-vs-untrusted reopen sweep, follow-ups guard)
- Migrations applied via the ledger + `db:verify-schema` clean; all four raw-SQL paths exercised against the live database

🤖 Generated with [Claude Code](https://claude.com/claude-code)