### PR TITLE
feat(leads): dashboard hosts become board cards + host-WON matching

### DIFF
--- a/src/app/api/v2/group-orders/[code]/send-link/route.ts
+++ b/src/app/api/v2/group-orders/[code]/send-link/route.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import { prisma } from '@/lib/database/client';
 import { sendEmail } from '@/lib/email/resend-client';
 import { dashboardLinkEmail } from '@/lib/email/templates/dashboard-link';
+import { mirrorDashboardHostLead } from '@/lib/leads/dashboard-lead';
 import { postToCoreLinq } from '@/lib/webhooks/ghl';
 import { checkRateLimit } from '@/lib/security/rate-limit';
 
@@ -72,6 +73,17 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       await prisma.groupOrderV2.update({
         where: { shareCode: code },
         data: updateData,
+      });
+      // Lead Flow board: this is the host handing over their contact info on
+      // /dashboard/* — a form-watcher skip path, so without this mirror the
+      // host is invisible to /admin/leads. Never throws.
+      await mirrorDashboardHostLead({
+        groupOrderId: groupOrder.id,
+        shareCode: code,
+        hostName: groupOrder.hostName,
+        hostEmail: hostEmail || null,
+        hostPhone: hostPhone || null,
+        createdVia: 'send-link',
       });
     }
 

--- a/src/app/api/v2/group-orders/route.ts
+++ b/src/app/api/v2/group-orders/route.ts
@@ -5,9 +5,26 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { CreateGroupOrderV2Schema } from '@/lib/group-orders-v2/validation';
 import { createGroupOrder } from '@/lib/group-orders-v2/service';
+import { checkRateLimit } from '@/lib/security/rate-limit';
 
 export async function POST(request: NextRequest) {
   try {
+    // Public, unauthenticated route. Each create now also mirrors the host to
+    // the Lead Flow board, so an unthrottled caller could spam fabricated
+    // leads (with arbitrary host emails) onto /admin/leads. A real user
+    // creates one dashboard — 10/hour/IP is generous for humans, tight for a
+    // script. Fails open on a KV hiccup (throttle, not access control).
+    const ip =
+      request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+      request.headers.get('x-real-ip') ||
+      'unknown';
+    if (!(await checkRateLimit('group-order-create', ip, 10, 3600))) {
+      return NextResponse.json(
+        { success: false, error: 'Too many requests — try again shortly' },
+        { status: 429 }
+      );
+    }
+
     const body = await request.json();
     const parsed = CreateGroupOrderV2Schema.safeParse(body);
     if (!parsed.success) {

--- a/src/lib/group-orders-v2/service.ts
+++ b/src/lib/group-orders-v2/service.ts
@@ -6,6 +6,7 @@
 import { prisma } from '@/lib/database/client';
 import { calculateDeliveryFee } from '@/lib/delivery/rates';
 import { isLastMinuteDate } from '@/lib/lastMinute/dates';
+import { mirrorDashboardHostLead } from '@/lib/leads/dashboard-lead';
 import { assertVariantsPurchasable } from '@/lib/products/availability';
 import {
   generateShareCode,
@@ -287,6 +288,22 @@ export async function createGroupOrder(
       },
     },
     include: fullGroupIncludes,
+  });
+
+  // Lead Flow board: a host with contact info is a sales lead. Never throws.
+  await mirrorDashboardHostLead({
+    groupOrderId: group.id,
+    shareCode: group.shareCode,
+    hostName: input.hostName,
+    hostEmail: input.hostEmail || null,
+    hostPhone: input.hostPhone || null,
+    partyType: group.partyType,
+    deliveryDate:
+      tabDeliveryDates.length > 0
+        ? new Date(Math.min(...tabDeliveryDates.map((d) => d.getTime())))
+        : null,
+    source: group.source,
+    createdVia: 'group-create',
   });
 
   return serializeGroup(group);
@@ -1036,6 +1053,28 @@ export async function createDashboardOrder(
     include: fullGroupIncludes,
   });
 
