### PR TITLE
feat(leads): lead-source enum foundation (GROUP_DASHBOARD, PARTNER_INQUIRY, OPS_INVOICE, LEAD_MAGNET)

### DIFF
--- a/prisma/migrations/manual/2026-07-14-lead-source-group-dashboard.sql
+++ b/prisma/migrations/manual/2026-07-14-lead-source-group-dashboard.sql
@@ -1,0 +1,10 @@
+-- Lead-capture gap closure — GROUP_DASHBOARD LeadSourceWidget enum value.
+-- Server-stamped source for GroupOrderV2 dashboard hosts mirrored onto the
+-- Lead Flow board (never claimable by the public pixel).
+--
+-- Deliberately its own file with NO BEGIN/COMMIT: ALTER TYPE ... ADD VALUE
+-- cannot share a transaction with statements that use the new value, and the
+-- migration runner executes each file as a single query. Keep this file to
+-- exactly this one statement. (Precedent: 2026-07-06-followups-emailtype.sql.)
+
+ALTER TYPE "LeadSourceWidget" ADD VALUE IF NOT EXISTS 'GROUP_DASHBOARD';

--- a/prisma/migrations/manual/2026-07-14-lead-source-lead-magnet.sql
+++ b/prisma/migrations/manual/2026-07-14-lead-source-lead-magnet.sql
@@ -1,0 +1,11 @@
+-- Lead-capture gap closure — LEAD_MAGNET LeadSourceWidget enum value.
+-- Server-stamped source for lead-magnet popup submissions that include a
+-- phone number (party intent) — boards, unlike email-only EMAIL_SIGNUP
+-- captures which stay newsletter-only.
+--
+-- Deliberately its own file with NO BEGIN/COMMIT: ALTER TYPE ... ADD VALUE
+-- cannot share a transaction with statements that use the new value, and the
+-- migration runner executes each file as a single query. Keep this file to
+-- exactly this one statement. (Precedent: 2026-07-06-followups-emailtype.sql.)
+
+ALTER TYPE "LeadSourceWidget" ADD VALUE IF NOT EXISTS 'LEAD_MAGNET';

--- a/prisma/migrations/manual/2026-07-14-lead-source-ops-invoice.sql
+++ b/prisma/migrations/manual/2026-07-14-lead-source-ops-invoice.sql
@@ -1,0 +1,10 @@
+-- Lead-capture gap closure — OPS_INVOICE LeadSourceWidget enum value.
+-- Server-stamped source for leads mirrored from ops-created draft invoices
+-- to brand-new contacts (so sweepQuoteSent has a card to move to QUOTE_SENT).
+--
+-- Deliberately its own file with NO BEGIN/COMMIT: ALTER TYPE ... ADD VALUE
+-- cannot share a transaction with statements that use the new value, and the
+-- migration runner executes each file as a single query. Keep this file to
+-- exactly this one statement. (Precedent: 2026-07-06-followups-emailtype.sql.)
+
+ALTER TYPE "LeadSourceWidget" ADD VALUE IF NOT EXISTS 'OPS_INVOICE';

--- a/prisma/migrations/manual/2026-07-14-lead-source-partner-inquiry.sql
+++ b/prisma/migrations/manual/2026-07-14-lead-source-partner-inquiry.sql
@@ -1,0 +1,10 @@
+-- Lead-capture gap closure — PARTNER_INQUIRY LeadSourceWidget enum value.
+-- Server-stamped source for B2B contacts (partner inquiry forms + affiliate
+-- applications) mirrored onto the Lead Flow board.
+--
+-- Deliberately its own file with NO BEGIN/COMMIT: ALTER TYPE ... ADD VALUE
+-- cannot share a transaction with statements that use the new value, and the
+-- migration runner executes each file as a single query. Keep this file to
+-- exactly this one statement. (Precedent: 2026-07-06-followups-emailtype.sql.)
+
+ALTER TYPE "LeadSourceWidget" ADD VALUE IF NOT EXISTS 'PARTNER_INQUIRY';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3310,6 +3310,13 @@ enum LeadSourceWidget {
   PARTNER_FAREHARBOR_WEBHOOK
   PARTNER_EMAIL_OPTIN
   PARTNER_LANDING_PAGE
+  /// Server-stamped sources (lead-capture gap closure 2026-07-14) — never
+  /// claimable by the public pixel; see the 2026-07-14-lead-source-*.sql
+  /// manual migrations.
+  GROUP_DASHBOARD
+  PARTNER_INQUIRY
+  OPS_INVOICE
+  LEAD_MAGNET
   OTHER
 }
 

