### PR TITLE
fix(admin/leads): lead drawer becomes a contained pop-up with a visible X

### DIFF
--- a/src/app/admin/leads/_components/lead-drawer.tsx
+++ b/src/app/admin/leads/_components/lead-drawer.tsx
@@ -94,8 +94,11 @@ export default function LeadDrawer({
   const name = lead ? [lead.firstName, lead.lastName].filter(Boolean).join(' ') || lead.email || 'Lead' : 'Lead';
 
   return (
-    <BottomSheet open={leadId !== null} onClose={onClose} title={name}>
-      <div className="px-4 pb-8 pt-2 max-h-[80vh] overflow-y-auto">
+    // centered: contained pop-up with a visible X — a full-height sheet read
+    // as an inescapable takeover (operator feedback 2026-07-14). The sheet
+    // owns scrolling, so no inner max-h/overflow here.
+    <BottomSheet open={leadId !== null} onClose={onClose} title={name} centered>
+      <div className="px-4 pb-8 pt-2">
         {loading && !detail && <div className="py-10 text-center text-gray-400">Loading…</div>}
         {lead && detail && (
           <>

--- a/src/components/backend/kit/BottomSheet.tsx
+++ b/src/components/backend/kit/BottomSheet.tsx
@@ -8,17 +8,27 @@ import { createPortal } from 'react-dom';
  * only sanctioned blur; sheet slides up 200ms (quiet under reduced-motion via
  * the .pod-sheet-enter rule in globals.css). Portaled to <body> so transformed
  * ancestors can't trap the fixed positioning. z-50 per the shell z-scale.
+ *
+ * Every sheet gets an explicit X close button (Esc and backdrop-tap also
+ * close, but neither is discoverable — 2026-07-14 operator feedback).
+ *
+ * `centered`: render as a contained pop-up instead of an edge-to-edge sheet —
+ * a floating card with visible margins on mobile, centered on md+ — for
+ * content-heavy surfaces (e.g. the lead drawer) that would otherwise read as
+ * a full-screen takeover.
  */
 export default function BottomSheet({
   open,
   onClose,
   title,
   children,
+  centered = false,
 }: {
   open: boolean;
   onClose: () => void;
   title?: string;
   children: ReactNode;
+  centered?: boolean;
 }): ReactElement | null {
   useEffect(() => {
     if (!open) return;
@@ -35,6 +45,35 @@ export default function BottomSheet({
 
   if (!open || typeof document === 'undefined') return null;
 
+  const sheetInner = (
+    <>
+      <div className="sticky top-0 z-10 bg-white pt-2 pb-1 rounded-t-2xl">
+        {!centered && <div className="mx-auto w-9 h-1 rounded-full bg-gray-300" />}
+        <button
+          type="button"
+          aria-label="Close"
+          onClick={onClose}
+          className="absolute right-2 top-2 flex h-11 w-11 items-center justify-center rounded-lg text-gray-500 hover:text-gray-900 hover:bg-gray-100"
+        >
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+            <path
+              d="M5 5l10 10M15 5L5 15"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+          </svg>
+        </button>
+        {title && (
+          <div className="px-5 pt-3 pr-14 font-heading font-bold text-lg tracking-[0.08em] uppercase text-gray-900">
+            {title}
+          </div>
+        )}
+      </div>
+      <div className="px-5 pt-2">{children}</div>
+    </>
+  );
+
   return createPortal(
     <div className="fixed inset-0 z-50 print:hidden" role="dialog" aria-modal="true" aria-label={title}>
       <button
@@ -43,17 +82,17 @@ export default function BottomSheet({
         onClick={onClose}
         className="absolute inset-0 w-full h-full bg-black/50 backdrop-blur-sm cursor-default"
       />
-      <div className="pod-sheet-enter absolute bottom-0 left-0 right-0 max-h-[85vh] overflow-y-auto bg-white rounded-t-2xl shadow-xl pb-[max(16px,env(safe-area-inset-bottom))]">
-        <div className="sticky top-0 bg-white pt-2 pb-1 rounded-t-2xl">
-          <div className="mx-auto w-9 h-1 rounded-full bg-gray-300" />
-          {title && (
-            <div className="px-5 pt-3 font-heading font-bold text-lg tracking-[0.08em] uppercase text-gray-900">
-              {title}
-            </div>
-          )}
+      {centered ? (
+        <div className="absolute inset-0 flex items-end justify-center p-3 pb-[max(12px,env(safe-area-inset-bottom))] md:items-center pointer-events-none">
+          <div className="pod-sheet-enter pointer-events-auto relative w-full max-w-2xl max-h-[85vh] overflow-y-auto bg-white rounded-2xl shadow-xl pb-4">
+            {sheetInner}
+          </div>
         </div>
-        <div className="px-5 pt-2">{children}</div>
-      </div>
+      ) : (
+        <div className="pod-sheet-enter absolute bottom-0 left-0 right-0 max-h-[85vh] overflow-y-auto bg-white rounded-t-2xl shadow-xl pb-[max(16px,env(safe-area-inset-bottom))]">
+          {sheetInner}
+        </div>
+      )}
     </div>,
     document.body,
   );


### PR DESCRIPTION
Operator feedback: opening a lead card took over the entire screen and there was no visible way to close it (Esc / backdrop-tap only — neither discoverable).

- **Every kit BottomSheet now has an explicit X** in its sticky header (the More sheet, order action sheet, stock stepper, and filter sheet get it too — additive only).
- **New `centered` variant** renders a contained pop-up instead of an edge-to-edge sheet: floating card with visible margins on mobile, centered `max-w-2xl` modal on desktop.
- **The lead drawer uses `centered`** and drops its nested scroll container (the sheet owns scrolling).

Independent of the lead-capture PR chain — based on main, mergeable any time.

Gates: tsc ✓ · lint 0 errors ✓ · vitest ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)