+  // Lead Flow board: a host with contact info is a sales lead. Never throws.
+  await mirrorDashboardHostLead({
+    groupOrderId: group.id,
+    shareCode: group.shareCode,
+    hostName: input.hostName,
+    hostEmail: input.hostEmail || null,
+    hostPhone: input.hostPhone || null,
+    partyType: input.partyType || null,
+    deliveryDate,
+    source: input.source || 'DIRECT',
+    createdVia: input.isLastMinute ? 'last-minute-order' : 'dashboard-order',
+    attribution: input.attribution
+      ? {
+          utmSource: input.attribution.utmSource ?? null,
+          utmMedium: input.attribution.utmMedium ?? null,
+          utmCampaign: input.attribution.utmCampaign ?? null,
+          utmTerm: input.attribution.utmTerm ?? null,
+          utmContent: input.attribution.utmContent ?? null,
+        }
+      : null,
+  });
+
   return serializeGroup(group);
 }
 
@@ -1101,6 +1140,21 @@ export async function createMultiTabDashboardOrder(
       // and becomes host at that point.
     },
     include: fullGroupIncludes,
+  });
+
+  // Lead Flow board: affiliate-created dashboards usually have no host
+  // contact yet (arrives via claim/send-link/settings, which also mirror) —
+  // this covers the ones created WITH contact info. Never throws.
+  await mirrorDashboardHostLead({
+    groupOrderId: group.id,
+    shareCode: group.shareCode,
+    hostName: input.hostName,
+    hostEmail: input.hostEmail || null,
+    hostPhone: input.hostPhone || null,
+    partyType: input.partyType || null,
+    deliveryDate,
+    source: input.source || 'PARTNER_PAGE',
+    createdVia: 'affiliate-dashboard',
   });
 
   return { ...serializeGroup(group), hostClaimToken };
@@ -1201,4 +1255,33 @@ export async function updateGroupOrderFields(
     where: { shareCode },
     data: updateData,
   });
+
+  // Lead Flow board: host contact typed into dashboard settings is exactly
+  // the "invisible host" gap (/dashboard/* is a form-watcher skip path).
+  if (updateData.hostEmail || updateData.hostPhone) {
+    const fresh = await prisma.groupOrderV2.findUnique({
+      where: { shareCode },
+      select: {
+        id: true,
+        shareCode: true,
+        hostName: true,
+        hostEmail: true,
+        hostPhone: true,
+        partyType: true,
+        source: true,
+      },
+    });
+    if (fresh) {
+      await mirrorDashboardHostLead({
+        groupOrderId: fresh.id,
+        shareCode: fresh.shareCode,
+        hostName: fresh.hostName,
+        hostEmail: fresh.hostEmail,
+        hostPhone: fresh.hostPhone,
+        partyType: fresh.partyType,
+        source: fresh.source,
+        createdVia: 'dashboard-settings',
+      });
+    }
+  }
 }

