### PR TITLE
fix(leads): deferred review hardening — sizes, tests, tx atomicity, CoreLinq tuning

### DIFF
--- a/src/app/admin/leads/_components/drawer-facts.tsx
+++ b/src/app/admin/leads/_components/drawer-facts.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { ReactElement } from 'react';
+import type { LeadDetail } from './drawer-types';
+
+/**
+ * Drawer facts: the source/campaign/score grid plus the linked orders &
+ * quotes list (group-participant orders carry their "confirm before
+ * celebrating" caveat).
+ */
+export default function DrawerFacts({ detail }: { detail: LeadDetail }): ReactElement {
+  const { lead, orders, drafts } = detail;
+  return (
+    <>
+      <section className="mt-4 grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+        <Fact label="Source" value={`${lead.sourceWidget ?? '—'}${lead.sourcePage ? ` · ${lead.sourcePage}` : ''}`} />
+        <Fact label="Campaign" value={lead.utmCampaign ?? lead.utmSource ?? 'direct / unknown'} />
+        <Fact
+          label="Score breakdown"
+          value={
+            lead.scoreBreakdown
+              ? Object.entries(lead.scoreBreakdown)
+                  .map(([k, v]) => `${k.replace(/([A-Z])/g, ' $1').toLowerCase()} ${v}`)
+                  .join(' · ')
+              : '—'
+          }
+        />
+        <Fact label="Created" value={new Date(lead.createdAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })} />
+      </section>
+
+      {(orders.length > 0 || drafts.length > 0) && (
+        <section className="mt-4">
+          <h3 className="font-heading font-bold text-sm tracking-[0.1em] uppercase text-gray-500">
+            Orders & quotes
+          </h3>
+          <ul className="mt-1 space-y-1 text-sm">
+            {orders.map((o) => (
+              <li key={o.id}>
+                <a href={`/ops/orders/${o.id}`} className="text-brand-blue underline">
+                  Order #{o.orderNumber}
+                </a>{' '}
+                · ${o.total.toFixed(0)}
+                {o.isGroupParticipant && (
+                  <span className="text-gray-500"> · group payment (possible win — confirm)</span>
+                )}
+              </li>
+            ))}
+            {drafts.map((d) => (
+              <li key={d.id} className="text-gray-700">
+                Invoice {d.status.toLowerCase()} · ${Number(d.total).toFixed(0)}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </>
+  );
+}
+
+function Fact({ label, value }: { label: string; value: string }): ReactElement {
+  return (
+    <div>
+      <div className="text-xs font-semibold uppercase tracking-[0.08em] text-gray-500">{label}</div>
+      <div className="text-gray-800 break-words">{value}</div>
+    </div>
+  );
+}

--- a/src/app/admin/leads/_components/drawer-header.tsx
+++ b/src/app/admin/leads/_components/drawer-header.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { ReactElement } from 'react';
+import HqBadge from '@/components/backend/kit/Badge';
+import { temperatureFor } from '@/lib/leads/scoring';
+import type { LeadDetail } from './drawer-types';
+
+const TEMP_VARIANT = { hot: 'red', warm: 'amber', cold: 'gray' } as const;
+
+/** Drawer header: name, contact links, GHL escape hatch, temperature badge. */
+export default function DrawerHeader({
+  lead,
+  name,
+}: {
+  lead: LeadDetail['lead'];
+  name: string;
+}): ReactElement {
+  const temp = temperatureFor(lead.leadScore);
+  return (
+    <header className="flex items-start justify-between gap-3">
+      <div>
+        <h2 className="font-heading font-bold text-2xl tracking-[0.05em] text-gray-900">
+          {name}
+        </h2>
+        <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-sm">
+          {lead.email && (
+            <a href={`mailto:${lead.email}`} className="text-brand-blue underline">
+              {lead.email}
+            </a>
+          )}
+          {lead.phone && (
+            <a href={`tel:${lead.phone}`} className="text-brand-blue underline">
+              {lead.phone}
+            </a>
+          )}
+          <a
+            href="https://app.gohighlevel.com"
+            target="_blank"
+            rel="noreferrer"
+            className="text-gray-500 underline"
+            title="SMS lives in GHL until the CRM cutover"
+          >
+            Open GHL
+          </a>
+        </div>
+      </div>
+      {temp && (
+        <HqBadge variant={TEMP_VARIANT[temp]}>
+          {temp} {lead.leadScore}
+        </HqBadge>
+      )}
+    </header>
+  );
+}

--- a/src/app/admin/leads/_components/drawer-stage-actions.tsx
+++ b/src/app/admin/leads/_components/drawer-stage-actions.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { ReactElement } from 'react';
+import { PIPELINE_STAGES, type PipelineStage } from '@/lib/leads/pipeline-types';
+import { STAGE_LABELS } from '@/lib/leads/board-types';
+import type { LeadDetail } from './drawer-types';
+
+const OWNERS = ['', 'Allan', 'Brian'];
+
+/**
+ * Drawer action rows: the stage picker plus owner/snooze controls. Purely
+ * presentational — confirmation prompts and the PATCH calls live in the
+ * drawer's handlers.
+ */
+export default function DrawerStageActions({
+  lead,
+  mutating,
+  onMove,
+  onSetOwner,
+  onSnooze,
+}: {
+  lead: LeadDetail['lead'];
+  mutating: boolean;
+  onMove: (stage: PipelineStage) => void;
+  onSetOwner: (owner: string) => void;
+  onSnooze: (days: number | null) => void;
+}): ReactElement {
+  const snoozed = lead.snoozedUntil && new Date(lead.snoozedUntil) > new Date();
+  return (
+    <>
+      <section className="mt-4">
+        <div className="flex flex-wrap gap-1.5">
+          {PIPELINE_STAGES.map((stage) => (
+            <button
+              key={stage}
+              type="button"
+              onClick={() => onMove(stage)}
+              disabled={mutating}
+              className={`min-h-[36px] px-3 rounded-lg text-sm font-semibold tracking-[0.05em] border transition-colors ${
+                lead.pipelineStage === stage
+                  ? 'bg-brand-blue text-white border-brand-blue'
+                  : 'bg-white text-gray-700 border-gray-300 hover:border-brand-blue'
+              }`}
+            >
+              {STAGE_LABELS[stage]}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section className="mt-4 flex flex-wrap items-center gap-2 text-sm">
+        <label className="text-gray-600 font-semibold text-base">Owner</label>
+        <select
+          value={lead.owner ?? ''}
+          onChange={(e) => onSetOwner(e.target.value)}
+          className="min-h-[36px] rounded-lg border border-gray-300 px-2 text-base"
+        >
+          {OWNERS.map((o) => (
+            <option key={o} value={o}>
+              {o || 'Unassigned'}
+            </option>
+          ))}
+        </select>
+        <span className="text-gray-300">|</span>
+        <button type="button" onClick={() => onSnooze(3)} className="btn-ghost min-h-[36px]">
+          Snooze 3d
+        </button>
+        <button type="button" onClick={() => onSnooze(7)} className="btn-ghost min-h-[36px]">
+          Snooze 7d
+        </button>
+        {snoozed && (
+          <button type="button" onClick={() => onSnooze(null)} className="btn-ghost min-h-[36px] text-red-600">
+            Un-snooze
+          </button>
+        )}
+      </section>
+    </>
+  );
+}

--- a/src/app/admin/leads/_components/lead-drawer.tsx
+++ b/src/app/admin/leads/_components/lead-drawer.tsx
@@ -2,22 +2,21 @@
 
 import { ReactElement, useCallback, useEffect, useRef, useState } from 'react';
 import BottomSheet from '@/components/backend/kit/BottomSheet';
-import HqBadge from '@/components/backend/kit/Badge';
-import { PIPELINE_STAGES, type PipelineStage } from '@/lib/leads/pipeline-types';
-import { STAGE_LABELS } from '@/lib/leads/board-types';
-import { temperatureFor } from '@/lib/leads/scoring';
+import { type PipelineStage } from '@/lib/leads/pipeline-types';
 import type { LeadMutations } from './use-lead-mutations';
 import type { LeadDetail } from './drawer-types';
+import DrawerHeader from './drawer-header';
+import DrawerStageActions from './drawer-stage-actions';
+import DrawerFacts from './drawer-facts';
 import DrawerTimeline from './drawer-timeline';
 import ReplyComposer from './reply-composer';
 
-const TEMP_VARIANT = { hot: 'red', warm: 'amber', cold: 'gray' } as const;
-const OWNERS = ['', 'Allan', 'Brian'];
-
 /**
  * Card detail drawer — BottomSheet on all sizes (portaled, esc-closes).
- * Stage buttons confirm the destructive-feeling moves; Lost prompts for a
- * reason. Includes the 1:1 email reply composer.
+ * Owns the detail fetch + mutation handlers; the header/actions/facts
+ * sections are presentational children. Stage buttons confirm the
+ * destructive-feeling moves; Lost prompts for a reason. Includes the 1:1
+ * email reply composer.
  */
 export default function LeadDrawer({
   leadId,
@@ -92,137 +91,23 @@ export default function LeadDrawer({
 
   if (!leadId) return null;
   const lead = detail?.lead;
-  const temp = temperatureFor(lead?.leadScore ?? null);
   const name = lead ? [lead.firstName, lead.lastName].filter(Boolean).join(' ') || lead.email || 'Lead' : 'Lead';
 
   return (
     <BottomSheet open={leadId !== null} onClose={onClose} title={name}>
       <div className="px-4 pb-8 pt-2 max-h-[80vh] overflow-y-auto">
         {loading && !detail && <div className="py-10 text-center text-gray-400">Loading…</div>}
-        {lead && (
+        {lead && detail && (
           <>
-            <header className="flex items-start justify-between gap-3">
-              <div>
-                <h2 className="font-heading font-bold text-2xl tracking-[0.05em] text-gray-900">
-                  {name}
-                </h2>
-                <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-sm">
-                  {lead.email && (
-                    <a href={`mailto:${lead.email}`} className="text-brand-blue underline">
-                      {lead.email}
-                    </a>
-                  )}
-                  {lead.phone && (
-                    <a href={`tel:${lead.phone}`} className="text-brand-blue underline">
-                      {lead.phone}
-                    </a>
-                  )}
-                  <a
-                    href="https://app.gohighlevel.com"
-                    target="_blank"
-                    rel="noreferrer"
-                    className="text-gray-500 underline"
-                    title="SMS lives in GHL until the CRM cutover"
-                  >
-                    Open GHL
-                  </a>
-                </div>
-              </div>
-              {temp && (
-                <HqBadge variant={TEMP_VARIANT[temp]}>
-                  {temp} {lead.leadScore}
-                </HqBadge>
-              )}
-            </header>
-
-            <section className="mt-4">
-              <div className="flex flex-wrap gap-1.5">
-                {PIPELINE_STAGES.map((stage) => (
-                  <button
-                    key={stage}
-                    type="button"
-                    onClick={() => void moveTo(stage)}
-                    disabled={mutations.mutating}
-                    className={`min-h-[36px] px-3 rounded-lg text-sm font-semibold tracking-[0.05em] border transition-colors ${
-                      lead.pipelineStage === stage
-                        ? 'bg-brand-blue text-white border-brand-blue'
-                        : 'bg-white text-gray-700 border-gray-300 hover:border-brand-blue'
-                    }`}
-                  >
-                    {STAGE_LABELS[stage]}
-                  </button>
-                ))}
-              </div>
-            </section>
-
-            <section className="mt-4 grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
-              <Fact label="Source" value={`${lead.sourceWidget ?? '—'}${lead.sourcePage ? ` · ${lead.sourcePage}` : ''}`} />
-              <Fact label="Campaign" value={lead.utmCampaign ?? lead.utmSource ?? 'direct / unknown'} />
-              <Fact
-                label="Score breakdown"
-                value={
-                  lead.scoreBreakdown
-                    ? Object.entries(lead.scoreBreakdown)
-                        .map(([k, v]) => `${k.replace(/([A-Z])/g, ' $1').toLowerCase()} ${v}`)
-                        .join(' · ')
-                    : '—'
-                }
-              />
-              <Fact label="Created" value={new Date(lead.createdAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })} />
-            </section>
-
-            <section className="mt-4 flex flex-wrap items-center gap-2 text-sm">
-              <label className="text-gray-600 font-semibold text-base">Owner</label>
-              <select
-                value={lead.owner ?? ''}
-                onChange={(e) => void setOwner(e.target.value)}
-                className="min-h-[36px] rounded-lg border border-gray-300 px-2 text-base"
-              >
-                {OWNERS.map((o) => (
-                  <option key={o} value={o}>
-                    {o || 'Unassigned'}
-                  </option>
-                ))}
-              </select>
-              <span className="text-gray-300">|</span>
-              <button type="button" onClick={() => void snooze(3)} className="btn-ghost min-h-[36px]">
-                Snooze 3d
-              </button>
-              <button type="button" onClick={() => void snooze(7)} className="btn-ghost min-h-[36px]">
-                Snooze 7d
-              </button>
-              {lead.snoozedUntil && new Date(lead.snoozedUntil) > new Date() && (
-                <button type="button" onClick={() => void snooze(null)} className="btn-ghost min-h-[36px] text-red-600">
-                  Un-snooze
-                </button>
-              )}
-            </section>
-
-            {(detail.orders.length > 0 || detail.drafts.length > 0) && (
-              <section className="mt-4">
-                <h3 className="font-heading font-bold text-sm tracking-[0.1em] uppercase text-gray-500">
-                  Orders & quotes
-                </h3>
-                <ul className="mt-1 space-y-1 text-sm">
-                  {detail.orders.map((o) => (
-                    <li key={o.id}>
-                      <a href={`/ops/orders/${o.id}`} className="text-brand-blue underline">
-                        Order #{o.orderNumber}
-                      </a>{' '}
-                      · ${o.total.toFixed(0)}
-                      {o.isGroupParticipant && (
-                        <span className="text-gray-500"> · group payment (possible win — confirm)</span>
-                      )}
-                    </li>
-                  ))}
-                  {detail.drafts.map((d) => (
-                    <li key={d.id} className="text-gray-700">
-                      Invoice {d.status.toLowerCase()} · ${Number(d.total).toFixed(0)}
-                    </li>
-                  ))}
-                </ul>
-              </section>
-            )}
+            <DrawerHeader lead={lead} name={name} />
+            <DrawerStageActions
+              lead={lead}
+              mutating={mutations.mutating}
+              onMove={(stage) => void moveTo(stage)}
+              onSetOwner={(owner) => void setOwner(owner)}
+              onSnooze={(days) => void snooze(days)}
+            />
+            <DrawerFacts detail={detail} />
 
             <section className="mt-4">
               <h3 className="font-heading font-bold text-sm tracking-[0.1em] uppercase text-gray-500">
@@ -263,14 +148,5 @@ export default function LeadDrawer({
         )}
       </div>
     </BottomSheet>
-  );
-}
-
-function Fact({ label, value }: { label: string; value: string }): ReactElement {
-  return (
-    <div>
-      <div className="text-xs font-semibold uppercase tracking-[0.08em] text-gray-500">{label}</div>
-      <div className="text-gray-800 break-words">{value}</div>
-    </div>
   );
 }

--- a/src/app/admin/leads/_components/use-lead-mutations.ts
+++ b/src/app/admin/leads/_components/use-lead-mutations.ts
@@ -2,7 +2,8 @@
  * Client mutations for the Lead Flow board — stage moves, card metadata
  * patches — mirroring use-strategy-mutations. `mutating` disables the
  * drawer's action buttons while a call is in flight (the board has no
- * background poll; data reloads after each mutation).
+ * background poll; data reloads after each mutation, EXCEPT notes-only
+ * patches — the notes autosave must not refetch the whole board per save).
  */
 
 'use client';
@@ -27,11 +28,11 @@ export function useLeadMutations(onChanged: () => Promise<void>): LeadMutations 
   const [pending, setPending] = useState(0);
 
   const run = useCallback(
-    async (fn: () => Promise<Response>): Promise<boolean> => {
+    async (fn: () => Promise<Response>, opts?: { refetch?: boolean }): Promise<boolean> => {
       setPending((n) => n + 1);
       try {
         const res = await fn();
-        if (res.ok) await onChanged();
+        if (res.ok && opts?.refetch !== false) await onChanged();
         return res.ok;
       } catch {
         return false;
@@ -58,14 +59,21 @@ export function useLeadMutations(onChanged: () => Promise<void>): LeadMutations 
     (
       id: string,
       input: { notes?: string | null; owner?: string | null; snoozedUntil?: string | null },
-    ) =>
-      run(() =>
-        fetch(`/api/v1/admin/leads/${id}`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(input),
-        }),
-      ),
+    ) => {
+      // Notes never render on the board, so the autosave (one PATCH per typing
+      // pause) must not trigger a full board refetch — owner/snooze changes do.
+      const keys = Object.keys(input);
+      const notesOnly = keys.length > 0 && keys.every((k) => k === 'notes');
+      return run(
+        () =>
+          fetch(`/api/v1/admin/leads/${id}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(input),
+          }),
+        { refetch: !notesOnly },
+      );
+    },
     [run],
   );
 

--- a/src/lib/features/feature-flags.ts
+++ b/src/lib/features/feature-flags.ts
@@ -47,6 +47,12 @@ export const FEATURE_FLAGS = {
   // "postponed" state. Set by the deadline cron or the operator; reset to
   // resume selling. See src/lib/full-moon/event-state.ts.
   FULL_MOON_POSTPONED: 'full_moon_postponed',
+
+  // Not a rollout flag — a debounce stamp. The row's updatedAt records when
+  // the operator was last emailed about CoreLinq ingest failures, so a CRM
+  // outage alerts once per window instead of once per form submit. See
+  // src/lib/webhooks/corelinq-alert.ts.
+  CORELINQ_INGEST_ALERTED: 'corelinq_ingest_alerted',
 } as const;
 
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS];

--- a/src/lib/leads/__tests__/board-data.test.ts
+++ b/src/lib/leads/__tests__/board-data.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Lead Flow board read-side: needs-response + suggest-lost derivations on
+ * the card projection, duplicate-email flags, KPI math, and the Won/Lost
+ * 30-day column window vs the all-time closed counts.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Lead } from '@prisma/client';
+
+interface MockLead {
+  id: string;
+  email: string | null;
+  phone: string | null;
+  firstName: string | null;
+  lastName: string | null;
+  status: string;
+  sourceWidget: string | null;
+  metadata: unknown;
+  resumeCart: unknown;
+  pipelineStage: string | null;
+  stageChangedAt: Date | null;
+  boardSortOrder: number;
+  leadScore: number | null;
+  scoreBreakdown: unknown;
+  lastContactedAt: Date | null;
+  lastActivityAt: Date | null;
+  reopenedAt: Date | null;
+  owner: string | null;
+  snoozedUntil: Date | null;
+  lostReason: string | null;
+  wonAt: Date | null;
+  lostAt: Date | null;
+  orderId: string | null;
+  draftOrderId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const db: {
+  leads: MockLead[];
+  followUps: Array<{ leadId: string; status: string }>;
+} = { leads: [], followUps: [] };
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function matchesWhere(lead: MockLead, where: Record<string, any>): boolean {
+  for (const [key, cond] of Object.entries(where)) {
+    if (key === 'OR') {
+      const ors = cond as Array<Record<string, any>>;
+      if (!ors.some((o) => matchesWhere(lead, o))) return false;
+      continue;
+    }
+    const value = (lead as unknown as Record<string, unknown>)[key];
+    if (cond && typeof cond === 'object' && !Array.isArray(cond) && !(cond instanceof Date)) {
+      if ('in' in cond && !cond.in.includes(value)) return false;
+      if ('not' in cond && value === cond.not) return false;
+      if ('gte' in cond && !((value as Date) >= cond.gte)) return false;
+    } else if (value !== cond) {
+      return false;
+    }
+  }
+  return true;
+}
+
+vi.mock('@/lib/database/client', () => ({
+  prisma: {
+    lead: {
+      findMany: vi.fn(async ({ where, take }: any) =>
+        db.leads.filter((l) => matchesWhere(l, where ?? {})).slice(0, take ?? 500)
+      ),
+      groupBy: vi.fn(async ({ where }: any) => {
+        const byStage = new Map<string | null, number>();
+        for (const l of db.leads.filter((x) => matchesWhere(x, where ?? {}))) {
+          byStage.set(l.pipelineStage, (byStage.get(l.pipelineStage) ?? 0) + 1);
+        }
+        return [...byStage.entries()].map(([pipelineStage, n]) => ({
+          pipelineStage,
+          _count: { _all: n },
+        }));
+      }),
+    },
+    followUpJob: {
+      groupBy: vi.fn(async ({ where }: any) => {
+        const byLead = new Map<string, number>();
+        for (const f of db.followUps) {
+          if (!where.leadId.in.includes(f.leadId)) continue;
+          if (!where.status.in.includes(f.status)) continue;
+          byLead.set(f.leadId, (byLead.get(f.leadId) ?? 0) + 1);
+        }
+        return [...byLead.entries()].map(([leadId, n]) => ({ leadId, _count: { _all: n } }));
+      }),
+    },
+  },
+}));
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+// The enroll sweep is pipeline behavior with its own tests — stub it so the
+// board read stays a read. isNewsletterOnly stays real (tray filtering).
+vi.mock('../pipeline', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../pipeline')>();
+  return { ...actual, sweepEnrollSubmitted: vi.fn(async () => 0) };
+});
+
+import { getBoardData, toBoardLead } from '../board-data';
+
+const DAY_MS = 86_400_000;
+function daysAgo(n: number): Date {
+  return new Date(Date.now() - n * DAY_MS);
+}
+
+let seq = 0;
+function makeLead(overrides: Partial<MockLead> = {}): MockLead {
+  const lead: MockLead = {
+    id: `lead-${++seq}`,
+    email: `guest${seq}@example.com`,
+    phone: null,
+    firstName: 'Guest',
+    lastName: `${seq}`,
+    status: 'SUBMITTED',
+    sourceWidget: 'CONTACT_FORM',
+    metadata: { contactForm: { eventType: 'party' } },
+    resumeCart: null,
+    pipelineStage: 'NEW',
+    stageChangedAt: daysAgo(1),
+    boardSortOrder: seq,
+    leadScore: 50,
+    scoreBreakdown: null,
+    lastContactedAt: null,
+    lastActivityAt: null,
+    reopenedAt: null,
+    owner: null,
+    snoozedUntil: null,
+    lostReason: null,
+    wonAt: null,
+    lostAt: null,
+    orderId: null,
+    draftOrderId: null,
+    createdAt: daysAgo(2),
+    updatedAt: daysAgo(1),
+    ...overrides,
+  };
+  db.leads.push(lead);
+  return lead;
+}
+
+const asLead = (l: MockLead): Lead => l as unknown as Lead;
+const ctx = (over: Partial<{ hasFollowUp: boolean; isDuplicate: boolean; now: Date }> = {}) => ({
+  hasFollowUp: false,
+  isDuplicate: false,
+  now: new Date(),
+  ...over,
+});
+
+beforeEach(() => {
+  db.leads = [];
+  db.followUps = [];
+  seq = 0;
+});
+
+describe('toBoardLead — needs-response derivation', () => {
+  it('is true when the lead was never contacted', () => {
+    const card = toBoardLead(asLead(makeLead()), ctx());
+    expect(card.needsResponse).toBe(true);
+  });
+
+  it('is true when activity landed after the last contact', () => {
+    const lead = makeLead({ lastContactedAt: daysAgo(3), lastActivityAt: daysAgo(1) });
+    expect(toBoardLead(asLead(lead), ctx()).needsResponse).toBe(true);
+  });
+
+  it('is false once contacted after the latest activity', () => {
+    const lead = makeLead({ lastActivityAt: daysAgo(3), lastContactedAt: daysAgo(1) });
+    expect(toBoardLead(asLead(lead), ctx()).needsResponse).toBe(false);
+  });
+
+  it('falls back to createdAt as the signal when there is no activity', () => {
+    const lead = makeLead({ createdAt: daysAgo(1), lastContactedAt: daysAgo(3) });
+    expect(toBoardLead(asLead(lead), ctx()).needsResponse).toBe(true);
+  });
+
+  it('is always false for closed and off-board cards', () => {
+    const won = makeLead({ pipelineStage: 'WON' });
+    const trayed = makeLead({ pipelineStage: null });
+    expect(toBoardLead(asLead(won), ctx()).needsResponse).toBe(false);
+    expect(toBoardLead(asLead(trayed), ctx()).needsResponse).toBe(false);
+  });
+});
+
+describe('toBoardLead — suggest-lost', () => {
+  it('flags open cards whose event date has passed', () => {
+    const lead = makeLead({
+      metadata: { contactForm: { eventType: 'party', eventDate: '2026-01-01' } },
+    });
+    expect(toBoardLead(asLead(lead), ctx()).suggestLost).toBe(true);
+  });
+
+  it('flags open cards quiet for more than 30 days', () => {
+    const lead = makeLead({ createdAt: daysAgo(45), lastActivityAt: daysAgo(40) });
+    expect(toBoardLead(asLead(lead), ctx()).suggestLost).toBe(true);
+  });
+
+  it('does not flag fresh cards with a future event', () => {
+    const lead = makeLead({
+      metadata: { contactForm: { eventType: 'party', eventDate: '2099-01-01' } },
+      lastActivityAt: daysAgo(1),
+    });
+    expect(toBoardLead(asLead(lead), ctx()).suggestLost).toBe(false);
+  });
+});
+
+describe('getBoardData — duplicate flag', () => {
+  it('marks every card sharing an email, case-insensitively', async () => {
+    makeLead({ email: 'Dupe@Example.com' });
+    makeLead({ email: 'dupe@example.com', pipelineStage: 'CONTACTED' });
+    makeLead({ email: 'solo@example.com' });
+
+    const data = await getBoardData();
+    const cards = Object.values(data.columns).flat();
+    const dupes = cards.filter((c) => c.isDuplicate).map((c) => c.email?.toLowerCase());
+    expect(dupes.sort()).toEqual(['dupe@example.com', 'dupe@example.com']);
+    expect(cards.find((c) => c.email === 'solo@example.com')?.isDuplicate).toBe(false);
+  });
+});
+
+describe('getBoardData — KPI math', () => {
+  it('computes newThisWeek / hot / needsResponse over open columns only', async () => {
+    makeLead({ leadScore: 85 }); // hot, new this week, unanswered
+    makeLead({ createdAt: daysAgo(10), lastContactedAt: daysAgo(1) }); // old, answered
+    makeLead({ pipelineStage: 'WON', stageChangedAt: daysAgo(1), leadScore: 90 }); // closed — excluded
+
+    const { kpis } = await getBoardData();
+    expect(kpis.newThisWeek).toBe(1);
+    expect(kpis.hot).toBe(1);
+    expect(kpis.needsResponse).toBe(1);
+  });
+
+  it('computes won/lost 30d and a rounded conversion rate', async () => {
+    makeLead({ pipelineStage: 'WON', stageChangedAt: daysAgo(3) });
+    makeLead({ pipelineStage: 'WON', stageChangedAt: daysAgo(5) });
+    makeLead({ pipelineStage: 'LOST', stageChangedAt: daysAgo(7) });
+
+    const { kpis } = await getBoardData();
+    expect(kpis.won30d).toBe(2);
+    expect(kpis.lost30d).toBe(1);
+    expect(kpis.conversionPct).toBe(67); // 2/3 rounded
+  });
+
+  it('reports null conversion when nothing closed in the window', async () => {
+    makeLead();
+    const { kpis } = await getBoardData();
+    expect(kpis.conversionPct).toBeNull();
+  });
+});
+
+describe('getBoardData — Won/Lost 30-day window vs all-time closed counts', () => {
+  it('drops stale closed cards from columns but keeps them in closedCounts', async () => {
+    makeLead({ pipelineStage: 'WON', stageChangedAt: daysAgo(40) }); // outside window
+    makeLead({ pipelineStage: 'WON', stageChangedAt: daysAgo(5) });
+    makeLead({ pipelineStage: 'LOST', stageChangedAt: daysAgo(45) }); // outside window
+
+    const data = await getBoardData();
+    expect(data.columns.WON).toHaveLength(1);
+    expect(data.columns.LOST).toHaveLength(0);
+    expect(data.kpis.won30d).toBe(1);
+    expect(data.kpis.lost30d).toBe(0);
+    // Column headers show the true totals.
+    expect(data.closedCounts).toEqual({ won: 2, lost: 1 });
+  });
+});

--- a/src/lib/leads/__tests__/pipeline.test.ts
+++ b/src/lib/leads/__tests__/pipeline.test.ts
@@ -38,7 +38,8 @@ const db: {
   drafts: Array<{ id: string; customerEmail: string; status: string; createdAt: Date }>;
   wonOrderRows: Array<{ id: string }>;
   reopenRows: Array<{ id: string }>;
-} = { leads: [], events: [], drafts: [], wonOrderRows: [], reopenRows: [] };
+  queryLog: Array<{ strings: string[]; values: unknown[] }>;
+} = { leads: [], events: [], drafts: [], wonOrderRows: [], reopenRows: [], queryLog: [] };
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 function matchesWhere(lead: MockLead, where: Record<string, any>): boolean {
@@ -61,8 +62,8 @@ function matchesWhere(lead: MockLead, where: Record<string, any>): boolean {
   return true;
 }
 
-vi.mock('@/lib/database/client', () => ({
-  prisma: {
+vi.mock('@/lib/database/client', () => {
+  const client: any = {
     lead: {
       findUnique: vi.fn(async ({ where }: any) => db.leads.find((l) => l.id === where.id) ?? null),
       findMany: vi.fn(async ({ where, take }: any) =>
@@ -115,14 +116,30 @@ vi.mock('@/lib/database/client', () => ({
         return hit ? { id: hit.id } : null;
       }),
     },
-    $queryRaw: vi.fn(async (strings: TemplateStringsArray) => {
+    $queryRaw: vi.fn(async (strings: TemplateStringsArray, ...values: unknown[]) => {
+      db.queryLog.push({ strings: [...strings], values });
       const sql = Array.isArray(strings) ? strings.join('?') : String(strings);
       // sweepReopens' candidate query vs findWonOrder's order match.
       if (sql.includes('last_activity_at')) return db.reopenRows;
       return db.wonOrderRows;
     }),
-  },
-}));
+  };
+  // Interactive-transaction stub with honest rollback semantics: lead field
+  // mutations and event appends made inside the callback revert if it throws,
+  // so atomicity assertions mean something.
+  client.$transaction = vi.fn(async (fn: any) => {
+    const leadSnapshots = db.leads.map((l) => ({ ref: l, copy: { ...l } }));
+    const eventsLen = db.events.length;
+    try {
+      return await fn(client);
+    } catch (err) {
+      for (const { ref, copy } of leadSnapshots) Object.assign(ref, copy);
+      db.events.length = eventsLen;
+      throw err;
+    }
+  });
+  return { prisma: client };
+});
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
 import {
@@ -136,8 +153,37 @@ import {
   sweepWonMatches,
   syncStageFromConversion,
   transitionStage,
+  wonOrderIdentity,
 } from '../pipeline';
 import { validateTransition } from '../pipeline-types';
+import { prisma } from '@/lib/database/client';
+
+/**
+ * Flatten a captured tagged-template query (Prisma.sql fragments included)
+ * into plain SQL text + bind params, so tests can assert on the filters the
+ * real database would see.
+ */
+function flattenSql(
+  strings: readonly string[],
+  values: readonly unknown[],
+): { text: string; params: unknown[] } {
+  let text = '';
+  const params: unknown[] = [];
+  strings.forEach((s, i) => {
+    text += s;
+    if (i >= values.length) return;
+    const v = values[i] as { strings?: readonly string[]; values?: readonly unknown[] } | null;
+    if (v && typeof v === 'object' && Array.isArray(v.strings)) {
+      const inner = flattenSql(v.strings, v.values ?? []);
+      text += inner.text;
+      params.push(...inner.params);
+    } else {
+      text += '?';
+      params.push(values[i]);
+    }
+  });
+  return { text, params };
+}
 
 let seq = 0;
 function makeLead(overrides: Partial<MockLead> = {}): MockLead {
@@ -178,6 +224,7 @@ beforeEach(() => {
   db.drafts = [];
   db.wonOrderRows = [];
   db.reopenRows = [];
+  db.queryLog = [];
   seq = 0;
 });
 
@@ -432,5 +479,93 @@ describe('matchFloor', () => {
     expect(
       matchFloor({ createdAt: reopenedAt, reopenedAt: createdAt })
     ).toEqual(reopenedAt); // stale reopen older than creation is ignored
+  });
+});
+
+describe('stage-write atomicity', () => {
+  const txMock = () => prisma.$transaction as unknown as ReturnType<typeof vi.fn>;
+  const createMock = () => prisma.leadEvent.create as unknown as ReturnType<typeof vi.fn>;
+
+  it('routes the stage write + audit event through one transaction', async () => {
+    const lead = makeLead({ pipelineStage: 'NEW', stageChangedAt: new Date() });
+    const before = txMock().mock.calls.length;
+    await transitionStage(lead.id, 'CONTACTED', { via: 'drag' });
+    expect(txMock().mock.calls.length).toBe(before + 1);
+  });
+
+  it('rolls the stage write back when the audit-event append fails', async () => {
+    const lead = makeLead({ pipelineStage: 'NEW', stageChangedAt: new Date() });
+    createMock().mockRejectedValueOnce(new Error('db down'));
+    await expect(transitionStage(lead.id, 'CONTACTED', { via: 'drag' })).rejects.toThrow(
+      'db down'
+    );
+    expect(lead.pipelineStage).toBe('NEW'); // stage change did not survive alone
+    expect(db.events).toHaveLength(0);
+  });
+
+  it('rolls an enroll back when its audit-event append fails', async () => {
+    const lead = makeLead();
+    createMock().mockRejectedValueOnce(new Error('db down'));
+    await expect(enrollLeadIfEligible(lead.id)).rejects.toThrow('db down');
+    expect(lead.pipelineStage).toBeNull();
+    expect(db.events).toHaveLength(0);
+  });
+});
+
+describe('wonOrderIdentity', () => {
+  const base = { createdAt: new Date('2026-06-01T00:00:00Z'), reopenedAt: null };
+  const asClause = (sql: unknown) =>
+    sql as { strings: readonly string[]; values: readonly unknown[] };
+
+  it('builds a case-insensitive email clause', () => {
+    const { identity } = wonOrderIdentity({ ...base, email: 'Guest@Example.com', phone: null });
+    expect(identity).toHaveLength(1);
+    const { text, params } = flattenSql(asClause(identity[0]).strings, asClause(identity[0]).values);
+    expect(text).toBe('LOWER(customer_email) = LOWER(?)');
+    expect(params).toEqual(['Guest@Example.com']);
+  });
+
+  it('builds a last-10-digits phone clause', () => {
+    const { identity } = wonOrderIdentity({ ...base, email: null, phone: '(512) 555-0187' });
+    expect(identity).toHaveLength(1);
+    const { text, params } = flattenSql(asClause(identity[0]).strings, asClause(identity[0]).values);
+    expect(text).toBe(
+      "RIGHT(REGEXP_REPLACE(COALESCE(customer_phone, ''), '\\D', '', 'g'), 10) = ?"
+    );
+    expect(params).toEqual(['5125550187']);
+  });
+
+  it('emits both clauses when both identities exist, none when neither does', () => {
+    expect(
+      wonOrderIdentity({ ...base, email: 'a@b.co', phone: '5125550187' }).identity
+    ).toHaveLength(2);
+    expect(wonOrderIdentity({ ...base, email: null, phone: null }).identity).toHaveLength(0);
+  });
+
+  it('floors at the reopen date when newer than creation', () => {
+    const reopenedAt = new Date('2026-07-01T00:00:00Z');
+    expect(
+      wonOrderIdentity({ ...base, email: 'a@b.co', phone: null, reopenedAt }).floor
+    ).toEqual(reopenedAt);
+    expect(wonOrderIdentity({ ...base, email: 'a@b.co', phone: null }).floor).toEqual(
+      base.createdAt
+    );
+  });
+});
+
+describe('findWonOrder SQL filters (via sweepWonMatches)', () => {
+  it('excludes group-participant payments, requires PAID-ish status, floors at the lead date', async () => {
+    const lead = makeLead({ pipelineStage: 'QUOTE_SENT', stageChangedAt: new Date() });
+    db.wonOrderRows = [{ id: 'order-1' }];
+    await sweepWonMatches();
+
+    expect(db.queryLog).toHaveLength(1);
+    const { text, params } = flattenSql(db.queryLog[0].strings, db.queryLog[0].values);
+    expect(text).toContain("financial_status IN ('PAID', 'PARTIALLY_REFUNDED')");
+    expect(text).toContain('group_order_v2_id IS NULL');
+    expect(text).toContain('created_at >= ?');
+    expect(text).toContain('LOWER(customer_email) = LOWER(?)');
+    expect(params).toContainEqual(lead.createdAt); // the match floor
+    expect(params).toContainEqual('guest@example.com');
   });
 });

--- a/src/lib/leads/board-data.ts
+++ b/src/lib/leads/board-data.ts
@@ -20,12 +20,23 @@ export type { BoardData, BoardFilters, BoardKpis, BoardLead } from './board-type
 const CLOSED_WINDOW_DAYS = 30;
 const TRAY_LIMIT = 60;
 
+/** All-time Won/Lost tallies as returned by the pipelineStage groupBy. */
+interface StageCount {
+  pipelineStage: string | null;
+  _count: { _all: number };
+}
+
 function displayName(lead: Lead): string {
   const name = [lead.firstName, lead.lastName].filter(Boolean).join(' ').trim();
   return name || lead.email || lead.phone || 'Unknown lead';
 }
 
-function toBoardLead(
+/**
+ * Project a Lead row onto its board card. Pure given the flags in `ctx`
+ * (exported for tests — needs-response and suggest-lost derivations live
+ * here).
+ */
+export function toBoardLead(
   lead: Lead,
   ctx: {
     hasFollowUp: boolean;
@@ -125,12 +136,15 @@ export async function getHotLeadsNeedingReply(): Promise<{
   return { count: row.count, oldestWaitHours };
 }
 
-/** Build the full board payload. Runs the enroll sweep first so it's always fresh. */
-export async function getBoardData(filters: BoardFilters = {}): Promise<BoardData> {
-  const now = new Date();
-  await sweepEnrollSubmitted().catch(() => undefined);
-
-  const closedFloor = new Date(now.getTime() - CLOSED_WINDOW_DAYS * 86_400_000);
+/**
+ * The three parallel board reads: active + recently-closed cards, all-time
+ * Won/Lost tallies (no window — the column header shows the true total), and
+ * the uncommitted tray when requested.
+ */
+async function fetchBoardRows(
+  includePartial: boolean,
+  closedFloor: Date,
+): Promise<{ boarded: Lead[]; closedCountsRaw: StageCount[]; tray: Lead[] }> {
   const [boarded, closedCountsRaw, tray] = await Promise.all([
     prisma.lead.findMany({
       where: {
@@ -147,7 +161,7 @@ export async function getBoardData(filters: BoardFilters = {}): Promise<BoardDat
       where: { pipelineStage: { in: ['WON', 'LOST'] } },
       _count: { _all: true },
     }),
-    filters.includePartial
+    includePartial
       ? prisma.lead.findMany({
           where: {
             pipelineStage: null,
@@ -159,30 +173,40 @@ export async function getBoardData(filters: BoardFilters = {}): Promise<BoardDat
         })
       : Promise.resolve([] as Lead[]),
   ]);
+  return { boarded, closedCountsRaw, tray };
+}
 
-  const all = [...boarded, ...tray];
-  const ids = all.map((l) => l.id);
-
+/**
+ * Per-card flags that need the whole result set: active follow-up jobs
+ * (one grouped query) and duplicate-email detection across boarded + tray.
+ */
+async function loadCardFlags(all: Lead[]): Promise<{
+  followUpLeads: Set<string>;
+  emailCounts: Map<string, number>;
+}> {
   const followUps = await prisma.followUpJob.groupBy({
     by: ['leadId'],
-    where: { leadId: { in: ids }, status: { in: ['scheduled', 'sent'] } },
+    where: { leadId: { in: all.map((l) => l.id) }, status: { in: ['scheduled', 'sent'] } },
     _count: { _all: true },
   });
-  const followUpLeads = new Set(followUps.map((r) => r.leadId));
-
   const emailCounts = new Map<string, number>();
   for (const l of all) {
     const key = l.email?.toLowerCase();
     if (key) emailCounts.set(key, (emailCounts.get(key) ?? 0) + 1);
   }
+  return {
+    followUpLeads: new Set(followUps.flatMap((r) => (r.leadId ? [r.leadId] : []))),
+    emailCounts,
+  };
+}
 
-  const toCard = (lead: Lead): BoardLead =>
-    toBoardLead(lead, {
-      hasFollowUp: followUpLeads.has(lead.id),
-      isDuplicate: (emailCounts.get(lead.email?.toLowerCase() ?? '') ?? 0) > 1,
-      now,
-    });
-
+/** Group boarded cards into stage columns, then apply the view filters. */
+export function buildColumns(
+  boarded: Lead[],
+  toCard: (lead: Lead) => BoardLead,
+  filters: BoardFilters,
+  now: Date,
+): Record<PipelineStage, BoardLead[]> {
   const columns = Object.fromEntries(
     PIPELINE_STAGES.map((s) => [s, [] as BoardLead[]]),
   ) as Record<PipelineStage, BoardLead[]>;
@@ -193,13 +217,17 @@ export async function getBoardData(filters: BoardFilters = {}): Promise<BoardDat
   for (const stage of PIPELINE_STAGES) {
     columns[stage] = applyFilters(columns[stage], filters, now);
   }
+  return columns;
+}
 
-  const trayCards = applyFilters(
-    tray.filter((l) => !isNewsletterOnly(l)).map(toCard),
-    filters,
-    now,
-  );
-
+/**
+ * KPI tiles from the (already filtered) columns. Won/Lost tiles read the
+ * 30-day columns, NOT the all-time closed counts — "this month's win rate".
+ */
+export function computeKpis(
+  columns: Record<PipelineStage, BoardLead[]>,
+  now: Date,
+): BoardKpis {
   const weekFloor = new Date(now.getTime() - 7 * 86_400_000);
   const open = (['NEW', 'CONTACTED', 'QUALIFIED', 'QUOTE_SENT'] as const).flatMap(
     (s) => columns[s],
@@ -207,7 +235,7 @@ export async function getBoardData(filters: BoardFilters = {}): Promise<BoardDat
   const won30d = columns.WON.length;
   const lost30d = columns.LOST.length;
   const closedTotal = won30d + lost30d;
-  const kpis: BoardKpis = {
+  return {
     newThisWeek: open.filter((c) => new Date(c.createdAt) >= weekFloor).length,
     hot: open.filter((c) => c.temperature === 'hot').length,
     needsResponse: open.filter((c) => c.needsResponse).length,
@@ -215,17 +243,47 @@ export async function getBoardData(filters: BoardFilters = {}): Promise<BoardDat
     lost30d,
     conversionPct: closedTotal > 0 ? Math.round((won30d / closedTotal) * 100) : null,
   };
+}
 
-  const closedCounts = {
-    won: closedCountsRaw.find((r) => r.pipelineStage === 'WON')?._count._all ?? 0,
-    lost: closedCountsRaw.find((r) => r.pipelineStage === 'LOST')?._count._all ?? 0,
+/** All-time Won/Lost totals for the column headers. */
+export function summarizeClosedCounts(raw: StageCount[]): { won: number; lost: number } {
+  return {
+    won: raw.find((r) => r.pipelineStage === 'WON')?._count._all ?? 0,
+    lost: raw.find((r) => r.pipelineStage === 'LOST')?._count._all ?? 0,
   };
+}
+
+/** Build the full board payload. Runs the enroll sweep first so it's always fresh. */
+export async function getBoardData(filters: BoardFilters = {}): Promise<BoardData> {
+  const now = new Date();
+  await sweepEnrollSubmitted().catch(() => undefined);
+
+  const closedFloor = new Date(now.getTime() - CLOSED_WINDOW_DAYS * 86_400_000);
+  const { boarded, closedCountsRaw, tray } = await fetchBoardRows(
+    filters.includePartial === true,
+    closedFloor,
+  );
+  const { followUpLeads, emailCounts } = await loadCardFlags([...boarded, ...tray]);
+
+  const toCard = (lead: Lead): BoardLead =>
+    toBoardLead(lead, {
+      hasFollowUp: followUpLeads.has(lead.id),
+      isDuplicate: (emailCounts.get(lead.email?.toLowerCase() ?? '') ?? 0) > 1,
+      now,
+    });
+
+  const columns = buildColumns(boarded, toCard, filters, now);
+  const trayCards = applyFilters(
+    tray.filter((l) => !isNewsletterOnly(l)).map(toCard),
+    filters,
+    now,
+  );
 
   return {
     columns,
-    closedCounts,
+    closedCounts: summarizeClosedCounts(closedCountsRaw),
     tray: trayCards,
-    kpis,
+    kpis: computeKpis(columns, now),
     generatedAt: now.toISOString(),
   };
 }

--- a/src/lib/leads/pipeline.ts
+++ b/src/lib/leads/pipeline.ts
@@ -84,13 +84,14 @@ export function matchFloor(lead: { createdAt: Date; reopenedAt: Date | null }): 
 }
 
 async function appendStageEvent(
+  db: Prisma.TransactionClient,
   leadId: string,
   from: PipelineStage | null,
   to: PipelineStage,
   via: StageChangeVia,
   extra?: Record<string, unknown>,
 ): Promise<void> {
-  await prisma.leadEvent.create({
+  await db.leadEvent.create({
     data: {
       leadId,
       type: 'CUSTOM',
@@ -197,15 +198,23 @@ export async function transitionStage(
     return { ok: true, moved: false, reason: 'not-in-from-stage', lead };
   }
 
-  const updated = await prisma.lead.updateMany({
-    where: { id: leadId, pipelineStage: lead.pipelineStage },
-    data: stageSideEffects(from, to, opts, now),
+  // Stage write + audit event commit together — a crash between them must
+  // not leave a stage change with no stage.changed event (deferred review
+  // finding). Rescore stays OUTSIDE: it is deliberately best-effort and must
+  // not roll back a landed move.
+  const moved = await prisma.$transaction(async (tx) => {
+    const updated = await tx.lead.updateMany({
+      where: { id: leadId, pipelineStage: lead.pipelineStage },
+      data: stageSideEffects(from, to, opts, now),
+    });
+    if (updated.count === 0) return false;
+    await appendStageEvent(tx, leadId, from, to, opts.via, opts.eventExtra);
+    return true;
   });
-  if (updated.count === 0) {
+  if (!moved) {
     return { ok: true, moved: false, reason: 'concurrent-change' };
   }
 
-  await appendStageEvent(leadId, from, to, opts.via, opts.eventExtra);
   await recomputeLeadScore(leadId).catch(() => undefined);
   const fresh = await prisma.lead.findUnique({ where: { id: leadId } });
   return { ok: true, moved: true, lead: fresh ?? undefined };
@@ -224,16 +233,22 @@ export async function enrollLeadIfEligible(
   if (!lead || lead.pipelineStage !== null) return false;
   if (!isBoardEligible(lead, { allowPartial: opts.allowPartial })) return false;
 
-  const updated = await prisma.lead.updateMany({
-    where: { id: leadId, pipelineStage: null },
-    data: {
-      pipelineStage: 'NEW',
-      stageChangedAt: now,
-      boardSortOrder: topSortOrder(now),
-    },
+  // Same atomicity rule as transitionStage: enroll + its audit event commit
+  // together.
+  const enrolled = await prisma.$transaction(async (tx) => {
+    const updated = await tx.lead.updateMany({
+      where: { id: leadId, pipelineStage: null },
+      data: {
+        pipelineStage: 'NEW',
+        stageChangedAt: now,
+        boardSortOrder: topSortOrder(now),
+      },
+    });
+    if (updated.count === 0) return false;
+    await appendStageEvent(tx, leadId, null, 'NEW', opts.via ?? 'enroll');
+    return true;
   });
-  if (updated.count === 0) return false;
-  await appendStageEvent(leadId, null, 'NEW', opts.via ?? 'enroll');
+  if (!enrolled) return false;
   await recomputeLeadScore(leadId).catch(() => undefined);
   return true;
 }
@@ -348,6 +363,29 @@ export async function sweepQuoteSent(): Promise<number> {
 }
 
 /**
+ * Identity clauses + date floor for the won-order match, extracted pure so
+ * the SQL inputs are testable without a database: email matches
+ * case-insensitively, phone matches on the last 10 digits, and a lead with
+ * neither yields no clauses (the caller must then skip the query).
+ */
+export function wonOrderIdentity(lead: {
+  email: string | null;
+  phone: string | null;
+  createdAt: Date;
+  reopenedAt: Date | null;
+}): { floor: Date; identity: Prisma.Sql[] } {
+  const identity: Prisma.Sql[] = [];
+  if (lead.email) identity.push(Prisma.sql`LOWER(customer_email) = LOWER(${lead.email})`);
+  const last10 = phoneLast10(lead.phone);
+  if (last10) {
+    identity.push(
+      Prisma.sql`RIGHT(REGEXP_REPLACE(COALESCE(customer_phone, ''), '\\D', '', 'g'), 10) = ${last10}`,
+    );
+  }
+  return { floor: matchFloor(lead), identity };
+}
+
+/**
  * High-confidence paid-order match for one lead: email (case-insensitive) or
  * last-10-digit phone, created on/after the lead (or its reopen), and NOT a
  * GroupOrderV2 participant payment (a $40 guest chip-in is not a won party —
@@ -359,15 +397,7 @@ async function findWonOrder(lead: {
   createdAt: Date;
   reopenedAt: Date | null;
 }): Promise<{ id: string } | null> {
-  const floor = matchFloor(lead);
-  const last10 = phoneLast10(lead.phone);
-  const identity: Prisma.Sql[] = [];
-  if (lead.email) identity.push(Prisma.sql`LOWER(customer_email) = LOWER(${lead.email})`);
-  if (last10) {
-    identity.push(
-      Prisma.sql`RIGHT(REGEXP_REPLACE(COALESCE(customer_phone, ''), '\\D', '', 'g'), 10) = ${last10}`,
-    );
-  }
+  const { floor, identity } = wonOrderIdentity(lead);
   if (identity.length === 0) return null;
   const rows = await prisma.$queryRaw<Array<{ id: string }>>`
     SELECT id FROM orders
@@ -404,23 +434,28 @@ export async function sweepWonMatches(): Promise<number> {
   for (const lead of leads) {
     const order = await findWonOrder(lead);
     if (!order) continue;
+    const from = isPipelineStage(lead.pipelineStage) ? lead.pipelineStage : null;
     // Guarded update — concurrent sweeps / a staff drag serialize on the row
     // and the loser's WHERE no longer matches (READ COMMITTED re-check).
-    const updated = await prisma.lead.updateMany({
-      where: { id: lead.id, pipelineStage: { in: [...ACTIVE_STAGES] } },
-      data: {
-        pipelineStage: 'WON',
-        stageChangedAt: now,
-        wonAt: now,
-        orderId: order.id,
-        status: 'CONVERTED',
-        boardSortOrder: topSortOrder(now),
-      },
+    // Wrapped with its audit event so the two commit together.
+    const wonMove = await prisma.$transaction(async (tx) => {
+      const updated = await tx.lead.updateMany({
+        where: { id: lead.id, pipelineStage: { in: [...ACTIVE_STAGES] } },
+        data: {
+          pipelineStage: 'WON',
+          stageChangedAt: now,
+          wonAt: now,
+          orderId: order.id,
+          status: 'CONVERTED',
+          boardSortOrder: topSortOrder(now),
+        },
+      });
+      if (updated.count === 0) return false;
+      await appendStageEvent(tx, lead.id, from, 'WON', 'order', { orderId: order.id });
+      return true;
     });
-    if (updated.count === 0) continue;
+    if (!wonMove) continue;
     won++;
-    const from = isPipelineStage(lead.pipelineStage) ? lead.pipelineStage : null;
-    await appendStageEvent(lead.id, from, 'WON', 'order', { orderId: order.id });
     await recomputeLeadScore(lead.id).catch(() => undefined);
   }
   return won;

--- a/src/lib/webhooks/__tests__/corelinq-alert.test.ts
+++ b/src/lib/webhooks/__tests__/corelinq-alert.test.ts
@@ -1,0 +1,42 @@
+/**
+ * CoreLinq alert sanitizers: PII redaction + HTML escaping of the failure
+ * detail that may embed CoreLinq's raw error body in the operator email.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// The module pulls in prisma + Resend for the alerting path; the pure
+// sanitizers under test never touch them.
+vi.mock('@/lib/database/client', () => ({ prisma: {} }));
+vi.mock('@/lib/email/resend-client', () => ({ sendEmail: vi.fn() }));
+
+import { escapeHtml, sanitizeAlertDetail } from '../corelinq-alert';
+
+describe('escapeHtml', () => {
+  it('escapes & before < so entities survive intact', () => {
+    expect(escapeHtml('<b>&lt;</b>')).toBe('&lt;b>&amp;lt;&lt;/b>');
+  });
+});
+
+describe('sanitizeAlertDetail', () => {
+  it('redacts email addresses from the detail', () => {
+    const out = sanitizeAlertDetail('HTTP 400: invalid field email="jane.doe+vip@gmail.com"');
+    expect(out).not.toContain('jane.doe');
+    expect(out).toContain('[email]');
+  });
+
+  it('redacts 10+-digit phone runs but leaves status codes and dates alone', () => {
+    const out = sanitizeAlertDetail('HTTP 422 at 2026-07-13: phone +1 (512) 555-0187 rejected');
+    expect(out).not.toContain('555-0187');
+    expect(out).toContain('[phone]');
+    expect(out).toContain('HTTP 422');
+    expect(out).toContain('2026-07-13');
+  });
+
+  it('truncates to 300 chars and escapes HTML', () => {
+    const out = sanitizeAlertDetail(`<script>${'x'.repeat(400)}`);
+    expect(out.startsWith('&lt;script>')).toBe(true);
+    // 300 input chars, then escaping may lengthen the string — but no raw '<'.
+    expect(out).not.toContain('<');
+  });
+});

--- a/src/lib/webhooks/corelinq-alert.ts
+++ b/src/lib/webhooks/corelinq-alert.ts
@@ -1,0 +1,123 @@
+/**
+ * Operator alerting for CoreLinq ingest failures (security review MEDIUM-2).
+ *
+ * postToCoreLinq is fire-and-forget: once the GHL fan-out is retired after
+ * cutover, a silently failing ingest means lost lead notifications with
+ * nobody watching the '[CoreLinq Ingest]' log lines. This emails the
+ * operator instead — debounced to at most one email per window so a CRM
+ * outage during a busy form-submit hour cannot flood the inbox.
+ *
+ * Debounce is claimed atomically through the feature_flags row
+ * `corelinq_ingest_alerted` (its updatedAt is the last-alerted stamp;
+ * updateMany's WHERE guards the window so concurrent lambdas race safely),
+ * with an in-memory fast path per instance. Never throws, and the send is
+ * time-bounded — this runs awaited on customer form-submit paths.
+ */
+
+import { EmailType, Prisma } from '@prisma/client';
+import { prisma } from '@/lib/database/client';
+import { sendEmail } from '@/lib/email/resend-client';
+import { FEATURE_FLAGS } from '@/lib/features/feature-flags';
+
+const OPS_ALERT_EMAIL = process.env.OPS_ALERT_EMAIL || 'allan@partyondelivery.com';
+const ALERT_WINDOW_MS = 6 * 60 * 60 * 1000; // one email per 6h, per failure burst
+const SEND_TIMEOUT_MS = 2500; // customer path — never wait longer than this on Resend
+const DETAIL_MAX_CHARS = 300;
+
+/** Per-instance fast path — skip the DB claim when this lambda alerted recently. */
+let lastAlertAttemptAt = 0;
+
+/** Minimal HTML escape for text-node contexts (& first so &lt; survives). */
+export function escapeHtml(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;');
+}
+
+/**
+ * Redact lead PII (emails, 10+-digit phone runs), truncate, and HTML-escape
+ * a failure detail before it may be embedded in the alert email. The detail
+ * can contain CoreLinq's raw error body, which might echo submitted contact
+ * fields back; the alert diagnoses an integration failure and never needs
+ * customer data. Pure — exported for tests.
+ */
+export function sanitizeAlertDetail(detail: string): string {
+  const redacted = detail
+    .replace(/[\w.+-]+@[\w-]+(?:\.[\w-]+)+/g, '[email]')
+    .replace(/\+?\d(?:[\s().-]*\d){9,}/g, '[phone]');
+  return escapeHtml(redacted.slice(0, DETAIL_MAX_CHARS));
+}
+
+/**
+ * Atomically claim the right to send this window's alert. Exactly one caller
+ * per window wins: the UPDATE only matches when the stamp is older than the
+ * window, and the CREATE's unique-key violation tells a racing lambda it
+ * lost. Non-race DB errors fail OPEN (send anyway) — this is an alerting
+ * path, and the in-memory window still bounds sends per instance.
+ */
+async function claimAlertWindow(now: Date): Promise<boolean> {
+  const cutoff = new Date(now.getTime() - ALERT_WINDOW_MS);
+  const description = `CoreLinq ingest failure alert last sent ${now.toISOString()}`;
+  const claimed = await prisma.featureFlag.updateMany({
+    where: { key: FEATURE_FLAGS.CORELINQ_INGEST_ALERTED, updatedAt: { lt: cutoff } },
+    data: { enabled: true, description },
+  });
+  if (claimed.count > 0) return true;
+
+  const existing = await prisma.featureFlag.findUnique({
+    where: { key: FEATURE_FLAGS.CORELINQ_INGEST_ALERTED },
+    select: { id: true },
+  });
+  if (existing) return false; // stamp is fresh — someone alerted this window
+
+  try {
+    await prisma.featureFlag.create({
+      data: { key: FEATURE_FLAGS.CORELINQ_INGEST_ALERTED, enabled: true, description },
+    });
+    return true;
+  } catch (err) {
+    const lostRace =
+      err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002';
+    return !lostRace;
+  }
+}
+
+/**
+ * Email the operator that CoreLinq ingest is failing. Debounced; safe to call
+ * on every failure; the send itself is capped at SEND_TIMEOUT_MS.
+ */
+export async function alertCoreLinqIngestFailure(event: string, detail: string): Promise<void> {
+  try {
+    const now = new Date();
+    if (now.getTime() - lastAlertAttemptAt < ALERT_WINDOW_MS) return;
+    if (!(await claimAlertWindow(now))) {
+      lastAlertAttemptAt = now.getTime();
+      return;
+    }
+    lastAlertAttemptAt = now.getTime();
+
+    // Race, don't await bare: a slow Resend must not hold a customer's
+    // form-submit response (security review MEDIUM). Losing the race can
+    // drop this window's email — the console.error log lines remain.
+    await Promise.race([
+      sendEmail({
+        to: OPS_ALERT_EMAIL,
+        subject: 'CoreLinq ingest is failing — lead fan-out not reaching the CRM',
+        type: EmailType.WELCOME, // reuse — internal ops alert, no dedicated type
+        html: `
+          <h2>CoreLinq ingest failure</h2>
+          <p>A <code>postToCoreLinq</code> call failed at ${now.toISOString()}.</p>
+          <p><strong>Event:</strong> ${escapeHtml(event)}</p>
+          <p><strong>Detail (PII redacted):</strong> ${sanitizeAlertDetail(detail)}</p>
+          <p>Leads and orders keep flowing on the site — only the CRM mirror is
+          affected. Check the Vercel logs for <code>[CoreLinq Ingest]</code>
+          lines and the CoreLinq app's health. Further failures are suppressed
+          for 6 hours.</p>
+        `,
+        metadata: { kind: 'corelinq-ingest-alert', event },
+      }),
+      new Promise<void>((resolve) => setTimeout(resolve, SEND_TIMEOUT_MS)),
+    ]);
+  } catch (err) {
+    // Alerting must never make a failing fan-out worse.
+    console.error('[CoreLinq Ingest] alert send failed:', err);
+  }
+}

--- a/src/lib/webhooks/ghl.ts
+++ b/src/lib/webhooks/ghl.ts
@@ -5,6 +5,8 @@
  * No-ops silently when GHL_ORDER_WEBHOOK_URL is not set.
  */
 
+import { alertCoreLinqIngestFailure } from './corelinq-alert';
+
 const GHL_WEBHOOK_URL = process.env.GHL_ORDER_WEBHOOK_URL;
 const GHL_REVIEW_WEBHOOK_URL = process.env.GHL_REVIEW_WEBHOOK_URL;
 const GHL_DASHBOARD_WEBHOOK_URL = process.env.GHL_DASHBOARD_WEBHOOK_URL;
@@ -122,7 +124,8 @@ function buildItemsSummary(
  * only this fires. The payload must carry an `event` discriminator — the
  * ingest route switches on it.
  *
- * Fire-and-forget: logs errors, never throws. No-ops silently when
+ * Fire-and-forget: logs errors + emails the operator (debounced, see
+ * corelinq-alert.ts) on failure, never throws. No-ops silently when
  * CORELINQ_INGEST_URL is not set.
  */
 export async function postToCoreLinq<T extends { event: string }>(
@@ -137,14 +140,21 @@ export async function postToCoreLinq<T extends { event: string }>(
       body: JSON.stringify(payload),
       // These fan-outs are AWAITED on customer form-submit paths (Vercel
       // freezes un-awaited work) — a slow/down CRM must not hold the
-      // customer's response hostage.
-      signal: AbortSignal.timeout(3000),
+      // customer's response hostage. 1500ms per the cutover review: the
+      // ingest route is a single upsert, so anything slower IS an outage.
+      signal: AbortSignal.timeout(1500),
     });
     if (!res.ok) {
-      console.error('[CoreLinq Ingest] Failed:', payload.event, res.status, await res.text());
+      const body = await res.text();
+      console.error('[CoreLinq Ingest] Failed:', payload.event, res.status, body);
+      await alertCoreLinqIngestFailure(payload.event, `HTTP ${res.status}: ${body}`);
     }
   } catch (err) {
     console.error('[CoreLinq Ingest] Error:', payload.event, err);
+    await alertCoreLinqIngestFailure(
+      payload.event,
+      err instanceof Error ? `${err.name}: ${err.message}` : String(err),
+    );
   }
 }
 


### PR DESCRIPTION
Follow-up to the Lead Flow stack (#241 → #242 → #243, all merged 2026-07-13). Originally built stacked on #243's branch; rebased onto `main` after the stack merged — verified the squashed content on main is byte-identical to the stack tip this was built against (`git diff 853480d7 a7114749` empty).

Applies the five deliberately-deferred findings from the 2026-07-13 Lead Flow reviews:

### 1. Component-size conventions
- `lead-drawer.tsx` 276 → **152 lines**: header, stage-picker/owner/snooze, and facts/orders sections extracted to presentational components (`drawer-header.tsx` 54, `drawer-stage-actions.tsx` 79, `drawer-facts.tsx` 67). All handlers, confirms, and state stay in the drawer — behavior-preserving JSX moves, verified hunk-by-hunk.
- `getBoardData()` ~103 → **33 lines** via `fetchBoardRows` / `loadCardFlags` / `buildColumns` / `computeKpis` / `summarizeClosedCounts`, each under 50 lines. Queries, filters, and KPI math preserved verbatim; `toBoardLead` is now exported for tests.

### 2. Test coverage (64 lead+webhook tests, up from 39; suite 797 green)
- **New `board-data.test.ts` (13 tests)**: needs-response derivation (never-contacted / activity-after-contact / contacted-after-activity / closed & tray cards), suggest-lost (event passed, 30d quiet), duplicate-email flag (case-insensitive), KPI math (newThisWeek / hot / needsResponse / won-lost 30d / rounded + null conversionPct), and the Won/Lost 30-day column window vs all-time `closedCounts`.
- **`pipeline.test.ts` (+8 tests)**: `wonOrderIdentity` extracted pure from `findWonOrder` and tested directly (email clause, last-10 phone clause, both/neither, reopen floor); SQL-string assertions on the real query via a template-flattening capture — proves `financial_status IN ('PAID','PARTIALLY_REFUNDED')`, `group_order_v2_id IS NULL` (group-participant exclusion), and `created_at >= <floor>` reach the database; transaction-atomicity tests with an honest-rollback `$transaction` mock.

### 3. transitionStage transactionality
`transitionStage`, and for the same audit invariant `enrollLeadIfEligible` + `sweepWonMatches`, now wrap the race-guarded `updateMany` + `stage.changed` LeadEvent append in `prisma.$transaction` — a crash can no longer leave a stage change with no audit event. The guarded WHERE (concurrent-move safety) is unchanged inside the tx. **Deliberate:** `recomputeLeadScore` stays outside the transaction — it is best-effort by design (`.catch(() => undefined)`) and must not roll back a landed move.

### 4. Notes autosave refetch
Notes-only PATCHes skip the `onChanged` board refetch (the board never renders notes). Owner/snooze/stage changes still refetch; closing the drawer still reloads the board.

### 5. CoreLinq cutover tuning (security review MEDIUM-2)
- `postToCoreLinq` timeout **3000 → 1500 ms** (awaited on customer form-submit paths; the ingest route is a single upsert).
- **New `corelinq-alert.ts`**: on either failure path (non-OK or thrown/timeout) the operator gets an email (`OPS_ALERT_EMAIL`, default allan@) — debounced to one per 6h via an atomic `feature_flags` claim (`corelinq_ingest_alerted`, updateMany-guarded so racing lambdas can't spam) plus an in-memory fast path. Never throws; runs only on failure, so the happy path is untouched.
- Everything here stays **inert until `CORELINQ_INGEST_URL` is set** — which must wait for fork PR partyon-crm#6, per the stack notes.

### Reviews
- **`security-reviewer` agent (full diff): SAFE TO MERGE WITH FOLLOWUPS — 0 critical / 0 high / 1 medium / 2 low, and every finding is fixed in this same commit:**
  - MEDIUM (CWE-400): the alert's `sendEmail` had no timeout while sitting awaited on 6 public form-submit routes → the send is now raced against a 2.5s cap (losing the race can drop that window's email; the `[CoreLinq Ingest]` log lines remain).
  - LOW (latent CWE-79): `event` was interpolated unescaped into the alert HTML → now escaped (though all current callers pass hardcoded literals).
  - LOW (PII): CoreLinq's error body could echo lead email/phone into the operator email → `sanitizeAlertDetail` now redacts email + 10+-digit phone patterns before truncate/escape, with unit tests.
  - Reliability nit: the debounce-claim `create()` treated every DB error as "lost the race" → now only P2002 counts as lost; other errors fail open (in-memory window still bounds sends).
  - Reviewer also confirmed: stack invariants intact (no LeadStatus writes outside the won sweep, trustedSubmit gates unchanged, no updatedAt fallback in scoring, race-guarded WHERE preserved inside the transactions), board-data refactor behavior-preserving (`take` limits + filters unchanged), drawer split byte-equivalent JSX, admin routes' auth untouched, and the `feature_flags` stamp can't interfere with real flag evaluation (keyed lookups; rolloutPercentage stays 0). Known cosmetic: the stamp row shows up in any list-all-flags admin UI.
- Self-review pass on top: verified the wholesale board-data.ts rewrite hunk-by-hunk against the stack tip; caught the `&`-before-`<` escaping order.

### Gates (after security fixes)
- `npx tsc --noEmit` ✓ 0 errors
- `npm run lint` ✓ 0 errors (pre-existing `<img>` warnings only)
- `npm run test:run` ✓ 797/797

### Not in scope
- External log-drain/monitor alerting infra (Vercel drain not enabled; not configurable from the repo) — the in-code operator email covers MEDIUM-2's intent.
- No schema changes, no route changes, no flag flips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
