### PR TITLE
feat(leads): B2B intake boards — partner inquiries + affiliate applications

### DIFF
--- a/src/app/api/partners/inquiry/__tests__/route.test.ts
+++ b/src/app/api/partners/inquiry/__tests__/route.test.ts
@@ -28,12 +28,22 @@ vi.mock('@/lib/email/resend-audiences', () => ({ addContactToAudience: vi.fn() }
 
 const prismaMock = vi.hoisted(() => ({
   partnerInquiry: { findFirst: vi.fn(), update: vi.fn() },
+  lead: { update: vi.fn() },
 }));
 vi.mock('@/lib/database/client', () => ({
   kv: {},
   isKVConfigured: () => false,
   prisma: prismaMock,
 }));
+
+const leadCaptureMock = vi.hoisted(() => ({
+  upsertLead: vi.fn(),
+  markLeadStatus: vi.fn(),
+}));
+vi.mock('@/lib/leads/leadCapture', () => leadCaptureMock);
+
+const pipelineMock = vi.hoisted(() => ({ enrollLeadIfEligible: vi.fn() }));
+vi.mock('@/lib/leads/pipeline', () => pipelineMock);
 
 import { POST } from '../route';
 
@@ -67,6 +77,15 @@ beforeEach(() => {
   emailMock.sendPartnerOnePagerEmail.mockReset();
   prismaMock.partnerInquiry.findFirst.mockReset();
   prismaMock.partnerInquiry.update.mockReset();
+  prismaMock.lead.update.mockReset();
+  leadCaptureMock.upsertLead.mockReset();
+  leadCaptureMock.markLeadStatus.mockReset();
+  pipelineMock.enrollLeadIfEligible.mockReset();
+  leadCaptureMock.upsertLead.mockResolvedValue({
+    id: 'lead-1',
+    status: 'PARTIAL',
+    metadata: null,
+  });
 });
 
 describe('POST /api/partners/inquiry', () => {
@@ -135,5 +154,49 @@ describe('POST /api/partners/inquiry', () => {
     expect(res.status).toBe(200);
     expect(json.success).toBe(true);
     expect(json.inquiryId).toBeUndefined();
+  });
+
+  it('mirrors a successful inquiry onto the Lead Flow board (PARTNER_INQUIRY, promoted)', async () => {
+    dbMock.savePartnerInquiry.mockResolvedValue({ id: 'inq_123' });
+
+    await POST(makeRequest(validBody));
+
+    expect(leadCaptureMock.upsertLead).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'jane@example.com', firstName: 'Jane' }),
+      expect.objectContaining({ sourceWidget: 'PARTNER_INQUIRY' }),
+    );
+    expect(prismaMock.lead.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          metadata: expect.objectContaining({
+            partnerInquiry: expect.objectContaining({ inquiryId: 'inq_123' }),
+          }),
+        }),
+      }),
+    );
+    expect(leadCaptureMock.markLeadStatus).toHaveBeenCalledWith('lead-1', 'SUBMITTED');
+  });
+
+  it('never downgrades a CONVERTED lead — enroll only', async () => {
+    dbMock.savePartnerInquiry.mockResolvedValue({ id: 'inq_124' });
+    leadCaptureMock.upsertLead.mockResolvedValue({
+      id: 'lead-2',
+      status: 'CONVERTED',
+      metadata: null,
+    });
+
+    await POST(makeRequest(validBody));
+
+    expect(leadCaptureMock.markLeadStatus).not.toHaveBeenCalled();
+    expect(pipelineMock.enrollLeadIfEligible).toHaveBeenCalledWith('lead-2');
+  });
+
+  it('writes NO lead when the honeypot trips or the save fails', async () => {
+    await POST(makeRequest({ ...validBody, [HONEYPOT_FIELD]: 'http://spam.example' }));
+    expect(leadCaptureMock.upsertLead).not.toHaveBeenCalled();
+
+    dbMock.savePartnerInquiry.mockResolvedValue(null);
+    await POST(makeRequest(validBody));
+    expect(leadCaptureMock.upsertLead).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/partners/inquiry/route.ts
+++ b/src/app/api/partners/inquiry/route.ts
@@ -6,6 +6,8 @@ import { addContactToAudience } from '@/lib/email/resend-audiences'
 import { kv, isKVConfigured, prisma } from '@/lib/database/client'
 import { isHoneypotTripped } from '@/lib/forms/honeypot'
 import { enqueueJourney } from '@/lib/followups/enqueue'
+import { markLeadStatus, upsertLead } from '@/lib/leads/leadCapture'
+import { enrollLeadIfEligible } from '@/lib/leads/pipeline'
 
 // Sources that trigger an automated outbound email with the partner one-pager
 // PDF + Calendly CTA (in addition to the existing ops notification).
@@ -252,6 +254,54 @@ export async function POST(request: NextRequest) {
       interests: inquiry.interests ? inquiry.interests.split(', ') : [],
       message: inquiry.message || inquiry.notes,
     })
+
+    // Lead Flow board: a B2B inquiry is a sales lead (2026-07-13 audit gap).
+    // Runs only after every bot gate + a successful save. Guarded promote —
+    // never downgrades an existing SUBMITTED/CONVERTED lead — and NO
+    // trustedSubmit (this route is not zod-validated, so it must not gain
+    // the power to reopen closed cards). Never throws.
+    if (dbResult?.id) {
+      try {
+        const [pFirst, ...pRest] = inquiry.contactName.split(/\s+/)
+        const lead = await upsertLead(
+          {
+            email: inquiry.email,
+            phone: inquiry.phone || null,
+            firstName: pFirst || null,
+            lastName: pRest.join(' ') || null,
+          },
+          { sourcePage: '/partners', sourceWidget: 'PARTNER_INQUIRY' }
+        )
+        if (lead) {
+          const prevMeta = (lead.metadata as Record<string, unknown> | null) ?? {}
+          await prisma.lead.update({
+            where: { id: lead.id },
+            data: {
+              // Last-touch stamp — this B2B submission is the active context.
+              sourcePage: '/partners',
+              sourceWidget: 'PARTNER_INQUIRY',
+              metadata: {
+                ...prevMeta,
+                partnerInquiry: {
+                  inquiryId: dbResult.id,
+                  businessName: inquiry.businessName || null,
+                  businessType: inquiry.businessType || inquiry.partnerType || null,
+                  source: inquiry.source || null,
+                  submittedAt: new Date().toISOString(),
+                },
+              },
+            },
+          })
+          if (lead.status === 'PARTIAL' || lead.status === 'ANONYMOUS') {
+            await markLeadStatus(lead.id, 'SUBMITTED')
+          } else {
+            await enrollLeadIfEligible(lead.id)
+          }
+        }
+      } catch (leadErr) {
+        console.warn('[Partner Inquiry] lead mirror failed:', leadErr)
+      }
+    }
 
     // Send email notification via Resend
     try {

--- a/src/app/api/v1/affiliate/apply/route.ts
+++ b/src/app/api/v1/affiliate/apply/route.ts
@@ -6,6 +6,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createPartnerApplication } from '@/lib/affiliates/affiliate-service';
 import { enqueueJourney } from '@/lib/followups/enqueue';
+import { markLeadStatus, upsertLead } from '@/lib/leads/leadCapture';
+import { enrollLeadIfEligible } from '@/lib/leads/pipeline';
+import { prisma } from '@/lib/database/client';
 import { AffiliateCategory } from '@prisma/client';
 
 const VALID_CATEGORIES: AffiliateCategory[] = ['BARTENDER', 'BOAT', 'VENUE', 'PLANNER', 'OTHER'];
@@ -49,6 +52,50 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       notes,
       consent,
     });