--- a/src/lib/leads/__tests__/dashboard-lead.test.ts
+++ b/src/lib/leads/__tests__/dashboard-lead.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Dashboard host → Lead mirror: contactability gate, placeholder-name skip,
+ * guarded promotion (never downgrade), OTHER-provenance upgrade, no-reopen
+ * (no trustedSubmit), and never-throws.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const upsertLead = vi.fn();
+const markLeadStatus = vi.fn();
+const recordEvent = vi.fn();
+const enrollLeadIfEligible = vi.fn();
+const leadUpdate = vi.fn();
+
+vi.mock('../leadCapture', () => ({
+  upsertLead: (...args: unknown[]) => upsertLead(...args),
+  markLeadStatus: (...args: unknown[]) => markLeadStatus(...args),
+  recordEvent: (...args: unknown[]) => recordEvent(...args),
+}));
+vi.mock('../pipeline', () => ({
+  enrollLeadIfEligible: (...args: unknown[]) => enrollLeadIfEligible(...args),
+}));
+vi.mock('@/lib/database/client', () => ({
+  prisma: { lead: { update: (...args: unknown[]) => leadUpdate(...args) } },
+}));
+
+import { mirrorDashboardHostLead } from '../dashboard-lead';
+
+const baseRef = {
+  groupOrderId: 'g-1',
+  shareCode: 'ABC123',
+  hostName: 'Jane Doe',
+  hostEmail: 'jane@example.com',
+  hostPhone: null,
+  createdVia: 'dashboard-order',
+} as const;
+
+function stubLead(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'lead-1',
+    status: 'PARTIAL',
+    sourceWidget: null,
+    metadata: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  upsertLead.mockResolvedValue(stubLead());
+  markLeadStatus.mockResolvedValue(undefined);
+  recordEvent.mockResolvedValue(undefined);
+  enrollLeadIfEligible.mockResolvedValue(true);
+  leadUpdate.mockResolvedValue(undefined);
+});
+
+describe('mirrorDashboardHostLead', () => {
+  it('no email AND no phone → complete no-op', async () => {
+    await mirrorDashboardHostLead({ ...baseRef, hostEmail: null, hostPhone: null });
+    expect(upsertLead).not.toHaveBeenCalled();
+    expect(recordEvent).not.toHaveBeenCalled();
+  });
+
+  it('drops the Party Host placeholder name but still mirrors the contact', async () => {
+    await mirrorDashboardHostLead({ ...baseRef, hostName: 'Party Host' });
+    expect(upsertLead).toHaveBeenCalledWith(
+      expect.objectContaining({ firstName: null, lastName: null, email: 'jane@example.com' }),
+      expect.objectContaining({ sourceWidget: 'GROUP_DASHBOARD' }),
+    );
+  });
+
+  it('splits a real host name and stamps the dashboard sourcePage', async () => {
+    await mirrorDashboardHostLead(baseRef);
+    expect(upsertLead).toHaveBeenCalledWith(
+      expect.objectContaining({ firstName: 'Jane', lastName: 'Doe' }),
+      expect.objectContaining({ sourcePage: '/dashboard/ABC123' }),
+    );
+  });
+
+  it('promotes PARTIAL leads to SUBMITTED (columns), never touching closed statuses', async () => {
+    await mirrorDashboardHostLead(baseRef);
+    expect(markLeadStatus).toHaveBeenCalledWith('lead-1', 'SUBMITTED');
+    expect(enrollLeadIfEligible).not.toHaveBeenCalled();
+  });
+
+  it('CONVERTED leads are not downgraded — enroll only', async () => {
+    upsertLead.mockResolvedValue(stubLead({ status: 'CONVERTED', sourceWidget: 'CONTACT_FORM' }));
+    await mirrorDashboardHostLead(baseRef);
+    expect(markLeadStatus).not.toHaveBeenCalled();
+    expect(enrollLeadIfEligible).toHaveBeenCalledWith('lead-1');
+  });
+
+  it('upgrades null/OTHER provenance to GROUP_DASHBOARD but never a real widget', async () => {
+    upsertLead.mockResolvedValue(stubLead({ sourceWidget: 'OTHER' }));
+    await mirrorDashboardHostLead(baseRef);
+    expect(leadUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ sourceWidget: 'GROUP_DASHBOARD' }),
+      }),
+    );
+
+    leadUpdate.mockClear();
+    upsertLead.mockResolvedValue(stubLead({ status: 'SUBMITTED', sourceWidget: 'CONTACT_FORM' }));
+    await mirrorDashboardHostLead(baseRef);
+    const data = (leadUpdate.mock.calls[0][0] as { data: Record<string, unknown> }).data;
+    expect(data.sourceWidget).toBeUndefined(); // real widget kept
+    expect(data.metadata).toMatchObject({
+      groupDashboard: expect.objectContaining({ groupOrderId: 'g-1', shareCode: 'ABC123' }),
+    });
+  });
+
+  it('records a timeline event WITHOUT trustedSubmit (cannot reopen closed cards)', async () => {
+    await mirrorDashboardHostLead(baseRef);
+    const evt = recordEvent.mock.calls[0][0] as Record<string, unknown>;
+    expect(evt.type).toBe('FORM_SUBMIT');
+    expect(evt.widget).toBe('GROUP_DASHBOARD');
+    expect('trustedSubmit' in evt).toBe(false);
+  });
+
+  it('never throws — dashboard creation survives a lead-layer failure', async () => {
+    upsertLead.mockRejectedValue(new Error('db down'));
+    await expect(mirrorDashboardHostLead(baseRef)).resolves.toBeUndefined();
+  });
+});