--- a/src/app/admin/leads/_components/board-filters.tsx
+++ b/src/app/admin/leads/_components/board-filters.tsx
@@ -6,11 +6,15 @@ import type { BoardFilters } from '@/lib/leads/board-types';
 
 const SOURCE_OPTIONS = [
   ['', 'All sources'],
+  ['GROUP_DASHBOARD', 'Party Dashboard'],
   ['PARTNER_LANDING_PAGE', 'Concierge'],
   ['CONTACT_FORM', 'Contact / Quote'],
+  ['PARTNER_INQUIRY', 'B2B / Partner'],
+  ['OPS_INVOICE', 'Ops Invoice'],
   ['QUICK_BUY', 'Quick Buy'],
   ['PACKAGE_BUILDER', 'Package Builder'],
   ['DRINK_CALCULATOR', 'Calculator'],
+  ['LEAD_MAGNET', 'Lead Magnet'],
   ['EMAIL_SIGNUP', 'Email Signup'],
   ['OTHER', 'Site'],
 ] as const;

--- a/src/lib/leads/__tests__/pipeline.test.ts
+++ b/src/lib/leads/__tests__/pipeline.test.ts
@@ -252,6 +252,17 @@ describe('board eligibility', () => {
     expect(isNewsletterOnly({ sourceWidget: 'CONTACT_FORM', metadata: {} })).toBe(false);
   });
 
+  it('gap-closure metadata keys count as inquiries; leadMagnet deliberately does not', () => {
+    const signup = (metadata: Record<string, unknown>) =>
+      isNewsletterOnly({ sourceWidget: 'EMAIL_SIGNUP', metadata: { newsletter: {}, ...metadata } });
+    expect(signup({ groupDashboard: { shareCode: 'abc' } })).toBe(false);
+    expect(signup({ partnerInquiry: { inquiryId: 'p1' } })).toBe(false);
+    expect(signup({ affiliateApplication: { applicationId: 'a1' } })).toBe(false);
+    expect(signup({ opsInvoice: { draftOrderId: 'd1' } })).toBe(false);
+    // Email-only lead-magnet capture stays newsletter-only (no phone = no intent).
+    expect(signup({ leadMagnet: { magnetId: 'checklist' } })).toBe(true);
+  });
+
   it('requires contact info and SUBMITTED (or PARTIAL only when allowed)', () => {
     const asLite = (l: MockLead) => l as unknown as Parameters<typeof isBoardEligible>[0];
     const base = makeLead({ email: null, phone: null });

--- a/src/lib/leads/__tests__/scoring.test.ts
+++ b/src/lib/leads/__tests__/scoring.test.ts
@@ -195,3 +195,37 @@ describe('computeLeadScore — per-surface fixtures', () => {
     expect(maxed.score).toBe(100);
   });
 });
+
+describe('computeLeadScore — gap-closure sources (2026-07-14)', () => {
+  const base = { createdAt: NOW, lastActivityAt: NOW, now: NOW } as const;
+
+  it('groupDashboard metadata scores like a real quote and feeds facts', () => {
+    const { breakdown } = computeLeadScore({
+      ...base,
+      sourceWidget: 'GROUP_DASHBOARD',
+      metadata: {
+        groupDashboard: { deliveryDate: isoDaysFromNow(6), partyType: 'bachelorette' },
+      },
+    });
+    expect(breakdown.sourceQuality).toBe(16);
+    expect(breakdown.eventProximity).toBe(30); // deliveryDate drives proximity
+  });
+
+  it('new widget tiers: OPS_INVOICE 16, PARTNER_INQUIRY 14, LEAD_MAGNET 6', () => {
+    const q = (w: string) =>
+      computeLeadScore({ ...base, sourceWidget: w, metadata: {} }).breakdown.sourceQuality;
+    expect(q('OPS_INVOICE')).toBe(16);
+    expect(q('PARTNER_INQUIRY')).toBe(14);
+    expect(q('LEAD_MAGNET')).toBe(6);
+    expect(q('EMAIL_SIGNUP')).toBe(2); // unchanged
+  });
+
+  it('opsInvoice deliveryDate reaches event proximity', () => {
+    const { breakdown } = computeLeadScore({
+      ...base,
+      sourceWidget: 'OPS_INVOICE',
+      metadata: { opsInvoice: { deliveryDate: isoDaysFromNow(10) } },
+    });
+    expect(breakdown.eventProximity).toBe(26); // ≤14 days
+  });
+});

--- a/src/lib/leads/board-types.ts
+++ b/src/lib/leads/board-types.ts
@@ -83,5 +83,9 @@ export const SOURCE_LABELS: Record<string, string> = {
   PARTNER_FAREHARBOR_WEBHOOK: 'Partner',
   PARTNER_EMAIL_OPTIN: 'Partner',
   PARTNER_LANDING_PAGE: 'Concierge',
+  GROUP_DASHBOARD: 'Party Dashboard',
+  PARTNER_INQUIRY: 'B2B / Partner',
+  OPS_INVOICE: 'Ops Invoice',
+  LEAD_MAGNET: 'Lead Magnet',
   OTHER: 'Site',
 };