+
+    // Lead Flow board: an affiliate application is a B2B lead — and
+    // /affiliate/* is a form-watcher skip path, so without this mirror the
+    // applicant is completely invisible to /admin/leads (2026-07-13 audit
+    // gap). Guarded promote, NO trustedSubmit (route is hand-validated, not
+    // zod — must not gain reopen power). Never throws.
+    try {
+      const [aFirst, ...aRest] = String(contactName).split(/\s+/);
+      const lead = await upsertLead(
+        {
+          email,
+          phone: phone || null,
+          firstName: aFirst || null,
+          lastName: aRest.join(' ') || null,
+        },
+        { sourcePage: '/affiliate/apply', sourceWidget: 'PARTNER_INQUIRY' }
+      );
+      if (lead) {
+        const prevMeta = (lead.metadata as Record<string, unknown> | null) ?? {};
+        await prisma.lead.update({
+          where: { id: lead.id },
+          data: {
+            sourcePage: '/affiliate/apply',
+            sourceWidget: 'PARTNER_INQUIRY',
+            metadata: {
+              ...prevMeta,
+              affiliateApplication: {
+                applicationId: application.id,
+                businessName: businessName || null,
+                category,
+                submittedAt: new Date().toISOString(),
+              },
+            },
+          },
+        });
+        if (lead.status === 'PARTIAL' || lead.status === 'ANONYMOUS') {
+          await markLeadStatus(lead.id, 'SUBMITTED');
+        } else {
+          await enrollLeadIfEligible(lead.id);
+        }
+      }
+    } catch (leadErr) {
+      console.warn('[Affiliate Apply API] lead mirror failed:', leadErr);
+    }
 
     // Queue the affiliate-apply follow-up (ack next tick, +120h check-in
     // while still PENDING). Flag-gated; deduped on the application id, which


### PR DESCRIPTION
PR 4/7. Partner inquiries (6 pages) + affiliate applications stored contacts in their own tables, never a Lead (/affiliate/* is additionally a form-watcher skip path — fully invisible). Both now upsert a `PARTNER_INQUIRY` lead after every bot gate + successful save, with entity-linking metadata; guarded promote; **NO trustedSubmit** (hand-validated routes must not gain reopen power). Filterable via the board's B2B / Partner source. Tests: mirror on success, CONVERTED never downgraded, no lead on honeypot/failed save.

---
Part of the lead-capture gap closure (full-site audit 2026-07-13). **Stacked chain — merge in order 1→7.** Chain-tip gates: tsc ✓ · lint 0 ✓ · vitest 843/843 ✓. Security: 0 critical; the 2 HIGH + 1 MED + 1 LOW raised are all fixed on-branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)