### PR TITLE
feat(admin): Lead Flow Kanban board at /admin/leads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.66.0",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@google-analytics/data": "^5.2.1",
         "@google/generative-ai": "^0.24.1",
         "@heroicons/react": "^2.2.0",
@@ -676,6 +679,59 @@
         "@so-ric/colorspace": "^1.1.6",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.66.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@google-analytics/data": "^5.2.1",
     "@google/generative-ai": "^0.24.1",
     "@heroicons/react": "^2.2.0",

--- a/src/app/admin/brians-stuff/page.tsx
+++ b/src/app/admin/brians-stuff/page.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
 // Force-dynamic so the lead + upsell tracker queries always hit the DB.
 export const dynamic = 'force-dynamic';
 
-type SP = Promise<{ tab?: string }>;
+type SP = Promise<{ tab?: string; lead?: string }>;
 
 /**
  * Admin-only landing page for Brian's reference docs + tools.
@@ -55,7 +55,7 @@ export default async function Page({ searchParams }: { searchParams: SP }) {
       playbook={<PlaybookClient />}
       experiments={<ExperimentsView />}
       tracker={<UpsellTrackerView />}
-      leads={<LeadsView />}
+      leads={<LeadsView deepLinkedLeadId={params.lead ?? null} />}
       events={<EventsView />}
       magnets={<LeadMagnetView />}
       seo={<SeoIntelligenceView />}

--- a/src/app/admin/leads/_components/board-column.tsx
+++ b/src/app/admin/leads/_components/board-column.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { ReactElement } from 'react';
+import { useDroppable } from '@dnd-kit/core';
+import type { BoardLead } from '@/lib/leads/board-types';
+import type { PipelineStage } from '@/lib/leads/pipeline-types';
+import { STAGE_LABELS } from '@/lib/leads/board-types';
+import LeadCard from './lead-card';
+
+const HEADER_TONES: Record<PipelineStage, string> = {
+  NEW: 'text-brand-blue',
+  CONTACTED: 'text-sky-700',
+  QUALIFIED: 'text-indigo-700',
+  QUOTE_SENT: 'text-amber-700',
+  WON: 'text-green-700',
+  LOST: 'text-gray-500',
+};
+
+/** One droppable Kanban column. Scroll-snap target on mobile. */
+export default function BoardColumn({
+  stage,
+  cards,
+  totalCount,
+  onOpen,
+}: {
+  stage: PipelineStage;
+  cards: BoardLead[];
+  /** For Won/Lost: all-time count when the column is 30d-capped. */
+  totalCount?: number;
+  onOpen: (id: string) => void;
+}): ReactElement {
+  const { setNodeRef, isOver } = useDroppable({ id: stage });
+  const isClosed = stage === 'WON' || stage === 'LOST';
+
+  return (
+    <section
+      ref={setNodeRef}
+      className={`flex flex-col w-[280px] md:w-[300px] shrink-0 snap-start rounded-xl border ${
+        isOver ? 'border-brand-blue bg-blue-50/60' : 'border-gray-200 bg-gray-50'
+      } transition-colors`}
+      aria-label={`${STAGE_LABELS[stage]} column`}
+    >
+      <header className="flex items-center justify-between px-3 pt-3 pb-2">
+        <h2
+          className={`font-heading font-bold text-sm tracking-[0.1em] uppercase ${HEADER_TONES[stage]}`}
+        >
+          {STAGE_LABELS[stage]}
+        </h2>
+        <span className="text-sm font-semibold text-gray-500">
+          {cards.length}
+          {isClosed && totalCount != null && totalCount > cards.length
+            ? ` / ${totalCount}`
+            : ''}
+        </span>
+      </header>
+      <div className="flex flex-col gap-2 px-2 pb-2 overflow-y-auto min-h-[120px] max-h-[calc(100vh-320px)]">
+        {cards.map((lead) => (
+          <LeadCard key={lead.id} lead={lead} onOpen={onOpen} />
+        ))}
+        {cards.length === 0 && (
+          <div className="text-sm text-gray-400 text-center py-6 border border-dashed border-gray-200 rounded-lg m-1">
+            {isClosed ? `No ${STAGE_LABELS[stage].toLowerCase()} in 30d` : 'Drop leads here'}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/app/admin/leads/_components/board-filters.tsx
+++ b/src/app/admin/leads/_components/board-filters.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ReactElement } from 'react';
+import { ReactElement, useEffect, useRef, useState } from 'react';
 import SegmentedControl from '@/components/backend/kit/SegmentedControl';
 import type { BoardFilters } from '@/lib/leads/board-types';
 
@@ -23,6 +23,19 @@ export default function BoardFilters({
   filters: BoardFilters;
   onChange: (next: BoardFilters) => void;
 }): ReactElement {
+  // Debounce the search box — every filter change triggers a board GET, and
+  // per-keystroke fetches waste server sweeps and can resolve out of order.
+  const [qDraft, setQDraft] = useState(filters.q ?? '');
+  const qTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => setQDraft(filters.q ?? ''), [filters.q]);
+  const onSearchChange = (value: string): void => {
+    setQDraft(value);
+    if (qTimer.current) clearTimeout(qTimer.current);
+    qTimer.current = setTimeout(() => {
+      onChange({ ...filters, q: value || undefined });
+    }, 300);
+  };
+
   return (
     <div className="flex flex-col md:flex-row md:items-center gap-2">
       <SegmentedControl
@@ -53,8 +66,8 @@ export default function BoardFilters({
         </select>
         <input
           type="search"
-          value={filters.q ?? ''}
-          onChange={(e) => onChange({ ...filters, q: e.target.value || undefined })}
+          value={qDraft}
+          onChange={(e) => onSearchChange(e.target.value)}
           placeholder="Search name, email, phone"
           className="flex-1 min-w-0 min-h-[44px] rounded-lg border border-white/20 bg-white/10 text-white placeholder:text-[#B7C4D0] text-base px-3"
           aria-label="Search leads"

--- a/src/app/admin/leads/_components/board-filters.tsx
+++ b/src/app/admin/leads/_components/board-filters.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { ReactElement } from 'react';
+import SegmentedControl from '@/components/backend/kit/SegmentedControl';
+import type { BoardFilters } from '@/lib/leads/board-types';
+
+const SOURCE_OPTIONS = [
+  ['', 'All sources'],
+  ['PARTNER_LANDING_PAGE', 'Concierge'],
+  ['CONTACT_FORM', 'Contact / Quote'],
+  ['QUICK_BUY', 'Quick Buy'],
+  ['PACKAGE_BUILDER', 'Package Builder'],
+  ['DRINK_CALCULATOR', 'Calculator'],
+  ['EMAIL_SIGNUP', 'Email Signup'],
+  ['OTHER', 'Site'],
+] as const;
+
+/** Temperature segments + source select + search + tray/snooze toggles. */
+export default function BoardFilters({
+  filters,
+  onChange,
+}: {
+  filters: BoardFilters;
+  onChange: (next: BoardFilters) => void;
+}): ReactElement {
+  return (
+    <div className="flex flex-col md:flex-row md:items-center gap-2">
+      <SegmentedControl
+        className="md:max-w-[360px]"
+        segments={[
+          { key: '', label: 'All' },
+          { key: 'hot', label: 'Hot' },
+          { key: 'warm', label: 'Warm' },
+          { key: 'cold', label: 'Cold' },
+        ]}
+        active={filters.temp ?? ''}
+        onChange={(key) =>
+          onChange({ ...filters, temp: (key || undefined) as BoardFilters['temp'] })
+        }
+      />
+      <div className="flex flex-1 items-center gap-2">
+        <select
+          value={filters.source ?? ''}
+          onChange={(e) => onChange({ ...filters, source: e.target.value || undefined })}
+          className="min-h-[44px] rounded-lg border border-white/20 bg-white/10 text-white text-sm px-2 [&>option]:text-gray-900"
+          aria-label="Filter by source"
+        >
+          {SOURCE_OPTIONS.map(([value, label]) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
+        </select>
+        <input
+          type="search"
+          value={filters.q ?? ''}
+          onChange={(e) => onChange({ ...filters, q: e.target.value || undefined })}
+          placeholder="Search name, email, phone"
+          className="flex-1 min-w-0 min-h-[44px] rounded-lg border border-white/20 bg-white/10 text-white placeholder:text-[#B7C4D0] text-base px-3"
+          aria-label="Search leads"
+        />
+      </div>
+      <div className="flex items-center gap-4 text-sm text-[#B7C4D0]">
+        <label className="flex items-center gap-1.5 cursor-pointer whitespace-nowrap">
+          <input
+            type="checkbox"
+            checked={filters.includePartial ?? false}
+            onChange={(e) => onChange({ ...filters, includePartial: e.target.checked || undefined })}
+            className="accent-brand-yellow w-4 h-4"
+          />
+          Incomplete leads
+        </label>
+        <label className="flex items-center gap-1.5 cursor-pointer whitespace-nowrap">
+          <input
+            type="checkbox"
+            checked={filters.showSnoozed ?? false}
+            onChange={(e) => onChange({ ...filters, showSnoozed: e.target.checked || undefined })}
+            className="accent-brand-yellow w-4 h-4"
+          />
+          Snoozed
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/leads/_components/drawer-timeline.tsx
+++ b/src/app/admin/leads/_components/drawer-timeline.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { ReactElement } from 'react';
+import HqBadge from '@/components/backend/kit/Badge';
+import type { LeadDetail } from './drawer-types';
+
+interface TimelineEntry {
+  at: string;
+  kind: 'event' | 'email' | 'followup';
+  label: string;
+  detail?: string | null;
+}
+
+function eventLabel(e: LeadDetail['events'][number]): string {
+  const meta = (e.metadata ?? {}) as Record<string, unknown>;
+  if (meta.kind === 'stage.changed') {
+    return `Stage: ${meta.from ?? 'off board'} → ${meta.to} (${meta.via})`;
+  }
+  if (meta.kind === 'email.reply') return `Replied by email: "${meta.subject}"`;
+  switch (e.type) {
+    case 'FORM_SUBMIT':
+      return `Submitted a form${e.widget ? ` (${e.widget})` : ''}`;
+    case 'CHECKOUT_START':
+      return 'Started checkout / asked for a quote';
+    case 'FIELD_BLUR':
+      return `Typed ${e.fieldName ?? 'a field'}`;
+    case 'PAGE_VIEW':
+      return `Viewed ${e.page ?? 'a page'}`;
+    case 'CART_ADD':
+      return 'Added to cart';
+    case 'CONVERSION':
+      return 'Converted (payment confirmed)';
+    case 'STEP_COMPLETE':
+      return `Completed a step${e.widget ? ` (${e.widget})` : ''}`;
+    default:
+      return e.type;
+  }
+}
+
+/** Merge LeadEvents + EmailLogs + FollowUpJobs into one descending feed. */
+export default function DrawerTimeline({ detail }: { detail: LeadDetail }): ReactElement {
+  const entries: TimelineEntry[] = [
+    ...detail.events.map((e) => ({
+      at: e.occurredAt,
+      kind: 'event' as const,
+      label: eventLabel(e),
+      detail: e.page,
+    })),
+    ...detail.emailLogs.map((l) => ({
+      at: l.createdAt,
+      kind: 'email' as const,
+      label: `Email ${l.status.toLowerCase()}: "${l.subject}"`,
+      detail: l.type,
+    })),
+    ...detail.followUps.map((f) => ({
+      at: f.sentAt ?? f.scheduledFor,
+      kind: 'followup' as const,
+      label:
+        f.status === 'scheduled'
+          ? `Follow-up queued: ${f.journeyKey} step ${f.step}`
+          : `Follow-up ${f.status}: ${f.journeyKey} step ${f.step}${f.cancelReason ? ` (${f.cancelReason})` : ''}`,
+    })),
+  ].sort((a, b) => (a.at < b.at ? 1 : -1));
+
+  if (entries.length === 0) {
+    return <p className="text-sm text-gray-400 py-4">No activity recorded yet.</p>;
+  }
+
+  return (
+    <ol className="space-y-2">
+      {entries.slice(0, 60).map((entry, i) => (
+        <li key={i} className="flex items-start gap-2 text-sm">
+          <HqBadge
+            variant={entry.kind === 'email' ? 'blue' : entry.kind === 'followup' ? 'amber' : 'gray'}
+            className="mt-[1px] shrink-0"
+          >
+            {entry.kind === 'event' ? 'site' : entry.kind}
+          </HqBadge>
+          <div className="min-w-0">
+            <div className="text-gray-800">{entry.label}</div>
+            <div className="text-xs text-gray-400">
+              {new Date(entry.at).toLocaleString('en-US', {
+                month: 'short',
+                day: 'numeric',
+                hour: 'numeric',
+                minute: '2-digit',
+                timeZone: 'America/Chicago',
+              })}
+              {entry.detail ? ` · ${entry.detail}` : ''}
+            </div>
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/src/app/admin/leads/_components/drawer-timeline.tsx
+++ b/src/app/admin/leads/_components/drawer-timeline.tsx
@@ -78,7 +78,7 @@ export default function DrawerTimeline({ detail }: { detail: LeadDetail }): Reac
           </HqBadge>
           <div className="min-w-0">
             <div className="text-gray-800">{entry.label}</div>
-            <div className="text-xs text-gray-400">
+            <div className="text-sm text-gray-400">
               {new Date(entry.at).toLocaleString('en-US', {
                 month: 'short',
                 day: 'numeric',

--- a/src/app/admin/leads/_components/drawer-types.ts
+++ b/src/app/admin/leads/_components/drawer-types.ts
@@ -1,0 +1,67 @@
+/**
+ * Client-side shape of GET /api/v1/admin/leads/[id] — only the fields the
+ * drawer renders. Server returns the full Prisma Lead; extra fields ignored.
+ */
+
+export interface LeadDetail {
+  lead: {
+    id: string;
+    email: string | null;
+    phone: string | null;
+    firstName: string | null;
+    lastName: string | null;
+    status: string;
+    pipelineStage: string | null;
+    leadScore: number | null;
+    scoreBreakdown: Record<string, number> | null;
+    sourcePage: string | null;
+    sourceWidget: string | null;
+    utmSource: string | null;
+    utmMedium: string | null;
+    utmCampaign: string | null;
+    owner: string | null;
+    snoozedUntil: string | null;
+    notes: string | null;
+    metadata: Record<string, unknown> | null;
+    createdAt: string;
+  };
+  events: Array<{
+    id: string;
+    type: string;
+    page: string | null;
+    widget: string | null;
+    fieldName: string | null;
+    metadata: Record<string, unknown> | null;
+    occurredAt: string;
+  }>;
+  followUps: Array<{
+    id: string;
+    journeyKey: string;
+    step: number;
+    status: string;
+    scheduledFor: string;
+    sentAt: string | null;
+    cancelReason: string | null;
+  }>;
+  emailLogs: Array<{
+    id: string;
+    subject: string;
+    type: string;
+    status: string;
+    createdAt: string;
+  }>;
+  orders: Array<{
+    id: string;
+    orderNumber: number;
+    total: number;
+    createdAt: string;
+    isGroupParticipant: boolean;
+  }>;
+  drafts: Array<{
+    id: string;
+    status: string;
+    total: unknown;
+    createdAt: string;
+    token: string;
+  }>;
+}

--- a/src/app/admin/leads/_components/kpi-strip.tsx
+++ b/src/app/admin/leads/_components/kpi-strip.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { ReactElement } from 'react';
+import KPITile from '@/components/backend/kit/KPITile';
+import type { BoardKpis } from '@/lib/leads/board-types';
+
+/** Top-line board stats. */
+export default function KpiStrip({ kpis }: { kpis: BoardKpis }): ReactElement {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+      <KPITile label="New this week" value={String(kpis.newThisWeek)} />
+      <KPITile
+        label="Hot leads"
+        value={String(kpis.hot)}
+        valueTone={kpis.hot > 0 ? 'red' : 'default'}
+      />
+      <KPITile
+        label="Needs response"
+        value={String(kpis.needsResponse)}
+        delta={kpis.needsResponse > 0 ? 'reply from the card' : 'all caught up'}
+        deltaTone={kpis.needsResponse > 0 ? 'red' : 'green'}
+      />
+      <KPITile
+        label="Won · 30d"
+        value={String(kpis.won30d)}
+        delta={
+          kpis.conversionPct != null
+            ? `${kpis.conversionPct}% of closed`
+            : 'no closed leads yet'
+        }
+        deltaTone={kpis.conversionPct != null && kpis.conversionPct >= 50 ? 'green' : 'gray'}
+      />
+    </div>
+  );
+}

--- a/src/app/admin/leads/_components/lead-card.tsx
+++ b/src/app/admin/leads/_components/lead-card.tsx
@@ -5,19 +5,14 @@ import { useDraggable } from '@dnd-kit/core';
 import HqBadge from '@/components/backend/kit/Badge';
 import type { BoardLead } from '@/lib/leads/board-types';
 import { SOURCE_LABELS } from '@/lib/leads/board-types';
+import { daysUntilCT } from '@/lib/leads/scoring';
 
-/** Days until the event, from YYYY-MM-DD (positive = future). */
-function daysUntil(dateStr: string): number {
-  const today = new Date();
-  const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
-  const ms = Date.parse(`${dateStr.slice(0, 10)}T12:00:00Z`) - Date.parse(`${todayStr}T12:00:00Z`);
-  return Math.round(ms / 86_400_000);
-}
-
+// Countdown uses the shared CT-safe date math (scoring.ts) — the business
+// runs on America/Chicago days, not the viewer's browser timezone.
 function eventChip(eventDate: string | null): string | null {
   if (!eventDate) return null;
-  const days = daysUntil(eventDate);
-  if (Number.isNaN(days)) return null;
+  const days = daysUntilCT(eventDate, new Date());
+  if (days == null) return null;
   if (days < 0) return `${Math.abs(days)}d ago`;
   if (days === 0) return 'Today';
   if (days === 1) return 'Tomorrow';
@@ -86,7 +81,7 @@ export default function LeadCard({
       <div className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-gray-600">
         {lead.occasion && <span className="capitalize">{lead.occasion.replace(/-/g, ' ')}</span>}
         {chip && (
-          <span className={daysUntil(lead.eventDate as string) < 0 ? 'text-gray-400' : 'text-brand-blue font-medium'}>
+          <span className={chip.endsWith('ago') ? 'text-gray-400' : 'text-brand-blue font-medium'}>
             {chip}
           </span>
         )}

--- a/src/app/admin/leads/_components/lead-card.tsx
+++ b/src/app/admin/leads/_components/lead-card.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { ReactElement } from 'react';
+import { useDraggable } from '@dnd-kit/core';
+import HqBadge from '@/components/backend/kit/Badge';
+import type { BoardLead } from '@/lib/leads/board-types';
+import { SOURCE_LABELS } from '@/lib/leads/board-types';
+
+/** Days until the event, from YYYY-MM-DD (positive = future). */
+function daysUntil(dateStr: string): number {
+  const today = new Date();
+  const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+  const ms = Date.parse(`${dateStr.slice(0, 10)}T12:00:00Z`) - Date.parse(`${todayStr}T12:00:00Z`);
+  return Math.round(ms / 86_400_000);
+}
+
+function eventChip(eventDate: string | null): string | null {
+  if (!eventDate) return null;
+  const days = daysUntil(eventDate);
+  if (Number.isNaN(days)) return null;
+  if (days < 0) return `${Math.abs(days)}d ago`;
+  if (days === 0) return 'Today';
+  if (days === 1) return 'Tomorrow';
+  return `in ${days}d`;
+}
+
+const TEMP_VARIANT = { hot: 'red', warm: 'amber', cold: 'gray' } as const;
+
+/**
+ * One Kanban card. Draggable on desktop (pointer, 8px threshold) and via
+ * long-press on touch; tap opens the drawer (dnd-kit only claims the pointer
+ * once the drag threshold is passed, so click stays intact).
+ */
+export default function LeadCard({
+  lead,
+  onOpen,
+}: {
+  lead: BoardLead;
+  onOpen: (id: string) => void;
+}): ReactElement {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: lead.id,
+  });
+
+  const chip = eventChip(lead.eventDate);
+  const snoozed = lead.snoozedUntil && new Date(lead.snoozedUntil) > new Date();
+  const style = transform
+    ? { transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`, zIndex: 30 }
+    : undefined;
+
+  return (
+    <button
+      ref={setNodeRef}
+      type="button"
+      onClick={() => onOpen(lead.id)}
+      style={style}
+      {...listeners}
+      {...attributes}
+      className={`relative w-full text-left bg-white rounded-xl border border-gray-200 p-3 shadow-sm hover:shadow-md transition-shadow touch-manipulation ${
+        isDragging ? 'opacity-90 shadow-lg ring-2 ring-brand-blue' : ''
+      } ${snoozed ? 'opacity-55' : ''}`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex items-center gap-1.5">
+            {lead.needsResponse && (
+              <span
+                className="w-2 h-2 rounded-full bg-red-500 shrink-0"
+                title="Waiting on a reply"
+              />
+            )}
+            <span className="font-semibold text-sm text-gray-900 truncate">{lead.name}</span>
+          </div>
+          <div className="text-sm text-gray-500 truncate">
+            {lead.email ?? lead.phone ?? '—'}
+          </div>
+        </div>
+        {lead.temperature && (
+          <HqBadge variant={TEMP_VARIANT[lead.temperature]}>
+            {lead.temperature}
+            {lead.score != null ? ` ${lead.score}` : ''}
+          </HqBadge>
+        )}
+      </div>
+
+      <div className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-gray-600">
+        {lead.occasion && <span className="capitalize">{lead.occasion.replace(/-/g, ' ')}</span>}
+        {chip && (
+          <span className={daysUntil(lead.eventDate as string) < 0 ? 'text-gray-400' : 'text-brand-blue font-medium'}>
+            {chip}
+          </span>
+        )}
+        {lead.headcount != null && <span>{lead.headcount} ppl</span>}
+        {lead.budgetPerPerson != null && <span>${lead.budgetPerPerson}/pp</span>}
+      </div>
+
+      <div className="mt-2 flex items-center justify-between text-xs">
+        <span className="text-gray-400 uppercase tracking-[0.05em] font-semibold">
+          {SOURCE_LABELS[lead.sourceWidget ?? ''] ?? 'Site'}
+        </span>
+        <span className="flex items-center gap-1.5">
+          {lead.isDuplicate && <HqBadge variant="gray">dupe</HqBadge>}
+          {lead.hasFollowUp && (
+            <span title="Automated follow-up scheduled/sent" aria-label="Follow-up scheduled">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="w-3.5 h-3.5 text-gray-400">
+                <circle cx="12" cy="12" r="9" />
+                <path d="M12 7v5l3 2" />
+              </svg>
+            </span>
+          )}
+          {lead.owner && <span className="text-gray-500 font-medium">{lead.owner}</span>}
+        </span>
+      </div>
+    </button>
+  );
+}

--- a/src/app/admin/leads/_components/lead-drawer.tsx
+++ b/src/app/admin/leads/_components/lead-drawer.tsx
@@ -1,0 +1,261 @@
+'use client';
+
+import { ReactElement, useCallback, useEffect, useRef, useState } from 'react';
+import BottomSheet from '@/components/backend/kit/BottomSheet';
+import HqBadge from '@/components/backend/kit/Badge';
+import { PIPELINE_STAGES, type PipelineStage } from '@/lib/leads/pipeline-types';
+import { STAGE_LABELS } from '@/lib/leads/board-types';
+import { temperatureFor } from '@/lib/leads/scoring';
+import type { LeadMutations } from './use-lead-mutations';
+import type { LeadDetail } from './drawer-types';
+import DrawerTimeline from './drawer-timeline';
+
+const TEMP_VARIANT = { hot: 'red', warm: 'amber', cold: 'gray' } as const;
+const OWNERS = ['', 'Allan', 'Brian'];
+
+/**
+ * Card detail drawer — BottomSheet on all sizes (portaled, esc-closes).
+ * Stage buttons confirm the destructive-feeling moves; Lost prompts for a
+ * reason. The reply composer lands here in the follow-up PR.
+ */
+export default function LeadDrawer({
+  leadId,
+  onClose,
+  mutations,
+}: {
+  leadId: string | null;
+  onClose: () => void;
+  mutations: LeadMutations;
+}): ReactElement | null {
+  const [detail, setDetail] = useState<LeadDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [notes, setNotes] = useState('');
+  const notesTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const load = useCallback(async (): Promise<void> => {
+    if (!leadId) return;
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/v1/admin/leads/${leadId}`);
+      if (res.ok) {
+        const body = await res.json();
+        setDetail(body.data);
+        setNotes(body.data?.lead?.notes ?? '');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [leadId]);
+
+  useEffect(() => {
+    setDetail(null);
+    void load();
+  }, [load]);
+
+  const saveNotes = (value: string): void => {
+    setNotes(value);
+    if (notesTimer.current) clearTimeout(notesTimer.current);
+    notesTimer.current = setTimeout(() => {
+      if (leadId) void mutations.patchLead(leadId, { notes: value });
+    }, 800);
+  };
+
+  const moveTo = async (stage: PipelineStage): Promise<void> => {
+    if (!detail || !leadId) return;
+    const from = detail.lead.pipelineStage;
+    if (from === stage) return;
+    let lostReason: string | null = null;
+    if (stage === 'WON' && !window.confirm('Mark this lead as Won?')) return;
+    if (from === 'WON' && !window.confirm('Move this lead OUT of Won?')) return;
+    if (stage === 'LOST') {
+      const input = window.prompt('Why was this lead lost? (optional)', '');
+      if (input === null) return;
+      lostReason = input.trim() || null;
+    }
+    const ok = await mutations.moveStage(leadId, stage, { lostReason });
+    if (ok) void load();
+  };
+
+  const snooze = async (days: number | null): Promise<void> => {
+    if (!leadId) return;
+    const until = days ? new Date(Date.now() + days * 86_400_000).toISOString() : null;
+    const ok = await mutations.patchLead(leadId, { snoozedUntil: until });
+    if (ok) void load();
+  };
+
+  const setOwner = async (owner: string): Promise<void> => {
+    if (!leadId) return;
+    const ok = await mutations.patchLead(leadId, { owner: owner || null });
+    if (ok) void load();
+  };
+
+  if (!leadId) return null;
+  const lead = detail?.lead;
+  const temp = temperatureFor(lead?.leadScore ?? null);
+  const name = lead ? [lead.firstName, lead.lastName].filter(Boolean).join(' ') || lead.email || 'Lead' : 'Lead';
+
+  return (
+    <BottomSheet open={leadId !== null} onClose={onClose} title={name}>
+      <div className="px-4 pb-8 pt-2 max-h-[80vh] overflow-y-auto">
+        {loading && !detail && <div className="py-10 text-center text-gray-400">Loading…</div>}
+        {lead && (
+          <>
+            <header className="flex items-start justify-between gap-3">
+              <div>
+                <h2 className="font-heading font-bold text-2xl tracking-[0.05em] text-gray-900">
+                  {name}
+                </h2>
+                <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-sm">
+                  {lead.email && (
+                    <a href={`mailto:${lead.email}`} className="text-brand-blue underline">
+                      {lead.email}
+                    </a>
+                  )}
+                  {lead.phone && (
+                    <a href={`tel:${lead.phone}`} className="text-brand-blue underline">
+                      {lead.phone}
+                    </a>
+                  )}
+                  <a
+                    href="https://app.gohighlevel.com"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-gray-500 underline"
+                    title="SMS lives in GHL until the CRM cutover"
+                  >
+                    Open GHL
+                  </a>
+                </div>
+              </div>
+              {temp && (
+                <HqBadge variant={TEMP_VARIANT[temp]}>
+                  {temp} {lead.leadScore}
+                </HqBadge>
+              )}
+            </header>
+
+            <section className="mt-4">
+              <div className="flex flex-wrap gap-1.5">
+                {PIPELINE_STAGES.map((stage) => (
+                  <button
+                    key={stage}
+                    type="button"
+                    onClick={() => void moveTo(stage)}
+                    disabled={mutations.mutating}
+                    className={`min-h-[36px] px-3 rounded-lg text-sm font-semibold tracking-[0.05em] border transition-colors ${
+                      lead.pipelineStage === stage
+                        ? 'bg-brand-blue text-white border-brand-blue'
+                        : 'bg-white text-gray-700 border-gray-300 hover:border-brand-blue'
+                    }`}
+                  >
+                    {STAGE_LABELS[stage]}
+                  </button>
+                ))}
+              </div>
+            </section>
+
+            <section className="mt-4 grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+              <Fact label="Source" value={`${lead.sourceWidget ?? '—'}${lead.sourcePage ? ` · ${lead.sourcePage}` : ''}`} />
+              <Fact label="Campaign" value={lead.utmCampaign ?? lead.utmSource ?? 'direct / unknown'} />
+              <Fact
+                label="Score breakdown"
+                value={
+                  lead.scoreBreakdown
+                    ? Object.entries(lead.scoreBreakdown)
+                        .map(([k, v]) => `${k.replace(/([A-Z])/g, ' $1').toLowerCase()} ${v}`)
+                        .join(' · ')
+                    : '—'
+                }
+              />
+              <Fact label="Created" value={new Date(lead.createdAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })} />
+            </section>
+
+            <section className="mt-4 flex flex-wrap items-center gap-2 text-sm">
+              <label className="text-gray-500 font-semibold uppercase text-xs tracking-[0.08em]">Owner</label>
+              <select
+                value={lead.owner ?? ''}
+                onChange={(e) => void setOwner(e.target.value)}
+                className="min-h-[36px] rounded-lg border border-gray-300 px-2 text-base"
+              >
+                {OWNERS.map((o) => (
+                  <option key={o} value={o}>
+                    {o || 'Unassigned'}
+                  </option>
+                ))}
+              </select>
+              <span className="text-gray-300">|</span>
+              <button type="button" onClick={() => void snooze(3)} className="btn-ghost min-h-[36px]">
+                Snooze 3d
+              </button>
+              <button type="button" onClick={() => void snooze(7)} className="btn-ghost min-h-[36px]">
+                Snooze 7d
+              </button>
+              {lead.snoozedUntil && new Date(lead.snoozedUntil) > new Date() && (
+                <button type="button" onClick={() => void snooze(null)} className="btn-ghost min-h-[36px] text-red-600">
+                  Un-snooze
+                </button>
+              )}
+            </section>
+
+            {(detail.orders.length > 0 || detail.drafts.length > 0) && (
+              <section className="mt-4">
+                <h3 className="font-heading font-bold text-sm tracking-[0.1em] uppercase text-gray-500">
+                  Orders & quotes
+                </h3>
+                <ul className="mt-1 space-y-1 text-sm">
+                  {detail.orders.map((o) => (
+                    <li key={o.id}>
+                      <a href={`/ops/orders/${o.id}`} className="text-brand-blue underline">
+                        Order #{o.orderNumber}
+                      </a>{' '}
+                      · ${o.total.toFixed(0)}
+                      {o.isGroupParticipant && (
+                        <span className="text-gray-500"> · group payment (possible win — confirm)</span>
+                      )}
+                    </li>
+                  ))}
+                  {detail.drafts.map((d) => (
+                    <li key={d.id} className="text-gray-700">
+                      Invoice {d.status.toLowerCase()} · ${Number(d.total).toFixed(0)}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            )}
+
+            <section className="mt-4">
+              <h3 className="font-heading font-bold text-sm tracking-[0.1em] uppercase text-gray-500">
+                Notes
+              </h3>
+              <textarea
+                value={notes}
+                onChange={(e) => saveNotes(e.target.value)}
+                rows={3}
+                placeholder="Internal notes — autosaves"
+                className="mt-1 w-full rounded-lg border border-gray-300 p-2 text-base"
+              />
+            </section>
+
+            <section className="mt-4">
+              <h3 className="font-heading font-bold text-sm tracking-[0.1em] uppercase text-gray-500">
+                Timeline
+              </h3>
+              <div className="mt-2">
+                <DrawerTimeline detail={detail} />
+              </div>
+            </section>
+          </>
+        )}
+      </div>
+    </BottomSheet>
+  );
+}
+
+function Fact({ label, value }: { label: string; value: string }): ReactElement {
+  return (
+    <div>
+      <div className="text-xs font-semibold uppercase tracking-[0.08em] text-gray-500">{label}</div>
+      <div className="text-gray-800 break-words">{value}</div>
+    </div>
+  );
+}

--- a/src/app/admin/leads/_components/lead-drawer.tsx
+++ b/src/app/admin/leads/_components/lead-drawer.tsx
@@ -171,7 +171,7 @@ export default function LeadDrawer({
             </section>
 
             <section className="mt-4 flex flex-wrap items-center gap-2 text-sm">
-              <label className="text-gray-500 font-semibold uppercase text-xs tracking-[0.08em]">Owner</label>
+              <label className="text-gray-600 font-semibold text-base">Owner</label>
               <select
                 value={lead.owner ?? ''}
                 onChange={(e) => void setOwner(e.target.value)}

--- a/src/app/admin/leads/_components/leads-board.tsx
+++ b/src/app/admin/leads/_components/leads-board.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { ReactElement, useState } from 'react';
+import {
+  DndContext,
+  PointerSensor,
+  TouchSensor,
+  closestCorners,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import type { BoardData, BoardLead } from '@/lib/leads/board-types';
+import { PIPELINE_STAGES, isPipelineStage, type PipelineStage } from '@/lib/leads/pipeline-types';
+import BoardColumn from './board-column';
+import LeadCard from './lead-card';
+import type { LeadMutations } from './use-lead-mutations';
+
+/**
+ * The Kanban surface: droppable column per stage + the optional
+ * "Uncommitted" tray. Drops move stage optimistically and roll back if the
+ * PATCH fails; Won/Lost drops confirm first (same rules as the drawer's
+ * stage picker).
+ */
+export default function LeadsBoard({
+  data,
+  onOpen,
+  mutations,
+  optimisticMove,
+  rollback,
+}: {
+  data: BoardData;
+  onOpen: (id: string) => void;
+  mutations: LeadMutations;
+  optimisticMove: (leadId: string, to: PipelineStage) => void;
+  rollback: () => void;
+}): ReactElement {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 8 } }),
+  );
+  const [dragging, setDragging] = useState(false);
+
+  const findCard = (id: string): BoardLead | undefined =>
+    [...Object.values(data.columns).flat(), ...data.tray].find((c) => c.id === id);
+
+  const handleDragEnd = async (event: DragEndEvent): Promise<void> => {
+    setDragging(false);
+    const leadId = String(event.active.id);
+    const target = event.over?.id;
+    if (!target || !isPipelineStage(target)) return;
+    const card = findCard(leadId);
+    if (!card || card.stage === target) return;
+
+    let lostReason: string | null = null;
+    if (target === 'WON' && !window.confirm(`Mark ${card.name} as Won?`)) return;
+    if (card.stage === 'WON' && !window.confirm(`Move ${card.name} OUT of Won?`)) return;
+    if (target === 'LOST') {
+      const input = window.prompt(`Why was ${card.name} lost? (optional)`, '');
+      if (input === null) return;
+      lostReason = input.trim() || null;
+    }
+
+    optimisticMove(leadId, target);
+    const ok = await mutations.moveStage(leadId, target, { lostReason });
+    if (!ok) rollback();
+  };
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCorners}
+      onDragStart={() => setDragging(true)}
+      onDragCancel={() => setDragging(false)}
+      onDragEnd={(e) => void handleDragEnd(e)}
+    >
+      <div
+        className={`flex gap-3 overflow-x-auto pb-4 snap-x snap-mandatory md:snap-none ${
+          dragging ? 'select-none' : ''
+        }`}
+      >
+        {PIPELINE_STAGES.map((stage) => (
+          <BoardColumn
+            key={stage}
+            stage={stage}
+            cards={data.columns[stage]}
+            totalCount={
+              stage === 'WON'
+                ? data.closedCounts.won
+                : stage === 'LOST'
+                  ? data.closedCounts.lost
+                  : undefined
+            }
+            onOpen={onOpen}
+          />
+        ))}
+      </div>
+
+      {data.tray.length > 0 && (
+        <section className="mt-2">
+          <h2 className="font-heading font-bold text-sm tracking-[0.1em] uppercase text-gray-500">
+            Uncommitted — typed an email but never finished ({data.tray.length})
+          </h2>
+          <p className="text-sm text-gray-400 mb-2">
+            Drag one onto the board (or tap it) to start working it.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2">
+            {data.tray.map((lead) => (
+              <LeadCard key={lead.id} lead={lead} onOpen={onOpen} />
+            ))}
+          </div>
+        </section>
+      )}
+    </DndContext>
+  );
+}

--- a/src/app/admin/leads/_components/use-lead-mutations.ts
+++ b/src/app/admin/leads/_components/use-lead-mutations.ts
@@ -1,0 +1,72 @@
+/**
+ * Client mutations for the Lead Flow board — stage moves, card metadata
+ * patches — mirroring use-strategy-mutations. `mutating` suspends the board's
+ * background refresh so an in-flight optimistic drag can't be clobbered.
+ */
+
+'use client';
+
+import { useCallback, useState } from 'react';
+import type { PipelineStage } from '@/lib/leads/pipeline-types';
+
+export interface LeadMutations {
+  mutating: boolean;
+  moveStage: (
+    id: string,
+    stage: PipelineStage,
+    opts?: { lostReason?: string | null },
+  ) => Promise<boolean>;
+  patchLead: (
+    id: string,
+    input: { notes?: string | null; owner?: string | null; snoozedUntil?: string | null },
+  ) => Promise<boolean>;
+}
+
+export function useLeadMutations(onChanged: () => Promise<void>): LeadMutations {
+  const [pending, setPending] = useState(0);
+
+  const run = useCallback(
+    async (fn: () => Promise<Response>): Promise<boolean> => {
+      setPending((n) => n + 1);
+      try {
+        const res = await fn();
+        if (res.ok) await onChanged();
+        return res.ok;
+      } catch {
+        return false;
+      } finally {
+        setPending((n) => n - 1);
+      }
+    },
+    [onChanged],
+  );
+
+  const moveStage = useCallback(
+    (id: string, stage: PipelineStage, opts?: { lostReason?: string | null }) =>
+      run(() =>
+        fetch(`/api/v1/admin/leads/${id}/stage`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ stage, lostReason: opts?.lostReason ?? undefined }),
+        }),
+      ),
+    [run],
+  );
+
+  const patchLead = useCallback(
+    (
+      id: string,
+      input: { notes?: string | null; owner?: string | null; snoozedUntil?: string | null },
+    ) =>
+      run(() =>
+        fetch(`/api/v1/admin/leads/${id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(input),
+        }),
+      ),
+    [run],
+  );
+
+  return { mutating: pending > 0, moveStage, patchLead };
+}

--- a/src/app/admin/leads/_components/use-lead-mutations.ts
+++ b/src/app/admin/leads/_components/use-lead-mutations.ts
@@ -1,7 +1,8 @@
 /**
  * Client mutations for the Lead Flow board — stage moves, card metadata
- * patches — mirroring use-strategy-mutations. `mutating` suspends the board's
- * background refresh so an in-flight optimistic drag can't be clobbered.
+ * patches — mirroring use-strategy-mutations. `mutating` disables the
+ * drawer's action buttons while a call is in flight (the board has no
+ * background poll; data reloads after each mutation).
  */
 
 'use client';

--- a/src/app/admin/leads/page.tsx
+++ b/src/app/admin/leads/page.tsx
@@ -5,8 +5,10 @@
  *
  * Every submitted lead lands here as a card: New → Contacted → Qualified →
  * Quote Sent → Won → Lost, scored cold/warm/hot. Deep-linkable via
- * ?lead=<id> (the URL GHL notifications carry). Data refreshes on demand and
- * after every mutation; refresh is suspended while a drag is in flight.
+ * ?lead=<id> (the URL GHL notifications carry). Data loads on open and after
+ * every mutation (no background poll); a request-sequence guard drops
+ * out-of-order responses, and a failed stage move re-syncs from the server
+ * rather than restoring a possibly-stale snapshot.
  */
 
 import { ReactElement, Suspense, useCallback, useEffect, useRef, useState } from 'react';
@@ -20,6 +22,8 @@ import BoardFiltersBar from './_components/board-filters';
 import LeadsBoard from './_components/leads-board';
 import LeadDrawer from './_components/lead-drawer';
 import { useLeadMutations } from './_components/use-lead-mutations';
+
+const TEMPS = ['hot', 'warm', 'cold'] as const;
 
 function filtersToQuery(f: BoardFilters): string {
   const params = new URLSearchParams();
@@ -36,17 +40,34 @@ function LeadsPageInner(): ReactElement {
   const search = useSearchParams();
   const router = useRouter();
   const [data, setData] = useState<BoardData | null>(null);
-  const [filters, setFilters] = useState<BoardFilters>(() => ({
-    temp: (search?.get('temp') as BoardFilters['temp']) ?? undefined,
-  }));
+  const [loadFailed, setLoadFailed] = useState(false);
+  const [filters, setFilters] = useState<BoardFilters>(() => {
+    const temp = search?.get('temp');
+    return {
+      // Validate — a garbage ?temp= must not wedge the board in a 400 loop.
+      temp: TEMPS.includes(temp as (typeof TEMPS)[number])
+        ? (temp as BoardFilters['temp'])
+        : undefined,
+    };
+  });
   const [openLead, setOpenLead] = useState<string | null>(search?.get('lead') ?? null);
-  const snapshotRef = useRef<BoardData | null>(null);
+  // Out-of-order fetch guard: only the latest request may write state.
+  const loadSeqRef = useRef(0);
 
   const load = useCallback(async (): Promise<void> => {
-    const res = await fetch(`/api/v1/admin/leads/board?${filtersToQuery(filters)}`);
-    if (res.ok) {
-      const body = await res.json();
-      setData(body.data);
+    const seq = ++loadSeqRef.current;
+    try {
+      const res = await fetch(`/api/v1/admin/leads/board?${filtersToQuery(filters)}`);
+      if (seq !== loadSeqRef.current) return; // superseded by a newer request
+      if (res.ok) {
+        const body = await res.json();
+        setData(body.data);
+        setLoadFailed(false);
+      } else {
+        setLoadFailed(true);
+      }
+    } catch {
+      if (seq === loadSeqRef.current) setLoadFailed(true);
     }
   }, [filters]);
 
@@ -54,12 +75,17 @@ function LeadsPageInner(): ReactElement {
     void load();
   }, [load]);
 
+  // Deep links can also arrive via client-side nav while already mounted.
+  useEffect(() => {
+    const fromUrl = search?.get('lead') ?? null;
+    if (fromUrl) setOpenLead(fromUrl);
+  }, [search]);
+
   const mutations = useLeadMutations(load);
 
   const optimisticMove = useCallback((leadId: string, to: PipelineStage): void => {
     setData((prev) => {
       if (!prev) return prev;
-      snapshotRef.current = prev;
       const columns = Object.fromEntries(
         Object.entries(prev.columns).map(([k, cards]) => [k, cards.filter((c) => c.id !== leadId)]),
       ) as BoardData['columns'];
@@ -71,9 +97,11 @@ function LeadsPageInner(): ReactElement {
     });
   }, []);
 
+  // On a failed move, re-sync from the server — a stored snapshot could
+  // resurrect an older drag's state when two moves overlap (review #4).
   const rollback = useCallback((): void => {
-    if (snapshotRef.current) setData(snapshotRef.current);
-  }, []);
+    void load();
+  }, [load]);
 
   const openDrawer = (id: string): void => {
     setOpenLead(id);
@@ -121,6 +149,13 @@ function LeadsPageInner(): ReactElement {
               rollback={rollback}
             />
           </>
+        ) : loadFailed ? (
+          <div className="card text-center py-10">
+            <p className="text-gray-700">Couldn&apos;t load the board.</p>
+            <button type="button" onClick={() => void load()} className="btn-primary mt-3">
+              Try again
+            </button>
+          </div>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
             <SkeletonCard />

--- a/src/app/admin/leads/page.tsx
+++ b/src/app/admin/leads/page.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+/**
+ * Lead Flow — the Kanban lead pipeline (/admin/leads).
+ *
+ * Every submitted lead lands here as a card: New → Contacted → Qualified →
+ * Quote Sent → Won → Lost, scored cold/warm/hot. Deep-linkable via
+ * ?lead=<id> (the URL GHL notifications carry). Data refreshes on demand and
+ * after every mutation; refresh is suspended while a drag is in flight.
+ */
+
+import { ReactElement, Suspense, useCallback, useEffect, useRef, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import NavyBand from '@/components/backend/shell/NavyBand';
+import SkeletonCard from '@/components/backend/kit/SkeletonCard';
+import type { BoardData, BoardFilters } from '@/lib/leads/board-types';
+import type { PipelineStage } from '@/lib/leads/pipeline-types';
+import KpiStrip from './_components/kpi-strip';
+import BoardFiltersBar from './_components/board-filters';
+import LeadsBoard from './_components/leads-board';
+import LeadDrawer from './_components/lead-drawer';
+import { useLeadMutations } from './_components/use-lead-mutations';
+
+function filtersToQuery(f: BoardFilters): string {
+  const params = new URLSearchParams();
+  if (f.temp) params.set('temp', f.temp);
+  if (f.occasion) params.set('occasion', f.occasion);
+  if (f.source) params.set('source', f.source);
+  if (f.q) params.set('q', f.q);
+  if (f.showSnoozed) params.set('showSnoozed', 'true');
+  if (f.includePartial) params.set('includePartial', 'true');
+  return params.toString();
+}
+
+function LeadsPageInner(): ReactElement {
+  const search = useSearchParams();
+  const router = useRouter();
+  const [data, setData] = useState<BoardData | null>(null);
+  const [filters, setFilters] = useState<BoardFilters>(() => ({
+    temp: (search?.get('temp') as BoardFilters['temp']) ?? undefined,
+  }));
+  const [openLead, setOpenLead] = useState<string | null>(search?.get('lead') ?? null);
+  const snapshotRef = useRef<BoardData | null>(null);
+
+  const load = useCallback(async (): Promise<void> => {
+    const res = await fetch(`/api/v1/admin/leads/board?${filtersToQuery(filters)}`);
+    if (res.ok) {
+      const body = await res.json();
+      setData(body.data);
+    }
+  }, [filters]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const mutations = useLeadMutations(load);
+
+  const optimisticMove = useCallback((leadId: string, to: PipelineStage): void => {
+    setData((prev) => {
+      if (!prev) return prev;
+      snapshotRef.current = prev;
+      const columns = Object.fromEntries(
+        Object.entries(prev.columns).map(([k, cards]) => [k, cards.filter((c) => c.id !== leadId)]),
+      ) as BoardData['columns'];
+      const card =
+        Object.values(prev.columns).flat().find((c) => c.id === leadId) ??
+        prev.tray.find((c) => c.id === leadId);
+      if (card) columns[to] = [{ ...card, stage: to }, ...columns[to]];
+      return { ...prev, columns, tray: prev.tray.filter((c) => c.id !== leadId) };
+    });
+  }, []);
+
+  const rollback = useCallback((): void => {
+    if (snapshotRef.current) setData(snapshotRef.current);
+  }, []);
+
+  const openDrawer = (id: string): void => {
+    setOpenLead(id);
+    const params = new URLSearchParams(window.location.search);
+    params.set('lead', id);
+    router.replace(`/admin/leads?${params.toString()}`, { scroll: false });
+  };
+  const closeDrawer = (): void => {
+    setOpenLead(null);
+    const params = new URLSearchParams(window.location.search);
+    params.delete('lead');
+    router.replace(`/admin/leads${params.size ? `?${params}` : ''}`, { scroll: false });
+    void load();
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 pb-10">
+      <NavyBand>
+        <div className="pb-3 space-y-3">
+          <div className="flex items-center justify-between">
+            <p className="text-sm text-[#B7C4D0]">
+              Every inquiry, scored and tracked to Won or Lost.
+            </p>
+            <button
+              type="button"
+              onClick={() => void load()}
+              className="min-h-[36px] px-3 rounded-lg bg-white/10 text-white text-sm font-semibold hover:bg-white/20"
+            >
+              Refresh
+            </button>
+          </div>
+          <BoardFiltersBar filters={filters} onChange={setFilters} />
+        </div>
+      </NavyBand>
+
+      <div className="px-3 md:px-5 mt-4 space-y-4 max-w-[1800px] mx-auto">
+        {data ? (
+          <>
+            <KpiStrip kpis={data.kpis} />
+            <LeadsBoard
+              data={data}
+              onOpen={openDrawer}
+              mutations={mutations}
+              optimisticMove={optimisticMove}
+              rollback={rollback}
+            />
+          </>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+            <SkeletonCard />
+            <SkeletonCard />
+            <SkeletonCard />
+          </div>
+        )}
+      </div>
+
+      <LeadDrawer leadId={openLead} onClose={closeDrawer} mutations={mutations} />
+    </div>
+  );
+}
+
+export default function LeadsPage(): ReactElement {
+  return (
+    <Suspense fallback={<div className="min-h-screen bg-gray-50" />}>
+      <LeadsPageInner />
+    </Suspense>
+  );
+}

--- a/src/app/api/ops/nav-badges/__tests__/route.test.ts
+++ b/src/app/api/ops/nav-badges/__tests__/route.test.ts
@@ -16,10 +16,14 @@ const prismaMock = vi.hoisted(() => ({
 
 const authMock = vi.hoisted(() => ({ requireOpsAuth: vi.fn() }));
 const groupingMock = vi.hoisted(() => ({ todayCT: vi.fn() }));
+const boardMock = vi.hoisted(() => ({ getHotLeadsNeedingReply: vi.fn() }));
 
 vi.mock('@/lib/database/client', () => ({ prisma: prismaMock }));
 vi.mock('@/lib/auth/ops-session', () => ({ requireOpsAuth: authMock.requireOpsAuth }));
 vi.mock('@/lib/ops/cooler-grouping', () => ({ todayCT: groupingMock.todayCT }));
+vi.mock('@/lib/leads/board-data', () => ({
+  getHotLeadsNeedingReply: boardMock.getHotLeadsNeedingReply,
+}));
 
 import { GET } from '../route';
 
@@ -30,6 +34,8 @@ beforeEach(() => {
   prismaMock.financeRecommendation.count.mockReset();
   authMock.requireOpsAuth.mockReset();
   groupingMock.todayCT.mockReturnValue('2026-07-09');
+  boardMock.getHotLeadsNeedingReply.mockReset();
+  boardMock.getHotLeadsNeedingReply.mockResolvedValue({ count: 0, oldestWaitHours: null });
 });
 
 describe('GET /api/ops/nav-badges', () => {
@@ -47,10 +53,11 @@ describe('GET /api/ops/nav-badges', () => {
     prismaMock.recommendationItem.count.mockResolvedValue(2);
     prismaMock.operationsRecommendation.count.mockResolvedValue(1);
     prismaMock.financeRecommendation.count.mockResolvedValue(3);
+    boardMock.getHotLeadsNeedingReply.mockResolvedValue({ count: 5, oldestWaitHours: 3 });
 
     const res = await GET();
     const body = await res.json();
-    expect(body).toEqual({ ordersToday: 4, recsOpen: 6 });
+    expect(body).toEqual({ ordersToday: 4, recsOpen: 6, leadsHot: 5 });
   });
 
   it('scopes ordersToday to the UTC window of the CT date, undelivered, non-cancelled', async () => {
@@ -69,15 +76,16 @@ describe('GET /api/ops/nav-badges', () => {
     expect(where.status).toEqual({ not: 'CANCELLED' });
   });
 
-  it('employee gets ordersToday but no recommendation queries', async () => {
+  it('employee gets ordersToday but no recommendation or lead queries', async () => {
     authMock.requireOpsAuth.mockResolvedValue({ role: 'employee' });
     prismaMock.order.count.mockResolvedValue(7);
 
     const res = await GET();
     const body = await res.json();
-    expect(body).toEqual({ ordersToday: 7, recsOpen: 0 });
+    expect(body).toEqual({ ordersToday: 7, recsOpen: 0, leadsHot: 0 });
     expect(prismaMock.recommendationItem.count).not.toHaveBeenCalled();
     expect(prismaMock.operationsRecommendation.count).not.toHaveBeenCalled();
     expect(prismaMock.financeRecommendation.count).not.toHaveBeenCalled();
+    expect(boardMock.getHotLeadsNeedingReply).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/ops/nav-badges/route.ts
+++ b/src/app/api/ops/nav-badges/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/database/client';
 import { requireOpsAuth } from '@/lib/auth/ops-session';
 import { todayCT } from '@/lib/ops/cooler-grouping';
+import { getHotLeadsNeedingReply } from '@/lib/leads/board-data';
 
 export const dynamic = 'force-dynamic';
 
@@ -14,6 +15,7 @@ export const dynamic = 'force-dynamic';
  * - recsOpen (admin only): open+approved recommendations across the three
  *   stores — mirrors listUnifiedRecommendations' default statuses, but as
  *   count() queries so the badge never pays for the 250-row list.
+ * - leadsHot (admin only): hot Lead Flow cards waiting on a reply.
  */
 export async function GET(): Promise<NextResponse> {
   const auth = await requireOpsAuth();
@@ -24,8 +26,9 @@ export async function GET(): Promise<NextResponse> {
   const end = new Date(start.getTime() + 24 * 60 * 60 * 1000);
 
   const openStatuses = ['open', 'approved'];
+  const isAdmin = auth.role === 'admin';
 
-  const [ordersToday, ...recCounts] = await Promise.all([
+  const [ordersToday, hotLeads, ...recCounts] = await Promise.all([
     prisma.order.count({
       where: {
         deliveryDate: { gte: start, lt: end },
@@ -33,7 +36,10 @@ export async function GET(): Promise<NextResponse> {
         status: { not: 'CANCELLED' },
       },
     }),
-    ...(auth.role === 'admin'
+    isAdmin
+      ? getHotLeadsNeedingReply().catch(() => ({ count: 0, oldestWaitHours: null }))
+      : Promise.resolve({ count: 0, oldestWaitHours: null }),
+    ...(isAdmin
       ? [
           prisma.recommendationItem.count({ where: { status: { in: openStatuses } } }),
           prisma.operationsRecommendation.count({ where: { status: { in: openStatuses } } }),
@@ -44,5 +50,5 @@ export async function GET(): Promise<NextResponse> {
 
   const recsOpen = recCounts.reduce((sum, n) => sum + n, 0);
 
-  return NextResponse.json({ ordersToday, recsOpen });
+  return NextResponse.json({ ordersToday, recsOpen, leadsHot: hotLeads.count });
 }

--- a/src/app/api/v1/admin/leads/[id]/route.ts
+++ b/src/app/api/v1/admin/leads/[id]/route.ts
@@ -1,0 +1,163 @@
+/**
+ * /api/v1/admin/leads/[id]
+ *
+ * GET   — drawer detail: lead, timeline (events + emails + follow-ups),
+ *         matched orders/drafts (email or last-10 phone), score breakdown.
+ * PATCH — notes / owner / snoozedUntil (board metadata only; stage changes
+ *         go through the /stage route so the transition matrix applies).
+ */
+import { NextResponse, type NextRequest } from 'next/server';
+import { z } from 'zod';
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/database/client';
+import { requireAdminRole } from '@/lib/auth/ops-session';
+import { phoneLast10 } from '@/lib/leads/phone';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+interface MatchedOrder {
+  id: string;
+  orderNumber: number;
+  total: number;
+  createdAt: string;
+  isGroupParticipant: boolean;
+}
+
+/** Paid orders matching the lead's identity — group ones flagged "possible". */
+async function matchedOrders(lead: {
+  email: string | null;
+  phone: string | null;
+}): Promise<MatchedOrder[]> {
+  const last10 = phoneLast10(lead.phone);
+  const identity: Prisma.Sql[] = [];
+  if (lead.email) identity.push(Prisma.sql`LOWER(customer_email) = LOWER(${lead.email})`);
+  if (last10) {
+    identity.push(
+      Prisma.sql`RIGHT(REGEXP_REPLACE(COALESCE(customer_phone, ''), '\\D', '', 'g'), 10) = ${last10}`,
+    );
+  }
+  if (identity.length === 0) return [];
+  const rows = await prisma.$queryRaw<
+    Array<{ id: string; order_number: number; total: number; created_at: Date; is_group: boolean }>
+  >`
+    SELECT id, order_number, total::float AS total, created_at,
+           (group_order_v2_id IS NOT NULL OR group_order_id IS NOT NULL) AS is_group
+    FROM orders
+    WHERE financial_status IN ('PAID', 'PARTIALLY_REFUNDED')
+      AND (${Prisma.join(identity, ' OR ')})
+    ORDER BY created_at DESC
+    LIMIT 5
+  `;
+  return rows.map((r) => ({
+    id: r.id,
+    orderNumber: r.order_number,
+    total: r.total,
+    createdAt: r.created_at.toISOString(),
+    isGroupParticipant: r.is_group,
+  }));
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const auth = await requireAdminRole();
+  if (auth instanceof NextResponse) return auth;
+  const { id } = await params;
+
+  const lead = await prisma.lead.findUnique({ where: { id } });
+  if (!lead) {
+    return NextResponse.json({ success: false, error: 'not_found' }, { status: 404 });
+  }
+
+  const [events, followUps, emailLogs, orders, drafts] = await Promise.all([
+    prisma.leadEvent.findMany({
+      where: { leadId: id },
+      orderBy: { occurredAt: 'desc' },
+      take: 50,
+    }),
+    prisma.followUpJob.findMany({
+      where: { leadId: id },
+      orderBy: { createdAt: 'desc' },
+      take: 10,
+      select: {
+        id: true,
+        journeyKey: true,
+        step: true,
+        status: true,
+        scheduledFor: true,
+        sentAt: true,
+        cancelReason: true,
+      },
+    }),
+    lead.email
+      ? prisma.emailLog.findMany({
+          where: { to: { equals: lead.email, mode: 'insensitive' } },
+          orderBy: { createdAt: 'desc' },
+          take: 10,
+          select: { id: true, subject: true, type: true, status: true, createdAt: true },
+        })
+      : Promise.resolve([]),
+    matchedOrders(lead),
+    lead.email
+      ? prisma.draftOrder.findMany({
+          where: { customerEmail: { equals: lead.email, mode: 'insensitive' } },
+          orderBy: { createdAt: 'desc' },
+          take: 5,
+          select: { id: true, status: true, total: true, createdAt: true, token: true },
+        })
+      : Promise.resolve([]),
+  ]);
+
+  return NextResponse.json({
+    success: true,
+    data: { lead, events, followUps, emailLogs, orders, drafts },
+  });
+}
+
+const patchSchema = z
+  .object({
+    notes: z.string().max(10_000).nullable().optional(),
+    owner: z.string().max(40).nullable().optional(),
+    snoozedUntil: z.string().datetime().nullable().optional(),
+  })
+  .refine(
+    (v) => v.notes !== undefined || v.owner !== undefined || v.snoozedUntil !== undefined,
+    { message: 'empty_patch' },
+  );
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const auth = await requireAdminRole();
+  if (auth instanceof NextResponse) return auth;
+  const { id } = await params;
+
+  let body: z.infer<typeof patchSchema>;
+  try {
+    body = patchSchema.parse(await req.json());
+  } catch {
+    return NextResponse.json({ success: false, error: 'invalid_body' }, { status: 400 });
+  }
+
+  try {
+    const lead = await prisma.lead.update({
+      where: { id },
+      data: {
+        notes: body.notes === undefined ? undefined : body.notes,
+        owner: body.owner === undefined ? undefined : body.owner,
+        snoozedUntil:
+          body.snoozedUntil === undefined
+            ? undefined
+            : body.snoozedUntil === null
+              ? null
+              : new Date(body.snoozedUntil),
+      },
+    });
+    return NextResponse.json({ success: true, data: { lead } });
+  } catch {
+    return NextResponse.json({ success: false, error: 'not_found' }, { status: 404 });
+  }
+}

--- a/src/app/api/v1/admin/leads/[id]/stage/route.ts
+++ b/src/app/api/v1/admin/leads/[id]/stage/route.ts
@@ -1,0 +1,53 @@
+/**
+ * PATCH /api/v1/admin/leads/[id]/stage — move a card on the Lead Flow board.
+ *
+ * Body: { stage, sortOrder?, lostReason? }. All moves route through
+ * transitionStage (single writer: audit LeadEvent, side-effect stamps,
+ * score recompute). Tray promotions (stage was NULL) are allowed for any
+ * lead with contact info.
+ */
+import { NextResponse, type NextRequest } from 'next/server';
+import { z } from 'zod';
+import { requireAdminRole } from '@/lib/auth/ops-session';
+import { PIPELINE_STAGES } from '@/lib/leads/pipeline-types';
+import { transitionStage } from '@/lib/leads/pipeline';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const bodySchema = z.object({
+  stage: z.enum(PIPELINE_STAGES),
+  sortOrder: z.number().finite().optional(),
+  lostReason: z.string().max(200).nullable().optional(),
+});
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const auth = await requireAdminRole();
+  if (auth instanceof NextResponse) return auth;
+  const { id } = await params;
+
+  let body: z.infer<typeof bodySchema>;
+  try {
+    body = bodySchema.parse(await req.json());
+  } catch {
+    return NextResponse.json({ success: false, error: 'invalid_body' }, { status: 400 });
+  }
+
+  const result = await transitionStage(id, body.stage, {
+    via: 'drag',
+    sortOrder: body.sortOrder,
+    lostReason: body.lostReason ?? undefined,
+  });
+
+  if (!result.ok) {
+    const status = result.reason === 'lead-not-found' ? 404 : 400;
+    return NextResponse.json({ success: false, error: result.reason }, { status });
+  }
+  return NextResponse.json({
+    success: true,
+    data: { moved: result.moved, reason: result.reason ?? null, lead: result.lead ?? null },
+  });
+}

--- a/src/app/api/v1/admin/leads/board/route.ts
+++ b/src/app/api/v1/admin/leads/board/route.ts
@@ -1,0 +1,46 @@
+/**
+ * GET /api/v1/admin/leads/board — the Lead Flow Kanban payload.
+ *
+ * Under /api/v1/admin/** for the middleware session gate; requireAdminRole
+ * in-route because leads are PII (the employee redirect is client-side only).
+ * Runs the enroll sweep first so a freshly-submitted lead appears on open.
+ */
+import { NextResponse, type NextRequest } from 'next/server';
+import { z } from 'zod';
+import { requireAdminRole } from '@/lib/auth/ops-session';
+import { getBoardData } from '@/lib/leads/board-data';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const filtersSchema = z.object({
+  temp: z.enum(['hot', 'warm', 'cold']).optional(),
+  occasion: z.string().max(60).optional(),
+  source: z.string().max(60).optional(),
+  q: z.string().max(120).optional(),
+  showSnoozed: z.coerce.boolean().optional(),
+  includePartial: z.coerce.boolean().optional(),
+});
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const auth = await requireAdminRole();
+  if (auth instanceof NextResponse) return auth;
+
+  const parsed = filtersSchema.safeParse(
+    Object.fromEntries(req.nextUrl.searchParams.entries()),
+  );
+  if (!parsed.success) {
+    return NextResponse.json({ success: false, error: 'invalid_filters' }, { status: 400 });
+  }
+
+  try {
+    const data = await getBoardData(parsed.data);
+    return NextResponse.json({ success: true, data });
+  } catch (error) {
+    console.error('[admin/leads/board] failed:', error);
+    return NextResponse.json(
+      { success: false, error: 'Failed to build board' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/admin/LeadsView.tsx
+++ b/src/components/admin/LeadsView.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { prisma } from '@/lib/database/client';
 
 /**
@@ -42,7 +43,12 @@ function fmtDate(d: Date) {
   });
 }
 
-export default async function LeadsView() {
+export default async function LeadsView({
+  deepLinkedLeadId,
+}: {
+  /** `?lead=<id>` carried by old GHL-notification URLs — forwarded to the board. */
+  deepLinkedLeadId?: string | null;
+} = {}) {
   const [leads, totalLeads, anonSessions, partialCount, submittedCount, convertedCount, conciergeCount] =
     await Promise.all([
       prisma.lead.findMany({
@@ -68,6 +74,19 @@ export default async function LeadsView() {
 
   return (
     <div className="space-y-6">
+      {/* The working surface is now the Lead Flow board; this tab stays as
+          the raw storage view. Old GHL links carry ?lead= — forward it. */}
+      <div className="flex items-center justify-between rounded-xl border border-brand-blue/30 bg-blue-50 px-4 py-3">
+        <p className="text-sm text-gray-700">
+          Work leads on the Kanban board — stages, hot/warm/cold, replies.
+        </p>
+        <Link
+          href={deepLinkedLeadId ? `/admin/leads?lead=${deepLinkedLeadId}` : '/admin/leads'}
+          className="btn-primary min-h-[36px] px-3 py-1.5 text-sm whitespace-nowrap"
+        >
+          Open Lead Flow board
+        </Link>
+      </div>
       {/* Top-line counters */}
       <div className="grid grid-cols-2 md:grid-cols-6 gap-3">
         <Stat label="Total leads" value={totalLeads} />

--- a/src/components/backend/shell/MoreSheet.tsx
+++ b/src/components/backend/shell/MoreSheet.tsx
@@ -22,7 +22,8 @@ function Tile({
   badges: NavBadges;
   onNavigate: () => void;
 }): ReactElement {
-  const count = dest.badge === 'recs' ? badges.recsOpen : 0;
+  const count =
+    dest.badge === 'recs' ? badges.recsOpen : dest.badge === 'leads' ? badges.leadsHot : 0;
   return (
     <Link
       href={dest.href}

--- a/src/components/backend/shell/SidebarNav.tsx
+++ b/src/components/backend/shell/SidebarNav.tsx
@@ -24,7 +24,14 @@ function SidebarItem({
   badges: NavBadges;
 }): ReactElement {
   const active = isDestActive(dest, pathname);
-  const count = dest.badge === 'orders' ? badges.ordersToday : dest.badge === 'recs' ? badges.recsOpen : 0;
+  const count =
+    dest.badge === 'orders'
+      ? badges.ordersToday
+      : dest.badge === 'recs'
+        ? badges.recsOpen
+        : dest.badge === 'leads'
+          ? badges.leadsHot
+          : 0;
   return (
     <Link
       href={dest.href}

--- a/src/components/backend/shell/icons.tsx
+++ b/src/components/backend/shell/icons.tsx
@@ -15,6 +15,7 @@ export type HqIconName =
   | 'dashboard'
   | 'analytics'
   | 'customers'
+  | 'leads'
   | 'email'
   | 'recs'
   | 'money'
@@ -106,6 +107,10 @@ const PATHS: Record<HqIconName, ReactElement> = {
       <circle cx="12" cy="12" r="6" />
       <circle cx="12" cy="12" r="2" />
     </>
+  ),
+  leads: (
+    // Funnel — leads flow in wide, convert narrow.
+    <path d="M3 4h18l-7 8v6l-4 2v-8L3 4z" />
   ),
   reports: (
     <>

--- a/src/components/backend/shell/nav-config.ts
+++ b/src/components/backend/shell/nav-config.ts
@@ -8,7 +8,7 @@ import type { HqIconName } from './icons';
  */
 export type StaffRole = 'admin' | 'employee';
 
-export type BadgeKey = 'orders' | 'recs';
+export type BadgeKey = 'orders' | 'recs' | 'leads';
 
 export interface NavDest {
   href: string;
@@ -49,6 +49,7 @@ export const BUSINESS_DESTS: NavDest[] = [
   { href: '/admin/dashboard', label: 'Dashboard', icon: 'dashboard', match: ['/admin/dashboard'], roles: ['admin'] },
   { href: '/admin/analytics', label: 'Analytics', icon: 'analytics', match: ['/admin/analytics'], roles: ['admin'] },
   { href: '/admin/customers', label: 'Customers', icon: 'customers', match: ['/admin/customers'], roles: ['admin'] },
+  { href: '/admin/leads', label: 'Leads', icon: 'leads', match: ['/admin/leads'], roles: ['admin'], badge: 'leads' },
   { href: '/admin/emails', label: 'Email', icon: 'email', match: ['/admin/emails', '/admin/email-signups'], roles: ['admin'] },
   { href: '/admin/recommendations', label: 'Recs', icon: 'recs', match: ['/admin/recommendations'], roles: ['admin'], badge: 'recs' },
   { href: '/admin/finance', label: 'Money', icon: 'money', match: ['/admin/finance'], roles: ['admin'] },
@@ -87,6 +88,7 @@ const SCREEN_TITLES: Array<[string, string]> = [
   ['/admin/strategy', 'Game Plan'],
   ['/admin/analytics', 'Analytics'],
   ['/admin/customers', 'Customers'],
+  ['/admin/leads', 'Leads'],
   ['/admin/emails', 'Email'],
   ['/admin/email-signups', 'Email'],
   ['/admin/recommendations', 'Recommendations'],

--- a/src/components/backend/shell/useNavBadges.ts
+++ b/src/components/backend/shell/useNavBadges.ts
@@ -6,9 +6,11 @@ import { usePathname } from 'next/navigation';
 export interface NavBadges {
   ordersToday: number;
   recsOpen: number;
+  /** Hot Lead Flow cards waiting on a reply (admin only; 0 for employees). */
+  leadsHot: number;
 }
 
-const EMPTY: NavBadges = { ordersToday: 0, recsOpen: 0 };
+const EMPTY: NavBadges = { ordersToday: 0, recsOpen: 0, leadsHot: 0 };
 
 /**
  * Lightweight tab-badge counts. Refetches on route change (an operator who
@@ -31,6 +33,7 @@ export function useNavBadges(enabled: boolean): NavBadges {
             setBadges({
               ordersToday: data.ordersToday ?? 0,
               recsOpen: data.recsOpen ?? 0,
+              leadsHot: data.leadsHot ?? 0,
             });
           }
         })

--- a/src/lib/leads/board-data.ts
+++ b/src/lib/leads/board-data.ts
@@ -1,0 +1,237 @@
+/**
+ * Lead Flow board — read-side aggregation for /admin/leads.
+ *
+ * One round trip builds the whole board: columns grouped by stage (Won/Lost
+ * capped to the last 30 days), the "Uncommitted" tray (PARTIAL leads with
+ * contact info), KPI tiles, and per-card facts. Needs-response and follow-up
+ * flags come from two grouped queries over the boarded ids — never a per-card
+ * scan of lead_events.
+ */
+
+import { prisma } from '@/lib/database/client';
+import type { Lead } from '@prisma/client';
+import { extractLeadFacts, temperatureFor } from './scoring';
+import { isNewsletterOnly, sweepEnrollSubmitted } from './pipeline';
+import { PIPELINE_STAGES, type PipelineStage } from './pipeline-types';
+import type { BoardData, BoardFilters, BoardKpis, BoardLead } from './board-types';
+
+export type { BoardData, BoardFilters, BoardKpis, BoardLead } from './board-types';
+
+const CLOSED_WINDOW_DAYS = 30;
+const TRAY_LIMIT = 60;
+
+function displayName(lead: Lead): string {
+  const name = [lead.firstName, lead.lastName].filter(Boolean).join(' ').trim();
+  return name || lead.email || lead.phone || 'Unknown lead';
+}
+
+function toBoardLead(
+  lead: Lead,
+  ctx: {
+    lastSubmitAt: Date | null;
+    hasFollowUp: boolean;
+    isDuplicate: boolean;
+    now: Date;
+  },
+): BoardLead {
+  const facts = extractLeadFacts(lead.metadata);
+  const lastSignal = ctx.lastSubmitAt ?? lead.createdAt;
+  const needsResponse =
+    lead.lastContactedAt === null || lastSignal > lead.lastContactedAt;
+  const eventPassed =
+    facts.eventDate != null && facts.eventDate < ctx.now.toISOString().slice(0, 10);
+  const quietMs = ctx.now.getTime() - (lead.lastActivityAt ?? lead.updatedAt).getTime();
+  const isOpenStage =
+    lead.pipelineStage !== 'WON' && lead.pipelineStage !== 'LOST' && lead.pipelineStage !== null;
+  return {
+    id: lead.id,
+    name: displayName(lead),
+    email: lead.email,
+    phone: lead.phone,
+    stage: (lead.pipelineStage as PipelineStage | null) ?? null,
+    sortOrder: lead.boardSortOrder,
+    score: lead.leadScore,
+    temperature: temperatureFor(lead.leadScore),
+    occasion: facts.occasion,
+    eventDate: facts.eventDate,
+    headcount: facts.headcount,
+    budgetPerPerson: facts.budgetPerPerson,
+    sourceWidget: lead.sourceWidget,
+    sourcePage: lead.sourcePage,
+    owner: lead.owner,
+    needsResponse: isOpenStage ? needsResponse : false,
+    hasFollowUp: ctx.hasFollowUp,
+    isDuplicate: ctx.isDuplicate,
+    snoozedUntil: lead.snoozedUntil?.toISOString() ?? null,
+    lastContactedAt: lead.lastContactedAt?.toISOString() ?? null,
+    lastActivityAt: lead.lastActivityAt?.toISOString() ?? null,
+    lostReason: lead.lostReason,
+    createdAt: lead.createdAt.toISOString(),
+    stageChangedAt: lead.stageChangedAt?.toISOString() ?? null,
+    suggestLost: isOpenStage && (eventPassed || quietMs > 30 * 86_400_000),
+  };
+}
+
+function applyFilters(cards: BoardLead[], f: BoardFilters, now: Date): BoardLead[] {
+  return cards.filter((c) => {
+    if (f.temp && c.temperature !== f.temp) return false;
+    if (f.occasion && (c.occasion ?? '').toLowerCase() !== f.occasion.toLowerCase()) return false;
+    if (f.source && c.sourceWidget !== f.source) return false;
+    if (!f.showSnoozed && c.snoozedUntil && new Date(c.snoozedUntil) > now) return false;
+    if (f.q) {
+      const hay = `${c.name} ${c.email ?? ''} ${c.phone ?? ''}`.toLowerCase();
+      if (!hay.includes(f.q.toLowerCase())) return false;
+    }
+    return true;
+  });
+}
+
+/**
+ * Count of hot, unanswered, un-snoozed leads — shared by the nav badge and
+ * the /ops/today triage row. Raw SQL because Prisma can't compare two
+ * columns (last_activity_at > last_contacted_at). Returns the oldest wait so
+ * the triage row can escalate to red past 48h.
+ */
+export async function getHotLeadsNeedingReply(): Promise<{
+  count: number;
+  oldestWaitHours: number | null;
+}> {
+  const rows = await prisma.$queryRaw<
+    Array<{ count: number; oldest: Date | null }>
+  >`
+    SELECT COUNT(*)::int AS count, MIN(stage_changed_at) AS oldest
+    FROM leads
+    WHERE pipeline_stage IN ('NEW', 'CONTACTED', 'QUALIFIED', 'QUOTE_SENT')
+      AND lead_score >= 70
+      AND (snoozed_until IS NULL OR snoozed_until <= NOW())
+      AND (
+        last_contacted_at IS NULL
+        OR (last_activity_at IS NOT NULL AND last_activity_at > last_contacted_at)
+      )
+  `;
+  const row = rows[0];
+  if (!row || row.count === 0) return { count: 0, oldestWaitHours: null };
+  const oldestWaitHours = row.oldest
+    ? (Date.now() - row.oldest.getTime()) / 3_600_000
+    : null;
+  return { count: row.count, oldestWaitHours };
+}
+
+/** Build the full board payload. Runs the enroll sweep first so it's always fresh. */
+export async function getBoardData(filters: BoardFilters = {}): Promise<BoardData> {
+  const now = new Date();
+  await sweepEnrollSubmitted().catch(() => undefined);
+
+  const closedFloor = new Date(now.getTime() - CLOSED_WINDOW_DAYS * 86_400_000);
+  const [boarded, closedCountsRaw, tray] = await Promise.all([
+    prisma.lead.findMany({
+      where: {
+        OR: [
+          { pipelineStage: { in: ['NEW', 'CONTACTED', 'QUALIFIED', 'QUOTE_SENT'] } },
+          { pipelineStage: { in: ['WON', 'LOST'] }, stageChangedAt: { gte: closedFloor } },
+        ],
+      },
+      orderBy: [{ boardSortOrder: 'asc' }, { createdAt: 'desc' }],
+      take: 500,
+    }),
+    prisma.lead.groupBy({
+      by: ['pipelineStage'],
+      where: { pipelineStage: { in: ['WON', 'LOST'] } },
+      _count: { _all: true },
+    }),
+    filters.includePartial
+      ? prisma.lead.findMany({
+          where: {
+            pipelineStage: null,
+            status: 'PARTIAL',
+            OR: [{ email: { not: null } }, { phone: { not: null } }],
+          },
+          orderBy: { updatedAt: 'desc' },
+          take: TRAY_LIMIT,
+        })
+      : Promise.resolve([] as Lead[]),
+  ]);
+
+  const all = [...boarded, ...tray];
+  const ids = all.map((l) => l.id);
+
+  const [submitAgg, followUps] = await Promise.all([
+    prisma.leadEvent.groupBy({
+      by: ['leadId'],
+      where: {
+        leadId: { in: ids },
+        type: { in: ['FORM_SUBMIT', 'CHECKOUT_START'] },
+      },
+      _max: { occurredAt: true },
+    }),
+    prisma.followUpJob.groupBy({
+      by: ['leadId'],
+      where: { leadId: { in: ids }, status: { in: ['scheduled', 'sent'] } },
+      _count: { _all: true },
+    }),
+  ]);
+  const lastSubmitByLead = new Map(
+    submitAgg.map((r) => [r.leadId, r._max.occurredAt]),
+  );
+  const followUpLeads = new Set(followUps.map((r) => r.leadId));
+
+  const emailCounts = new Map<string, number>();
+  for (const l of all) {
+    const key = l.email?.toLowerCase();
+    if (key) emailCounts.set(key, (emailCounts.get(key) ?? 0) + 1);
+  }
+
+  const toCard = (lead: Lead): BoardLead =>
+    toBoardLead(lead, {
+      lastSubmitAt: lastSubmitByLead.get(lead.id) ?? null,
+      hasFollowUp: followUpLeads.has(lead.id),
+      isDuplicate: (emailCounts.get(lead.email?.toLowerCase() ?? '') ?? 0) > 1,
+      now,
+    });
+
+  const columns = Object.fromEntries(
+    PIPELINE_STAGES.map((s) => [s, [] as BoardLead[]]),
+  ) as Record<PipelineStage, BoardLead[]>;
+  for (const lead of boarded) {
+    const card = toCard(lead);
+    if (card.stage) columns[card.stage].push(card);
+  }
+  for (const stage of PIPELINE_STAGES) {
+    columns[stage] = applyFilters(columns[stage], filters, now);
+  }
+
+  const trayCards = applyFilters(
+    tray.filter((l) => !isNewsletterOnly(l)).map(toCard),
+    filters,
+    now,
+  );
+
+  const weekFloor = new Date(now.getTime() - 7 * 86_400_000);
+  const open = (['NEW', 'CONTACTED', 'QUALIFIED', 'QUOTE_SENT'] as const).flatMap(
+    (s) => columns[s],
+  );
+  const won30d = columns.WON.length;
+  const lost30d = columns.LOST.length;
+  const closedTotal = won30d + lost30d;
+  const kpis: BoardKpis = {
+    newThisWeek: open.filter((c) => new Date(c.createdAt) >= weekFloor).length,
+    hot: open.filter((c) => c.temperature === 'hot').length,
+    needsResponse: open.filter((c) => c.needsResponse).length,
+    won30d,
+    lost30d,
+    conversionPct: closedTotal > 0 ? Math.round((won30d / closedTotal) * 100) : null,
+  };
+
+  const closedCounts = {
+    won: closedCountsRaw.find((r) => r.pipelineStage === 'WON')?._count._all ?? 0,
+    lost: closedCountsRaw.find((r) => r.pipelineStage === 'LOST')?._count._all ?? 0,
+  };
+
+  return {
+    columns,
+    closedCounts,
+    tray: trayCards,
+    kpis,
+    generatedAt: now.toISOString(),
+  };
+}

--- a/src/lib/leads/board-data.ts
+++ b/src/lib/leads/board-data.ts
@@ -8,11 +8,11 @@
  * scan of lead_events.
  */
 
+import { Prisma, type Lead } from '@prisma/client';
 import { prisma } from '@/lib/database/client';
-import type { Lead } from '@prisma/client';
-import { extractLeadFacts, temperatureFor } from './scoring';
+import { dateStrCT, extractLeadFacts, temperatureFor, SCORE_THRESHOLDS } from './scoring';
 import { isNewsletterOnly, sweepEnrollSubmitted } from './pipeline';
-import { PIPELINE_STAGES, type PipelineStage } from './pipeline-types';
+import { ACTIVE_STAGES, PIPELINE_STAGES, type PipelineStage } from './pipeline-types';
 import type { BoardData, BoardFilters, BoardKpis, BoardLead } from './board-types';
 
 export type { BoardData, BoardFilters, BoardKpis, BoardLead } from './board-types';
@@ -28,19 +28,22 @@ function displayName(lead: Lead): string {
 function toBoardLead(
   lead: Lead,
   ctx: {
-    lastSubmitAt: Date | null;
     hasFollowUp: boolean;
     isDuplicate: boolean;
     now: Date;
   },
 ): BoardLead {
   const facts = extractLeadFacts(lead.metadata);
-  const lastSignal = ctx.lastSubmitAt ?? lead.createdAt;
+  // Same signal as getHotLeadsNeedingReply so the nav badge and the board's
+  // "Needs response" KPI can never disagree (review #9).
+  const lastSignal = lead.lastActivityAt ?? lead.createdAt;
   const needsResponse =
     lead.lastContactedAt === null || lastSignal > lead.lastContactedAt;
+  // CT calendar day, not UTC — a 7pm CT board view must not mark today's
+  // event as already passed (review #6).
   const eventPassed =
-    facts.eventDate != null && facts.eventDate < ctx.now.toISOString().slice(0, 10);
-  const quietMs = ctx.now.getTime() - (lead.lastActivityAt ?? lead.updatedAt).getTime();
+    facts.eventDate != null && facts.eventDate.slice(0, 10) < dateStrCT(ctx.now);
+  const quietMs = ctx.now.getTime() - (lead.lastActivityAt ?? lead.createdAt).getTime();
   const isOpenStage =
     lead.pipelineStage !== 'WON' && lead.pipelineStage !== 'LOST' && lead.pipelineStage !== null;
   return {
@@ -96,13 +99,18 @@ export async function getHotLeadsNeedingReply(): Promise<{
   count: number;
   oldestWaitHours: number | null;
 }> {
+  // Threshold + stage list interpolated from the shared constants (still
+  // bind parameters) so tweaking SCORE_THRESHOLDS never leaves this stale.
+  const stages = Prisma.join(ACTIVE_STAGES.map((s) => Prisma.sql`${s}`));
   const rows = await prisma.$queryRaw<
     Array<{ count: number; oldest: Date | null }>
   >`
-    SELECT COUNT(*)::int AS count, MIN(stage_changed_at) AS oldest
+    SELECT COUNT(*)::int AS count,
+           -- "waiting since" = the unanswered activity, not the stage age
+           MIN(COALESCE(last_activity_at, stage_changed_at)) AS oldest
     FROM leads
-    WHERE pipeline_stage IN ('NEW', 'CONTACTED', 'QUALIFIED', 'QUOTE_SENT')
-      AND lead_score >= 70
+    WHERE pipeline_stage IN (${stages})
+      AND lead_score >= ${SCORE_THRESHOLDS.hot}
       AND (snoozed_until IS NULL OR snoozed_until <= NOW())
       AND (
         last_contacted_at IS NULL
@@ -155,24 +163,11 @@ export async function getBoardData(filters: BoardFilters = {}): Promise<BoardDat
   const all = [...boarded, ...tray];
   const ids = all.map((l) => l.id);
 
-  const [submitAgg, followUps] = await Promise.all([
-    prisma.leadEvent.groupBy({
-      by: ['leadId'],
-      where: {
-        leadId: { in: ids },
-        type: { in: ['FORM_SUBMIT', 'CHECKOUT_START'] },
-      },
-      _max: { occurredAt: true },
-    }),
-    prisma.followUpJob.groupBy({
-      by: ['leadId'],
-      where: { leadId: { in: ids }, status: { in: ['scheduled', 'sent'] } },
-      _count: { _all: true },
-    }),
-  ]);
-  const lastSubmitByLead = new Map(
-    submitAgg.map((r) => [r.leadId, r._max.occurredAt]),
-  );
+  const followUps = await prisma.followUpJob.groupBy({
+    by: ['leadId'],
+    where: { leadId: { in: ids }, status: { in: ['scheduled', 'sent'] } },
+    _count: { _all: true },
+  });
   const followUpLeads = new Set(followUps.map((r) => r.leadId));
 
   const emailCounts = new Map<string, number>();
@@ -183,7 +178,6 @@ export async function getBoardData(filters: BoardFilters = {}): Promise<BoardDat
 
   const toCard = (lead: Lead): BoardLead =>
     toBoardLead(lead, {
-      lastSubmitAt: lastSubmitByLead.get(lead.id) ?? null,
       hasFollowUp: followUpLeads.has(lead.id),
       isDuplicate: (emailCounts.get(lead.email?.toLowerCase() ?? '') ?? 0) > 1,
       now,

--- a/src/lib/leads/board-types.ts
+++ b/src/lib/leads/board-types.ts
@@ -1,0 +1,87 @@
+/**
+ * Lead Flow board — shared DTO types (Prisma-free so the /admin/leads client
+ * components can import them; the server aggregation lives in board-data.ts).
+ */
+
+import type { Temperature } from './scoring';
+import type { PipelineStage } from './pipeline-types';
+
+export interface BoardLead {
+  id: string;
+  name: string;
+  email: string | null;
+  phone: string | null;
+  stage: PipelineStage | null;
+  sortOrder: number;
+  score: number | null;
+  temperature: Temperature | null;
+  occasion: string | null;
+  eventDate: string | null;
+  headcount: number | null;
+  budgetPerPerson: number | null;
+  sourceWidget: string | null;
+  sourcePage: string | null;
+  owner: string | null;
+  needsResponse: boolean;
+  hasFollowUp: boolean;
+  isDuplicate: boolean;
+  snoozedUntil: string | null;
+  lastContactedAt: string | null;
+  lastActivityAt: string | null;
+  lostReason: string | null;
+  createdAt: string;
+  stageChangedAt: string | null;
+  /** Suggest-Lost chip: event date passed or quiet for 30 days. */
+  suggestLost: boolean;
+}
+
+export interface BoardKpis {
+  newThisWeek: number;
+  hot: number;
+  needsResponse: number;
+  won30d: number;
+  lost30d: number;
+  conversionPct: number | null;
+}
+
+export interface BoardData {
+  columns: Record<PipelineStage, BoardLead[]>;
+  closedCounts: { won: number; lost: number };
+  tray: BoardLead[];
+  kpis: BoardKpis;
+  generatedAt: string;
+}
+
+export interface BoardFilters {
+  temp?: Temperature;
+  occasion?: string;
+  source?: string;
+  q?: string;
+  showSnoozed?: boolean;
+  includePartial?: boolean;
+}
+
+/** Human labels for the board columns. */
+export const STAGE_LABELS: Record<PipelineStage, string> = {
+  NEW: 'New',
+  CONTACTED: 'Contacted',
+  QUALIFIED: 'Qualified',
+  QUOTE_SENT: 'Quote Sent',
+  WON: 'Won',
+  LOST: 'Lost',
+};
+
+/** Source-widget labels for cards/filters. */
+export const SOURCE_LABELS: Record<string, string> = {
+  QUICK_BUY: 'Quick Buy',
+  PACKAGE_BUILDER: 'Package Builder',
+  A_LA_CARTE: 'A La Carte',
+  CALL_BOOKING: 'Call Booking',
+  EMAIL_SIGNUP: 'Email Signup',
+  CONTACT_FORM: 'Contact / Quote',
+  DRINK_CALCULATOR: 'Calculator',
+  PARTNER_FAREHARBOR_WEBHOOK: 'Partner',
+  PARTNER_EMAIL_OPTIN: 'Partner',
+  PARTNER_LANDING_PAGE: 'Concierge',
+  OTHER: 'Site',
+};

--- a/src/lib/leads/scoring.ts
+++ b/src/lib/leads/scoring.ts
@@ -127,6 +127,40 @@ function extractBudgetPerPerson(meta: unknown): number | null {
   return m ? Number(m[1]) : null;
 }
 
+export interface LeadFacts {
+  occasion: string | null;
+  eventDate: string | null;
+  headcount: number | null;
+  budgetPerPerson: number | null;
+}
+
+/**
+ * Card-facing facts extracted from the per-surface metadata payloads.
+ * Shared by the board API so extraction rules live in exactly one place.
+ */
+export function extractLeadFacts(meta: unknown): LeadFacts {
+  const occasionCandidates = [
+    metaSection(meta, 'conciergeQuiz')?.partyType,
+    metaSection(meta, 'chatQuiz')?.partyType,
+    metaSection(meta, 'unifiedQuote')?.partyType,
+    metaSection(meta, 'eventQuiz')?.partyType,
+    metaSection(meta, 'contactForm')?.eventType,
+  ];
+  let occasion: string | null = null;
+  for (const c of occasionCandidates) {
+    if (typeof c === 'string' && c.trim()) {
+      occasion = c.trim();
+      break;
+    }
+  }
+  return {
+    occasion,
+    eventDate: extractEventDate(meta),
+    headcount: extractHeadcount(meta),
+    budgetPerPerson: extractBudgetPerPerson(meta),
+  };
+}
+
 function eventProximityPoints(meta: unknown, now: Date): number {
   // event-quiz has no date — only a today/tomorrow/future chip.
   const timing = metaSection(meta, 'eventQuiz')?.timing;

--- a/src/lib/ops/today-data.ts
+++ b/src/lib/ops/today-data.ts
@@ -10,6 +10,7 @@ import { prisma } from '@/lib/database/client';
 import { FinancialStatus, OrderStatus, Prisma } from '@prisma/client';
 import { getOrdersView } from './orders-view-data';
 import { getOpsEventSummaries } from '@/lib/events/ops-summary';
+import { getHotLeadsNeedingReply } from '@/lib/leads/board-data';
 import { todayCT } from './cooler-grouping';
 
 const LOW_STOCK_THRESHOLD = 10; // mirrors /api/v1/inventory
@@ -184,13 +185,16 @@ async function getRecsOpenCount(): Promise<number> {
 export async function getTodayData(role: 'admin' | 'employee'): Promise<TodayData> {
   const now = new Date();
 
-  const [view, stock, carts, lastWeekRevenue, events, recsOpen] = await Promise.all([
+  const [view, stock, carts, lastWeekRevenue, events, recsOpen, hotLeads] = await Promise.all([
     getOrdersView({ days: 1 }),
     getStockCounts(),
     getUnpaidCartSummary(now),
     getLastWeekSameDayRevenue(),
     getOpsEventSummaries(),
     role === 'admin' ? getRecsOpenCount() : Promise.resolve(0),
+    role === 'admin'
+      ? getHotLeadsNeedingReply().catch(() => ({ count: 0, oldestWaitHours: null }))
+      : Promise.resolve({ count: 0, oldestWaitHours: null }),
   ]);
 
   const todayKey = todayCT();
@@ -273,6 +277,18 @@ export async function getTodayData(role: 'admin' | 'employee'): Promise<TodayDat
       title: `${carts.staleCount} unpaid cart${carts.staleCount === 1 ? '' : 's'} sitting >24h`,
       actionLabel: 'Nudge',
       href: '/ops/orders?view=carts',
+    });
+  }
+  if (hotLeads.count > 0) {
+    // Admin-only by construction (count is 0 for employees, and the href is
+    // an admin route the client redirect would bounce them from anyway).
+    triage.push({
+      key: 'hot-leads',
+      severity: (hotLeads.oldestWaitHours ?? 0) > 48 ? 'red' : 'amber',
+      badge: 'LEADS',
+      title: `${hotLeads.count} hot lead${hotLeads.count === 1 ? '' : 's'} waiting on a reply`,
+      actionLabel: 'Open board',
+      href: '/admin/leads?temp=hot',
     });
   }
   if (stock.low > 0) {


### PR DESCRIPTION
Part 2 of 3 (stacked on #241). The working surface: a drag-drop Kanban for every inbound lead.

## What
- Board at `/admin/leads`: six stage columns (New → Contacted → Qualified → Quote Sent → Won → Lost, Won/Lost windowed to 30 days with all-time counts), an "Uncommitted" tray for incomplete leads behind a toggle, KPI strip, temperature/source/search filters (search debounced)
- Cards: temperature badge + score, occasion, CT-safe event countdown, headcount/budget, source, needs-response dot, follow-up icon, duplicate flag, snooze dimming
- Drawer (deep-linkable `?lead=<id>` — the URL GHL notifications carry): stage picker with confirms (Won in/out, Lost reason prompt), owner, snooze, score breakdown, matched orders & quotes (group payments flagged as "possible win" needing confirmation), autosaving notes, merged timeline (site events + emails + follow-ups)
- Drag-drop via dnd-kit (same versions as the CRM fork); mobile long-press drag + tap-to-open stage picker; optimistic moves that re-sync from the server on failure; request-sequence guard against out-of-order fetches; error state with retry
- APIs under `/api/v1/admin/leads/*` (middleware session gate + in-route `requireAdminRole`, zod everywhere): board GET (runs the enroll sweep so the board is always fresh), detail GET, PATCH meta, PATCH stage
- Shell: Leads nav entry + funnel icon + `leadsHot` badge (admin-role-branched in nav-badges), `/ops/today` triage row "hot leads waiting on a reply" (amber → red past 48h, admin-gated)
- Brian's Stuff leads tab keeps working: banner link + old `?lead=` deep links carry through to the board

## Review hardening (independent code review, fixed in-branch)
Needs-response signal unified with the nav badge; CT (not UTC) day for "event passed"; shared CT date math on cards; SQL literals from shared constants; wait-time measured from the unanswered activity; text-size conventions.

## Verified
tsc/lint/tests green; board aggregation + hot-leads SQL exercised against the live database; unauthenticated probes on all new routes return 401 and the page compiles/serves on a dev server. Not verified: authenticated drag interaction in a real browser (auto-mode boundary — please click around after deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)