### PR TITLE
feat(leads): enrich lead-flow drawer with event facts + activity summary

### DIFF
--- a/src/app/admin/leads/_components/__tests__/drawer-derive.test.ts
+++ b/src/app/admin/leads/_components/__tests__/drawer-derive.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Pure drawer-derivation helpers: event-date formatting (CT-safe), the
+ * "days away" phrasing, occasion humanizing, score-breakdown/short-date
+ * formatting, and the at-a-glance activity summary chips.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { LeadDetail } from '../drawer-types';
+import {
+  deriveActivitySummary,
+  describeDaysAway,
+  eventIsPast,
+  formatEventDate,
+  formatScoreBreakdown,
+  formatShortDate,
+  humanizeOccasion,
+} from '../drawer-derive';
+
+/** Fixed clock: 2026-07-13 18:00 UTC = 1pm CT (same as scoring.test.ts). */
+const NOW = new Date('2026-07-13T18:00:00Z');
+
+describe('formatEventDate', () => {
+  it('formats a YYYY-MM-DD date from its parts (no UTC-midnight off-by-one)', () => {
+    // Built from Y/M/D parts, so the day is stable in every viewer timezone —
+    // a naive `new Date('2026-08-15')` would render Aug 14 west of UTC.
+    expect(formatEventDate('2026-08-15')).toContain('Aug 15, 2026');
+    expect(formatEventDate('2026-08-15')).toContain('Sat');
+  });
+
+  it('reads the date off a full ISO timestamp too', () => {
+    expect(formatEventDate('2026-08-15T00:00:00Z')).toContain('Aug 15, 2026');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(formatEventDate('  2026-12-31  ')).toContain('Dec 31, 2026');
+  });
+
+  it('falls back to the raw string when it is not a parseable date', () => {
+    expect(formatEventDate('sometime in the fall')).toBe('sometime in the fall');
+  });
+});
+
+describe('describeDaysAway', () => {
+  it('phrases today / tomorrow / future / past / yesterday', () => {
+    expect(describeDaysAway('2026-07-13', NOW)).toBe('today');
+    expect(describeDaysAway('2026-07-14', NOW)).toBe('tomorrow');
+    expect(describeDaysAway('2026-07-20', NOW)).toBe('in 7 days');
+    expect(describeDaysAway('2026-07-12', NOW)).toBe('yesterday');
+    expect(describeDaysAway('2026-07-08', NOW)).toBe('5 days ago');
+  });
+
+  it('returns null for an unparseable date', () => {
+    expect(describeDaysAway('nope', NOW)).toBeNull();
+  });
+});
+
+describe('eventIsPast', () => {
+  it('is true only for a date strictly before today (CT)', () => {
+    expect(eventIsPast('2026-07-12', NOW)).toBe(true);
+    expect(eventIsPast('2026-07-13', NOW)).toBe(false); // today is not past
+    expect(eventIsPast('2026-07-20', NOW)).toBe(false);
+    expect(eventIsPast('garbage', NOW)).toBe(false);
+  });
+});
+
+describe('humanizeOccasion', () => {
+  it('title-cases kebab/snake occasions', () => {
+    expect(humanizeOccasion('bachelor-party')).toBe('Bachelor Party');
+    expect(humanizeOccasion('corporate_event')).toBe('Corporate Event');
+    expect(humanizeOccasion('wedding')).toBe('Wedding');
+    expect(humanizeOccasion('lake-travis-boat')).toBe('Lake Travis Boat');
+    expect(humanizeOccasion('  bachelorette  ')).toBe('Bachelorette');
+  });
+});
+
+describe('formatShortDate', () => {
+  it('formats a timestamp as "Mon D, YYYY"', () => {
+    const out = formatShortDate('2026-07-14T12:00:00Z');
+    expect(out).toMatch(/^[A-Z][a-z]{2} \d{1,2}, \d{4}$/);
+    expect(out).toContain('Jul');
+    expect(out).toContain('2026');
+  });
+});
+
+describe('formatScoreBreakdown', () => {
+  it('renders a de-camel-cased factor list', () => {
+    expect(formatScoreBreakdown({ eventProximity: 30, dealSize: 25 })).toBe(
+      'event proximity 30 · deal size 25',
+    );
+  });
+
+  it('renders an em dash when there is no breakdown', () => {
+    expect(formatScoreBreakdown(null)).toBe('—');
+    expect(formatScoreBreakdown({})).toBe('—');
+  });
+});
+
+// --- deriveActivitySummary -------------------------------------------------
+
+let seq = 0;
+const isoDaysAgo = (n: number): string => new Date(NOW.getTime() - n * 86_400_000).toISOString();
+
+function ev(type: string): LeadDetail['events'][number] {
+  return {
+    id: `ev-${seq++}`,
+    type,
+    page: null,
+    widget: null,
+    fieldName: null,
+    metadata: null,
+    occurredAt: NOW.toISOString(),
+  };
+}
+
+function emailLog(status: string, createdAt: string): LeadDetail['emailLogs'][number] {
+  return { id: `em-${seq++}`, subject: 'Your inquiry', type: 'reply', status, createdAt };
+}
+
+function draft(status = 'SENT'): LeadDetail['drafts'][number] {
+  return { id: `dr-${seq++}`, status, total: 500, createdAt: NOW.toISOString(), token: 't' };
+}
+
+function makeDetail(over: Partial<LeadDetail>): LeadDetail {
+  return {
+    lead: {
+      id: 'l1',
+      email: 'a@b.com',
+      phone: null,
+      firstName: null,
+      lastName: null,
+      status: 'ACTIVE',
+      pipelineStage: 'NEW',
+      leadScore: 50,
+      scoreBreakdown: null,
+      sourcePage: null,
+      sourceWidget: null,
+      utmSource: null,
+      utmMedium: null,
+      utmCampaign: null,
+      owner: null,
+      snoozedUntil: null,
+      notes: null,
+      metadata: null,
+      createdAt: NOW.toISOString(),
+    },
+    events: [],
+    followUps: [],
+    emailLogs: [],
+    orders: [],
+    drafts: [],
+    ...over,
+  };
+}
+
+describe('deriveActivitySummary', () => {
+  it('returns no chips when there is no activity', () => {
+    expect(deriveActivitySummary(makeDetail({}), NOW)).toEqual([]);
+  });
+
+  it('flags a quote only when an invoice actually went out', () => {
+    const sent = deriveActivitySummary(makeDetail({ drafts: [draft('SENT')] }), NOW);
+    expect(sent).toContainEqual({ key: 'quote', label: 'Quote sent', variant: 'blue' });
+
+    // PENDING (never sent), CANCELLED and EXPIRED must NOT claim "Quote sent" —
+    // that would contradict the invoice-status line the facts panel shows.
+    for (const dead of ['PENDING', 'CANCELLED', 'EXPIRED']) {
+      const chips = deriveActivitySummary(makeDetail({ drafts: [draft(dead)] }), NOW);
+      expect(chips.some((c) => c.key === 'quote')).toBe(false);
+    }
+  });
+
+  it('shows outbound-email recency from the most recent log', () => {
+    const detail = makeDetail({
+      emailLogs: [emailLog('sent', isoDaysAgo(5)), emailLog('delivered', isoDaysAgo(2))],
+    });
+    const emailed = deriveActivitySummary(detail, NOW).find((c) => c.key === 'emailed');
+    expect(emailed?.label).toBe('Emailed 2d ago');
+  });
+
+  it('says "today" and "1d ago" at the boundaries', () => {
+    expect(
+      deriveActivitySummary(makeDetail({ emailLogs: [emailLog('sent', isoDaysAgo(0))] }), NOW).find(
+        (c) => c.key === 'emailed',
+      )?.label,
+    ).toBe('Emailed today');
+    expect(
+      deriveActivitySummary(makeDetail({ emailLogs: [emailLog('sent', isoDaysAgo(1))] }), NOW).find(
+        (c) => c.key === 'emailed',
+      )?.label,
+    ).toBe('Emailed 1d ago');
+  });
+
+  it('surfaces an opened email (the strongest engagement signal available)', () => {
+    const opened = deriveActivitySummary(
+      makeDetail({ emailLogs: [emailLog('opened', isoDaysAgo(1))] }),
+      NOW,
+    );
+    expect(opened).toContainEqual({ key: 'opened', label: 'Opened email', variant: 'green' });
+
+    // A merely sent/delivered email is not "opened".
+    const delivered = deriveActivitySummary(
+      makeDetail({ emailLogs: [emailLog('delivered', isoDaysAgo(1))] }),
+      NOW,
+    );
+    expect(delivered.some((c) => c.key === 'opened')).toBe(false);
+  });
+
+  it('flags checkout, a form submit, and counts site visits', () => {
+    const detail = makeDetail({
+      events: [ev('CHECKOUT_START'), ev('FORM_SUBMIT'), ev('PAGE_VIEW'), ev('PAGE_VIEW'), ev('PAGE_VIEW')],
+    });
+    const chips = deriveActivitySummary(detail, NOW);
+    expect(chips).toContainEqual({ key: 'checkout', label: 'Started checkout', variant: 'amber' });
+    expect(chips).toContainEqual({ key: 'submitted', label: 'Submitted a form', variant: 'gray' });
+    expect(chips).toContainEqual({ key: 'visits', label: '3 site visits', variant: 'gray' });
+  });
+
+  it('singularizes a lone site visit and treats STEP_COMPLETE as a submit', () => {
+    const chips = deriveActivitySummary(
+      makeDetail({ events: [ev('STEP_COMPLETE'), ev('PAGE_VIEW')] }),
+      NOW,
+    );
+    expect(chips).toContainEqual({ key: 'submitted', label: 'Submitted a form', variant: 'gray' });
+    expect(chips).toContainEqual({ key: 'visits', label: '1 site visit', variant: 'gray' });
+  });
+
+  it('orders chips: quote → emailed → engagement → checkout → submit → visits', () => {
+    const detail = makeDetail({
+      drafts: [draft()],
+      emailLogs: [emailLog('opened', isoDaysAgo(2))],
+      events: [ev('CHECKOUT_START'), ev('FORM_SUBMIT'), ev('PAGE_VIEW')],
+    });
+    expect(deriveActivitySummary(detail, NOW).map((c) => c.key)).toEqual([
+      'quote',
+      'emailed',
+      'opened',
+      'checkout',
+      'submitted',
+      'visits',
+    ]);
+  });
+});

