### PR TITLE
security(finance): verify Plaid webhook signatures (fail closed)

### DIFF
--- a/src/app/api/webhooks/plaid/route.ts
+++ b/src/app/api/webhooks/plaid/route.ts
@@ -5,14 +5,18 @@
  * about TRANSACTIONS / SYNC_UPDATES_AVAILABLE — kicks off a sync for the
  * affected PlaidItem. Other webhook types are acknowledged but ignored.
  *
- * Auth: Plaid signs webhooks via the `plaid-verification` JWT header. For
- * V1 we trust the connection (sandbox / pre-prod) and just log; production
- * hardening adds JWT verification once the operator promotes to production.
+ * Auth: every request must carry Plaid's `plaid-verification` header — an
+ * ES256 JWT binding the exact request body (request_body_sha256). Verified
+ * fail-closed via verifyPlaidWebhookJwt (alg pinning, published-key signature,
+ * 5-minute freshness, constant-time body-hash check). Unverified requests get
+ * a 401 and are never processed; Plaid retries webhooks, so a transient
+ * key-fetch failure only delays the sync.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/database/client';
 import { syncItem } from '@/lib/finance/plaid-sync-service';
+import { verifyPlaidWebhookJwt } from '@/lib/finance/plaid-client';
 
 export const maxDuration = 60;
 
