### PR TITLE
feat(leads): ops invoices to new contacts become QUOTE_SENT-trackable

### DIFF
--- a/src/app/api/v1/admin/draft-orders/__tests__/route.test.ts
+++ b/src/app/api/v1/admin/draft-orders/__tests__/route.test.ts
@@ -1,0 +1,143 @@
+/**
+ * POST /api/v1/admin/draft-orders — the ops-invoice lead mirror (2026-07-13
+ * audit gap #7): an invoice to a brand-new contact must produce an
+ * OPS_INVOICE board card; group-attached drafts must not (the dashboard-host
+ * mirror owns those).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const draftOrdersMock = vi.hoisted(() => ({
+  createDraftOrder: vi.fn(),
+  listDraftOrders: vi.fn(),
+  calculateDraftOrderAmounts: vi.fn(),
+}));
+vi.mock('@/lib/draft-orders', () => draftOrdersMock);
+
+const leadCaptureMock = vi.hoisted(() => ({
+  upsertLead: vi.fn(),
+  markLeadStatus: vi.fn(),
+}));
+vi.mock('@/lib/leads/leadCapture', () => leadCaptureMock);
+
+const pipelineMock = vi.hoisted(() => ({ enrollLeadIfEligible: vi.fn() }));
+vi.mock('@/lib/leads/pipeline', () => pipelineMock);
+
+const prismaMock = vi.hoisted(() => ({ lead: { update: vi.fn() } }));
+vi.mock('@/lib/database/client', () => ({
+  kv: {},
+  isKVConfigured: () => false,
+  prisma: prismaMock,
+}));
+
+// Ops-auth gate passes in these tests (a valid session); route logic is what's
+// under test. A separate case flips it to assert the 401 short-circuit.
+const opsAuthMock = vi.hoisted(() => ({ requireOpsAuth: vi.fn() }));
+vi.mock('@/lib/auth/ops-session', () => opsAuthMock);
+
+import { POST } from '../route';
+import { NextResponse } from 'next/server';
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/v1/admin/draft-orders', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = {
+  customerEmail: 'new-contact@example.com',
+  customerName: 'Pat Miller',
+  customerPhone: '512-555-0100',
+  deliveryAddress: '1 Main St',
+  deliveryCity: 'Austin',
+  deliveryZip: '78701',
+  deliveryDate: '2026-08-01',
+  deliveryTime: '12:00 PM - 2:00 PM',
+  items: [
+    { productId: 'p1', variantId: 'v1', title: 'Beer Bucket', quantity: 1, price: 50 },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  opsAuthMock.requireOpsAuth.mockResolvedValue({ sub: 'ops-user' });
+  draftOrdersMock.calculateDraftOrderAmounts.mockReturnValue({
+    subtotal: 50,
+    taxAmount: 4,
+    deliveryFee: 20,
+    discountAmount: 0,
+  });
+  draftOrdersMock.createDraftOrder.mockResolvedValue({ id: 'draft-1', token: 'tok_1' });
+  leadCaptureMock.upsertLead.mockResolvedValue({
+    id: 'lead-1',
+    status: 'PARTIAL',
+    sourceWidget: null,
+    metadata: null,
+  });
+  prismaMock.lead.update.mockResolvedValue({});
+});
+
+describe('POST /api/v1/admin/draft-orders', () => {
+  it('mirrors a non-group draft into an OPS_INVOICE lead linked to the draft', async () => {
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(200);
+
+    expect(leadCaptureMock.upsertLead).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'new-contact@example.com', firstName: 'Pat' }),
+      expect.objectContaining({ sourceWidget: 'OPS_INVOICE' }),
+    );
+    expect(prismaMock.lead.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          draftOrderId: 'draft-1',
+          sourceWidget: 'OPS_INVOICE', // null provenance upgraded
+          metadata: expect.objectContaining({
+            opsInvoice: expect.objectContaining({ draftOrderId: 'draft-1' }),
+          }),
+        }),
+      }),
+    );
+    expect(leadCaptureMock.markLeadStatus).toHaveBeenCalledWith('lead-1', 'SUBMITTED');
+  });
+
+  it('skips the mirror for group-attached drafts', async () => {
+    await POST(makeRequest({ ...validBody, groupOrderId: 'group-1' }));
+    expect(leadCaptureMock.upsertLead).not.toHaveBeenCalled();
+  });
+
+  it('keeps a real sourceWidget and never downgrades a CONVERTED lead', async () => {
+    leadCaptureMock.upsertLead.mockResolvedValue({
+      id: 'lead-2',
+      status: 'CONVERTED',
+      sourceWidget: 'CONTACT_FORM',
+      metadata: null,
+    });
+    await POST(makeRequest(validBody));
+
+    const data = (prismaMock.lead.update.mock.calls[0][0] as { data: Record<string, unknown> })
+      .data;
+    expect(data.sourceWidget).toBeUndefined();
+    expect(leadCaptureMock.markLeadStatus).not.toHaveBeenCalled();
+    expect(pipelineMock.enrollLeadIfEligible).toHaveBeenCalledWith('lead-2');
+  });
+
+  it('still returns the invoice when the lead mirror fails', async () => {
+    leadCaptureMock.upsertLead.mockRejectedValue(new Error('db down'));
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(200);
+    expect((await res.json()).success).toBe(true);
+  });
+
+  it('short-circuits with the ops-auth response and never creates a draft', async () => {
+    opsAuthMock.requireOpsAuth.mockResolvedValue(
+      NextResponse.json({ error: 'unauthorized' }, { status: 401 }),
+    );
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(401);
+    expect(draftOrdersMock.createDraftOrder).not.toHaveBeenCalled();
+    expect(leadCaptureMock.upsertLead).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/v1/admin/draft-orders/route.ts
+++ b/src/app/api/v1/admin/draft-orders/route.ts
@@ -7,6 +7,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { createDraftOrder, listDraftOrders, calculateDraftOrderAmounts } from '@/lib/draft-orders';
+import { markLeadStatus, upsertLead } from '@/lib/leads/leadCapture';
+import { enrollLeadIfEligible } from '@/lib/leads/pipeline';
+import { requireOpsAuth } from '@/lib/auth/ops-session';
 import { DraftOrderStatus } from '@prisma/client';
 import { prisma } from '@/lib/database/client';
 
@@ -121,6 +124,12 @@ export async function GET(request: NextRequest) {
  */
 export async function POST(request: NextRequest) {
   try {
+    // Defense in depth: middleware already gates /api/v1/admin/**, but this
+    // route creates invoices + mirrors leads — carry its own ops-auth so a
+    // future middleware-matcher change can't silently expose it.
+    const auth = await requireOpsAuth();
+    if (auth instanceof NextResponse) return auth;
+
     const body = await request.json();
     const validated = CreateDraftOrderSchema.parse(body);
 
@@ -147,6 +156,56 @@ export async function POST(request: NextRequest) {
       discountAmount: amounts.discountAmount,
       expiresAt,
     });
+
+    // Lead Flow board: an ops invoice to a brand-new contact had no Lead, so
+    // QUOTE_SENT tracking missed them entirely (2026-07-13 audit gap #7).
+    // Hooked HERE, not in the draft-orders lib — the full-moon ticket path
+    // calls the lib directly and must stay lead-free. Group-attached drafts
+    // skip (the dashboard-host mirror owns those). Card enters NEW; the
+    // existing sweepQuoteSent moves it to QUOTE_SENT once the invoice is
+    // SENT/VIEWED. Never throws.
+    if (!validated.groupOrderId) {
+      try {
+        const [cFirst, ...cRest] = validated.customerName.split(/\s+/);
+        const lead = await upsertLead(
+          {
+            email: validated.customerEmail,
+            phone: validated.customerPhone || null,
+            firstName: cFirst || null,
+            lastName: cRest.join(' ') || null,
+          },
+          { sourcePage: '/ops/orders/create', sourceWidget: 'OPS_INVOICE' },
+        );
+        if (lead) {
+          const prevMeta = (lead.metadata as Record<string, unknown> | null) ?? {};
+          // Ops acted, not the customer — only claim provenance when the
+          // lead has none (null/OTHER); never clobber a real widget.
+          const upgradeWidget = lead.sourceWidget === null || lead.sourceWidget === 'OTHER';
+          await prisma.lead.update({
+            where: { id: lead.id },
+            data: {
+              draftOrderId: draftOrder.id,
+              ...(upgradeWidget ? { sourceWidget: 'OPS_INVOICE' } : {}),
+              metadata: {
+                ...prevMeta,
+                opsInvoice: {
+                  draftOrderId: draftOrder.id,
+                  deliveryDate: validated.deliveryDate.toISOString().slice(0, 10),
+                  submittedAt: new Date().toISOString(),
+                },
+              },
+            },
+          });
+          if (lead.status === 'PARTIAL' || lead.status === 'ANONYMOUS') {
+            await markLeadStatus(lead.id, 'SUBMITTED');
+          } else {
+            await enrollLeadIfEligible(lead.id);
+          }
+        }
+      } catch (leadErr) {
+        console.warn('[Draft Orders API] lead mirror failed:', leadErr);
+      }
+    }
 
     // Generate invoice URL
     const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://partyondelivery.com';


### PR DESCRIPTION
PR 5/7. An ops invoice to a brand-new contact had no Lead, so sweepQuoteSent (existing-leads-only) never tracked it. The admin draft-orders POST now mirrors an `OPS_INVOICE` lead (route level — the full-moon ticket path calls the lib directly and stays lead-free), links Lead.draftOrderId, upgrades only null/OTHER provenance, guarded promote. Card enters NEW; the existing sweep moves it to QUOTE_SENT on SENT/VIEWED. Group drafts skip. **Security fix on this branch:** the POST now carries its own `requireOpsAuth()` (defense-in-depth over the middleware gate). 5 route tests incl. the 401 short-circuit.

---
Part of the lead-capture gap closure (full-site audit 2026-07-13). **Stacked chain — merge in order 1→7.** Chain-tip gates: tsc ✓ · lint 0 ✓ · vitest 843/843 ✓. Security: 0 critical; the 2 HIGH + 1 MED + 1 LOW raised are all fixed on-branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)