--- a/src/lib/leads/__tests__/pipeline.test.ts
+++ b/src/lib/leads/__tests__/pipeline.test.ts
@@ -153,6 +153,7 @@ import {
   sweepWonMatches,
   syncStageFromConversion,
   transitionStage,
+  wonGroupHostIdentity,
   wonOrderIdentity,
 } from '../pipeline';
 import { validateTransition } from '../pipeline-types';
@@ -528,22 +529,34 @@ describe('wonOrderIdentity', () => {
   const asClause = (sql: unknown) =>
     sql as { strings: readonly string[]; values: readonly unknown[] };
 
-  it('builds a case-insensitive email clause', () => {
+  it('builds a case-insensitive email clause on the order columns', () => {
     const { identity } = wonOrderIdentity({ ...base, email: 'Guest@Example.com', phone: null });
     expect(identity).toHaveLength(1);
     const { text, params } = flattenSql(asClause(identity[0]).strings, asClause(identity[0]).values);
-    expect(text).toBe('LOWER(customer_email) = LOWER(?)');
+    expect(text).toBe('LOWER(o.customer_email) = LOWER(?)');
     expect(params).toEqual(['Guest@Example.com']);
   });
 
-  it('builds a last-10-digits phone clause', () => {
+  it('builds a last-10-digits phone clause on the order columns', () => {
     const { identity } = wonOrderIdentity({ ...base, email: null, phone: '(512) 555-0187' });
     expect(identity).toHaveLength(1);
     const { text, params } = flattenSql(asClause(identity[0]).strings, asClause(identity[0]).values);
     expect(text).toBe(
-      "RIGHT(REGEXP_REPLACE(COALESCE(customer_phone, ''), '\\D', '', 'g'), 10) = ?"
+      "RIGHT(REGEXP_REPLACE(COALESCE(o.customer_phone, ''), '\\D', '', 'g'), 10) = ?"
     );
     expect(params).toEqual(['5125550187']);
+  });
+
+  it('wonGroupHostIdentity mirrors the clauses onto the group HOST columns', () => {
+    const clauses = wonGroupHostIdentity({ email: 'Host@Example.com', phone: '(512) 555-0187' });
+    expect(clauses).toHaveLength(2);
+    const email = flattenSql(asClause(clauses[0]).strings, asClause(clauses[0]).values);
+    const phone = flattenSql(asClause(clauses[1]).strings, asClause(clauses[1]).values);
+    expect(email.text).toBe('LOWER(g.host_email) = LOWER(?)');
+    expect(phone.text).toBe(
+      "RIGHT(REGEXP_REPLACE(COALESCE(g.host_phone, ''), '\\D', '', 'g'), 10) = ?"
+    );
+    expect(wonGroupHostIdentity({ email: null, phone: null })).toHaveLength(0);
   });
 
   it('emits both clauses when both identities exist, none when neither does', () => {
@@ -565,18 +578,23 @@ describe('wonOrderIdentity', () => {
 });
 
 describe('findWonOrder SQL filters (via sweepWonMatches)', () => {
-  it('excludes group-participant payments, requires PAID-ish status, floors at the lead date', async () => {
+  it('direct branch excludes group payments; host branch matches HOST columns only', async () => {
     const lead = makeLead({ pipelineStage: 'QUOTE_SENT', stageChangedAt: new Date() });
     db.wonOrderRows = [{ id: 'order-1' }];
     await sweepWonMatches();
 
     expect(db.queryLog).toHaveLength(1);
     const { text, params } = flattenSql(db.queryLog[0].strings, db.queryLog[0].values);
-    expect(text).toContain("financial_status IN ('PAID', 'PARTIALLY_REFUNDED')");
-    expect(text).toContain('group_order_v2_id IS NULL');
-    expect(text).toContain('created_at >= ?');
-    expect(text).toContain('LOWER(customer_email) = LOWER(?)');
+    expect(text).toContain("o.financial_status IN ('PAID', 'PARTIALLY_REFUNDED')");
+    expect(text).toContain('o.created_at >= ?');
+    // Direct branch: the lead's own order, group payments excluded (R1).
+    expect(text).toContain('o.group_order_v2_id IS NULL AND (LOWER(o.customer_email) = LOWER(?)');
+    // Host branch: any paid order on a dashboard the LEAD hosts — the join
+    // is on the group's HOST columns, so a guest's chip-in can't win the
+    // guest's own lead.
+    expect(text).toContain('o.group_order_v2_id IS NOT NULL AND (LOWER(g.host_email) = LOWER(?)');
+    expect(text).toContain('LEFT JOIN group_orders_v2 g ON g.id = o.group_order_v2_id');
     expect(params).toContainEqual(lead.createdAt); // the match floor
-    expect(params).toContainEqual('guest@example.com');
+    expect(params.filter((p) => p === 'guest@example.com')).toHaveLength(2); // both branches
   });
 });

--- a/src/lib/leads/dashboard-lead.ts
+++ b/src/lib/leads/dashboard-lead.ts
@@ -1,0 +1,131 @@
+/**
+ * GroupOrderV2 host → Lead Flow board mirror (lead-capture gap closure).
+ *
+ * A built-but-unpaid dashboard is the strongest sales signal on the site,
+ * but dashboard creation never wrote a Lead — hosts were invisible to
+ * /admin/leads. This helper is called (try/catch-wrapped, awaited) from the
+ * group-orders service after any write that lands host contact info:
+ * create flows, dashboard settings, and the send-link route. Service-level
+ * hooks cover every ingress: /order, /order/last-minute, /group/create, the
+ * Premier cruise webhook, and affiliate-created dashboards.
+ *
+ * Deliberate rules:
+ * - Host must be contactable (email or phone) — a bare name never anchors a
+ *   lead. The 'Party Host' placeholder name is dropped.
+ * - Explicit act ⇒ column card: PARTIAL/ANONYMOUS leads promote to SUBMITTED
+ *   (which enrolls); already-classified leads only get enrollLeadIfEligible.
+ *   Neither path can reopen a WON/LOST card (no trustedSubmit — that power
+ *   stays with the server-zod submit routes).
+ * - Group GUESTS are never mirrored (attendees, not planners) — no call site
+ *   exists for joins, and none should be added.
+ * - Never throws: dashboard creation must not break on board bookkeeping.
+ */
+
+import { enrollLeadIfEligible } from './pipeline';
+import { markLeadStatus, recordEvent, upsertLead, type LeadContext } from './leadCapture';
+import { prisma } from '@/lib/database/client';
+
+const PLACEHOLDER_HOST_NAME = 'Party Host';
+
+export interface DashboardHostRef {
+  groupOrderId: string;
+  shareCode: string;
+  hostName?: string | null;
+  hostEmail?: string | null;
+  hostPhone?: string | null;
+  partyType?: string | null;
+  /** First (or only) delivery date — feeds event-proximity scoring. */
+  deliveryDate?: Date | string | null;
+  /** GroupOrderV2.source (DIRECT / PARTNER_PAGE / WEBHOOK / ...). */
+  source?: string | null;
+  /** Which flow landed the contact info (create / settings / send-link...). */
+  createdVia: string;
+  /** Host first-touch attribution when the create flow captured it. */
+  attribution?: Pick<
+    LeadContext,
+    'utmSource' | 'utmMedium' | 'utmCampaign' | 'utmContent' | 'utmTerm'
+  > | null;
+}
+
+function splitName(hostName?: string | null): { firstName: string | null; lastName: string | null } {
+  const name = (hostName ?? '').trim();
+  if (!name || name === PLACEHOLDER_HOST_NAME) return { firstName: null, lastName: null };
+  const parts = name.split(/\s+/);
+  return { firstName: parts[0] ?? null, lastName: parts.slice(1).join(' ') || null };
+}
+
+function isoDateOnly(value?: Date | string | null): string | null {
+  if (!value) return null;
+  const d = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d.toISOString().slice(0, 10);
+}
+
+/**
+ * Mirror a dashboard host onto the Lead Flow board. Safe to call repeatedly
+ * (upsert by email/phone; metadata.groupDashboard is last-write-wins so the
+ * card always reflects the host's latest dashboard).
+ */
+export async function mirrorDashboardHostLead(ref: DashboardHostRef): Promise<void> {
+  try {
+    if (!ref.hostEmail && !ref.hostPhone) return;
+
+    const { firstName, lastName } = splitName(ref.hostName);
+    const lead = await upsertLead(
+      { email: ref.hostEmail, phone: ref.hostPhone, firstName, lastName },
+      {
+        sourcePage: `/dashboard/${ref.shareCode}`,
+        sourceWidget: 'GROUP_DASHBOARD',
+        ...(ref.attribution ?? {}),
+      },
+    );
+    if (!lead) return;
+
+    // Link the dashboard + upgrade weak provenance. upsertLead only fills
+    // blanks, so a watcher-created OTHER lead keeps OTHER — fix that here,
+    // but never overwrite a real widget (e.g. CONTACT_FORM from the chat).
+    const meta =
+      lead.metadata && typeof lead.metadata === 'object' && !Array.isArray(lead.metadata)
+        ? { ...(lead.metadata as Record<string, unknown>) }
+        : {};
+    meta.groupDashboard = {
+      groupOrderId: ref.groupOrderId,
+      shareCode: ref.shareCode,
+      partyType: ref.partyType ?? null,
+      deliveryDate: isoDateOnly(ref.deliveryDate),
+      source: ref.source ?? null,
+      createdVia: ref.createdVia,
+      linkedAt: new Date().toISOString(),
+    };
+    const upgradeWidget = lead.sourceWidget === null || lead.sourceWidget === 'OTHER';
+    await prisma.lead.update({
+      where: { id: lead.id },
+      data: {
+        metadata: meta as never,
+        ...(upgradeWidget ? { sourceWidget: 'GROUP_DASHBOARD' } : {}),
+      },
+    });
+
+    // Explicit act ⇒ column card. Guarded: never downgrade SUBMITTED/CONVERTED.
+    if (lead.status === 'PARTIAL' || lead.status === 'ANONYMOUS') {
+      await markLeadStatus(lead.id, 'SUBMITTED');
+    } else {
+      await enrollLeadIfEligible(lead.id);
+    }
+
+    // Timeline + activity bump. NO trustedSubmit — cannot reopen closed cards.
+    await recordEvent({
+      type: 'FORM_SUBMIT',
+      leadId: lead.id,
+      page: `/dashboard/${ref.shareCode}`,
+      widget: 'GROUP_DASHBOARD',
+      fieldName: `dashboard-${ref.createdVia}`,
+      metadata: {
+        groupOrderId: ref.groupOrderId,
+        shareCode: ref.shareCode,
+        via: ref.createdVia,
+      },
+    });
+  } catch (err) {
+    console.warn('[dashboard-lead] host mirror failed', err);
+  }
+}

--- a/src/lib/leads/pipeline.ts
+++ b/src/lib/leads/pipeline.ts
@@ -24,7 +24,11 @@ import {
   type PipelineStage,
   type StageChangeVia,
 } from './pipeline-types';
-import { phoneLast10 } from './phone';
+import { findWonOrder, matchFloor } from './won-match';
+
+// Identity/floor SQL assembly lives in won-match.ts; re-exported for callers
+// and tests that historically imported from here.
+export { matchFloor, wonOrderIdentity, wonGroupHostIdentity } from './won-match';
 
 /**
  * Metadata keys that mark a lead as a real party inquiry (vs newsletter).
@@ -78,18 +82,6 @@ export function isBoardEligible(
 /** Fractional rank: newest on top (lower sorts first). Drags write midpoints. */
 export function topSortOrder(now: Date = new Date()): number {
   return -Math.floor(now.getTime() / 1000);
-}
-
-/**
- * Earliest order/draft date that may count toward this lead's current
- * inquiry: the lead's creation, or its most recent reopen — a reopened
- * card's OLD order must not re-win it. Shared by the won matcher and the
- * quote-sent sweep.
- */
-export function matchFloor(lead: { createdAt: Date; reopenedAt: Date | null }): Date {
-  return lead.reopenedAt && lead.reopenedAt > lead.createdAt
-    ? lead.reopenedAt
-    : lead.createdAt;
 }
 
 async function appendStageEvent(
@@ -369,55 +361,6 @@ export async function sweepQuoteSent(): Promise<number> {
     }
   }
   return moved;
-}
-
-/**
- * Identity clauses + date floor for the won-order match, extracted pure so
- * the SQL inputs are testable without a database: email matches
- * case-insensitively, phone matches on the last 10 digits, and a lead with
- * neither yields no clauses (the caller must then skip the query).
- */
-export function wonOrderIdentity(lead: {
-  email: string | null;
-  phone: string | null;
-  createdAt: Date;
-  reopenedAt: Date | null;
-}): { floor: Date; identity: Prisma.Sql[] } {
-  const identity: Prisma.Sql[] = [];
-  if (lead.email) identity.push(Prisma.sql`LOWER(customer_email) = LOWER(${lead.email})`);
-  const last10 = phoneLast10(lead.phone);
-  if (last10) {
-    identity.push(
-      Prisma.sql`RIGHT(REGEXP_REPLACE(COALESCE(customer_phone, ''), '\\D', '', 'g'), 10) = ${last10}`,
-    );
-  }
-  return { floor: matchFloor(lead), identity };
-}
-
-/**
- * High-confidence paid-order match for one lead: email (case-insensitive) or
- * last-10-digit phone, created on/after the lead (or its reopen), and NOT a
- * GroupOrderV2 participant payment (a $40 guest chip-in is not a won party —
- * risk R1). Uses the idx_orders_customer_phone_last10 expression index.
- */
-async function findWonOrder(lead: {
-  email: string | null;
-  phone: string | null;
-  createdAt: Date;
-  reopenedAt: Date | null;
-}): Promise<{ id: string } | null> {
-  const { floor, identity } = wonOrderIdentity(lead);
-  if (identity.length === 0) return null;
-  const rows = await prisma.$queryRaw<Array<{ id: string }>>`
-    SELECT id FROM orders
-    WHERE financial_status IN ('PAID', 'PARTIALLY_REFUNDED')
-      AND group_order_v2_id IS NULL
-      AND created_at >= ${floor}
-      AND (${Prisma.join(identity, ' OR ')})
-    ORDER BY created_at ASC
-    LIMIT 1
-  `;
-  return rows[0] ?? null;
 }
 
 /**

--- a/src/lib/leads/won-match.ts
+++ b/src/lib/leads/won-match.ts
@@ -1,0 +1,102 @@
+/**
+ * Verified won-order matching for the Lead Flow board (extracted from
+ * pipeline.ts, which owns the sweep + stage writes; this module owns the
+ * identity/floor SQL assembly).
+ *
+ * Two match branches, one query:
+ *  - DIRECT orders (no group): the order's own customer_email/customer_phone
+ *    matches the lead. GroupOrderV2-participant payments are excluded here —
+ *    a $40 guest chip-in is not a won party (risk R1).
+ *  - GROUP orders where the LEAD IS THE HOST (gap closure 2026-07-14): any
+ *    paid order on a dashboard whose host_email/host_phone matches the lead
+ *    wins the HOST's lead — including guest payments on that dashboard,
+ *    because money arriving on your dashboard means your party is happening.
+ *    Guests' leads still can't be won by their own chip-ins: the join
+ *    matches the group's HOST columns, never the payer's.
+ *
+ * Uses idx_orders_customer_phone_last10 (direct branch) and the
+ * orders.group_order_v2_id index (host branch join).
+ */
+
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/database/client';
+import { phoneLast10 } from './phone';
+
+/**
+ * Earliest order date that may count toward this lead's current inquiry:
+ * the lead's creation, or its most recent reopen — a reopened card's OLD
+ * order must not re-win it. Shared by the won matcher and the quote-sent
+ * sweep.
+ */
+export function matchFloor(lead: { createdAt: Date; reopenedAt: Date | null }): Date {
+  return lead.reopenedAt && lead.reopenedAt > lead.createdAt
+    ? lead.reopenedAt
+    : lead.createdAt;
+}
+
+interface LeadIdentity {
+  email: string | null;
+  phone: string | null;
+  createdAt: Date;
+  reopenedAt: Date | null;
+}
+
+function identityClauses(
+  lead: Pick<LeadIdentity, 'email' | 'phone'>,
+  emailCol: string,
+  phoneCol: string,
+): Prisma.Sql[] {
+  const clauses: Prisma.Sql[] = [];
+  if (lead.email) {
+    clauses.push(Prisma.sql`LOWER(${Prisma.raw(emailCol)}) = LOWER(${lead.email})`);
+  }
+  const last10 = phoneLast10(lead.phone);
+  if (last10) {
+    clauses.push(
+      Prisma.sql`RIGHT(REGEXP_REPLACE(COALESCE(${Prisma.raw(phoneCol)}, ''), '\\D', '', 'g'), 10) = ${last10}`,
+    );
+  }
+  return clauses;
+}
+
+/**
+ * Identity clauses + date floor for the DIRECT order match, pure so the SQL
+ * inputs are testable without a database: email matches case-insensitively,
+ * phone matches on the last 10 digits, and a lead with neither yields no
+ * clauses (the caller must then skip the query).
+ */
+export function wonOrderIdentity(lead: LeadIdentity): { floor: Date; identity: Prisma.Sql[] } {
+  return { floor: matchFloor(lead), identity: identityClauses(lead, 'o.customer_email', 'o.customer_phone') };
+}
+
+/**
+ * Identity clauses matching the lead against a group order's HOST contact
+ * columns — the host-WON branch. Pure, mirrors wonOrderIdentity.
+ */
+export function wonGroupHostIdentity(lead: Pick<LeadIdentity, 'email' | 'phone'>): Prisma.Sql[] {
+  return identityClauses(lead, 'g.host_email', 'g.host_phone');
+}
+
+/**
+ * High-confidence paid-order match for one lead: created on/after the lead
+ * (or its reopen), and either a direct order in the lead's own name or any
+ * order on a dashboard the lead HOSTS.
+ */
+export async function findWonOrder(lead: LeadIdentity): Promise<{ id: string } | null> {
+  const { floor, identity } = wonOrderIdentity(lead);
+  if (identity.length === 0) return null;
+  const hostIdentity = wonGroupHostIdentity(lead);
+  const rows = await prisma.$queryRaw<Array<{ id: string }>>`
+    SELECT o.id FROM orders o
+    LEFT JOIN group_orders_v2 g ON g.id = o.group_order_v2_id
+    WHERE o.financial_status IN ('PAID', 'PARTIALLY_REFUNDED')
+      AND o.created_at >= ${floor}
+      AND (
+        (o.group_order_v2_id IS NULL AND (${Prisma.join(identity, ' OR ')}))
+        OR (o.group_order_v2_id IS NOT NULL AND (${Prisma.join(hostIdentity, ' OR ')}))
+      )
+    ORDER BY o.created_at ASC
+    LIMIT 1
+  `;
+  return rows[0] ?? null;
+}


### PR DESCRIPTION
PR 2/7 of the lead-capture chain (replaces #253, which GitHub auto-closed when its stacked base branch was deleted on the #252 merge — no content lost). The audit's biggest gap: 187 built-but-unpaid dashboards had contactable hosts and no Lead. `mirrorDashboardHostLead` (never throws, guarded promote, no reopen power, guests never mirrored) hooked at the group-service level — covers all 7 creation routes incl. the Premier cruise webhook + affiliate creates — plus send-link. **Host-WON:** won-match.ts adds a branch — any PAID order on a dashboard whose host contact matches the lead wins it (guests' chip-ins still can't win a guest's lead; R1 preserved). Public create route now rate-limits (10/hr/IP). Security re-review: SAFE. Gates: tsc/lint/vitest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)