@@ -26,7 +30,32 @@ interface PlaidWebhookBody {
 export async function POST(request: NextRequest): Promise<NextResponse> {
   const startedAt = Date.now();
   try {
-    const body = (await request.json().catch(() => ({}))) as PlaidWebhookBody;
+    // Verification needs the RAW body — the JWT signs its exact SHA-256.
+    // Read failure returns non-2xx explicitly (the generic catch below would
+    // 200, and Plaid only retries on non-2xx).
+    let rawBody: string;
+    try {
+      rawBody = await request.text();
+    } catch {
+      return NextResponse.json({ success: false, error: 'unreadable body' }, { status: 400 });
+    }
+    const verificationJwt = request.headers.get('plaid-verification');
+    if (!verificationJwt) {
+      console.warn('[plaid-webhook] rejected: missing plaid-verification header');
+      return NextResponse.json({ success: false, error: 'unauthorized' }, { status: 401 });
+    }
+    const verdict = await verifyPlaidWebhookJwt(rawBody, verificationJwt);
+    if (!verdict.ok) {
+      console.warn('[plaid-webhook] rejected:', verdict.reason);
+      return NextResponse.json({ success: false, error: 'unauthorized' }, { status: 401 });
+    }
+
+    let body: PlaidWebhookBody;
+    try {
+      body = JSON.parse(rawBody) as PlaidWebhookBody;
+    } catch {
+      body = {};
+    }
     const itemId = body.item_id;
     const type = body.webhook_type;
     const code = body.webhook_code;

--- a/src/lib/finance/__tests__/plaid-webhook-verification.test.ts
+++ b/src/lib/finance/__tests__/plaid-webhook-verification.test.ts
@@ -1,0 +1,166 @@
+// @vitest-environment node
+/**
+ * Plaid webhook signature verification — fail-closed on every path: wrong
+ * algorithm, bad signature, stale token, tampered body, unknown key, missing
+ * claim. Uses a real locally-generated ES256 keypair and an injected key
+ * fetcher (production fetches from Plaid's /webhook_verification_key/get).
+ *
+ * Runs in the node environment: jose's Web-API build checks payloads with
+ * `instanceof Uint8Array`, which fails across the jsdom/node realm boundary.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SignJWT, generateKeyPair, exportJWK } from 'jose';
+import { createHash } from 'crypto';
+import {
+  verifyPlaidWebhookJwt,
+  __resetWebhookVerificationState,
+} from '@/lib/finance/plaid-client';
+
+beforeEach(() => __resetWebhookVerificationState());
+
+const BODY = JSON.stringify({
+  webhook_type: 'TRANSACTIONS',
+  webhook_code: 'SYNC_UPDATES_AVAILABLE',
+  item_id: 'item-abc',
+});
+
+async function makeSigned(opts: {
+  kid: string;
+  body?: string;
+  iatOffsetSec?: number;
+  omitHash?: boolean;
+}) {
+  const { publicKey, privateKey } = await generateKeyPair('ES256');
+  const jwk = (await exportJWK(publicKey)) as Record<string, unknown>;
+  const payload: Record<string, unknown> = {};
+  if (!opts.omitHash) {
+    payload.request_body_sha256 = createHash('sha256')
+      .update(opts.body ?? BODY)
+      .digest('hex');
+  }
+  const iat = Math.floor(Date.now() / 1000) + (opts.iatOffsetSec ?? 0);
+  const token = await new SignJWT(payload)
+    .setProtectedHeader({ alg: 'ES256', kid: opts.kid })
+    .setIssuedAt(iat)
+    .sign(privateKey);
+  return { token, jwk };
+}
+
+describe('verifyPlaidWebhookJwt', () => {
+  it('accepts a fresh, correctly signed token whose hash matches the raw body', async () => {
+    const { token, jwk } = await makeSigned({ kid: 'k-valid' });
+    const r = await verifyPlaidWebhookJwt(BODY, token, async () => jwk);
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects when the body was tampered with (hash mismatch)', async () => {
+    const { token, jwk } = await makeSigned({ kid: 'k-tamper' });
+    const tampered = BODY.replace('item-abc', 'item-EVIL');
+    const r = await verifyPlaidWebhookJwt(tampered, token, async () => jwk);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain('hash mismatch');
+  });
+
+  it('rejects a non-ES256 token BEFORE fetching any key (alg pinning)', async () => {
+    // HS256 token signed with a symmetric secret — must be rejected on the
+    // header alone; the key fetcher must never be consulted.
+    const { SignJWT: S } = await import('jose');
+    const hsToken = await new S({ request_body_sha256: 'x' })
+      .setProtectedHeader({ alg: 'HS256', kid: 'k-hs' })
+      .setIssuedAt()
+      .sign(new TextEncoder().encode('secret'));
+    let fetcherCalled = false;
+    const r = await verifyPlaidWebhookJwt(BODY, hsToken, async () => {
+      fetcherCalled = true;
+      return {};
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain('unexpected alg');
+    expect(fetcherCalled).toBe(false);
+  });
+
+  it('rejects a stale token (iat older than 5 minutes — replay bound)', async () => {
+    const { token, jwk } = await makeSigned({ kid: 'k-stale', iatOffsetSec: -10 * 60 });
+    const r = await verifyPlaidWebhookJwt(BODY, token, async () => jwk);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain('freshness');
+  });
+
+  it('rejects when the verification key cannot be fetched (fail closed)', async () => {
+    const { token } = await makeSigned({ kid: 'k-unknown' });
+    const r = await verifyPlaidWebhookJwt(BODY, token, async () => {
+      throw new Error('no such key');
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain('key fetch failed');
+  });
+
+  it('rejects a signed token missing the request_body_sha256 claim', async () => {
+    const { token, jwk } = await makeSigned({ kid: 'k-noclaim', omitHash: true });
+    const r = await verifyPlaidWebhookJwt(BODY, token, async () => jwk);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain('request_body_sha256');
+  });
+
+  it('rejects garbage that is not a JWT at all', async () => {
+    const r = await verifyPlaidWebhookJwt(BODY, 'not-a-jwt', async () => ({}));
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects a token signed by a DIFFERENT key than the one published for its kid', async () => {
+    const { token } = await makeSigned({ kid: 'k-wrongkey' });
+    // Publish a different keypair's public JWK for the same kid.
+    const other = await generateKeyPair('ES256');
+    const otherJwk = (await exportJWK(other.publicKey)) as Record<string, unknown>;
+    const r = await verifyPlaidWebhookJwt(BODY, token, async () => otherJwk);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain('verification failed');
+  });
+
+  it('caches the key by kid — second verification does not re-fetch', async () => {
+    const { token, jwk } = await makeSigned({ kid: 'k-cache' });
+    let fetches = 0;
+    const getKey = async () => {
+      fetches++;
+      return jwk;
+    };
+    expect((await verifyPlaidWebhookJwt(BODY, token, getKey)).ok).toBe(true);
+    expect((await verifyPlaidWebhookJwt(BODY, token, getKey)).ok).toBe(true);
+    expect(fetches).toBe(1);
+  });
+
+  it('negative-caches a failed kid — no repeat Plaid call within the TTL', async () => {
+    const { token } = await makeSigned({ kid: 'k-neg' });
+    let fetches = 0;
+    const failing = async () => {
+      fetches++;
+      throw new Error('no such key');
+    };
+    expect((await verifyPlaidWebhookJwt(BODY, token, failing)).ok).toBe(false);
+    const second = await verifyPlaidWebhookJwt(BODY, token, failing);
+    expect(second.ok).toBe(false);
+    expect(second.reason).toContain('negative cache');
+    expect(fetches).toBe(1);
+  });
+
+  it('exhausts the global fetch budget under a flood of unique kids (fail closed, no extra fetches)', async () => {
+    // An attacker floods unique kids: each consumes one budgeted fetch; past
+    // the budget, requests are rejected WITHOUT any outbound call.
+    let fetches = 0;
+    const failing = async () => {
+      fetches++;
+      throw new Error('no such key');
+    };
+    for (let i = 0; i < 10; i++) {
+      const { token } = await makeSigned({ kid: `k-flood-${i}` });
+      await verifyPlaidWebhookJwt(BODY, token, failing);
+    }
+    expect(fetches).toBe(10);
+    const { token } = await makeSigned({ kid: 'k-flood-final' });
+    const r = await verifyPlaidWebhookJwt(BODY, token, failing);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain('budget exhausted');
+    expect(fetches).toBe(10); // the 11th never reached the fetcher
+  });
+});

--- a/src/lib/finance/plaid-client.ts
+++ b/src/lib/finance/plaid-client.ts
@@ -194,6 +194,142 @@ export async function removeItem(accessToken: string): Promise<void> {
   await client.itemRemove({ access_token: accessToken });
 }
 
+// ---------------------------------------------------------------------------
+// Webhook signature verification
+// ---------------------------------------------------------------------------
+
+/** Verification keys cached by kid — Plaid rotates rarely; refetch daily. */
+const webhookKeyCache = new Map<string, { jwk: Record<string, unknown>; fetchedAt: number }>();
+const WEBHOOK_KEY_TTL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Anti-amplification guards (security review): the kid comes from an
+ * ATTACKER-CONTROLLED header, and each unknown kid would otherwise cost a live
+ * authenticated Plaid API call — a flood of random kids could exhaust our
+ * Plaid quota and break legitimate verification.
+ * - Negative cache: a kid that failed to resolve is not retried for 60s.
+ * - Global budget: at most 10 key fetches per rolling minute, fail-closed
+ *   beyond it (Plaid retries webhooks, so a legit fetch delayed by an active
+ *   flood only postpones a sync). Legitimate traffic uses ~1 kid per key
+ *   rotation, so the budget is generous.
+ */
+const webhookKeyNegativeCache = new Map<string, number>(); // kid → failedAt
+const WEBHOOK_KEY_NEGATIVE_TTL_MS = 60 * 1000;
+const WEBHOOK_KEY_FETCH_BUDGET = 10;
+const WEBHOOK_KEY_FETCH_WINDOW_MS = 60 * 1000;
+let keyFetchTimestamps: number[] = [];
+
+/** Test-only: reset module-level verification state between test cases. */
+export function __resetWebhookVerificationState(): void {
+  webhookKeyCache.clear();
+  webhookKeyNegativeCache.clear();
+  keyFetchTimestamps = [];
+}
+
+/** Production key fetcher: Plaid's /webhook_verification_key/get by kid. */
+async function fetchPlaidWebhookKey(kid: string): Promise<Record<string, unknown>> {
+  const client = createClient();
+  const res = await client.webhookVerificationKeyGet({ key_id: kid });
+  return res.data.key as unknown as Record<string, unknown>;
+}
+
+/**
+ * Verify a Plaid webhook: the `plaid-verification` header is an ES256 JWT
+ * whose payload carries `request_body_sha256` — the SHA-256 of the EXACT raw
+ * request body. Verification therefore requires the raw text, not the parsed
+ * JSON. Checks, all fail-closed:
+ *   1. alg pinned to ES256 (a token claiming any other alg is rejected before
+ *      any key is fetched — no algorithm-confusion surface);
+ *   2. signature against Plaid's published key for the token's kid (fetched
+ *      via /webhook_verification_key/get, cached 24h);
+ *   3. iat freshness ≤ 5 minutes (Plaid's own guidance — bounds replay);
+ *   4. body hash equality, constant-time.
+ *
+ * `getKey` is injectable so the crypto path is unit-testable with a local
+ * keypair; production uses the Plaid fetcher.
+ */
+export async function verifyPlaidWebhookJwt(
+  rawBody: string,
+  token: string,
+  getKey: (kid: string) => Promise<Record<string, unknown>> = fetchPlaidWebhookKey
+): Promise<{ ok: boolean; reason: string }> {
+  const { decodeProtectedHeader, importJWK, jwtVerify } = await import('jose');
+  const { createHash, timingSafeEqual } = await import('crypto');
+
+  let kid: string;
+  try {
+    const header = decodeProtectedHeader(token);
+    if (header.alg !== 'ES256') {
+      return { ok: false, reason: `unexpected alg ${String(header.alg)}` };
+    }
+    if (!header.kid || typeof header.kid !== 'string') {
+      return { ok: false, reason: 'missing kid' };
+    }
+    kid = header.kid;
+  } catch {
+    return { ok: false, reason: 'malformed verification JWT' };
+  }
+
+  let jwk: Record<string, unknown>;
+  const cached = webhookKeyCache.get(kid);
+  if (cached && Date.now() - cached.fetchedAt < WEBHOOK_KEY_TTL_MS) {
+    jwk = cached.jwk;
+  } else {
+    // Negative cache: don't re-fetch a kid that just failed.
+    const failedAt = webhookKeyNegativeCache.get(kid);
+    if (failedAt && Date.now() - failedAt < WEBHOOK_KEY_NEGATIVE_TTL_MS) {
+      return { ok: false, reason: 'verification key recently failed to resolve (negative cache)' };
+    }
+    // Global fetch budget: bound total outbound key lookups per minute.
+    const windowStart = Date.now() - WEBHOOK_KEY_FETCH_WINDOW_MS;
+    keyFetchTimestamps = keyFetchTimestamps.filter((t) => t > windowStart);
+    if (keyFetchTimestamps.length >= WEBHOOK_KEY_FETCH_BUDGET) {
+      return { ok: false, reason: 'verification key fetch budget exhausted — retry later' };
+    }
+    keyFetchTimestamps.push(Date.now());
+    try {
+      jwk = await getKey(kid);
+      webhookKeyCache.set(kid, { jwk, fetchedAt: Date.now() });
+      webhookKeyNegativeCache.delete(kid);
+    } catch (err) {
+      webhookKeyNegativeCache.set(kid, Date.now());
+      // Bound the negative cache so a kid flood can't grow memory unboundedly.
+      if (webhookKeyNegativeCache.size > 200) {
+        const oldest = webhookKeyNegativeCache.keys().next().value;
+        if (oldest !== undefined) webhookKeyNegativeCache.delete(oldest);
+      }
+      return {
+        ok: false,
+        reason: `verification key fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    const key = await importJWK(jwk as Parameters<typeof importJWK>[0], 'ES256');
+    const verified = await jwtVerify(token, key, {
+      algorithms: ['ES256'],
+      maxTokenAge: '5 minutes',
+    });
+    payload = verified.payload as Record<string, unknown>;
+  } catch {
+    return { ok: false, reason: 'signature or freshness verification failed' };
+  }
+
+  const expected = payload.request_body_sha256;
+  if (typeof expected !== 'string' || expected.length === 0) {
+    return { ok: false, reason: 'missing request_body_sha256 claim' };
+  }
+  const actual = createHash('sha256').update(rawBody).digest('hex');
+  const a = Buffer.from(actual, 'utf8');
+  const b = Buffer.from(expected.toLowerCase(), 'utf8');
+  if (a.length !== b.length || !timingSafeEqual(a, b)) {
+    return { ok: false, reason: 'request body hash mismatch' };
+  }
+  return { ok: true, reason: 'verified' };
+}
+
 /**
  * Update the webhook URL on an already-linked Item. Used for the one-shot
  * backfill that wires the webhook on every existing PlaidItem (which were


### PR DESCRIPTION
Closes the gap flagged in the security posture review: `/api/webhooks/plaid` accepted any POST (verification was deferred \"until production\" — which arrived 2026-06).

Every request must now present Plaid's `plaid-verification` ES256 JWT. Fail-closed checks: alg pinning (before any key fetch), signature vs Plaid's published key by `kid` (cached 24h), 5-minute `iat` freshness, and a constant-time SHA-256 comparison of the **raw** request body against the token's `request_body_sha256` claim. Unverified → 401, never processed; Plaid retries webhooks so a transient key-fetch failure only delays a sync.

Key fetcher is injectable — 8 unit tests sign real ES256 JWTs locally (valid / tampered body / HS256 rejected pre-fetch / stale / key-fetch failure / missing claim / garbage / wrong key). 744 tests pass, tsc 0, lint clean.

Bounded pre-fix impact: forged webhooks could only trigger spurious syncs or flip an item to login_required — no data exposure. Post-deploy verification: negative probe (POST without header → 401) + watch for a verified real webhook in runtime logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)