--- a/src/lib/leads/pipeline.ts
+++ b/src/lib/leads/pipeline.ts
@@ -26,7 +26,12 @@ import {
 } from './pipeline-types';
 import { phoneLast10 } from './phone';
 
-/** Metadata keys that mark a lead as a real party inquiry (vs newsletter). */
+/**
+ * Metadata keys that mark a lead as a real party inquiry (vs newsletter).
+ * `leadMagnet` is deliberately absent: an email-only lead-magnet capture must
+ * stay newsletter-only (only phone-carrying magnet submits get the
+ * LEAD_MAGNET sourceWidget, which is not EMAIL_SIGNUP and boards normally).
+ */
 const INQUIRY_META_KEYS = [
   'conciergeQuiz',
   'chatQuiz',
@@ -34,6 +39,10 @@ const INQUIRY_META_KEYS = [
   'contactForm',
   'unifiedQuote',
   'quote',
+  'groupDashboard',
+  'partnerInquiry',
+  'affiliateApplication',
+  'opsInvoice',
 ] as const;
 
 const SWEEP_BATCH = 200;

--- a/src/lib/leads/scoring.ts
+++ b/src/lib/leads/scoring.ts
@@ -98,6 +98,8 @@ function extractEventDate(meta: unknown): string | null {
     metaSection(meta, 'chatQuiz')?.deliveryDate,
     metaSection(meta, 'unifiedQuote')?.deliveryDate,
     metaSection(meta, 'contactForm')?.eventDate,
+    metaSection(meta, 'groupDashboard')?.deliveryDate,
+    metaSection(meta, 'opsInvoice')?.deliveryDate,
   ];
   for (const c of candidates) {
     if (typeof c === 'string' && c.trim()) return c;
@@ -145,6 +147,8 @@ export function extractLeadFacts(meta: unknown): LeadFacts {
     metaSection(meta, 'unifiedQuote')?.partyType,
     metaSection(meta, 'eventQuiz')?.partyType,
     metaSection(meta, 'contactForm')?.eventType,
+    metaSection(meta, 'groupDashboard')?.partyType,
+    metaSection(meta, 'partnerInquiry')?.businessType,
   ];
   let occasion: string | null = null;
   for (const c of occasionCandidates) {
@@ -201,6 +205,7 @@ function sourceQualityPoints(sourceWidget: string | null | undefined, meta: unkn
   const m = asObject(meta) ?? {};
   if (m.conciergeQuiz) return 20; // full questionnaire w/ budget + dates
   if (m.unifiedQuote) return 16; // asked for a real quote
+  if (m.groupDashboard) return 16; // built a party dashboard — strong intent
   if (m.chatQuiz) return 14;
   if (m.eventQuiz) return 12;
   if (m.contactForm) return 10;
@@ -208,16 +213,21 @@ function sourceQualityPoints(sourceWidget: string | null | undefined, meta: unkn
     case 'QUICK_BUY':
     case 'PACKAGE_BUILDER':
     case 'CALL_BOOKING':
+    case 'GROUP_DASHBOARD':
+    case 'OPS_INVOICE':
       return 16;
     case 'PARTNER_LANDING_PAGE':
     case 'PARTNER_FAREHARBOR_WEBHOOK':
     case 'PARTNER_EMAIL_OPTIN':
+    case 'PARTNER_INQUIRY':
       return 14;
     case 'DRINK_CALCULATOR':
       return 12;
     case 'A_LA_CARTE':
     case 'CONTACT_FORM':
       return 10;
+    case 'LEAD_MAGNET':
+      return 6; // freebie popup — real intent only when a phone came with it
     case 'EMAIL_SIGNUP':
       return 2; // newsletter subscriber, not a party inquiry
     default:


### PR DESCRIPTION
PR 1/7. Four additive `LeadSourceWidget` values via ADR-0008 manual migrations (one `ADD VALUE IF NOT EXISTS` per file, no BEGIN/COMMIT). **Auto-applies on the prod deploy via the _manual_migrations ledger** (local pre-apply was policy-blocked). Board source labels + filter options; scoring tiers; groupDashboard/opsInvoice deliveryDate → event proximity + suggest-Lost; INQUIRY_META_KEYS gains the 4 sections (leadMagnet excluded so email-only magnet captures stay newsletter-only). Public pixel widget enum deliberately NOT extended — new values are server-stamped only.

---
Part of the lead-capture gap closure (full-site audit 2026-07-13). **Stacked chain — merge in order 1→7** (GitHub auto-retargets on branch delete). Chain-tip gates: tsc ✓ · lint 0 errors ✓ · vitest 843/843 ✓. security-reviewer on the full chain: 0 critical, and the 2 HIGH + 1 MEDIUM + 1 LOW it raised are all fixed on-branch (forged-trustedSubmit reopen guard in recordEvent, rate limits on lead-magnet + group-create, ops-auth defense-in-depth on draft-orders) — re-review in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)