### PR TITLE
fix(leads): hold lead-magnet popup until the 21+ age gate is answered

### DIFF
--- a/src/components/leadMagnet/LeadMagnetController.tsx
+++ b/src/components/leadMagnet/LeadMagnetController.tsx
@@ -49,6 +49,22 @@ function markShown(id: string) {
   }
 }
 
+/**
+ * Has the visitor cleared the site-wide 21+ age gate? AgeVerification stamps
+ * `age_verified` in localStorage on accept — this matches the truthy check
+ * DeliveryWindowGate uses, so both entrance gates read the flag identically.
+ * On a read error we return false: better to skip a non-essential marketing
+ * popup than risk painting it over a still-open gate.
+ */
+function isAgeVerified(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return !!localStorage.getItem('age_verified');
+  } catch {
+    return false;
+  }
+}
+
 export default function LeadMagnetController() {
   const pathname = usePathname();
   const [activeMagnet, setActiveMagnet] = useState<LeadMagnet | null>(null);
@@ -90,24 +106,55 @@ export default function LeadMagnetController() {
       }
     };
 
-    for (const t of candidate.triggers) {
-      if (t.type === 'time') {
-        const id = window.setTimeout(() => fire('time'), t.seconds * 1000);
-        cleanupFns.push(() => clearTimeout(id));
-      } else if (t.type === 'scroll') {
-        const onScroll = () => {
-          const doc = document.documentElement;
-          const total = doc.scrollHeight - window.innerHeight;
-          if (total <= 0) return;
-          const pct = (window.scrollY / total) * 100;
-          if (pct >= t.percent) fire('scroll');
-        };
-        window.addEventListener('scroll', onScroll, { passive: true });
-        cleanupFns.push(() => window.removeEventListener('scroll', onScroll));
+    // Automatic triggers (time-on-page, scroll depth) must NOT fire until the
+    // visitor has cleared the 21+ age gate. AgeVerification (z-100) and
+    // DeliveryWindowGate (z-210) are the required entrance gates; this modal
+    // renders at z-200, so firing on a timer while the age gate is still open
+    // would drop a marketing popup ON TOP of a legally-required gate — and
+    // before the visitor has made the gating choice. Poll for `age_verified`
+    // before wiring the triggers, mirroring how DeliveryWindowGate/DashboardTour
+    // wait on their prerequisite flag.
+    //
+    // Every page the current LEAD_MAGNETS target ('/', '/services/*', '/flyer')
+    // is age-gated, and the config excludes '/dashboard/*' and never lists
+    // '/order', so the delivery-window gate is never in play here. If you ever
+    // point a magnet at an age-gate-EXEMPT page, its automatic triggers won't
+    // fire until `age_verified` exists — rely on a manual trigger there.
+    const wireAutoTriggers = () => {
+      if (fired) return;
+      for (const t of candidate.triggers) {
+        if (t.type === 'time') {
+          const id = window.setTimeout(() => fire('time'), t.seconds * 1000);
+          cleanupFns.push(() => clearTimeout(id));
+        } else if (t.type === 'scroll') {
+          const onScroll = () => {
+            const doc = document.documentElement;
+            const total = doc.scrollHeight - window.innerHeight;
+            if (total <= 0) return;
+            const pct = (window.scrollY / total) * 100;
+            if (pct >= t.percent) fire('scroll');
+          };
+          window.addEventListener('scroll', onScroll, { passive: true });
+          cleanupFns.push(() => window.removeEventListener('scroll', onScroll));
+        }
       }
+    };
+
+    if (isAgeVerified()) {
+      wireAutoTriggers();
+    } else {
+      const poll = window.setInterval(() => {
+        if (isAgeVerified()) {
+          clearInterval(poll);
+          wireAutoTriggers();
+        }
+      }, 300);
+      cleanupFns.push(() => clearInterval(poll));
     }
 
-    // Manual trigger: any code can dispatch 'lead-magnet:open' to force it.
+    // Manual trigger stays live regardless of the age gate: it only fires on an
+    // explicit user action (e.g. the flyer page's "preview" button dispatches
+    // 'lead-magnet:open'), so it can never queue-jump a gate.
     const onManual = (ev: Event) => {
       const ce = ev as CustomEvent<{ id?: string }>;
       if (!ce.detail?.id || ce.detail.id === candidate.id) {

--- a/src/components/leadMagnet/__tests__/LeadMagnetController.test.tsx
+++ b/src/components/leadMagnet/__tests__/LeadMagnetController.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import LeadMagnetController from '../LeadMagnetController';
+
+/**
+ * Isolate the controller's trigger-gating logic from the modal's rendering
+ * (next/image, lead-event client, etc.). We only care WHETHER the controller
+ * decides to open a magnet, not how the modal looks.
+ */
+vi.mock('../LeadMagnetModal', () => ({
+  default: ({ open, magnet }: { open: boolean; magnet: { id: string } }) =>
+    open ? <div data-testid="lead-magnet-modal">{magnet.id}</div> : null,
+}));
+
+// `usePathname` is globally mocked to '/' in src/__tests__/setup.ts, which
+// matches the flagship magnet's `pages: ['/', ...]`, so it becomes the
+// candidate on mount.
+
+function setAgeVerified() {
+  localStorage.setItem('age_verified', '1');
+}
+
+const modal = () => screen.queryByTestId('lead-magnet-modal');
+
+beforeEach(() => {
+  // The test env's localStorage global is a partial stub; install a complete
+  // Map-backed one so getItem/setItem/removeItem all behave and stay isolated.
+  const store = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => void store.set(k, String(v)),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() {
+      return store.size;
+    },
+  });
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('LeadMagnetController — age-gate sequencing', () => {
+  it('does NOT open the magnet on the time trigger while the 21+ age gate is unresolved', () => {
+    render(<LeadMagnetController />);
+
+    // Advance well past the 25s time trigger (and ~100 poll ticks).
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+
+    // age_verified is absent, so the automatic trigger was never wired.
+    expect(modal()).toBeNull();
+  });
+
+  it('opens the magnet only after age_verified is set (poll tick, then time trigger)', () => {
+    render(<LeadMagnetController />);
+
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+    expect(modal()).toBeNull();
+
+    // Visitor clears the age gate.
+    setAgeVerified();
+
+    // The 300ms poll notices and wires the triggers...
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(modal()).toBeNull(); // wired, but the 25s timer hasn't elapsed yet
+
+    // ...then the time trigger fires.
+    act(() => {
+      vi.advanceTimersByTime(25_000);
+    });
+    expect(modal()).toBeInTheDocument();
+  });
+
+  it('wires the trigger immediately when age was already verified before mount', () => {
+    setAgeVerified();
+    render(<LeadMagnetController />);
+
+    act(() => {
+      vi.advanceTimersByTime(25_000);
+    });
+    expect(modal()).toBeInTheDocument();
+  });
+
+  it('honors a manual lead-magnet:open even before the age gate is cleared', () => {
+    render(<LeadMagnetController />);
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('lead-magnet:open', { detail: {} }));
+    });
+
+    // Manual (user-initiated) triggers are never gated — the flyer preview
+    // button must still work.
+    expect(modal()).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Site-wide audit for the DashboardTour anti-pattern (auto-starting overlays that appear over a required gate or before a gating choice), plus the one fix it surfaced.

**Offender found:** `LeadMagnetController` (mounted site-wide via the root layout's `PixelMount`) wired its **time-on-page (25s)** and **scroll** triggers on mount **without checking the 21+ age gate**. The lead-magnet modal renders at `z-[200]`; the required `AgeVerification` gate is `z-[100]`. On the magnet's configured pages (`/`, `/services/*`, `/flyer` — all age-gated), a first-time visitor slow to enter their DOB could get a **marketing popup painted on top of the legally-required age gate**, before making the gating choice.

**Fix:** the automatic (time/scroll) triggers now wait for `age_verified` to persist in localStorage, polling every 300ms until it's set — mirroring how `DeliveryWindowGate` and `DashboardTour` (#259) hold on their prerequisite flag. The **manual** `lead-magnet:open` trigger (the flyer "preview" button) stays live, since it's user-initiated and can't queue-jump a gate.

## Why this is the only offender

Verified against live code + two exploration passes:
- **DashboardTour** — already fixed by #259 (now on main as `c0045b08`); this PR is additive.
- `OnboardingTourProvider` — no independent auto-start (`startTour` has one caller).
- `/order`, `/products`, dashboard modals, PackageBuilder/QuickBuy, PartyChat, EventQuizModal, Cart — all **user-click** triggered, or on age-gate-exempt + non-delivery-gated pages (no gate to collide with).
- The **delivery-window gate** (`z-[210]`, fires on `/order` + `/dashboard`) is unaffected: the magnet config excludes `/dashboard/*` and never lists `/order`.

## Verification

- `npx tsc --noEmit` — my files clean; the 13 errors present are pre-existing on `main` (identical count with this change stashed).
- `npx next lint` on touched files — clean.
- `npm run test:run` — **853 passed** (76 files), incl. 4 new `LeadMagnetController.test.tsx` cases: stays closed while unverified, opens after `age_verified` (poll → time trigger), opens when pre-verified, manual bypass still works.
- Security-reviewer + Vercel-preview sequencing check.

## Note (not in scope)

The `PartyChat` FAB (`z-[150]`) renders above the age gate (`z-[100]`) but only opens on user click (persistent fixture, not an auto-start overlay), so it isn't this anti-pattern. Flagging as a possible minor follow-up if support chat should be gated pre-age-verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)