--- a/src/app/admin/leads/_components/drawer-derive.ts
+++ b/src/app/admin/leads/_components/drawer-derive.ts
@@ -1,0 +1,160 @@
+/**
+ * Pure display derivation for the lead drawer — Prisma- and React-free so it
+ * unit-tests without rendering. Two concerns:
+ *
+ *  - Event facts formatting (date + "days away" + occasion), shared with
+ *    drawer-facts.tsx.
+ *  - The at-a-glance activity summary (drawer-summary.tsx): a few HqBadge chips
+ *    derived from the timeline data so an operator sees where a lead stands
+ *    without reading the whole feed.
+ *
+ * Dates are the per-surface strings extractLeadFacts (scoring.ts) surfaces —
+ * usually YYYY-MM-DD or a full ISO timestamp. Countdown math reuses the CT-safe
+ * daysUntilCT so the drawer agrees with the board card's countdown chip.
+ */
+
+import { daysUntilCT } from '@/lib/leads/scoring';
+import type { HqBadgeVariant } from '@/components/backend/kit/Badge';
+import type { LeadDetail } from './drawer-types';
+
+/**
+ * Format a lead's event-date string for display, CT-safe. We read the calendar
+ * Y-M-D off the front and build a *local* Date from those parts, so
+ * `new Date('2026-08-15')`'s UTC-midnight parse (an off-by-one for CT evenings)
+ * can't shift the day. Falls back to the raw string when it isn't a parseable
+ * date — a surface could store free text.
+ */
+export function formatEventDate(dateStr: string): string {
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(dateStr.trim());
+  if (!m) return dateStr.trim();
+  const local = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+  return local.toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+/**
+ * Human "days away" phrase for an event date, or null when the value can't be
+ * parsed (the caller then shows just the formatted date). Lowercase because it
+ * reads as a suffix — "Sat, Aug 15, 2026 · in 32 days".
+ */
+export function describeDaysAway(dateStr: string, now: Date): string | null {
+  const days = daysUntilCT(dateStr, now);
+  if (days == null) return null;
+  if (days === 0) return 'today';
+  if (days === 1) return 'tomorrow';
+  if (days === -1) return 'yesterday';
+  if (days < 0) return `${Math.abs(days)} days ago`;
+  return `in ${days} days`;
+}
+
+/** True when the event has already passed (drives the muted-vs-accent color). */
+export function eventIsPast(dateStr: string, now: Date): boolean {
+  const days = daysUntilCT(dateStr, now);
+  return days != null && days < 0;
+}
+
+/** kebab/snake occasion → Title Case ("bachelor-party" → "Bachelor Party"). */
+export function humanizeOccasion(occasion: string): string {
+  return occasion
+    .trim()
+    .replace(/[-_]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Full ISO timestamp → "Jul 14, 2026" (CT calendar — the business runs on CT). */
+export function formatShortDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'America/Chicago',
+  });
+}
+
+/** Score breakdown map → "event proximity 30 · deal size 25 · …" (or "—"). */
+export function formatScoreBreakdown(breakdown: Record<string, number> | null): string {
+  if (!breakdown || Object.keys(breakdown).length === 0) return '—';
+  return Object.entries(breakdown)
+    .map(([k, v]) => `${k.replace(/([A-Z])/g, ' $1').toLowerCase()} ${v}`)
+    .join(' · ');
+}
+
+export interface ActivityChip {
+  key: string;
+  label: string;
+  variant: HqBadgeVariant;
+}
+
+/** "today" / "1d ago" / "Nd ago" for a past ISO timestamp. */
+function daysAgo(iso: string, now: Date): string {
+  const then = new Date(iso).getTime();
+  if (!Number.isFinite(then)) return '';
+  const days = Math.floor((now.getTime() - then) / 86_400_000);
+  if (days <= 0) return 'today';
+  if (days === 1) return '1d ago';
+  return `${days}d ago`;
+}
+
+/**
+ * DraftOrder statuses meaning an invoice actually reached the customer. PENDING
+ * (created-not-sent), EXPIRED and CANCELLED are excluded so the "Quote sent"
+ * chip can't contradict the real "Invoice cancelled/expired" line the facts
+ * panel shows right below it. Mirrors the DraftOrderStatus enum in schema.prisma.
+ */
+const QUOTE_SENT_STATUSES = new Set(['SENT', 'VIEWED', 'PAID', 'CONVERTED']);
+
+/**
+ * A handful of at-a-glance chips summarizing where a lead stands — quote sent,
+ * our outreach recency, whether they opened it, and their site behavior. The
+ * full detail still lives in the timeline; this is the scannable summary. Empty
+ * array when there's no activity worth flagging (caller renders nothing).
+ */
+export function deriveActivitySummary(detail: LeadDetail, now: Date): ActivityChip[] {
+  const { events, emailLogs, drafts } = detail;
+  const chips: ActivityChip[] = [];
+
+  // A quote/invoice actually went out — not a bare draft or a dead (expired/
+  // cancelled) one, which would misstate the lead's status.
+  if (drafts.some((d) => QUOTE_SENT_STATUSES.has(d.status))) {
+    chips.push({ key: 'quote', label: 'Quote sent', variant: 'blue' });
+  }
+
+  // Our most recent outbound email (emailLogs are outbound-only). The reduce —
+  // rather than emailLogs[0] — so we don't depend on the API's sort order.
+  if (emailLogs.length > 0) {
+    const latest = emailLogs.reduce((a, b) =>
+      new Date(a.createdAt).getTime() >= new Date(b.createdAt).getTime() ? a : b,
+    );
+    const rel = daysAgo(latest.createdAt, now);
+    chips.push({ key: 'emailed', label: rel ? `Emailed ${rel}` : 'Emailed', variant: 'blue' });
+  }
+
+  // Did they open one of our emails? EmailStatus has no CLICKED (Resend click
+  // tracking isn't wired), so OPENED is the strongest engagement signal we get.
+  if (emailLogs.some((l) => l.status.toLowerCase() === 'opened')) {
+    chips.push({ key: 'opened', label: 'Opened email', variant: 'green' });
+  }
+
+  // High-intent site behavior.
+  if (events.some((e) => e.type === 'CHECKOUT_START')) {
+    chips.push({ key: 'checkout', label: 'Started checkout', variant: 'amber' });
+  }
+  if (events.some((e) => e.type === 'FORM_SUBMIT' || e.type === 'STEP_COMPLETE')) {
+    chips.push({ key: 'submitted', label: 'Submitted a form', variant: 'gray' });
+  }
+  const visits = events.filter((e) => e.type === 'PAGE_VIEW').length;
+  if (visits > 0) {
+    chips.push({
+      key: 'visits',
+      label: visits === 1 ? '1 site visit' : `${visits} site visits`,
+      variant: 'gray',
+    });
+  }
+
+  return chips;
+}

