### PR TITLE
feat(compliance): A2P 10DLC age gate + affirmative SMS opt-in

### DIFF
--- a/src/app/api/v1/checkout/route.ts
+++ b/src/app/api/v1/checkout/route.ts
@@ -210,7 +210,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     // Get request body for optional params
     const body = await request.json().catch(() => ({}));
-    const { customerEmail, customerName, customerPhone, returnUrl, tipAmount: rawTip, attribution } = body;
+    const { customerEmail, customerName, customerPhone, returnUrl, tipAmount: rawTip, attribution, smsConsent } = body;
     const tipAmount = typeof rawTip === 'number' && rawTip > 0 ? Math.round(rawTip * 100) / 100 : 0;
 
     // Compute effective totals (affiliate free delivery applied in-memory only)
@@ -283,6 +283,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       overrideDeliveryFee: affiliateFreeDelivery ? 0 : undefined,
       tipAmount: tipAmount > 0 ? tipAmount : undefined,
       attribution: attribution && typeof attribution === 'object' ? attribution : undefined,
+      smsConsent: typeof smsConsent === 'boolean' ? smsConsent : undefined,
     });
 
     return NextResponse.json({

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -7,6 +7,7 @@ import DeliveryDateTimePicker from '@/components/checkout/DeliveryDateTimePicker
 import { useCartContext } from '@/contexts/CartContext';
 import { useCustomerContext } from '@/contexts/CustomerContext';
 import CustomerAuth from '@/components/CustomerAuth';
+import SmsConsentCheckbox from '@/components/consent/SmsConsentCheckbox';
 
 /** In-store pickup location — 7600 N. Lamar Blvd #A2, Austin TX 78752 */
 const STORE_PICKUP_ADDRESS = {
@@ -47,6 +48,9 @@ export default function CheckoutPage() {
   });
 
   const [acceptTerms, setAcceptTerms] = useState(false);
+  // A2P 10DLC: SMS opt-in is an affirmative action, unchecked by default and
+  // NOT required to check out (consent is not a condition of purchase).
+  const [smsConsent, setSmsConsent] = useState(false);
   const [discountCode, setDiscountCode] = useState('');
   const [isApplyingDiscount, setIsApplyingDiscount] = useState(false);
   const [discountFeedback, setDiscountFeedback] = useState<{ type: 'success' | 'error' | null; message: string }>({ type: null, message: '' });
@@ -294,6 +298,9 @@ export default function CheckoutPage() {
           customerEmail: billingAddress.email,
           customerName: `${billingAddress.firstName} ${billingAddress.lastName}`.trim(),
           customerPhone: billingAddress.phone,
+          // A2P 10DLC consent proof: true only when a phone is present AND the
+          // customer affirmatively checked the (unchecked-by-default) opt-in.
+          smsConsent: billingAddress.phone ? smsConsent : false,
           tipAmount: tipAmount > 0 ? tipAmount : undefined,
           attribution,
         }),
@@ -812,6 +819,15 @@ export default function CheckoutPage() {
                     </Link>
                   </span>
                 </label>
+
+                {/* SMS opt-in — optional, unchecked by default (A2P 10DLC) */}
+                <div className="mt-3">
+                  <SmsConsentCheckbox
+                    id="checkout-sms-consent"
+                    checked={smsConsent}
+                    onChange={setSmsConsent}
+                  />
+                </div>
 
                 {/* Checkout Error */}
                 {checkoutError && (

--- a/src/app/invoice/[token]/page.tsx
+++ b/src/app/invoice/[token]/page.tsx
@@ -21,10 +21,10 @@ export default function InvoicePage(): ReactElement {
   const [paymentLoading, setPaymentLoading] = useState(false);
   const [updatingItems, setUpdatingItems] = useState(false);
 
-  // Pre-checked 21+ acknowledgement — replaces the old site-wide
-  // age-verification modal. Customer can uncheck to block payment;
-  // legal control remains carding at the door.
-  const [ageConfirmed, setAgeConfirmed] = useState(true);
+  // 21+ acknowledgement — UNCHECKED by default (A2P 10DLC: express consent
+  // must be an affirmative user action, never pre-checked). Blocks payment
+  // until the customer checks it; carding at the door is the backstop.
+  const [ageConfirmed, setAgeConfirmed] = useState(false);
 
   // Discount code state
   const [discountInput, setDiscountInput] = useState('');

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,6 +25,7 @@ const GroupOrderProvider = dynamic(
 // Imported as a regular client component — App Router doesn't allow
 // `dynamic({ ssr: false })` inside Server Components (this layout is one).
 import PixelMount from '@/components/leads/PixelMount';
+import AgeVerification from '@/components/AgeVerification';
 
 const barlowCondensed = Barlow_Condensed({
   subsets: ['latin'],
@@ -137,12 +138,13 @@ export default function RootLayout({
         <CustomerProvider>
           <CartProvider>
             <GroupOrderProvider>
-              {/* Age verification is no longer a site-wide entrance gate.
-                  It moved to a pre-checked "21+" acknowledgement on the
-                  final checkout step (DashboardCheckoutModal, QuickBuyModal,
-                  /invoice/<token>). Legal control remains carding at the
-                  door — TABC compliance is identical, the modal was just
-                  costing us paid-traffic bounces. */}
+              {/* Site-wide 21+ entrance gate. Restored 2026-07-13 for A2P
+                  10DLC compliance — Twilio Trust & Safety requires an effective
+                  age-verification gate restricting site access to 21+. The gate
+                  blocks first-visit access (localStorage-persisted) and exempts
+                  only the paid-ad landers (AGE_GATE_EXEMPT_PATHS), which carry
+                  their own required, unchecked 21+ checkbox in-checkout. */}
+              <AgeVerification />
               <PixelMount />
               <ClientLayoutWrapper>
                 {children}

--- a/src/components/consent/SmsConsentCheckbox.tsx
+++ b/src/components/consent/SmsConsentCheckbox.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import type { ReactElement } from 'react';
+import Link from 'next/link';
+
+/**
+ * A2P 10DLC-compliant SMS opt-in checkbox.
+ *
+ * Twilio Trust & Safety requires SMS consent to be an **affirmative user
+ * action** — this checkbox MUST default to unchecked and never be pre-checked,
+ * and SMS consent must never be a condition of purchase. The label carries the
+ * CTIA-required elements: program description, message frequency, msg & data
+ * rates, STOP/HELP, and a link to the SMS terms.
+ *
+ * Used on every site surface that collects a phone number for texting
+ * (lead-magnet popup, checkout). Keep the copy identical across surfaces.
+ */
+export default function SmsConsentCheckbox({
+  checked,
+  onChange,
+  id = 'sms-consent',
+  className = '',
+}: {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  id?: string;
+  className?: string;
+}): ReactElement {
+  return (
+    <label htmlFor={id} className={`flex items-start gap-2 text-sm cursor-pointer ${className}`}>
+      <input
+        id={id}
+        name={id}
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="mt-0.5 rounded border-gray-300 text-brand-blue focus:ring-brand-blue"
+      />
+      <span className="text-gray-600 leading-snug">
+        Text me order updates and occasional offers from Party On Delivery. Message
+        frequency varies; msg &amp; data rates may apply. Reply STOP to opt out, HELP for
+        help. Consent is not a condition of purchase. See our{' '}
+        <Link href="/privacy" target="_blank" className="underline hover:text-gray-900">
+          Privacy Policy
+        </Link>
+        .
+      </span>
+    </label>
+  );
+}

--- a/src/components/dashboard/DashboardCheckoutModal.tsx
+++ b/src/components/dashboard/DashboardCheckoutModal.tsx
@@ -46,11 +46,10 @@ export default function DashboardCheckoutModal({
   // (API client signature update is a follow-up — for the preview the
   // UI gates the submit so we can iterate on copy before persistence).
   const [substitutionsOk, setSubstitutionsOk] = useState(true);
-  // Pre-checked per product policy — the customer can still uncheck it,
-  // but the default state is "yes." Replaces the old site-wide age-
-  // verification modal: legal compliance now lives in this single
-  // checkbox + carding at the door.
-  const [acceptanceConfirmed, setAcceptanceConfirmed] = useState(true);
+  // UNCHECKED by default (A2P 10DLC: express consent must be an affirmative
+  // user action, never pre-checked). The customer must check it to submit;
+  // the site-wide entrance gate + carding at the door are the backstops.
+  const [acceptanceConfirmed, setAcceptanceConfirmed] = useState(false);
   const [acceptanceError, setAcceptanceError] = useState('');
 
   // Discount -- pre-populate from dashboard promo if it's a discount type

--- a/src/components/events/DiscoCruiseInvite.tsx
+++ b/src/components/events/DiscoCruiseInvite.tsx
@@ -101,7 +101,9 @@ export default function DiscoCruiseInvite({ sections }: Props): ReactElement {
   const [phone, setPhone] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [ageConfirmed, setAgeConfirmed] = useState(true);
+  // 21+ acknowledgement — UNCHECKED by default (A2P 10DLC: express consent must
+  // be an affirmative user action, never pre-checked).
+  const [ageConfirmed, setAgeConfirmed] = useState(false);
 
   // Flat product index for cheap subtotal + summary lookups.
   const productById = useMemo(() => {

--- a/src/components/landing/QuickBuyModal.tsx
+++ b/src/components/landing/QuickBuyModal.tsx
@@ -103,10 +103,11 @@ export default function QuickBuyModal({
   const sundaySelected = isSunday(deliveryDate);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // Age compliance — pre-checked per product policy. Replaces the old
-  // site-wide entrance modal (now removed). Customer can still uncheck
-  // to block submit; legal control remains carding at the door.
-  const [ageConfirmed, setAgeConfirmed] = useState(true);
+  // Age compliance — UNCHECKED by default (A2P 10DLC: express consent must be
+  // an affirmative user action, never pre-checked). This is the age control on
+  // the paid landers (exempt from the site-wide gate); customer must check it
+  // to submit. Carding at the door is the backstop.
+  const [ageConfirmed, setAgeConfirmed] = useState(false);
   const handleAgeConfirmedChange = (checked: boolean) => {
     setAgeConfirmed(checked);
     if (checked) {

--- a/src/components/leadMagnet/LeadMagnetModal.tsx
+++ b/src/components/leadMagnet/LeadMagnetModal.tsx
@@ -15,6 +15,7 @@
 import { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import { sendLeadEvent } from '@/lib/leads/client';
+import SmsConsentCheckbox from '@/components/consent/SmsConsentCheckbox';
 import type { LeadMagnet } from '@/lib/leadMagnet/config';
 
 type Props = {
@@ -29,6 +30,8 @@ export default function LeadMagnetModal({ magnet, open, onClose, modeBadge }: Pr
   const [firstName, setFirstName] = useState('');
   const [email, setEmail] = useState('');
   const [phone, setPhone] = useState('');
+  // A2P 10DLC: SMS opt-in is an affirmative action — default unchecked.
+  const [smsConsent, setSmsConsent] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const lastBlurredRef = useRef<Record<string, string>>({});
@@ -88,6 +91,9 @@ export default function LeadMagnetModal({ magnet, open, onClose, modeBadge }: Pr
         leadMagnetId: magnet.id,
         rewardUrl: magnet.rewardUrl,
         flow: 'lead-magnet',
+        // A2P 10DLC consent proof: only true when a phone was given AND the
+        // customer affirmatively checked the (unchecked-by-default) opt-in.
+        smsConsent: phone.trim() ? smsConsent : false,
       },
       page: typeof window !== 'undefined' ? window.location.pathname : undefined,
     });
@@ -248,14 +254,22 @@ export default function LeadMagnetModal({ magnet, open, onClose, modeBadge }: Pr
                   navy={T.navy}
                 />
                 {magnet.askPhone && (
-                  <Input
-                    label="Phone (we'll text you reminders, no spam)"
-                    type="tel"
-                    value={phone}
-                    onChange={setPhone}
-                    onBlur={(v) => onFieldBlur('phone', v)}
-                    navy={T.navy}
-                  />
+                  <>
+                    <Input
+                      label="Phone (optional)"
+                      type="tel"
+                      value={phone}
+                      onChange={setPhone}
+                      onBlur={(v) => onFieldBlur('phone', v)}
+                      navy={T.navy}
+                    />
+                    <SmsConsentCheckbox
+                      id="lead-magnet-sms-consent"
+                      checked={smsConsent}
+                      onChange={setSmsConsent}
+                      className="pt-1"
+                    />
+                  </>
                 )}
                 <button
                   type="submit"

--- a/src/lib/stripe/checkout.ts
+++ b/src/lib/stripe/checkout.ts
@@ -27,6 +27,8 @@ export interface CheckoutMetadata {
   discountCode?: string;
   affiliateCode?: string;
   tipAmount?: string;
+  /** 'true' | 'false' — A2P 10DLC SMS marketing opt-in captured at checkout. */
+  smsConsent?: string;
 
   // First-touch marketing attribution (captured on landing, forwarded by client)
   landingPage?: string;
@@ -63,6 +65,8 @@ export interface CreateCheckoutOptions {
   affiliateCode?: string;
   overrideDeliveryFee?: number;
   tipAmount?: number;
+  /** A2P 10DLC: customer affirmatively opted in to marketing/reminder SMS. */
+  smsConsent?: boolean;
   attribution?: {
     landingPage?: string | null;
     utmSource?: string | null;
@@ -80,7 +84,7 @@ export interface CreateCheckoutOptions {
 export async function createCheckoutSession(
   options: CreateCheckoutOptions
 ): Promise<Stripe.Checkout.Session> {
-  const { cart, successUrl, cancelUrl, customerEmail, stripeCustomerId, affiliateCode, overrideDeliveryFee, tipAmount, attribution } = options;
+  const { cart, successUrl, cancelUrl, customerEmail, stripeCustomerId, affiliateCode, overrideDeliveryFee, tipAmount, attribution, smsConsent } = options;
 
   // Defense-in-depth: refuse to charge for any product that isn't ACTIVE (or whose variant isn't
   // availableForSale), re-read from the DB rather than trusting the cart snapshot. A product
@@ -157,6 +161,7 @@ export async function createCheckoutSession(
     discountCode: cart.discountCode || undefined,
     affiliateCode: affiliateCode || undefined,
     tipAmount: tipAmount && tipAmount > 0 ? tipAmount.toFixed(2) : undefined,
+    smsConsent: smsConsent === undefined ? undefined : smsConsent ? 'true' : 'false',
     landingPage: attribution?.landingPage || undefined,
     utmSource: attribution?.utmSource || undefined,
     utmMedium: attribution?.utmMedium || undefined,
@@ -185,11 +190,14 @@ export async function createCheckoutSession(
       enabled: true,
     },
     billing_address_collection: 'required',
-    // SMS consent disclosure shown at the phone-number field (A2P 10DLC opt-in).
+    // Transactional order/delivery texts for THIS order shown at the phone
+    // field. Marketing/reminder SMS consent is collected separately via an
+    // explicit, unchecked opt-in checkbox on our checkout + lead forms (A2P
+    // 10DLC express consent) — this disclosure is not the marketing opt-in.
     custom_text: {
       submit: {
         message:
-          'By providing your phone number, you agree to receive order and delivery text messages from Party On Delivery. Message and data rates may apply. Reply STOP to opt out. See our Privacy Policy at partyondelivery.com/privacy.',
+          'We may text you order and delivery updates for this order at the number you provide. Msg & data rates may apply. Reply STOP to opt out, HELP for help. See our Privacy Policy at partyondelivery.com/privacy.',
       },
     },
   };


### PR DESCRIPTION
## Why
Twilio Trust & Safety (case #27953198, Varun) rejected our A2P 10DLC campaign for two specific, fixable reasons — **not** category-level:
1. No effective age-gating restricting site access to 21+.
2. Non-compliant SMS opt-in — pre-checked / implied consent, not affirmative.

This fixes both on the live site so Twilio can re-review.

## What
- **Age gate:** re-mount the site-wide 21+ entrance gate (`<AgeVerification/>` in the root layout). It was deliberately unmounted for conversion; Twilio requires it. Paid-lander exemptions kept (they carry their own in-checkout 21+ check).
- **Un-pre-check all five 21+ boxes** (invoice, quick-buy, dashboard, disco-cruise; main checkout was already unchecked). Express consent must be affirmative — never pre-checked. **All still gate their submit button** (verified), so this is strictly stronger than the old pre-checked default.
- **Unchecked, affirmative SMS opt-in checkbox** (new `SmsConsentCheckbox`, CTIA-compliant copy) on the lead-magnet popup + `/checkout`. Consent is **optional (never a condition of purchase)** and recorded to lead metadata + Stripe session metadata. The Stripe phone-field disclosure is reframed as transactional.

## Verification
- `tsc --noEmit` clean on the changed files; `npm run lint` exit 0; 736 tests pass (pre-rebase; unchanged since). The 4 post-rebase tsc errors are all the upstream `/admin/leads` board's `@dnd-kit/core` — a stale-worktree `node_modules` gap (dep is in package.json), not this PR.
- **security-reviewer: SAFE TO MERGE.** Confirmed boxes are unchecked-by-default, consent never gates purchase, age gating intact, hydration-safe, no new PII exposure.

## Follow-up (tracked separately)
This PR **records** SMS consent but does not yet **enforce** it downstream — the order→GHL payload still forwards the phone unconditionally, and the follow-up enqueue defaults consent to false. Wiring `smsConsent` into the GHL payload + Stripe webhook + `enqueueJourney` (+ `createFreeOrder` for $0 orders, + a disclosure on the group-checkout Stripe sessions) is the real enforcement layer — a separate change (touches the payment webhook + likely an `Order.smsConsent` column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)