### PR TITLE
feat(compliance): A2P round 3 — DOB age gate + Twilio consent wording

### DIFF
--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -458,6 +458,15 @@ export default function CheckoutPage() {
                     />
                   </div>
                 </div>
+
+                {/* SMS opt-in — optional, unchecked by default (A2P 10DLC), paired with the phone field above */}
+                <div className="mt-4">
+                  <SmsConsentCheckbox
+                    id="checkout-sms-consent"
+                    checked={smsConsent}
+                    onChange={setSmsConsent}
+                  />
+                </div>
               </div>
 
               {/* Fulfillment Method Picker */}
@@ -819,15 +828,6 @@ export default function CheckoutPage() {
                     </Link>
                   </span>
                 </label>
-
-                {/* SMS opt-in — optional, unchecked by default (A2P 10DLC) */}
-                <div className="mt-3">
-                  <SmsConsentCheckbox
-                    id="checkout-sms-consent"
-                    checked={smsConsent}
-                    onChange={setSmsConsent}
-                  />
-                </div>
 
                 {/* Checkout Error */}
                 {checkoutError && (

--- a/src/components/AgeVerificationModal.tsx
+++ b/src/components/AgeVerificationModal.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -11,35 +12,70 @@ interface AgeVerificationModalProps {
   onVerify: () => void
 }
 
+/**
+ * Whole years from a YYYY-MM-DD date of birth to today. Returns null if the
+ * string isn't a valid calendar date.
+ */
+export function ageFromDob(dob: string): number | null {
+  const parts = dob.split('-').map((n) => parseInt(n, 10))
+  if (parts.length !== 3 || parts.some((n) => Number.isNaN(n))) return null
+  const [y, m, d] = parts
+  const birth = new Date(y, m - 1, d)
+  // Reject impossible dates (e.g. Feb 30 normalizes to March).
+  if (birth.getFullYear() !== y || birth.getMonth() !== m - 1 || birth.getDate() !== d) return null
+  const today = new Date()
+  let age = today.getFullYear() - y
+  const beforeBirthday = today.getMonth() + 1 < m || (today.getMonth() + 1 === m && today.getDate() < d)
+  if (beforeBirthday) age -= 1
+  return age
+}
+
 export default function AgeVerificationModal({ isOpen, onClose, onVerify }: AgeVerificationModalProps) {
   // Lock body scroll when modal is open
-  useBodyScrollLock(isOpen);
-  const handleYes = () => {
+  useBodyScrollLock(isOpen)
+  const [dob, setDob] = useState('')
+  const [error, setError] = useState('')
+
+  // Renders client-side only (parent opens via useEffect), so new Date() here
+  // never runs during SSR and can't cause a hydration mismatch.
+  const todayStr = new Date().toISOString().slice(0, 10)
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    const age = ageFromDob(dob)
+    if (age === null) {
+      setError('Please enter your date of birth.')
+      return
+    }
+    if (age < 21) {
+      setError('Sorry — you must be 21 or older to enter this site.')
+      return
+    }
     localStorage.setItem('age_verified', 'true')
     onVerify()
     onClose()
   }
 
-  const handleNo = () => {
+  const handleUnder = () => {
     onClose()
-    // Optionally redirect to a different page
+    // Send under-age / declining visitors away from the site.
     window.location.href = 'https://www.google.com'
   }
 
   return (
     <AnimatePresence>
       {isOpen && (
-        <motion.div 
+        <motion.div
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           className="fixed inset-0 z-[100] flex items-center justify-center bg-black/90 backdrop-blur-sm"
         >
-          <motion.div 
+          <motion.div
             initial={{ scale: 0.95, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}
             exit={{ scale: 0.95, opacity: 0 }}
-            transition={{ type: "spring", duration: 0.5 }}
+            transition={{ type: 'spring', duration: 0.5 }}
             className="bg-white max-w-sm w-full mx-4 border border-brand-yellow/20 shadow-2xl"
           >
             {/* Logo Header */}
@@ -64,33 +100,52 @@ export default function AgeVerificationModal({ isOpen, onClose, onVerify }: AgeV
                 </h2>
               </div>
 
-              {/* Question */}
-              <div className="bg-gray-50 py-4 px-4 mb-4 sm:py-6 sm:px-6 sm:mb-6 text-center">
-                <p className="text-base sm:text-lg text-gray-800 font-light tracking-wide">
-                  Are you 21 years of age or older?
-                </p>
-              </div>
+              <form onSubmit={handleSubmit}>
+                {/* Date of birth entry */}
+                <div className="bg-gray-50 py-4 px-4 mb-4 sm:py-6 sm:px-6 sm:mb-6">
+                  <label
+                    htmlFor="age-gate-dob"
+                    className="block text-base sm:text-lg text-gray-800 font-light tracking-wide text-center mb-3"
+                  >
+                    Please enter your date of birth
+                  </label>
+                  <input
+                    id="age-gate-dob"
+                    type="date"
+                    value={dob}
+                    max={todayStr}
+                    required
+                    onChange={(e) => {
+                      setDob(e.target.value)
+                      setError('')
+                    }}
+                    className="w-full px-4 py-3 border border-gray-300 text-center text-gray-900 focus:border-brand-yellow focus:outline-none"
+                  />
+                  {error && <p className="mt-3 text-sm text-red-600 text-center">{error}</p>}
+                </div>
 
-              {/* Buttons */}
-              <div className="grid grid-cols-2 gap-3 sm:gap-4">
-                <motion.button
-                  whileHover={{ scale: 1.02 }}
-                  whileTap={{ scale: 0.98 }}
-                  onClick={handleYes}
-                  className="py-3 sm:py-4 bg-brand-yellow text-gray-900 font-medium tracking-[0.08em] text-sm hover:bg-yellow-600 transition-colors"
-                >
-                  YES, I AM 21+
-                </motion.button>
+                {/* Buttons */}
+                <div className="grid grid-cols-2 gap-3 sm:gap-4">
+                  <motion.button
+                    type="submit"
+                    whileHover={{ scale: 1.02 }}
+                    whileTap={{ scale: 0.98 }}
+                    className="py-3 sm:py-4 bg-brand-yellow text-gray-900 font-medium tracking-[0.08em] text-sm hover:bg-yellow-600 transition-colors"
+                  >
+                    ENTER SITE
+                  </motion.button>
 
-                <motion.button
-                  whileHover={{ scale: 1.02 }}
-                  whileTap={{ scale: 0.98 }}
-                  onClick={handleNo}
-                  className="py-3 sm:py-4 border border-gray-300 text-gray-700 font-medium tracking-[0.08em] text-sm hover:bg-gray-50 transition-colors"
-                >
-                  NO
-                </motion.button>
-              </div>
+                  <motion.button
+                    type="button"
+                    whileHover={{ scale: 1.02 }}
+                    whileTap={{ scale: 0.98 }}
+                    onClick={handleUnder}
+                    className="py-3 sm:py-4 border border-gray-300 text-gray-700 font-medium tracking-[0.08em] text-sm hover:bg-gray-50 transition-colors"
+                  >
+                    I&apos;M UNDER 21
+                  </motion.button>
+                </div>
+              </form>
 
               {/* Legal Text */}
               <p className="mt-4 sm:mt-6 text-xs text-gray-500 text-center leading-relaxed px-2">

--- a/src/components/__tests__/ageFromDob.test.ts
+++ b/src/components/__tests__/ageFromDob.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { ageFromDob } from '../AgeVerificationModal'
+
+/** A YYYY-MM-DD string for `years` before today, shifted by `dayOffset` days. */
+function dobYearsAgo(years: number, dayOffset = 0): string {
+  const t = new Date()
+  const d = new Date(t.getFullYear() - years, t.getMonth(), t.getDate() + dayOffset)
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+describe('ageFromDob — 21+ gate boundaries', () => {
+  it('admits someone exactly 21 today', () => {
+    expect(ageFromDob(dobYearsAgo(21))).toBe(21)
+  })
+  it('blocks someone whose 21st birthday is tomorrow (still 20 today)', () => {
+    expect(ageFromDob(dobYearsAgo(21, 1))).toBe(20)
+  })
+  it('admits someone whose 21st birthday was yesterday', () => {
+    expect(ageFromDob(dobYearsAgo(21, -1))).toBe(21)
+  })
+  it('blocks a clear 20-year-old', () => {
+    expect(ageFromDob(dobYearsAgo(20))).toBe(20)
+  })
+  it('admits a 40-year-old', () => {
+    expect(ageFromDob(dobYearsAgo(40))).toBe(40)
+  })
+  it('returns null for empty / invalid / impossible dates', () => {
+    expect(ageFromDob('')).toBeNull()
+    expect(ageFromDob('not-a-date')).toBeNull()
+    expect(ageFromDob('2005-02-30')).toBeNull()
+    expect(ageFromDob('2005-13-01')).toBeNull()
+  })
+})

--- a/src/components/consent/SmsConsentCheckbox.tsx
+++ b/src/components/consent/SmsConsentCheckbox.tsx
@@ -37,11 +37,15 @@ export default function SmsConsentCheckbox({
         className="mt-0.5 rounded border-gray-300 text-brand-blue focus:ring-brand-blue"
       />
       <span className="text-gray-600 leading-snug">
-        Text me order updates and occasional offers from Party On Delivery. Message
-        frequency varies; msg &amp; data rates may apply. Reply STOP to opt out, HELP for
-        help. Consent is not a condition of purchase. See our{' '}
+        I agree to receive text messages from Party On Delivery about my orders. Message
+        frequency varies; message &amp; data rates may apply. Reply STOP to opt out, HELP for
+        help. See our{' '}
         <Link href="/privacy" target="_blank" className="underline hover:text-gray-900">
           Privacy Policy
+        </Link>{' '}
+        and{' '}
+        <Link href="/terms" target="_blank" className="underline hover:text-gray-900">
+          Terms and Conditions
         </Link>
         .
       </span>


### PR DESCRIPTION
## Why
Twilio T&S (case #27953198) re-reviewed and asked for two more specifics before approving:
1. The age gate must require **date-of-birth entry** (not a Yes/No button).
2. Use their **exact consent wording** with links to **both** Privacy Policy and Terms, paired with a phone field.

Follow-up to #248.

## What
- **AgeVerificationModal → DOB entry:** replaced Yes/No with a date-of-birth input; `ageFromDob` computes age and admits only 21+. Under-21/invalid → blocked with an error; no dismiss or overlay-click bypass. Shared component, so the site-wide gate **and** the per-product add-to-cart modals now require DOB.
- **Consent copy → Twilio's wording:** "I agree to receive text messages from Party On Delivery about my orders. Message frequency varies; message & data rates may apply. Reply STOP to opt out, HELP for help." + links to **both** `/privacy` and `/terms`. (Popup + checkout share this component.)
- **Checkout:** moved the SMS opt-in checkbox to sit directly under the phone field, so phone + affirmative consent read as one unit.

## Verification
- 6 new unit tests for `ageFromDob` cover the boundaries (exactly-21 admits, 21st-birthday-tomorrow blocks at 20, invalid/impossible dates → null). **814 tests pass.**
- My files: tsc-clean, lint exit 0. (3 unrelated tsc errors in the worktree are dependency-version noise in files this PR doesn't touch — recharts/stripe — not gated by CI.)
- UI/copy only — no new data/auth/payment logic; the unchanged `smsConsent` threading was covered by #248's security review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)