### PR TITLE
feat(leads): lead-magnet boards with phone + provenance hygiene + trustedSubmit hardening

### DIFF
--- a/src/app/api/v1/landing/lead-event/route.ts
+++ b/src/app/api/v1/landing/lead-event/route.ts
@@ -149,7 +149,10 @@ export async function POST(req: NextRequest) {
     parsed.identify ?? {},
     {
       sourcePage: parsed.page ?? null,
-      sourceWidget: (parsed.widget ?? null) as LeadSourceWidget | null,
+      // Raw pixel POSTs may omit widget — default to OTHER so board filters
+      // and scoring always see a named source (never null). upsertLead can
+      // later upgrade OTHER when a real widget arrives.
+      sourceWidget: (parsed.widget ?? 'OTHER') as LeadSourceWidget,
       ...parsed.utm,
     },
     session,

--- a/src/app/api/v1/lead-magnet/route.ts
+++ b/src/app/api/v1/lead-magnet/route.ts
@@ -4,9 +4,12 @@
  * Server endpoint called from the LeadMagnetModal when someone submits
  * the popup. Three jobs:
  *
- *   1. Send the welcome email via Resend (delivers the reward link)
- *   2. Stamp the lead row as SUBMITTED via the existing lead-event API
- *      (handled client-side; this endpoint only owns the email)
+ *   1. Own the Lead row (2026-07-13 audit gap): a phone-carrying submit is
+ *      real party intent → sourceWidget LEAD_MAGNET + SUBMITTED (boards);
+ *      an email-only submit stays EMAIL_SIGNUP (newsletter-only, off-board —
+ *      'leadMagnet' is deliberately NOT an inquiry metadata key). The client
+ *      pixel previously owned this and misfiled everything as EMAIL_SIGNUP.
+ *   2. Send the welcome email via Resend (delivers the reward link)
  *   3. Return ok=true so the modal can transition to the success state
  *
  * Silent failure mode: if Resend isn't configured (no RESEND_API_KEY),
@@ -17,6 +20,10 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import { sendEmail } from '@/lib/email/resend-client';
 import { leadMagnetEmail } from '@/lib/email/templates/lead-magnet';
+import { markLeadStatus, upsertLead } from '@/lib/leads/leadCapture';
+import { enrollLeadIfEligible } from '@/lib/leads/pipeline';
+import { prisma } from '@/lib/database/client';
+import { checkRateLimit } from '@/lib/security/rate-limit';
 import { EmailType } from '@prisma/client';
 
 export const runtime = 'nodejs';
@@ -33,6 +40,18 @@ const schema = z.object({
 });
 
 export async function POST(req: NextRequest) {
+  // Public + unauthenticated: this route both writes a Lead and sends real
+  // email to a caller-supplied address. Without a cap it's an email-bomb
+  // primitive (via our own Resend domain) + a board-spam vector. Same
+  // helper/shape as /api/contact and /api/v1/landing/lead-event.
+  const ip =
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    req.headers.get('x-real-ip') ||
+    'unknown';
+  if (!(await checkRateLimit('lead-magnet', ip, 5, 60))) {
+    return NextResponse.json({ ok: false, error: 'rate_limited' }, { status: 429 });
+  }
+
   let body: z.infer<typeof schema>;
   try {
     body = schema.parse(await req.json());
@@ -41,6 +60,49 @@ export async function POST(req: NextRequest) {
       { ok: false, error: 'invalid_body', detail: String(err) },
       { status: 400 },
     );
+  }
+
+  // ─── Own the Lead row (before the email — system of record first) ────
+  try {
+    const hasPhone = Boolean(body.phone && body.phone.trim());
+    const lead = await upsertLead(
+      { email: body.email, phone: body.phone ?? null, firstName: body.firstName },
+      { sourcePage: '/lead-magnet', sourceWidget: hasPhone ? 'LEAD_MAGNET' : 'EMAIL_SIGNUP' },
+    );
+    if (lead) {
+      const prevMeta = (lead.metadata as Record<string, unknown> | null) ?? {};
+      // Phone present ⇒ claim provenance even over EMAIL_SIGNUP (the client
+      // pixel stamps that on this very lead while they type) — but never
+      // over a real inquiry widget.
+      const upgradeWidget =
+        hasPhone &&
+        (lead.sourceWidget === null ||
+          lead.sourceWidget === 'OTHER' ||
+          lead.sourceWidget === 'EMAIL_SIGNUP');
+      await prisma.lead.update({
+        where: { id: lead.id },
+        data: {
+          ...(upgradeWidget ? { sourceWidget: 'LEAD_MAGNET' } : {}),
+          metadata: {
+            ...prevMeta,
+            leadMagnet: {
+              magnetId: body.magnetId,
+              magnetTitle: body.magnetTitle,
+              submittedAt: new Date().toISOString(),
+            },
+          },
+        },
+      });
+      if (hasPhone) {
+        if (lead.status === 'PARTIAL' || lead.status === 'ANONYMOUS') {
+          await markLeadStatus(lead.id, 'SUBMITTED');
+        } else {
+          await enrollLeadIfEligible(lead.id);
+        }
+      }
+    }
+  } catch (err) {
+    console.warn('[lead-magnet] lead mirror failed', err);
   }
 
   const { subject, html, text } = leadMagnetEmail({

--- a/src/app/wedding-drink-calculator/CalculatorClient.tsx
+++ b/src/app/wedding-drink-calculator/CalculatorClient.tsx
@@ -52,7 +52,10 @@ export default function CalculatorClient({ onResultsComputed }: Props = {}): Rea
   };
 
   return (
-    <div className="grid lg:grid-cols-5 gap-5 lg:gap-8">
+    // data-lead-widget: the global FormCaptureWatcher captures the quote
+    // form's contact fields — without this tag those leads land as generic
+    // OTHER instead of DRINK_CALCULATOR (2026-07-13 audit provenance gap).
+    <div className="grid lg:grid-cols-5 gap-5 lg:gap-8" data-lead-widget="drink-calculator">
       {/* Inputs column */}
       <div className="lg:col-span-2 space-y-3">
         {/* Guest count */}

--- a/src/app/wedding-drink-calculator/sections/QuoteFormSection.tsx
+++ b/src/app/wedding-drink-calculator/sections/QuoteFormSection.tsx
@@ -16,7 +16,10 @@ type Props = {
  */
 export default function QuoteFormSection({ plan }: Props): ReactElement {
   return (
-    <section id="quote-form" className="bg-gray-50 section-padding">
+    // data-lead-widget: the global FormCaptureWatcher captures this form's
+    // contact fields — the tag turns those leads from generic OTHER into
+    // DRINK_CALCULATOR (2026-07-13 audit provenance gap).
+    <section id="quote-form" className="bg-gray-50 section-padding" data-lead-widget="drink-calculator">
       <div className="container-custom max-w-3xl">
         <QuoteFormCard plan={plan} placement="bottom" />
       </div>

--- a/src/lib/leads/__tests__/leadCapture-record-event.test.ts
+++ b/src/lib/leads/__tests__/leadCapture-record-event.test.ts
@@ -1,0 +1,76 @@
+/**
+ * recordEvent trust-marker hardening (security review HIGH-1): a client-supplied
+ * `trustedSubmit` key inside `metadata` must never survive to the stored
+ * LeadEvent — only a server-set `trustedSubmit: true` flag may stamp it.
+ * Otherwise the public pixel route (which passes caller metadata verbatim)
+ * could forge the marker and make sweepReopens reopen any closed card.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const events: Array<Record<string, unknown>> = [];
+const prismaMock = vi.hoisted(() => ({
+  leadEvent: { create: vi.fn() },
+  lead: { update: vi.fn() },
+}));
+vi.mock('@/lib/database/client', () => ({ prisma: prismaMock }));
+
+const pipelineMock = vi.hoisted(() => ({
+  handleSubmitSignal: vi.fn(),
+  enrollLeadIfEligible: vi.fn(),
+}));
+vi.mock('../pipeline', () => pipelineMock);
+
+import { recordEvent } from '../leadCapture';
+
+beforeEach(() => {
+  events.length = 0;
+  vi.clearAllMocks();
+  prismaMock.leadEvent.create.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => {
+    events.push(data);
+    return data;
+  });
+  prismaMock.lead.update.mockResolvedValue({});
+});
+
+describe('recordEvent — trustedSubmit forgery guard', () => {
+  it('strips a client-forged trustedSubmit from an untrusted event', async () => {
+    await recordEvent({
+      type: 'FORM_SUBMIT',
+      leadId: 'lead-1',
+      metadata: { trustedSubmit: true, foo: 'bar' },
+      // no trustedSubmit flag → this is the public-pixel path
+    });
+    const stored = events[0].metadata as Record<string, unknown> | null;
+    expect(stored).toEqual({ foo: 'bar' }); // forged key gone, real keys kept
+    expect(pipelineMock.handleSubmitSignal).not.toHaveBeenCalled();
+  });
+
+  it('stores null metadata when the only key was a forged trustedSubmit', async () => {
+    await recordEvent({ type: 'FORM_SUBMIT', leadId: 'lead-1', metadata: { trustedSubmit: true } });
+    expect(events[0].metadata).toBeNull();
+    expect(pipelineMock.handleSubmitSignal).not.toHaveBeenCalled();
+  });
+
+  it('stamps trustedSubmit only when the server sets the flag (and reopens)', async () => {
+    await recordEvent({
+      type: 'FORM_SUBMIT',
+      leadId: 'lead-1',
+      trustedSubmit: true,
+      metadata: { flow: 'contact' },
+    });
+    expect(events[0].metadata).toEqual({ flow: 'contact', trustedSubmit: true });
+    expect(pipelineMock.handleSubmitSignal).toHaveBeenCalledWith('lead-1');
+  });
+
+  it('a forged trustedSubmit cannot ride a non-submit event type', async () => {
+    await recordEvent({
+      type: 'PAGE_VIEW',
+      leadId: 'lead-1',
+      trustedSubmit: true, // ignored: PAGE_VIEW is not a submit type
+      metadata: { trustedSubmit: true },
+    });
+    expect(events[0].metadata).toBeNull();
+    expect(pipelineMock.handleSubmitSignal).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/leads/__tests__/leadCapture-upsert.test.ts
+++ b/src/lib/leads/__tests__/leadCapture-upsert.test.ts
@@ -1,0 +1,105 @@
+/**
+ * upsertLead sourceWidget semantics (2026-07-13 provenance hygiene): OTHER
+ * is a placeholder any named widget may upgrade; a real widget is never
+ * overwritten. Guards the lead-event null→OTHER default from blocking later
+ * real-widget attribution.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const prismaMock = vi.hoisted(() => ({
+  lead: {
+    findFirst: vi.fn(),
+    findMany: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  },
+  visitorSession: { findUnique: vi.fn(), create: vi.fn(), update: vi.fn() },
+}));
+vi.mock('@/lib/database/client', () => ({ prisma: prismaMock }));
+vi.mock('../pipeline', () => ({
+  enrollLeadIfEligible: vi.fn(),
+  handleSubmitSignal: vi.fn(),
+}));
+
+import { upsertLead } from '../leadCapture';
+
+function existingLead(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'lead-1',
+    email: 'guest@example.com',
+    phone: null,
+    firstName: null,
+    lastName: null,
+    status: 'PARTIAL',
+    sourceWidget: null,
+    sourcePage: null,
+    lastPage: null,
+    utmSource: null,
+    utmMedium: null,
+    utmCampaign: null,
+    utmContent: null,
+    utmTerm: null,
+    metadata: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  prismaMock.lead.findMany.mockResolvedValue([]);
+  prismaMock.lead.update.mockImplementation(async ({ data }) => ({
+    ...existingLead(),
+    ...data,
+  }));
+});
+
+describe('upsertLead — sourceWidget upgrade rules', () => {
+  it('upgrades OTHER to a named widget', async () => {
+    prismaMock.lead.findFirst.mockResolvedValue(existingLead({ sourceWidget: 'OTHER' }));
+    await upsertLead(
+      { email: 'guest@example.com' },
+      { sourceWidget: 'DRINK_CALCULATOR' },
+    );
+    const data = prismaMock.lead.update.mock.calls[0][0].data;
+    expect(data.sourceWidget).toBe('DRINK_CALCULATOR');
+  });
+
+  it('fills a blank widget', async () => {
+    prismaMock.lead.findFirst.mockResolvedValue(existingLead({ sourceWidget: null }));
+    await upsertLead({ email: 'guest@example.com' }, { sourceWidget: 'QUICK_BUY' });
+    expect(prismaMock.lead.update.mock.calls[0][0].data.sourceWidget).toBe('QUICK_BUY');
+  });
+
+  it('never overwrites a real widget (even with OTHER)', async () => {
+    prismaMock.lead.findFirst.mockResolvedValue(
+      existingLead({ sourceWidget: 'CONTACT_FORM' }),
+    );
+    await upsertLead({ email: 'guest@example.com' }, { sourceWidget: 'OTHER' });
+    expect(prismaMock.lead.update.mock.calls[0][0].data.sourceWidget).toBe('CONTACT_FORM');
+  });
+
+  it('keeps OTHER when no widget is provided', async () => {
+    prismaMock.lead.findFirst.mockResolvedValue(existingLead({ sourceWidget: 'OTHER' }));
+    await upsertLead({ email: 'guest@example.com' }, {});
+    expect(prismaMock.lead.update.mock.calls[0][0].data.sourceWidget).toBe('OTHER');
+  });
+
+  it('EMAIL_SIGNUP cannot replace OTHER (public-pixel board-hiding guard)', async () => {
+    // An anonymous pixel caller who knows a victim's email must not be able
+    // to flip an OTHER lead newsletter-only (which would hide it from board
+    // enrollment).
+    prismaMock.lead.findFirst.mockResolvedValue(existingLead({ sourceWidget: 'OTHER' }));
+    await upsertLead(
+      { email: 'guest@example.com' },
+      { sourceWidget: 'EMAIL_SIGNUP' },
+    );
+    expect(prismaMock.lead.update.mock.calls[0][0].data.sourceWidget).toBe('OTHER');
+  });
+
+  it('EMAIL_SIGNUP may still fill a blank (true first source)', async () => {
+    prismaMock.lead.findFirst.mockResolvedValue(existingLead({ sourceWidget: null }));
+    await upsertLead({ email: 'guest@example.com' }, { sourceWidget: 'EMAIL_SIGNUP' });
+    expect(prismaMock.lead.update.mock.calls[0][0].data.sourceWidget).toBe('EMAIL_SIGNUP');
+  });
+});

--- a/src/lib/leads/leadCapture.ts
+++ b/src/lib/leads/leadCapture.ts
@@ -50,6 +50,9 @@ export type LeadContext = {
 
 const CLICK_ID_FIELDS = ['gclid', 'gbraid', 'wbraid', 'fbclid', 'msclkid'] as const;
 
+/** Widgets too weak to REPLACE an existing OTHER placeholder (see upsertLead). */
+const WEAK_SOURCE_WIDGETS: ReadonlySet<string> = new Set(['OTHER', 'EMAIL_SIGNUP']);
+
 /** Compact `{gclid: "..."}` object of the click ids present in ctx, or null. */
 function clickIdsFrom(ctx: LeadContext): Record<string, string> | null {
   const out: Record<string, string> = {};
@@ -253,7 +256,20 @@ export async function upsertLead(
         firstName: lead.firstName ?? firstName,
         lastName: lead.lastName ?? lastName,
         lastPage: nonEmpty(ctx.sourcePage) ?? lead.lastPage,
-        sourceWidget: lead.sourceWidget ?? ctx.sourceWidget ?? null,
+        // OTHER is a placeholder, not provenance — but only a STRONG named
+        // widget may replace it. EMAIL_SIGNUP is claimable by the public
+        // pixel, and letting it overwrite OTHER would let an anonymous
+        // caller who knows a victim's email flip their lead newsletter-only
+        // and hide it from board enrollment. A blank still takes any value
+        // (a true first source); a real widget is never overwritten.
+        sourceWidget:
+          lead.sourceWidget == null
+            ? ctx.sourceWidget ?? null
+            : lead.sourceWidget === 'OTHER' &&
+                ctx.sourceWidget &&
+                !WEAK_SOURCE_WIDGETS.has(ctx.sourceWidget)
+              ? ctx.sourceWidget
+              : lead.sourceWidget,
         utmSource: lead.utmSource ?? nonEmpty(ctx.utmSource),
         utmMedium: lead.utmMedium ?? nonEmpty(ctx.utmMedium),
         utmCampaign: lead.utmCampaign ?? nonEmpty(ctx.utmCampaign),
@@ -307,6 +323,16 @@ export async function recordEvent(opts: {
   if (!opts.sessionId && !opts.leadId) return null;
   const isSubmitType = opts.type === 'FORM_SUBMIT' || opts.type === 'CHECKOUT_START';
   const trusted = opts.trustedSubmit === true && isSubmitType;
+  // SECURITY: `trustedSubmit` inside a LeadEvent's metadata is what lets
+  // sweepReopens re-open a WON/LOST card. The public pixel route passes its
+  // caller-controlled `metadata` straight through here, so a forged
+  // `{trustedSubmit:true}` key must NEVER survive — strip it unconditionally
+  // and let only the server-set `trusted` flag re-add it. Without this, an
+  // anonymous caller who knows a victim's email could reopen any closed deal
+  // (the exact HIGH-1 threat this stamp exists to prevent).
+  const callerMeta: Record<string, unknown> = { ...(opts.metadata ?? {}) };
+  delete callerMeta.trustedSubmit;
+  const hasCallerMeta = Object.keys(callerMeta).length > 0;
   const event = await prisma.leadEvent.create({
     data: {
       type: opts.type,
@@ -319,8 +345,10 @@ export async function recordEvent(opts: {
       // Trusted submits are stamped so the reopen cron sweep can require
       // server-originated proof, not just a client-claimed FORM_SUBMIT.
       metadata: (trusted
-        ? { ...(opts.metadata ?? {}), trustedSubmit: true }
-        : (opts.metadata ?? null)) as never,
+        ? { ...callerMeta, trustedSubmit: true }
+        : hasCallerMeta
+          ? callerMeta
+          : null) as never,
     },
   });
   // Lead Flow board bookkeeping — must never break capture (module contract:


### PR DESCRIPTION
PR 6/7. Lead-magnet popup collects email + phone with party intent but the client pixel misfiled everything as EMAIL_SIGNUP (never boards). The server route now owns the lead: phone present ⇒ LEAD_MAGNET + boards; email-only ⇒ newsletter semantics preserved. `data-lead-widget="drink-calculator"` on both wedding-calculator quote-form placements. Pixel route defaults missing widget → OTHER; upsertLead treats OTHER as an upgradeable placeholder **with a WEAK_SOURCE_WIDGETS guard: EMAIL_SIGNUP/OTHER can never REPLACE an existing OTHER** (anti board-hiding). **Two security fixes on this branch:** (1) HIGH — `recordEvent` now strips any client-supplied `trustedSubmit` from metadata unconditionally, closing a public-pixel reopen-forgery bypass (an anonymous caller could reopen any closed card by email); (2) HIGH — lead-magnet route now rate-limits (5/min/IP), it was an unthrottled email-send + lead-write surface. Regression tests for both, plus the OTHER-upgrade guard.

---
Part of the lead-capture gap closure (full-site audit 2026-07-13). **Stacked chain — merge in order 1→7.** Chain-tip gates: tsc ✓ · lint 0 ✓ · vitest 843/843 ✓. Security: 0 critical; the 2 HIGH + 1 MED + 1 LOW raised are all fixed on-branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)