### PR TITLE
feat(leads): contact form boards realtime + event-quiz attribution + book-now wired

### DIFF
--- a/src/app/(main)/book-now/page.tsx
+++ b/src/app/(main)/book-now/page.tsx
@@ -2,12 +2,16 @@
 
 import { useState, useEffect, Suspense } from 'react'
 import { useSearchParams } from 'next/navigation'
+import Link from 'next/link'
 import Section from '@/components/Section'
 import VideoHero from '@/components/VideoHero'
 
 function BookNowContent() {
   const searchParams = useSearchParams()
   const [activeTab, setActiveTab] = useState('delivery')
+  const [submitting, setSubmitting] = useState(false)
+  const [submitted, setSubmitted] = useState(false)
+  const [error, setError] = useState<string | null>(null)
   const [formData, setFormData] = useState({
     service: '',
     package: '',
@@ -40,10 +44,46 @@ function BookNowContent() {
     setFormData(prev => ({ ...prev, [name]: value }))
   }
 
-  const handleSubmit = (e: React.FormEvent) => {
+  // Submits into the contact-form lead pipeline (SUBMITTED lead + board card
+  // + ops notification) — this form was a no-op console.log until the
+  // 2026-07-13 lead-capture audit. Delivery tab then continues into the real
+  // order flow; event tab shows the quote confirmation.
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    console.log('Form submitted:', formData)
-    // Integration with Shopify Storefront API would go here
+    setError(null)
+    setSubmitting(true)
+    try {
+      const details =
+        activeTab === 'delivery'
+          ? ['Fast delivery request (book-now)', formData.time && `Timing: ${formData.time}`, formData.location && `Address: ${formData.location}`]
+          : ['Event quote request (book-now)', formData.package && `Package: ${formData.package}`, formData.time && `Start time: ${formData.time}`, formData.location && `Venue: ${formData.location}`]
+      const res = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: formData.name,
+          email: formData.email,
+          phone: formData.phone,
+          eventType: activeTab === 'delivery' ? 'fast-delivery' : formData.service,
+          eventDate: formData.date,
+          guestCount: formData.guests,
+          message: [...details.filter(Boolean), formData.notes].filter(Boolean).join('\n'),
+        }),
+      })
+      const json = await res.json()
+      if (!res.ok || !json.success) {
+        throw new Error(json.error || 'Could not send your request. Please try again.')
+      }
+      if (activeTab === 'delivery') {
+        window.location.href = '/order'
+        return
+      }
+      setSubmitted(true)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong — please try again.')
+    } finally {
+      setSubmitting(false)
+    }
   }
 
   return (
@@ -89,6 +129,18 @@ function BookNowContent() {
             </button>
           </div>
 
+          {submitted ? (
+            <div className="bg-gray-50 p-8 rounded-2xl text-center">
+              <h2 className="font-heading text-2xl text-gray-900 mb-3">Request received!</h2>
+              <p className="text-base text-gray-700 mb-6">
+                We&apos;ll contact you within 2 hours with a custom quote. Want to get a head
+                start on drinks in the meantime?
+              </p>
+              <Link href="/order" className="btn-primary px-8 py-3 inline-block">
+                Start an Order
+              </Link>
+            </div>
+          ) : (
           <form onSubmit={handleSubmit} className="space-y-6">
             {activeTab === 'delivery' ? (
               <>
@@ -325,20 +377,31 @@ function BookNowContent() {
 
             {/* Submit Button */}
             <div className="text-center">
+              {error && (
+                <p className="mb-4 text-base text-red-600" role="alert">
+                  {error}
+                </p>
+              )}
               <button
                 type="submit"
-                className="btn-primary px-12 py-4 text-lg"
+                disabled={submitting}
+                className="btn-primary px-12 py-4 text-lg disabled:opacity-60"
               >
-                {activeTab === 'delivery' ? 'Continue to Products' : 'Request Quote'}
+                {submitting
+                  ? 'Sending…'
+                  : activeTab === 'delivery'
+                    ? 'Continue to Products'
+                    : 'Request Quote'}
               </button>
               <p className="mt-4 text-sm text-gray-700">
-                {activeTab === 'delivery' 
+                {activeTab === 'delivery'
                   ? "You'll be able to browse and add products on the next page"
                   : 'We\'ll contact you within 2 hours with a custom quote'
                 }
               </p>
             </div>
           </form>
+          )}
         </div>
       </Section>
 

--- a/src/app/api/contact/__tests__/route.test.ts
+++ b/src/app/api/contact/__tests__/route.test.ts
@@ -1,0 +1,101 @@
+/**
+ * POST /api/contact — the 5th trusted lead route (2026-07-13 audit gap #10):
+ * a contact-form send must promote the lead to SUBMITTED and fire a
+ * trustedSubmit FORM_SUBMIT so the card enrolls (or reopens) in realtime.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const leadCaptureMock = vi.hoisted(() => ({
+  upsertLead: vi.fn(),
+  recordEvent: vi.fn(),
+}));
+vi.mock('@/lib/leads/leadCapture', () => leadCaptureMock);
+
+const prismaMock = vi.hoisted(() => ({ lead: { update: vi.fn() } }));
+vi.mock('@/lib/database/client', () => ({
+  kv: {},
+  isKVConfigured: () => false,
+  prisma: prismaMock,
+}));
+
+vi.mock('@/lib/followups/enqueue', () => ({ enqueueJourney: vi.fn() }));
+vi.mock('@/lib/premier/pod-leads-sheet', () => ({ mirrorLeadToSheet: vi.fn() }));
+vi.mock('@/lib/leads/crm-mirror', () => ({ mirrorLeadToCrm: vi.fn() }));
+
+import { POST } from '../route';
+
+let ipCounter = 0;
+function makeRequest(body: unknown): NextRequest {
+  ipCounter += 1;
+  return new NextRequest('http://localhost/api/contact', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-forwarded-for': `10.2.0.${ipCounter}`,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = {
+  name: 'Jane Smith',
+  email: 'jane@example.com',
+  phone: '512-555-0187',
+  eventType: 'wedding',
+  eventDate: '2026-09-12',
+  guestCount: 40,
+  message: 'Need a bar setup for 40.',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  leadCaptureMock.upsertLead.mockResolvedValue({ id: 'lead-1', metadata: null });
+  leadCaptureMock.recordEvent.mockResolvedValue(null);
+  prismaMock.lead.update.mockResolvedValue({});
+});
+
+describe('POST /api/contact', () => {
+  it('promotes the lead to SUBMITTED with a last-touch source stamp', async () => {
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(200);
+    expect((await res.json()).success).toBe(true);
+
+    expect(prismaMock.lead.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'lead-1' },
+        data: expect.objectContaining({
+          status: 'SUBMITTED',
+          sourcePage: '/contact',
+          sourceWidget: 'CONTACT_FORM',
+        }),
+      }),
+    );
+  });
+
+  it('fires a trustedSubmit FORM_SUBMIT (realtime enroll/reopen)', async () => {
+    await POST(makeRequest(validBody));
+    expect(leadCaptureMock.recordEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'FORM_SUBMIT',
+        leadId: 'lead-1',
+        widget: 'CONTACT_FORM',
+        trustedSubmit: true,
+      }),
+    );
+  });
+
+  it('still succeeds for the customer when lead storage fails', async () => {
+    leadCaptureMock.upsertLead.mockRejectedValue(new Error('db down'));
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(200);
+    expect(leadCaptureMock.recordEvent).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid email without touching the lead layer', async () => {
+    const res = await POST(makeRequest({ ...validBody, email: 'not-an-email' }));
+    expect(res.status).toBe(400);
+    expect(leadCaptureMock.upsertLead).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -4,7 +4,9 @@
  * Historically this ONLY forwarded to a Zapier webhook: if Zapier was down
  * or the env var missing, the message was lost with no trace. Now the
  * submission is stored as a Lead (source CONTACT_FORM, full message in
- * metadata.contactForm) FIRST, then forwarded to Zapier as before, and the
+ * metadata.contactForm) FIRST — promoted to SUBMITTED with a trusted
+ * FORM_SUBMIT so it lands on the /admin/leads board in realtime (one of the
+ * 5 server-zod trusted routes) — then forwarded to Zapier as before, and the
  * contact-form follow-up journey is queued (ack on the next engine tick,
  * "did my reply reach you?" at +72h — flag-gated, deduped per submission).
  */
@@ -12,7 +14,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { prisma } from '@/lib/database/client';
-import { upsertLead } from '@/lib/leads/leadCapture';
+import { recordEvent, upsertLead } from '@/lib/leads/leadCapture';
 import { enqueueJourney } from '@/lib/followups/enqueue';
 import { checkRateLimit } from '@/lib/security/rate-limit';
 import { mirrorLeadToSheet } from '@/lib/premier/pod-leads-sheet';
@@ -72,6 +74,13 @@ export async function POST(request: NextRequest) {
         await prisma.lead.update({
           where: { id: lead.id },
           data: {
+            // A full contact-form send is a real inquiry — promote so the
+            // lead gets a board card instead of sitting PARTIAL in the tray
+            // forever (2026-07-13 audit gap #10). Last-touch source stamp:
+            // this submission is now the lead's active surface.
+            status: 'SUBMITTED',
+            sourcePage: '/contact',
+            sourceWidget: 'CONTACT_FORM',
             metadata: {
               ...existingMeta,
               contactForm: {
@@ -83,6 +92,18 @@ export async function POST(request: NextRequest) {
               },
             },
           },
+        });
+        // 5th trusted route (server-zod-validated + rate-limited): enrolls a
+        // new card in realtime and may reopen a closed one — a fresh contact
+        // message from a WON/LOST lead is a new conversation.
+        await recordEvent({
+          type: 'FORM_SUBMIT',
+          leadId: lead.id,
+          page: '/contact',
+          widget: 'CONTACT_FORM',
+          fieldName: 'contact-form-submit',
+          metadata: { eventType: body.eventType || null, submittedAt },
+          trustedSubmit: true,
         });
       }
     } catch (storageError) {

--- a/src/app/api/v1/event-quiz/submit/route.ts
+++ b/src/app/api/v1/event-quiz/submit/route.ts
@@ -21,6 +21,7 @@ import { z } from 'zod';
 import { sendEmail } from '@/lib/email/resend-client';
 import { eventQuizWelcomeEmail } from '@/lib/email/templates/event-quiz-welcome';
 import { upsertLead, recordEvent } from '@/lib/leads/leadCapture';
+import { attributionSchema, compactAttribution } from '@/lib/leads/attribution-schema';
 import { targetUrlFor } from '@/lib/eventQuiz/routing';
 import { enqueueJourney } from '@/lib/followups/enqueue';
 import { mirrorLeadToSheet } from '@/lib/premier/pod-leads-sheet';
@@ -58,6 +59,9 @@ const schema = z.object({
       ]),
     )
     .default([]),
+  // Optional/nullable so older cached client bundles never 400 (audit gap:
+  // event-quiz was the only trusted route dropping UTM attribution).
+  attribution: attributionSchema,
 });
 
 export async function POST(req: NextRequest) {
@@ -87,6 +91,17 @@ export async function POST(req: NextRequest) {
       {
         sourcePage: '/event-quiz',
         sourceWidget: 'CONTACT_FORM',
+        // UTM columns blank-fill + click ids merge into metadata.attribution.
+        utmSource: body.attribution?.utmSource,
+        utmMedium: body.attribution?.utmMedium,
+        utmCampaign: body.attribution?.utmCampaign,
+        utmContent: body.attribution?.utmContent,
+        utmTerm: body.attribution?.utmTerm,
+        gclid: body.attribution?.gclid,
+        gbraid: body.attribution?.gbraid,
+        wbraid: body.attribution?.wbraid,
+        fbclid: body.attribution?.fbclid,
+        msclkid: body.attribution?.msclkid,
       },
     );
 
@@ -94,6 +109,29 @@ export async function POST(req: NextRequest) {
       leadId = lead.id;
       // Promote to SUBMITTED + stamp the quiz answers in metadata so
       // the Leads dashboard can render them.
+      const prevMeta = (lead.metadata as Record<string, unknown> | null) ?? {};
+      const prevAttribution =
+        prevMeta.attribution &&
+        typeof prevMeta.attribution === 'object' &&
+        !Array.isArray(prevMeta.attribution)
+          ? (prevMeta.attribution as Record<string, unknown>)
+          : {};
+      const nextMeta: Record<string, unknown> = {
+        ...prevMeta,
+        eventQuiz: {
+          partyType: body.partyType,
+          timing: body.timing,
+          needs: body.needs,
+          submittedAt: new Date().toISOString(),
+          resumePath,
+        },
+      };
+      if (body.attribution) {
+        nextMeta.attribution = {
+          ...prevAttribution,
+          ...compactAttribution(body.attribution),
+        };
+      }
       await prisma.lead.update({
         where: { id: lead.id },
         data: {
@@ -102,16 +140,7 @@ export async function POST(req: NextRequest) {
           // even when the email matched an older lead row.
           sourcePage: '/event-quiz',
           sourceWidget: 'CONTACT_FORM',
-          metadata: {
-            ...((lead.metadata as Record<string, unknown> | null) ?? {}),
-            eventQuiz: {
-              partyType: body.partyType,
-              timing: body.timing,
-              needs: body.needs,
-              submittedAt: new Date().toISOString(),
-              resumePath,
-            },
-          },
+          metadata: nextMeta as never,
         },
       });
 
@@ -128,6 +157,10 @@ export async function POST(req: NextRequest) {
           partyType: body.partyType,
           timing: body.timing,
           needs: body.needs,
+          ...(body.attribution?.gclid && { gclid: body.attribution.gclid }),
+          ...(body.attribution?.utmCampaign && {
+            utmCampaign: body.attribution.utmCampaign,
+          }),
         },
       });
     }

--- a/src/components/quiz/EventQuizModal.tsx
+++ b/src/components/quiz/EventQuizModal.tsx
@@ -34,6 +34,7 @@ import {
   type EventNeed,
 } from '@/lib/eventQuiz/routing';
 import { sendLeadEvent } from '@/lib/leads/client';
+import { getAttribution } from '@/lib/analytics/attribution';
 
 const NAVY = '#0A1F33';
 const GOLD = '#F2D34F'; // brand-yellow — matches bachelor landing theme.primary
@@ -127,6 +128,9 @@ export default function EventQuizModal() {
           partyType,
           timing: timingSentinel,
           needs: Array.from(needs),
+          // First-touch UTM/click-id snapshot — the server persists it onto
+          // the Lead (the other quiz/quote surfaces already send this).
+          attribution: getAttribution(),
         }),
       });
       const json = await res.json();

--- a/src/lib/leads/leadCapture.ts
+++ b/src/lib/leads/leadCapture.ts
@@ -296,11 +296,11 @@ export async function recordEvent(opts: {
   fieldValue?: string | null;
   metadata?: Record<string, unknown> | null;
   /**
-   * Set ONLY by server-validated submit routes (chat, concierge, event-quiz,
-   * quote/start). The public pixel route must never set this: event `type`
-   * is client-chosen there, and a trusted submit is what re-opens WON/LOST
-   * board cards — an anonymous caller must not be able to do that with a
-   * victim's email (security review HIGH-1, 2026-07-13).
+   * Set ONLY by server-validated (zod) submit routes: chat, concierge,
+   * event-quiz, quote/start, contact. The public pixel route must never set
+   * this: event `type` is client-chosen there, and a trusted submit is what
+   * re-opens WON/LOST board cards — an anonymous caller must not be able to
+   * do that with a victim's email (security review HIGH-1, 2026-07-13).
    */
   trustedSubmit?: boolean;
 }) {


### PR DESCRIPTION
PR 3/7. `/api/contact` leads sat PARTIAL forever (tray-only) — now SUBMITTED + trustedSubmit FORM_SUBMIT, the **5th** server-zod trusted route (journeys untouched). `/api/v1/event-quiz/submit` was the only trusted route dropping UTM/click-ids — now accepts the shared attribution schema; the quiz modal sends getAttribution(). `/book-now`'s submit button **did nothing** (console.log) — now posts into the contact pipeline (event tab confirms, delivery tab continues to /order). 4 contact route tests.

---
Part of the lead-capture gap closure (full-site audit 2026-07-13). **Stacked chain — merge in order 1→7.** Chain-tip gates: tsc ✓ · lint 0 ✓ · vitest 843/843 ✓. Security: 0 critical; the 2 HIGH + 1 MED + 1 LOW raised are all fixed on-branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)