### PR TITLE
feat(leads): in-card email replies + CoreLinq lead.captured fan-out

### DIFF
--- a/src/app/admin/leads/_components/lead-drawer.tsx
+++ b/src/app/admin/leads/_components/lead-drawer.tsx
@@ -17,7 +17,7 @@ const OWNERS = ['', 'Allan', 'Brian'];
 /**
  * Card detail drawer — BottomSheet on all sizes (portaled, esc-closes).
  * Stage buttons confirm the destructive-feeling moves; Lost prompts for a
- * reason. The reply composer lands here in the follow-up PR.
+ * reason. Includes the 1:1 email reply composer.
  */
 export default function LeadDrawer({
   leadId,

--- a/src/app/admin/leads/_components/lead-drawer.tsx
+++ b/src/app/admin/leads/_components/lead-drawer.tsx
@@ -9,6 +9,7 @@ import { temperatureFor } from '@/lib/leads/scoring';
 import type { LeadMutations } from './use-lead-mutations';
 import type { LeadDetail } from './drawer-types';
 import DrawerTimeline from './drawer-timeline';
+import ReplyComposer from './reply-composer';
 
 const TEMP_VARIANT = { hot: 'red', warm: 'amber', cold: 'gray' } as const;
 const OWNERS = ['', 'Allan', 'Brian'];
@@ -222,6 +223,20 @@ export default function LeadDrawer({
                 </ul>
               </section>
             )}
+
+            <section className="mt-4">
+              <h3 className="font-heading font-bold text-sm tracking-[0.1em] uppercase text-gray-500">
+                Reply by email
+              </h3>
+              <div className="mt-2">
+                <ReplyComposer
+                  leadId={lead.id}
+                  leadEmail={lead.email}
+                  defaultSubject="Your Party On Delivery inquiry"
+                  onSent={() => void load()}
+                />
+              </div>
+            </section>
 
             <section className="mt-4">
               <h3 className="font-heading font-bold text-sm tracking-[0.1em] uppercase text-gray-500">

--- a/src/app/admin/leads/_components/reply-composer.tsx
+++ b/src/app/admin/leads/_components/reply-composer.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { ReactElement, useState } from 'react';
+
+/**
+ * 1:1 email composer on the lead card. Sends via the reply route (Resend,
+ * from/reply-to info@); success logs to the timeline and auto-moves NEW →
+ * Contacted, so the parent reloads on send.
+ */
+export default function ReplyComposer({
+  leadId,
+  leadEmail,
+  defaultSubject,
+  onSent,
+}: {
+  leadId: string;
+  leadEmail: string | null;
+  defaultSubject: string;
+  onSent: () => void;
+}): ReactElement {
+  const [subject, setSubject] = useState(defaultSubject);
+  const [body, setBody] = useState('');
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sentAt, setSentAt] = useState<string | null>(null);
+
+  if (!leadEmail) {
+    return (
+      <p className="text-sm text-gray-400">
+        No email on this lead — text them via GHL instead.
+      </p>
+    );
+  }
+
+  const send = async (): Promise<void> => {
+    if (!subject.trim() || !body.trim() || sending) return;
+    setSending(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/v1/admin/leads/${leadId}/reply`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ subject: subject.trim(), body: body.trim() }),
+      });
+      const payload = await res.json().catch(() => null);
+      if (res.ok) {
+        setBody('');
+        setSentAt(new Date().toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }));
+        onSent();
+      } else if (payload?.error === 'recipient_suppressed') {
+        setError('This address unsubscribed — email is blocked. Use GHL/phone instead.');
+      } else if (payload?.error === 'lead_has_no_email') {
+        setError('No email on this lead.');
+      } else {
+        setError('Send failed — try again.');
+      }
+    } catch {
+      setError('Send failed — try again.');
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <input
+        type="text"
+        value={subject}
+        onChange={(e) => setSubject(e.target.value)}
+        maxLength={200}
+        placeholder="Subject"
+        className="w-full rounded-lg border border-gray-300 p-2 text-base"
+        aria-label="Email subject"
+      />
+      <textarea
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        rows={5}
+        maxLength={10_000}
+        placeholder={`Reply to ${leadEmail} — sends from info@partyondelivery.com`}
+        className="w-full rounded-lg border border-gray-300 p-2 text-base"
+        aria-label="Email body"
+      />
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      {sentAt && !error && <p className="text-sm text-green-700">Sent at {sentAt}.</p>}
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={() => void send()}
+          disabled={sending || !subject.trim() || !body.trim()}
+          className="btn-primary min-h-[40px] px-4 disabled:opacity-50"
+        >
+          {sending ? 'Sending…' : 'Send email'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -16,6 +16,7 @@ import { upsertLead } from '@/lib/leads/leadCapture';
 import { enqueueJourney } from '@/lib/followups/enqueue';
 import { checkRateLimit } from '@/lib/security/rate-limit';
 import { mirrorLeadToSheet } from '@/lib/premier/pod-leads-sheet';
+import { mirrorLeadToCrm } from '@/lib/leads/crm-mirror';
 
 const bodySchema = z.object({
   name: z.string().trim().min(1, 'Name is required').max(120),
@@ -142,22 +143,23 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // Mirror to the POD Leads Google Sheet. AWAITED — Vercel kills
-    // un-awaited promises when the response returns. Never throws.
-    await mirrorLeadToSheet({
-      source: 'contact-form',
-      firstName: firstName || '',
-      lastName: restName.join(' '),
-      email: body.email,
-      phone: body.phone || '',
-      arrivalDate: body.eventDate || '',
-      partyType: body.eventType || '',
-      headcount: body.guestCount ?? '',
-      notes: body.message.slice(0, 500),
-      leadUrl: leadId
-        ? `https://partyondelivery.com/admin/brians-stuff?tab=leads&lead=${leadId}`
-        : '',
-    });
+    // Mirror to the POD Leads Google Sheet + CoreLinq CRM. AWAITED — Vercel
+    // kills un-awaited promises when the response returns. Never throw.
+    await Promise.allSettled([
+      mirrorLeadToSheet({
+        source: 'contact-form',
+        firstName: firstName || '',
+        lastName: restName.join(' '),
+        email: body.email,
+        phone: body.phone || '',
+        arrivalDate: body.eventDate || '',
+        partyType: body.eventType || '',
+        headcount: body.guestCount ?? '',
+        notes: body.message.slice(0, 500),
+        leadUrl: leadId ? `https://partyondelivery.com/admin/leads?lead=${leadId}` : '',
+      }),
+      mirrorLeadToCrm({ leadId }, 'contact-form'),
+    ]);
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/v1/admin/leads/[id]/reply/route.ts
+++ b/src/app/api/v1/admin/leads/[id]/reply/route.ts
@@ -14,7 +14,11 @@ import { prisma } from '@/lib/database/client';
 import { requireAdminRole } from '@/lib/auth/ops-session';
 import { sendEmailDetailed } from '@/lib/email/resend-client';
 import { buildLeadReplyEmail } from '@/lib/email/templates/lead-reply';
-import { recomputeLeadScore, transitionStage } from '@/lib/leads/pipeline';
+import {
+  enrollLeadIfEligible,
+  recomputeLeadScore,
+  transitionStage,
+} from '@/lib/leads/pipeline';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -84,26 +88,35 @@ export async function POST(
     );
   }
 
-  const now = new Date();
-  await prisma.leadEvent.create({
-    data: {
-      leadId: lead.id,
-      type: 'CUSTOM',
-      metadata: {
-        kind: 'email.reply',
-        emailLogId: result.emailLogId,
-        subject: email.subject,
-        sender: senderName,
-      } as never,
-    },
-  });
-  await prisma.lead.update({
-    where: { id: lead.id },
-    data: { lastContactedAt: now },
-  });
-  // Forward-only: a reply from NEW means the conversation started.
-  await transitionStage(lead.id, 'CONTACTED', { via: 'reply', onlyFrom: ['NEW'] });
-  await recomputeLeadScore(lead.id).catch(() => undefined);
+  // The email is OUT — a bookkeeping failure past this point must return
+  // success anyway, or the composer's "try again" would double-send the
+  // customer (review #11).
+  try {
+    const now = new Date();
+    await prisma.leadEvent.create({
+      data: {
+        leadId: lead.id,
+        type: 'CUSTOM',
+        metadata: {
+          kind: 'email.reply',
+          emailLogId: result.emailLogId,
+          subject: email.subject,
+          sender: senderName,
+        } as never,
+      },
+    });
+    await prisma.lead.update({
+      where: { id: lead.id },
+      data: { lastContactedAt: now },
+    });
+    // Replying IS working the lead — a tray (off-board) lead gets a card
+    // (review #12), and a reply from NEW starts the conversation.
+    await enrollLeadIfEligible(lead.id, { allowPartial: true });
+    await transitionStage(lead.id, 'CONTACTED', { via: 'reply', onlyFrom: ['NEW'] });
+    await recomputeLeadScore(lead.id).catch(() => undefined);
+  } catch (err) {
+    console.error('[leads/reply] post-send bookkeeping failed (email WAS sent)', err);
+  }
 
   return NextResponse.json({
     success: true,

--- a/src/app/api/v1/admin/leads/[id]/reply/route.ts
+++ b/src/app/api/v1/admin/leads/[id]/reply/route.ts
@@ -1,0 +1,112 @@
+/**
+ * POST /api/v1/admin/leads/[id]/reply — send a 1:1 email to a lead from the
+ * board's composer.
+ *
+ * Flow: admin auth → lead has an email → suppression-respecting Resend send
+ * (from/reply-to info@) → EmailLog (linked via metadata.leadId) → LeadEvent
+ * (kind: email.reply) → last_contacted_at stamp → auto NEW→CONTACTED →
+ * score recompute. 409s surface suppression to the composer.
+ */
+import { NextResponse, type NextRequest } from 'next/server';
+import { z } from 'zod';
+import { EmailType } from '@prisma/client';
+import { prisma } from '@/lib/database/client';
+import { requireAdminRole } from '@/lib/auth/ops-session';
+import { sendEmailDetailed } from '@/lib/email/resend-client';
+import { buildLeadReplyEmail } from '@/lib/email/templates/lead-reply';
+import { recomputeLeadScore, transitionStage } from '@/lib/leads/pipeline';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const REPLY_FROM_EMAIL = 'info@partyondelivery.com';
+
+const bodySchema = z.object({
+  subject: z.string().min(1).max(200),
+  body: z.string().min(1).max(10_000),
+});
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const auth = await requireAdminRole();
+  if (auth instanceof NextResponse) return auth;
+  const { id } = await params;
+
+  let input: z.infer<typeof bodySchema>;
+  try {
+    input = bodySchema.parse(await req.json());
+  } catch {
+    return NextResponse.json({ success: false, error: 'invalid_body' }, { status: 400 });
+  }
+
+  const lead = await prisma.lead.findUnique({ where: { id } });
+  if (!lead) {
+    return NextResponse.json({ success: false, error: 'not_found' }, { status: 404 });
+  }
+  if (!lead.email) {
+    return NextResponse.json(
+      { success: false, error: 'lead_has_no_email' },
+      { status: 409 },
+    );
+  }
+
+  const senderName = lead.owner || 'Allan';
+  const email = buildLeadReplyEmail({
+    subject: input.subject,
+    body: input.body,
+    senderName,
+  });
+
+  const result = await sendEmailDetailed({
+    to: lead.email,
+    subject: email.subject,
+    html: email.html,
+    text: email.text,
+    type: EmailType.LEAD_REPLY,
+    metadata: { leadId: lead.id },
+    from: { email: REPLY_FROM_EMAIL, name: `${senderName} at Party On Delivery` },
+    replyTo: REPLY_FROM_EMAIL,
+    respectSuppression: true,
+  });
+
+  if (result.suppressed) {
+    return NextResponse.json(
+      { success: false, error: 'recipient_suppressed' },
+      { status: 409 },
+    );
+  }
+  if (!result.sent) {
+    return NextResponse.json(
+      { success: false, error: result.error ?? 'send_failed' },
+      { status: 502 },
+    );
+  }
+
+  const now = new Date();
+  await prisma.leadEvent.create({
+    data: {
+      leadId: lead.id,
+      type: 'CUSTOM',
+      metadata: {
+        kind: 'email.reply',
+        emailLogId: result.emailLogId,
+        subject: email.subject,
+        sender: senderName,
+      } as never,
+    },
+  });
+  await prisma.lead.update({
+    where: { id: lead.id },
+    data: { lastContactedAt: now },
+  });
+  // Forward-only: a reply from NEW means the conversation started.
+  await transitionStage(lead.id, 'CONTACTED', { via: 'reply', onlyFrom: ['NEW'] });
+  await recomputeLeadScore(lead.id).catch(() => undefined);
+
+  return NextResponse.json({
+    success: true,
+    data: { emailLogId: result.emailLogId },
+  });
+}

--- a/src/app/api/v1/chat/submit/route.ts
+++ b/src/app/api/v1/chat/submit/route.ts
@@ -24,6 +24,7 @@ import { targetUrlFor } from '@/lib/eventQuiz/routing';
 import { recommendForChat } from '@/lib/chat/recommendation';
 import { isLastMinuteDate } from '@/lib/lastMinute/dates';
 import { mirrorLeadToSheet } from '@/lib/premier/pod-leads-sheet';
+import { mirrorLeadToCrm } from '@/lib/leads/crm-mirror';
 import { EmailType } from '@prisma/client';
 import { prisma } from '@/lib/database/client';
 
@@ -197,21 +198,22 @@ export async function POST(req: NextRequest) {
   // last-minute mode (delivery date is today or tomorrow in Austin TZ).
   const isLastMinute = isLastMinuteDate(body.deliveryDate);
 
-  // Mirror to the POD Leads Google Sheet. AWAITED — Vercel kills
-  // un-awaited promises when the response returns. Never throws.
-  await mirrorLeadToSheet({
-    source: 'party-chat',
-    firstName: body.firstName,
-    lastName: body.lastName ?? '',
-    email: body.email,
-    phone: body.phone ?? '',
-    arrivalDate: body.deliveryDate,
-    partyType: body.partyType,
-    headcount: body.headcount,
-    leadUrl: leadId
-      ? `https://partyondelivery.com/admin/brians-stuff?tab=leads&lead=${leadId}`
-      : '',
-  });
+  // Mirror to the POD Leads Google Sheet + CoreLinq CRM. AWAITED — Vercel
+  // kills un-awaited promises when the response returns. Never throw.
+  await Promise.allSettled([
+    mirrorLeadToSheet({
+      source: 'party-chat',
+      firstName: body.firstName,
+      lastName: body.lastName ?? '',
+      email: body.email,
+      phone: body.phone ?? '',
+      arrivalDate: body.deliveryDate,
+      partyType: body.partyType,
+      headcount: body.headcount,
+      leadUrl: leadId ? `https://partyondelivery.com/admin/leads?lead=${leadId}` : '',
+    }),
+    mirrorLeadToCrm({ leadId }, 'party-chat'),
+  ]);
 
   return NextResponse.json({
     ok: true,

--- a/src/app/api/v1/concierge/lead/route.ts
+++ b/src/app/api/v1/concierge/lead/route.ts
@@ -30,6 +30,7 @@ import { prisma } from '@/lib/database/client';
 import { upsertLead, recordEvent } from '@/lib/leads/leadCapture';
 import { attributionSchema, compactAttribution } from '@/lib/leads/attribution-schema';
 import { notifyConciergeLead } from '@/lib/webhooks/ghl';
+import { mirrorLeadToCrm } from '@/lib/leads/crm-mirror';
 import {
   appendLeadToPodLeadsSheet,
   formatCentralTimestamp,
@@ -213,9 +214,11 @@ export async function POST(req: NextRequest) {
   // ─── 2) Compose the tag array for GHL ────────────────────────────
   const tags = buildTags(body);
   const now = new Date();
+  // Deep link to the Lead Flow board (old brians-stuff URLs in GHL history
+  // still work — the leads tab forwards ?lead= to the board).
   const leadUrl = leadId
-    ? `https://partyondelivery.com/admin/brians-stuff?tab=leads&lead=${leadId}`
-    : 'https://partyondelivery.com/admin/brians-stuff?tab=leads';
+    ? `https://partyondelivery.com/admin/leads?lead=${leadId}`
+    : 'https://partyondelivery.com/admin/leads';
 
   // ─── 3) Side effects — ALL AWAITED ───────────────────────────────
   // GHL + email + sheet MUST be awaited before the response returns:
@@ -223,6 +226,10 @@ export async function POST(req: NextRequest) {
   // fire-and-forget promise gets killed mid-flight. That's exactly how
   // the founder's first bachelorette test lead vanished from the sheet.
   const sideEffects: Promise<unknown>[] = [];
+
+  // CoreLinq CRM lead mirror (inert until CORELINQ_INGEST_URL is set;
+  // internally never-throwing).
+  sideEffects.push(mirrorLeadToCrm({ leadId }, body.source));
 
   // GHL webhook (no-op until GHL_CONCIERGE_LEAD_WEBHOOK_URL is set;
   // internally never-throwing).

--- a/src/app/api/v1/event-quiz/submit/route.ts
+++ b/src/app/api/v1/event-quiz/submit/route.ts
@@ -24,6 +24,7 @@ import { upsertLead, recordEvent } from '@/lib/leads/leadCapture';
 import { targetUrlFor } from '@/lib/eventQuiz/routing';
 import { enqueueJourney } from '@/lib/followups/enqueue';
 import { mirrorLeadToSheet } from '@/lib/premier/pod-leads-sheet';
+import { mirrorLeadToCrm } from '@/lib/leads/crm-mirror';
 import { EmailType } from '@prisma/client';
 import { prisma } from '@/lib/database/client';
 
@@ -182,21 +183,22 @@ export async function POST(req: NextRequest) {
     }
   }
 
-  // Mirror to the POD Leads Google Sheet. AWAITED — Vercel kills
-  // un-awaited promises when the response returns. Never throws.
-  await mirrorLeadToSheet({
-    source: 'event-quiz',
-    firstName: body.firstName,
-    lastName: body.lastName ?? '',
-    email: body.email,
-    phone: body.phone ?? '',
-    partyType: body.partyType,
-    activities: body.needs.join(', '),
-    notes: `timing: ${body.timing}`,
-    leadUrl: leadId
-      ? `https://partyondelivery.com/admin/brians-stuff?tab=leads&lead=${leadId}`
-      : '',
-  });
+  // Mirror to the POD Leads Google Sheet + CoreLinq CRM. AWAITED — Vercel
+  // kills un-awaited promises when the response returns. Never throw.
+  await Promise.allSettled([
+    mirrorLeadToSheet({
+      source: 'event-quiz',
+      firstName: body.firstName,
+      lastName: body.lastName ?? '',
+      email: body.email,
+      phone: body.phone ?? '',
+      partyType: body.partyType,
+      activities: body.needs.join(', '),
+      notes: `timing: ${body.timing}`,
+      leadUrl: leadId ? `https://partyondelivery.com/admin/leads?lead=${leadId}` : '',
+    }),
+    mirrorLeadToCrm({ leadId }, 'event-quiz'),
+  ]);
 
   return NextResponse.json({
     ok: true,

--- a/src/app/api/v1/landing/quote/route.ts
+++ b/src/app/api/v1/landing/quote/route.ts
@@ -27,6 +27,7 @@ import { sendEmail } from '@/lib/email/resend-client';
 import { attributionSchema, attributionNoteLine } from '@/lib/leads/attribution-schema';
 import { cancelJobsForEmail, enqueueJourney } from '@/lib/followups/enqueue';
 import { mirrorLeadToSheet } from '@/lib/premier/pod-leads-sheet';
+import { mirrorLeadToCrm } from '@/lib/leads/crm-mirror';
 import { EmailType, DraftOrderStatus } from '@prisma/client';
 
 export const dynamic = 'force-dynamic';
@@ -248,21 +249,26 @@ export async function POST(request: NextRequest) {
       console.warn('[landing/quote] abandoned-quote cancel failed:', err);
     }
 
-    // Mirror to the POD Leads Google Sheet. AWAITED — Vercel kills
-    // un-awaited promises when the response returns. Never throws.
+    // Mirror to the POD Leads Google Sheet + CoreLinq CRM. AWAITED — Vercel
+    // kills un-awaited promises when the response returns. Never throw.
+    // (No Lead row in scope here — the pixel creates it client-side, so the
+    // CRM mirror resolves by email.)
     const nameParts = (body.customerName ?? '').trim().split(/\s+/);
-    await mirrorLeadToSheet({
-      source: `quickbuy:${body.occasion}`,
-      firstName: nameParts[0] ?? '',
-      lastName: nameParts.slice(1).join(' '),
-      email: body.customerEmail,
-      phone: body.customerPhone ?? '',
-      arrivalDate: body.deliveryDate,
-      partyType: body.occasion,
-      headcount: body.groupSize,
-      notes: `${body.mode} · invoice: ${draftOrder.token} · $${Number(draftOrder.total).toFixed(2)}`,
-      leadUrl: invoiceUrl,
-    });
+    await Promise.allSettled([
+      mirrorLeadToSheet({
+        source: `quickbuy:${body.occasion}`,
+        firstName: nameParts[0] ?? '',
+        lastName: nameParts.slice(1).join(' '),
+        email: body.customerEmail,
+        phone: body.customerPhone ?? '',
+        arrivalDate: body.deliveryDate,
+        partyType: body.occasion,
+        headcount: body.groupSize,
+        notes: `${body.mode} · invoice: ${draftOrder.token} · $${Number(draftOrder.total).toFixed(2)}`,
+        leadUrl: invoiceUrl,
+      }),
+      mirrorLeadToCrm({ email: body.customerEmail }, `quickbuy:${body.occasion}`),
+    ]);
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/v1/quote/start/route.ts
+++ b/src/app/api/v1/quote/start/route.ts
@@ -35,6 +35,7 @@ import { targetUrlFor } from '@/lib/eventQuiz/routing';
 import { createDashboardOrder, addDraftItem } from '@/lib/group-orders-v2/service';
 import { isLastMinuteDate } from '@/lib/lastMinute/dates';
 import { mirrorLeadToSheet } from '@/lib/premier/pod-leads-sheet';
+import { mirrorLeadToCrm } from '@/lib/leads/crm-mirror';
 import { prisma } from '@/lib/database/client';
 import { EmailType } from '@prisma/client';
 import type { PartyType as DashboardPartyType, DeliveryContextType } from '@/lib/group-orders-v2/types';
@@ -306,23 +307,24 @@ export async function POST(req: NextRequest) {
     }
   }
 
-  // Mirror to the POD Leads Google Sheet. AWAITED — Vercel kills
-  // un-awaited promises when the response returns. Never throws.
-  await mirrorLeadToSheet({
-    source: `quote-start:${body.source}`,
-    firstName: body.firstName,
-    lastName: body.lastName ?? '',
-    email: body.email,
-    phone: body.phone ?? '',
-    arrivalDate: body.deliveryDate,
-    partyType: body.partyType,
-    headcount: body.headcount,
-    activities: body.recommendedItems.map((r) => r.handle).join(', '),
-    notes: shareCode ? `dashboard: ${shareCode}` : '',
-    leadUrl: leadId
-      ? `https://partyondelivery.com/admin/brians-stuff?tab=leads&lead=${leadId}`
-      : '',
-  });
+  // Mirror to the POD Leads Google Sheet + CoreLinq CRM. AWAITED — Vercel
+  // kills un-awaited promises when the response returns. Never throw.
+  await Promise.allSettled([
+    mirrorLeadToSheet({
+      source: `quote-start:${body.source}`,
+      firstName: body.firstName,
+      lastName: body.lastName ?? '',
+      email: body.email,
+      phone: body.phone ?? '',
+      arrivalDate: body.deliveryDate,
+      partyType: body.partyType,
+      headcount: body.headcount,
+      activities: body.recommendedItems.map((r) => r.handle).join(', '),
+      notes: shareCode ? `dashboard: ${shareCode}` : '',
+      leadUrl: leadId ? `https://partyondelivery.com/admin/leads?lead=${leadId}` : '',
+    }),
+    mirrorLeadToCrm({ leadId }, `quote-start:${body.source}`),
+  ]);
 
   // Always return a redirectTo. If the dashboard create failed we fall
   // back to the matching landing page so the user isn't stranded.

--- a/src/lib/email/resend-client.ts
+++ b/src/lib/email/resend-client.ts
@@ -125,9 +125,10 @@ export async function sendEmailDetailed(
     },
   });
 
-  // If Resend is not configured, log and return
+  // If Resend is not configured, log and return (no recipient/subject at
+  // INFO — the EmailLog row above holds them; PII rule from 85d4159f)
   if (!resend) {
-    console.log('[Email] Would send email:', { to, subject, type });
+    console.log('[Email] Would send email:', { type, emailLogId: emailLog.id });
     await prisma.emailLog.update({
       where: { id: emailLog.id },
       data: {

--- a/src/lib/email/resend-client.ts
+++ b/src/lib/email/resend-client.ts
@@ -51,6 +51,9 @@ export interface SendEmailOptions {
   tags?: Array<{ name: string; value: string }>;
   /** Extra headers (e.g. List-Unsubscribe) */
   headers?: Record<string, string>;
+  /** Reply-To mailbox — where customer replies land (e.g. info@ for 1:1
+      lead replies; without this they'd route to the From default). */
+  replyTo?: string;
 }
 
 /**
@@ -95,13 +98,15 @@ export async function sendEmail(options: SendEmailOptions): Promise<string | nul
 export async function sendEmailDetailed(
   options: SendEmailDetailedOptions
 ): Promise<SendEmailDetailedResult> {
-  const { to, cc, subject, html, text, type, orderId, customerId, draftOrderId, metadata, attachments, tags, headers, from, respectSuppression } = options;
+  const { to, cc, subject, html, text, type, orderId, customerId, draftOrderId, metadata, attachments, tags, headers, replyTo, from, respectSuppression } = options;
 
   if (respectSuppression) {
     // Lazy import keeps the common transactional path free of the check.
     const { isSuppressed } = await import('@/lib/followups/suppression');
     if (await isSuppressed(to)) {
-      console.log('[Email] Skipped (suppressed):', { to, subject, type });
+      // No recipient/subject at INFO (PII rule, commit 85d4159f) — the
+      // suppression row itself is the queryable record.
+      console.log('[Email] Skipped (suppressed):', { type });
       return { sent: false, emailLogId: null, resendId: null, suppressed: true };
     }
   }
@@ -144,6 +149,7 @@ export async function sendEmailDetailed(
       subject,
       html,
       text,
+      ...(replyTo ? { replyTo } : {}),
       ...(attachments && attachments.length > 0 ? { attachments } : {}),
       ...(tags && tags.length > 0 ? { tags } : {}),
       ...(headers && Object.keys(headers).length > 0 ? { headers } : {}),
@@ -157,7 +163,7 @@ export async function sendEmailDetailed(
         where: { id: emailLog.id },
         data: { status: EmailStatus.FAILED, errorMessage },
       });
-      console.error('[Email] Failed to send:', { to, subject, type, error: result.error });
+      console.error('[Email] Failed to send:', { type, emailLogId: emailLog.id, error: result.error });
       return { sent: false, emailLogId: emailLog.id, resendId: null, error: errorMessage };
     }
 
@@ -171,7 +177,8 @@ export async function sendEmailDetailed(
       },
     });
 
-    console.log('[Email] Sent successfully:', { to, subject, type, resendId: result.data?.id });
+    // Recipient/subject live on the EmailLog row — keep INFO logs PII-free.
+    console.log('[Email] Sent successfully:', { type, emailLogId: emailLog.id, resendId: result.data?.id });
     return { sent: true, emailLogId: emailLog.id, resendId: result.data?.id || null };
   } catch (error) {
     // Update log with error
@@ -184,7 +191,7 @@ export async function sendEmailDetailed(
       },
     });
 
-    console.error('[Email] Failed to send:', { to, subject, type, error: errorMessage });
+    console.error('[Email] Failed to send:', { type, emailLogId: emailLog.id, error: errorMessage });
     return { sent: false, emailLogId: emailLog.id, resendId: null, error: errorMessage };
   }
 }

--- a/src/lib/email/templates/lead-reply.ts
+++ b/src/lib/email/templates/lead-reply.ts
@@ -1,0 +1,60 @@
+/**
+ * Lead Flow board — 1:1 reply email wrapper.
+ *
+ * Deliberately personal-looking: plain paragraphs, a human signature, no
+ * marketing chrome. Staff type the body in the board's composer; everything
+ * lead-derived or staff-typed is HTML-escaped (the body is trusted staff
+ * input, but escaping keeps a pasted "<" from breaking rendering, and the
+ * subject is newline-stripped so headers can't be injected).
+ *
+ * A 1:1 human reply is relationship/transactional content, but we keep the
+ * physical-address line anyway (it reads like a normal business signature).
+ */
+
+export const LEAD_REPLY_POSTAL_ADDRESS = '7600 N Lamar #A2, Austin, TX 78752';
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/** Strip CR/LF so a subject can never smuggle extra headers. */
+export function sanitizeSubject(subject: string): string {
+  return subject.replace(/[\r\n]+/g, ' ').trim().slice(0, 200);
+}
+
+export interface LeadReplyEmail {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+export function buildLeadReplyEmail(opts: {
+  subject: string;
+  body: string;
+  senderName: string;
+}): LeadReplyEmail {
+  const subject = sanitizeSubject(opts.subject);
+  const signature = `${opts.senderName}\nParty On Delivery\n(512) 660-6025 · partyondelivery.com`;
+  const text = `${opts.body}\n\n${signature}\n\nParty On Delivery · ${LEAD_REPLY_POSTAL_ADDRESS}`;
+
+  const paragraphs = `${opts.body}\n\n${signature}`
+    .split(/\n{2,}/)
+    .map(
+      (p) =>
+        `<p style="margin:0 0 16px;">${escapeHtml(p).replace(/\n/g, '<br/>')}</p>`,
+    )
+    .join('\n');
+
+  const html = `<div style="font-family:Arial,Helvetica,sans-serif;font-size:15px;line-height:1.6;color:#1f2937;max-width:600px;">
+${paragraphs}
+<p style="margin:24px 0 0;font-size:12px;color:#6b7280;">Party On Delivery · ${escapeHtml(
+    LEAD_REPLY_POSTAL_ADDRESS,
+  )}</p>
+</div>`;
+
+  return { subject, html, text };
+}

--- a/src/lib/leads/crm-mirror.ts
+++ b/src/lib/leads/crm-mirror.ts
@@ -1,0 +1,66 @@
+/**
+ * Lead Flow → CoreLinq CRM mirror.
+ *
+ * One helper the six submit routes call after their Lead write: fetches the
+ * fresh row, flattens the board facts, and fans out a `lead.captured` event
+ * via postToCoreLinq. Inert until CORELINQ_INGEST_URL is set (which waits on
+ * the fork accepting the event — see the partyon-crm follow-up PR).
+ *
+ * Never throws: a CRM mirror hiccup must not break a customer form submit.
+ */
+
+import { prisma } from '@/lib/database/client';
+import { notifyLeadCaptured } from '@/lib/webhooks/ghl';
+import { normalizeEmail } from './email-validation';
+import { extractLeadFacts, temperatureFor } from './scoring';
+
+const SITE_URL = 'https://partyondelivery.com';
+
+/** Deep link to a card on the Lead Flow board. */
+export function leadBoardUrl(leadId: string): string {
+  return `${SITE_URL}/admin/leads?lead=${leadId}`;
+}
+
+export interface LeadRef {
+  leadId?: string | null;
+  /** Fallback for routes with no Lead in scope (landing/quote — the pixel
+      creates the row client-side); resolves to the newest match. */
+  email?: string | null;
+}
+
+export async function mirrorLeadToCrm(ref: LeadRef, source: string): Promise<void> {
+  try {
+    const email = normalizeEmail(ref.email);
+    const lead = ref.leadId
+      ? await prisma.lead.findUnique({ where: { id: ref.leadId } })
+      : email
+        ? await prisma.lead.findFirst({ where: { email }, orderBy: { createdAt: 'desc' } })
+        : null;
+    if (!lead) return;
+    const facts = extractLeadFacts(lead.metadata);
+    await notifyLeadCaptured({
+      event: 'lead.captured',
+      leadId: lead.id,
+      first_name: lead.firstName ?? '',
+      last_name: lead.lastName ?? '',
+      email: lead.email ?? '',
+      phone: lead.phone ?? '',
+      source,
+      sourcePage: lead.sourcePage ?? '',
+      occasion: facts.occasion ?? '',
+      eventDate: facts.eventDate ?? '',
+      headcount: facts.headcount,
+      budgetPerPerson: facts.budgetPerPerson != null ? String(facts.budgetPerPerson) : '',
+      score: lead.leadScore,
+      temperature: temperatureFor(lead.leadScore) ?? '',
+      pipelineStage: lead.pipelineStage ?? '',
+      utmSource: lead.utmSource ?? '',
+      utmMedium: lead.utmMedium ?? '',
+      utmCampaign: lead.utmCampaign ?? '',
+      leadUrl: leadBoardUrl(lead.id),
+      capturedAt: new Date().toISOString(),
+    });
+  } catch (err) {
+    console.warn('[crm-mirror] lead.captured mirror failed', err);
+  }
+}

--- a/src/lib/webhooks/ghl.ts
+++ b/src/lib/webhooks/ghl.ts
@@ -135,6 +135,10 @@ export async function postToCoreLinq<T extends { event: string }>(
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
+      // These fan-outs are AWAITED on customer form-submit paths (Vercel
+      // freezes un-awaited work) — a slow/down CRM must not hold the
+      // customer's response hostage.
+      signal: AbortSignal.timeout(3000),
     });
     if (!res.ok) {
       console.error('[CoreLinq Ingest] Failed:', payload.event, res.status, await res.text());
@@ -403,4 +407,50 @@ export async function notifyConciergeLead(payload: GhlConciergeLeadPayload): Pro
   } catch (err) {
     console.error('[GHL Concierge Webhook] Error:', err);
   }
+}
+
+// ──────────────────────────────────────────────
+// Lead Flow board — CRM lead mirror
+// ──────────────────────────────────────────────
+
+export interface CoreLinqLeadCapturedPayload {
+  event: 'lead.captured';
+  /** Neon Lead.id — the fork's ingest upserts idempotently on this (the
+   *  submit routes fire on every re-submit and upsertLead reuses rows). */
+  leadId: string;
+  first_name: string;
+  last_name: string;
+  email: string;
+  phone: string;
+  /** Which surface captured it: 'party-chat' | 'premier-concierge' |
+   *  'event-quiz' | 'contact-form' | 'quote' | 'quickbuy:<occasion>'. */
+  source: string;
+  sourcePage: string;
+  occasion: string;
+  eventDate: string;         // ISO YYYY-MM-DD or ''
+  headcount: number | null;
+  budgetPerPerson: string;
+  /** Board state at capture time (score may still be null pre-cron). */
+  score: number | null;
+  temperature: string;       // 'hot' | 'warm' | 'cold' | ''
+  pipelineStage: string;     // usually 'NEW'
+  utmSource: string;
+  utmMedium: string;
+  utmCampaign: string;
+  /** Deep link to the Lead Flow board card. */
+  leadUrl: string;
+  capturedAt: string;
+}
+
+/**
+ * Mirror a captured lead to the CoreLinq CRM (no GHL leg — GHL already
+ * receives the concierge/newsletter events it cares about). Inert until
+ * CORELINQ_INGEST_URL is set, which must not happen before the fork's
+ * ingest accepts 'lead.captured' (else every submit logs a 400).
+ *
+ * Called AWAITED from the six submit routes only — never from the
+ * field-blur pixel route (that fires on every keystroke).
+ */
+export async function notifyLeadCaptured(payload: CoreLinqLeadCapturedPayload): Promise<void> {
+  await postToCoreLinq(payload);
 }


### PR DESCRIPTION
Part 3 of 3 (stacked on #242). Answering leads from the board + mirroring lead events to the CRM bridge.

## What
- Reply composer on the lead drawer: sends a personal plain-paragraph email via Resend from/reply-to info@, suppression-respecting (409 surfaces "unsubscribed" in the composer), disabled for phone-only leads
- `POST /api/v1/admin/leads/[id]/reply`: admin auth + zod, EmailLog linked via `metadata.leadId`, timeline LeadEvent, `last_contacted_at` stamp, auto NEW → Contacted, rescore; post-send bookkeeping is fenced so a DB hiccup can't 500 the composer into double-sending; replying to a tray lead enrolls it
- `resend-client`: `replyTo` support (customer replies land at info@, not orders@) + INFO logs made PII-free (project rule from 85d4159f)
- `lead-reply` template: escapeHtml on all content, newline-stripped subject (header-injection guard), postal-address line
- CRM bridge: `notifyLeadCaptured` (`lead.captured` event with the store Lead id for idempotent fork upserts) wired into all six submit routes; `postToCoreLinq` gains a 3s AbortSignal timeout (it is awaited on customer form-submit paths). Inert until `CORELINQ_INGEST_URL` is set — the fork-side ingest PR must merge first (partyon-crm `phase-2/lead-events`)
- Concierge + sheet deep links now point at `/admin/leads?lead=<id>`

## Reviews
security-reviewer: verdict-per-area clean after fixes (in #241); email path confirmed safe (header injection, escaping, suppression, hardcoded from/replyTo). Independent code review findings #11/#12 fixed here.

## Verified
tsc/lint/tests green; the exact send path exercised end-to-end with a real one-time send to the owner's address (EmailLog SENT, stage auto-move, PII-free logs observed, synthetic test lead removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)