--- a/src/app/admin/leads/_components/drawer-facts.tsx
+++ b/src/app/admin/leads/_components/drawer-facts.tsx
@@ -1,65 +1,128 @@
 'use client';
 
-import { ReactElement } from 'react';
+import { ReactElement, ReactNode } from 'react';
+import { extractLeadFacts } from '@/lib/leads/scoring';
 import type { LeadDetail } from './drawer-types';
+import {
+  describeDaysAway,
+  eventIsPast,
+  formatEventDate,
+  formatScoreBreakdown,
+  formatShortDate,
+  humanizeOccasion,
+} from './drawer-derive';
 
 /**
- * Drawer facts: the source/campaign/score grid plus the linked orders &
- * quotes list (group-participant orders carry their "confirm before
+ * Drawer facts: the event details (date/occasion/headcount/budget — shown only
+ * when captured) lead, then the source/campaign/score grid and the linked
+ * orders & quotes list (group-participant orders carry their "confirm before
  * celebrating" caveat).
  */
 export default function DrawerFacts({ detail }: { detail: LeadDetail }): ReactElement {
   const { lead, orders, drafts } = detail;
+  const facts = extractLeadFacts(lead.metadata);
+  const now = new Date();
+  const daysAway = facts.eventDate ? describeDaysAway(facts.eventDate, now) : null;
+  const past = facts.eventDate ? eventIsPast(facts.eventDate, now) : false;
+
   return (
     <>
       <section className="mt-4 grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
-        <Fact label="Source" value={`${lead.sourceWidget ?? '—'}${lead.sourcePage ? ` · ${lead.sourcePage}` : ''}`} />
-        <Fact label="Campaign" value={lead.utmCampaign ?? lead.utmSource ?? 'direct / unknown'} />
+        {facts.eventDate && (
+          <Fact
+            label="Event date"
+            wide
+            value={<EventDateValue dateStr={facts.eventDate} daysAway={daysAway} past={past} />}
+          />
+        )}
+        {facts.occasion && <Fact label="Occasion" value={humanizeOccasion(facts.occasion)} />}
+        {facts.headcount != null && <Fact label="Headcount" value={`${facts.headcount} guests`} />}
+        {facts.budgetPerPerson != null && (
+          <Fact label="Budget / person" value={`$${facts.budgetPerPerson}`} />
+        )}
         <Fact
-          label="Score breakdown"
-          value={
-            lead.scoreBreakdown
-              ? Object.entries(lead.scoreBreakdown)
-                  .map(([k, v]) => `${k.replace(/([A-Z])/g, ' $1').toLowerCase()} ${v}`)
-                  .join(' · ')
-              : '—'
-          }
+          label="Source"
+          value={`${lead.sourceWidget ?? '—'}${lead.sourcePage ? ` · ${lead.sourcePage}` : ''}`}
         />
-        <Fact label="Created" value={new Date(lead.createdAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })} />
+        <Fact label="Campaign" value={lead.utmCampaign ?? lead.utmSource ?? 'direct / unknown'} />
+        <Fact label="Score breakdown" value={formatScoreBreakdown(lead.scoreBreakdown)} />
+        <Fact label="Created" value={formatShortDate(lead.createdAt)} />
       </section>
 
-      {(orders.length > 0 || drafts.length > 0) && (
-        <section className="mt-4">
-          <h3 className="font-heading font-bold text-sm tracking-[0.1em] uppercase text-gray-500">
-            Orders & quotes
-          </h3>
-          <ul className="mt-1 space-y-1 text-sm">
-            {orders.map((o) => (
-              <li key={o.id}>
-                <a href={`/ops/orders/${o.id}`} className="text-brand-blue underline">
-                  Order #{o.orderNumber}
-                </a>{' '}
-                · ${o.total.toFixed(0)}
-                {o.isGroupParticipant && (
-                  <span className="text-gray-500"> · group payment (possible win — confirm)</span>
-                )}
-              </li>
-            ))}
-            {drafts.map((d) => (
-              <li key={d.id} className="text-gray-700">
-                Invoice {d.status.toLowerCase()} · ${Number(d.total).toFixed(0)}
-              </li>
-            ))}
-          </ul>
-        </section>
+      <OrdersAndQuotes orders={orders} drafts={drafts} />
+    </>
+  );
+}
+
+/** Event date + a colored "days away" suffix (muted once the event has passed). */
+function EventDateValue({
+  dateStr,
+  daysAway,
+  past,
+}: {
+  dateStr: string;
+  daysAway: string | null;
+  past: boolean;
+}): ReactElement {
+  return (
+    <>
+      {formatEventDate(dateStr)}
+      {daysAway && (
+        <span className={past ? 'text-gray-400' : 'text-brand-blue font-medium'}>
+          {` · ${daysAway}`}
+        </span>
       )}
     </>
   );
 }
 
-function Fact({ label, value }: { label: string; value: string }): ReactElement {
+/** Matched paid orders + draft invoices, if any. */
+function OrdersAndQuotes({
+  orders,
+  drafts,
+}: {
+  orders: LeadDetail['orders'];
+  drafts: LeadDetail['drafts'];
+}): ReactElement | null {
+  if (orders.length === 0 && drafts.length === 0) return null;
   return (
-    <div>
+    <section className="mt-4">
+      <h3 className="font-heading font-bold text-sm tracking-[0.1em] uppercase text-gray-500">
+        Orders & quotes
+      </h3>
+      <ul className="mt-1 space-y-1 text-sm">
+        {orders.map((o) => (
+          <li key={o.id}>
+            <a href={`/ops/orders/${o.id}`} className="text-brand-blue underline">
+              Order #{o.orderNumber}
+            </a>{' '}
+            · ${o.total.toFixed(0)}
+            {o.isGroupParticipant && (
+              <span className="text-gray-500"> · group payment (possible win — confirm)</span>
+            )}
+          </li>
+        ))}
+        {drafts.map((d) => (
+          <li key={d.id} className="text-gray-700">
+            Invoice {d.status.toLowerCase()} · ${Number(d.total).toFixed(0)}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function Fact({
+  label,
+  value,
+  wide,
+}: {
+  label: string;
+  value: ReactNode;
+  wide?: boolean;
+}): ReactElement {
+  return (
+    <div className={wide ? 'col-span-2' : undefined}>
       <div className="text-xs font-semibold uppercase tracking-[0.08em] text-gray-500">{label}</div>
       <div className="text-gray-800 break-words">{value}</div>
     </div>

--- a/src/app/admin/leads/_components/drawer-summary.tsx
+++ b/src/app/admin/leads/_components/drawer-summary.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { ReactElement } from 'react';
+import HqBadge from '@/components/backend/kit/Badge';
+import type { LeadDetail } from './drawer-types';
+import { deriveActivitySummary } from './drawer-derive';
+
+/**
+ * At-a-glance activity strip below the header: a few chips ("Quote sent",
+ * "Emailed 2d ago", "Opened email", "Submitted a form", "3 site visits") so an
+ * operator sees where the lead stands without reading the full timeline. It's a
+ * summary of the same events — renders nothing when there's no activity yet.
+ */
+export default function DrawerSummary({ detail }: { detail: LeadDetail }): ReactElement | null {
+  const chips = deriveActivitySummary(detail, new Date());
+  if (chips.length === 0) return null;
+  return (
+    <div className="mt-3 flex flex-wrap gap-1.5">
+      {chips.map((c) => (
+        <HqBadge key={c.key} variant={c.variant}>
+          {c.label}
+        </HqBadge>
+      ))}
+    </div>
+  );
+}

--- a/src/app/admin/leads/_components/lead-drawer.tsx
+++ b/src/app/admin/leads/_components/lead-drawer.tsx
@@ -6,6 +6,7 @@ import { type PipelineStage } from '@/lib/leads/pipeline-types';
 import type { LeadMutations } from './use-lead-mutations';
 import type { LeadDetail } from './drawer-types';
 import DrawerHeader from './drawer-header';
+import DrawerSummary from './drawer-summary';
 import DrawerStageActions from './drawer-stage-actions';
 import DrawerFacts from './drawer-facts';
 import DrawerTimeline from './drawer-timeline';
@@ -103,6 +104,7 @@ export default function LeadDrawer({
         {lead && detail && (
           <>
             <DrawerHeader lead={lead} name={name} />
+            <DrawerSummary detail={detail} />
             <DrawerStageActions
               lead={lead}
               mutating={mutations.mutating}


### PR DESCRIPTION
## What
Enriches the contact-card drawer on the Lead Flow board (`/admin/leads`) so an operator can read a lead at a glance.

**1. Event facts in the drawer facts panel** (`drawer-facts.tsx`)
The event details are already captured in `Lead.metadata`; the drawer just wasn't showing them. Added conditional rows (only when present):
- **Event date** — full-width headline, nicely formatted, with a colored "days away" suffix (`· in 32 days`, muted once past). Reuses the CT-safe `daysUntilCT` from `scoring.ts` so it agrees with the board card's countdown chip.
- **Occasion** (title-cased), **Headcount**, **Budget / person**.

Facts are derived with the existing pure `extractLeadFacts(lead.metadata)` — the same function `board-data.ts` already uses server-side for the card face.

**2. At-a-glance activity strip** (`drawer-summary.tsx`, new)
A small row of `HqBadge` chips below the header — **Quote sent**, **Emailed 2d ago**, **Opened email**, **Submitted a form**, **N site visits** — derived from `detail.drafts / emailLogs / events`. It's a summary of the same data the timeline already shows in full; renders nothing when there's no activity.

## Design notes
- Pure derivation lives in `drawer-derive.ts` (React/Prisma-free) with unit coverage.
- "Quote sent" is gated on `DraftOrderStatus` values that actually reached the customer (SENT/VIEWED/PAID/CONVERTED) so it can't contradict the "Invoice cancelled/expired" line the facts panel shows right below it.
- Components stay under the 200-line / 50-line-function limits; `Fact`/`EventDateValue`/`OrdersAndQuotes` extracted.

## Out of scope
Inbound email (a customer emailing `info@`) is **not** ingested onto the board — those replies live in the Resend/GHL inbox. Surfacing them needs a Resend-inbound/forwarding integration (separate, larger).

## Tests / gates
- New `__tests__/drawer-derive.test.ts` — 19 cases (date formatting/off-by-one, days-away phrasing, occasion humanizing, score-breakdown, and every summary-chip branch incl. dead-draft exclusion).
- `tsc --noEmit` clean (no new errors), `npm run lint` clean, full suite green.
- Independent staff-engineer review run pre-merge; two findings (draft-status gating + a dead email-status branch) fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)