### PR TITLE
feat(leads): ingest inbound info@ emails onto the Lead Flow board

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -172,6 +172,16 @@ GOOGLE_SEARCH_CONSOLE_SITE=sc-domain:partyondelivery.com
 # JSON blob fallback used by ga4-behavior
 GOOGLE_APPLICATION_CREDENTIALS_JSON=your-google-credentials-json
 
+# Inbound email → Lead Flow board (docs/inbound-email-setup.md). Polls this
+# mailbox's Gmail INBOX via a service account with domain-wide delegation.
+GMAIL_INBOUND_ADDRESS=info@partyondelivery.com
+# STRONGLY RECOMMENDED: a DEDICATED service account for Gmail (distinct from the
+# analytics GOOGLE_* one), so granting it domain-wide gmail.readonly doesn't
+# widen the analytics key to "read any mailbox in the domain". Falls back to
+# GOOGLE_SERVICE_ACCOUNT_EMAIL / GOOGLE_PRIVATE_KEY when these are unset.
+GMAIL_SERVICE_ACCOUNT_EMAIL=your-gmail-service-account@project.iam.gserviceaccount.com
+GMAIL_PRIVATE_KEY=your-gmail-service-account-private-key
+
 # ==========================================
 # GOOGLE CALENDAR (ops scheduling)
 # ==========================================

--- a/docs/inbound-email-setup.md
+++ b/docs/inbound-email-setup.md
@@ -1,0 +1,74 @@
+# Inbound email → Lead Flow board (setup)
+
+When a customer emails **info@partyondelivery.com**, a cron polls the mailbox,
+turns each likely-inquiry message into a card on `/admin/leads`, and stores the
+message so you can read it in the card drawer ("Messages from them") and reply
+with the existing composer.
+
+- **Poller:** `src/lib/leads/inbound-email.ts` (`pollInboundEmails`)
+- **Cron:** `GET /api/cron/inbound-email` — every 15 min (`vercel.json`), `CRON_SECRET` bearer
+- **Gmail client:** `src/lib/email/gmail-client.ts` — reuses the existing Google service account, impersonating info@ with the read-only Gmail scope
+- **Storage:** `inbound_emails` table (one row per Gmail message, deduped by message id)
+
+The code ships **inert** until the two Google steps below are done — the cron
+returns `{ ok: true, configured: false }` and does nothing.
+
+## What only you can do (external, one-time)
+
+It needs Gmail turned on and permission to read the info@ mailbox.
+
+### 1. Enable the Gmail API
+In the Google Cloud project that owns the service account:
+**APIs & Services → Enable APIs → Gmail API → Enable.**
+
+### 2. Use a DEDICATED service account (strongly recommended)
+Domain-wide delegation is keyed on **(service-account client ID, scope)**, not
+on the mailbox — so granting `gmail.readonly` to the *shared analytics* account
+(`GOOGLE_SERVICE_ACCOUNT_EMAIL`) would let that key impersonate **any** mailbox
+in the Workspace, and a leak of it would then expose every employee's Gmail.
+Create a **separate** service account just for this (Cloud console → IAM &
+Admin → Service Accounts → Create), and set `GMAIL_SERVICE_ACCOUNT_EMAIL` /
+`GMAIL_PRIVATE_KEY` (step 4). The code falls back to the shared `GOOGLE_*`
+account if you skip this, but then the blast radius above applies.
+
+### 3. Grant domain-wide delegation for read-only Gmail
+Gmail is per-user, so the service account must be allowed to *impersonate* the
+mailbox. In the **Google Workspace Admin console** (admin.google.com):
+
+**Security → Access and data control → API controls → Domain-wide delegation → Add new**, then enter:
+- **Client ID:** the (dedicated) service account's numeric client ID (Cloud console → the service account → "Unique ID")
+- **OAuth scope:** `https://www.googleapis.com/auth/gmail.readonly`
+
+(Read-only on purpose: we never modify labels or send from Gmail — replies go
+out through Resend as they do today, and dedupe is tracked in our own DB.)
+
+### 4. Env vars (Vercel → Project → Settings → Environment Variables)
+- `GMAIL_SERVICE_ACCOUNT_EMAIL` / `GMAIL_PRIVATE_KEY` — the **dedicated** Gmail service account (step 2). Optional but recommended; falls back to `GOOGLE_SERVICE_ACCOUNT_EMAIL` / `GOOGLE_PRIVATE_KEY`.
+- `GMAIL_INBOUND_ADDRESS` — the mailbox to poll. Optional; defaults to `info@partyondelivery.com`.
+- `CRON_SECRET` — already set (the cron shares it with the other lead crons).
+
+## Verify it's live
+
+```bash
+curl -s -H "Authorization: Bearer $CRON_SECRET" \
+  https://partyondelivery.com/api/cron/inbound-email
+```
+
+- `{ "configured": false }` → step 1/2 creds missing (service-account env not present).
+- HTTP 401 → `CRON_SECRET` missing or wrong.
+- A Google **403 / "unauthorized_client"** in the logs → delegation (step 2) not granted yet, or the scope/client-ID is wrong.
+- `{ "configured": true, "scanned": N, "ingested": M, "skippedNoise": K, ... }` → working. New inquiries appear on `/admin/leads` within ~15 min.
+
+## Behavior notes
+
+- **Only likely inquiries board.** Mail from `no-reply@`/`notifications@`/etc, or
+  carrying `List-Unsubscribe` / `List-Id` / `Precedence: bulk` / `Auto-Submitted`
+  headers, or from `@partyondelivery.com`, is skipped and logged quietly
+  (`[inbound-email] skipped <reason> <from>`) — never carded. Tune the rules in
+  `src/lib/leads/inbound-email-parse.ts` (`shouldIngestInbound`).
+- **Idempotent.** Re-polling never double-inserts (unique Gmail message id). The
+  window is the last 2 days of INBOX; a message already stored is skipped.
+- **Threading.** A customer's reply to our reply lands back in info@ and threads
+  onto the same lead (matched by email), bumping it back to "needs response".
+- **No auto-reply yet.** This phase only ingests + shows the message; you reply
+  manually from the card. AI/automated replies are a planned follow-up.

--- a/prisma/migrations/manual/2026-07-14-inbound-emails-table.sql
+++ b/prisma/migrations/manual/2026-07-14-inbound-emails-table.sql
@@ -1,0 +1,32 @@
+-- Inbound-email ingestion — inbound_emails table.
+-- One row per customer email received at info@partyondelivery.com (pulled by
+-- the Gmail poller in src/lib/leads/inbound-email.ts), linked to its Lead so
+-- the board drawer can show "what people are emailing us". Additive +
+-- idempotent; gmail_message_id is UNIQUE so re-polling never double-inserts.
+--
+-- id has no DB default: Prisma supplies the uuid app-side (@default(uuid())),
+-- matching the leads table. lead_id FK is ON DELETE SET NULL so the message
+-- record survives if a lead is ever removed.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS "inbound_emails" (
+  "id"               TEXT PRIMARY KEY,
+  "gmail_message_id" TEXT NOT NULL UNIQUE,
+  "gmail_thread_id"  TEXT,
+  "lead_id"          TEXT REFERENCES "leads"("id") ON DELETE SET NULL,
+  "from_email"       TEXT NOT NULL,
+  "from_name"        TEXT,
+  "to_address"       TEXT,
+  "subject"          TEXT,
+  "snippet"          TEXT,
+  "body_text"        TEXT,
+  "received_at"      TIMESTAMPTZ NOT NULL,
+  "metadata"         JSONB,
+  "created_at"       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "inbound_emails_lead_id_idx" ON "inbound_emails" ("lead_id");
+CREATE INDEX IF NOT EXISTS "inbound_emails_received_at_idx" ON "inbound_emails" ("received_at");
+
+COMMIT;

--- a/prisma/migrations/manual/2026-07-14-lead-source-inbound-email.sql
+++ b/prisma/migrations/manual/2026-07-14-lead-source-inbound-email.sql
@@ -1,0 +1,11 @@
+-- Inbound-email ingestion — INBOUND_EMAIL LeadSourceWidget enum value.
+-- Server-stamped source for leads created when a customer emails
+-- info@partyondelivery.com (Gmail poller → Lead Flow board). Never claimable
+-- by the public pixel — same class as the 2026-07-14 gap-closure sources.
+--
+-- Own file, NO BEGIN/COMMIT: ALTER TYPE ... ADD VALUE cannot share a
+-- transaction with statements that use the new value, and the migration runner
+-- executes each file as a single query. Keep this file to exactly one
+-- statement. (Precedent: 2026-07-14-lead-source-lead-magnet.sql.)
+
+ALTER TYPE "LeadSourceWidget" ADD VALUE IF NOT EXISTS 'INBOUND_EMAIL';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3317,6 +3317,9 @@ enum LeadSourceWidget {
   PARTNER_INQUIRY
   OPS_INVOICE
   LEAD_MAGNET
+  /// Customer emailed info@partyondelivery.com — ingested by the Gmail poller
+  /// (2026-07-14-lead-source-inbound-email.sql). Server-stamped, not pixel-claimable.
+  INBOUND_EMAIL
   OTHER
 }
 
@@ -3380,6 +3383,7 @@ model Lead {
 
   events          LeadEvent[]
   sessions        VisitorSession[]
+  inboundEmails   InboundEmail[]
 
   createdAt       DateTime        @default(now()) @map("created_at")
   updatedAt       DateTime        @updatedAt      @map("updated_at")
@@ -3392,6 +3396,34 @@ model Lead {
   @@index([pipelineStage, boardSortOrder])
   @@index([lastContactedAt])
   @@map("leads")
+}
+
+/// Inbound customer email received at info@partyondelivery.com, pulled by the
+/// Gmail poller (src/lib/leads/inbound-email.ts) and linked to its Lead so the
+/// board drawer can show "what people are emailing us". One row per Gmail
+/// message; gmailMessageId is unique for idempotent ingestion. See
+/// 2026-07-14-inbound-emails-table.sql.
+model InboundEmail {
+  id             String   @id @default(uuid())
+  gmailMessageId String   @unique @map("gmail_message_id")
+  gmailThreadId  String?  @map("gmail_thread_id")
+  leadId         String?  @map("lead_id")
+  fromEmail      String   @map("from_email")
+  fromName       String?  @map("from_name")
+  toAddress      String?  @map("to_address")
+  subject        String?
+  snippet        String?
+  /// Plaintext body (HTML stripped) — what the operator reads in the drawer.
+  bodyText       String?  @map("body_text") @db.Text
+  receivedAt     DateTime @map("received_at")
+  metadata       Json?
+  createdAt      DateTime @default(now()) @map("created_at")
+
+  lead           Lead?    @relation(fields: [leadId], references: [id], onDelete: SetNull)
+
+  @@index([leadId])
+  @@index([receivedAt])
+  @@map("inbound_emails")
 }
 
 enum LeadEventType {

--- a/src/app/admin/leads/_components/__tests__/drawer-derive.test.ts
+++ b/src/app/admin/leads/_components/__tests__/drawer-derive.test.ts
@@ -120,6 +120,18 @@ function draft(status = 'SENT'): LeadDetail['drafts'][number] {
   return { id: `dr-${seq++}`, status, total: 500, createdAt: NOW.toISOString(), token: 't' };
 }
 
+function inbound(receivedAt: string): LeadDetail['inboundEmails'][number] {
+  return {
+    id: `in-${seq++}`,
+    fromEmail: 'jane@example.com',
+    fromName: 'Jane',
+    subject: 'Boat party?',
+    snippet: 'Hi, wondering about a boat...',
+    bodyText: 'Hi, wondering about a boat party for 20 on Aug 15.',
+    receivedAt,
+  };
+}
+
 function makeDetail(over: Partial<LeadDetail>): LeadDetail {
   return {
     lead: {
@@ -148,6 +160,7 @@ function makeDetail(over: Partial<LeadDetail>): LeadDetail {
     emailLogs: [],
     orders: [],
     drafts: [],
+    inboundEmails: [],
     ...over,
   };
 }
@@ -155,6 +168,11 @@ function makeDetail(over: Partial<LeadDetail>): LeadDetail {
 describe('deriveActivitySummary', () => {
   it('returns no chips when there is no activity', () => {
     expect(deriveActivitySummary(makeDetail({}), NOW)).toEqual([]);
+  });
+
+  it('leads with "Emailed us" when a customer emailed in', () => {
+    const chips = deriveActivitySummary(makeDetail({ inboundEmails: [inbound(isoDaysAgo(1))] }), NOW);
+    expect(chips[0]).toEqual({ key: 'emailed-us', label: 'Emailed us 1d ago', variant: 'green' });
   });
 
   it('flags a quote only when an invoice actually went out', () => {
@@ -224,13 +242,15 @@ describe('deriveActivitySummary', () => {
     expect(chips).toContainEqual({ key: 'visits', label: '1 site visit', variant: 'gray' });
   });
 
-  it('orders chips: quote → emailed → engagement → checkout → submit → visits', () => {
+  it('orders chips: emailed-us → quote → emailed → engagement → checkout → submit → visits', () => {
     const detail = makeDetail({
+      inboundEmails: [inbound(isoDaysAgo(1))],
       drafts: [draft()],
       emailLogs: [emailLog('opened', isoDaysAgo(2))],
       events: [ev('CHECKOUT_START'), ev('FORM_SUBMIT'), ev('PAGE_VIEW')],
     });
     expect(deriveActivitySummary(detail, NOW).map((c) => c.key)).toEqual([
+      'emailed-us',
       'quote',
       'emailed',
       'opened',

--- a/src/app/admin/leads/_components/drawer-derive.ts
+++ b/src/app/admin/leads/_components/drawer-derive.ts
@@ -115,8 +115,18 @@ const QUOTE_SENT_STATUSES = new Set(['SENT', 'VIEWED', 'PAID', 'CONVERTED']);
  * array when there's no activity worth flagging (caller renders nothing).
  */
 export function deriveActivitySummary(detail: LeadDetail, now: Date): ActivityChip[] {
-  const { events, emailLogs, drafts } = detail;
+  const { events, emailLogs, drafts, inboundEmails } = detail;
   const chips: ActivityChip[] = [];
+
+  // A customer emailed us — the freshest "they're waiting on you" signal, so
+  // it leads the strip.
+  if (inboundEmails.length > 0) {
+    const latest = inboundEmails.reduce((a, b) =>
+      new Date(a.receivedAt).getTime() >= new Date(b.receivedAt).getTime() ? a : b,
+    );
+    const rel = daysAgo(latest.receivedAt, now);
+    chips.push({ key: 'emailed-us', label: rel ? `Emailed us ${rel}` : 'Emailed us', variant: 'green' });
+  }
 
   // A quote/invoice actually went out — not a bare draft or a dead (expired/
   // cancelled) one, which would misstate the lead's status.

--- a/src/app/admin/leads/_components/drawer-inbound.tsx
+++ b/src/app/admin/leads/_components/drawer-inbound.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { ReactElement } from 'react';
+import type { LeadDetail } from './drawer-types';
+
+/** "Mon D, h:mm AM" in CT — the business runs on Central time. */
+function fmtWhen(iso: string): string {
+  return new Date(iso).toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone: 'America/Chicago',
+  });
+}
+
+/**
+ * "Messages from them" — the actual inbound emails a customer sent to info@,
+ * so an operator can read what they wrote before replying (the composer sits
+ * right below). Newest first; long bodies scroll inside their own card.
+ * Renders nothing when there's no inbound mail.
+ */
+export default function DrawerInbound({
+  inboundEmails,
+}: {
+  inboundEmails: LeadDetail['inboundEmails'];
+}): ReactElement | null {
+  if (inboundEmails.length === 0) return null;
+  return (
+    <section className="mt-4">
+      <h3 className="font-heading font-bold text-sm tracking-[0.1em] uppercase text-gray-500">
+        Messages from them
+      </h3>
+      <ul className="mt-2 space-y-3">
+        {inboundEmails.map((m) => (
+          <li key={m.id} className="rounded-lg border border-gray-200 bg-gray-50 p-3">
+            <div className="flex items-baseline justify-between gap-2">
+              <span className="font-semibold text-sm text-gray-900 break-words">
+                {m.subject || '(no subject)'}
+              </span>
+              <span className="shrink-0 text-sm text-gray-400">{fmtWhen(m.receivedAt)}</span>
+            </div>
+            {m.bodyText ? (
+              <p className="mt-1 max-h-48 overflow-y-auto whitespace-pre-wrap break-words text-sm text-gray-700">
+                {m.bodyText}
+              </p>
+            ) : m.snippet ? (
+              <p className="mt-1 break-words text-sm text-gray-600">{m.snippet}</p>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/app/admin/leads/_components/drawer-timeline.tsx
+++ b/src/app/admin/leads/_components/drawer-timeline.tsx
@@ -1,15 +1,23 @@
 'use client';
 
 import { ReactElement } from 'react';
-import HqBadge from '@/components/backend/kit/Badge';
+import HqBadge, { type HqBadgeVariant } from '@/components/backend/kit/Badge';
 import type { LeadDetail } from './drawer-types';
 
 interface TimelineEntry {
   at: string;
-  kind: 'event' | 'email' | 'followup';
+  kind: 'event' | 'email' | 'followup' | 'inbound';
   label: string;
   detail?: string | null;
 }
+
+/** Badge style + label per timeline entry kind. */
+const KIND_BADGE: Record<TimelineEntry['kind'], { variant: HqBadgeVariant; label: string }> = {
+  event: { variant: 'gray', label: 'site' },
+  email: { variant: 'blue', label: 'email' },
+  followup: { variant: 'amber', label: 'followup' },
+  inbound: { variant: 'green', label: 'inbox' },
+};
 
 function eventLabel(e: LeadDetail['events'][number]): string {
   const meta = (e.metadata ?? {}) as Record<string, unknown>;
@@ -60,6 +68,12 @@ export default function DrawerTimeline({ detail }: { detail: LeadDetail }): Reac
           ? `Follow-up queued: ${f.journeyKey} step ${f.step}`
           : `Follow-up ${f.status}: ${f.journeyKey} step ${f.step}${f.cancelReason ? ` (${f.cancelReason})` : ''}`,
     })),
+    ...detail.inboundEmails.map((m) => ({
+      at: m.receivedAt,
+      kind: 'inbound' as const,
+      label: `Emailed us${m.subject ? `: "${m.subject}"` : ''}`,
+      detail: m.snippet,
+    })),
   ].sort((a, b) => (a.at < b.at ? 1 : -1));
 
   if (entries.length === 0) {
@@ -70,11 +84,8 @@ export default function DrawerTimeline({ detail }: { detail: LeadDetail }): Reac
     <ol className="space-y-2">
       {entries.slice(0, 60).map((entry, i) => (
         <li key={i} className="flex items-start gap-2 text-sm">
-          <HqBadge
-            variant={entry.kind === 'email' ? 'blue' : entry.kind === 'followup' ? 'amber' : 'gray'}
-            className="mt-[1px] shrink-0"
-          >
-            {entry.kind === 'event' ? 'site' : entry.kind}
+          <HqBadge variant={KIND_BADGE[entry.kind].variant} className="mt-[1px] shrink-0">
+            {KIND_BADGE[entry.kind].label}
           </HqBadge>
           <div className="min-w-0">
             <div className="text-gray-800">{entry.label}</div>

--- a/src/app/admin/leads/_components/drawer-types.ts
+++ b/src/app/admin/leads/_components/drawer-types.ts
@@ -64,4 +64,14 @@ export interface LeadDetail {
     createdAt: string;
     token: string;
   }>;
+  /** Customer emails received at info@ (Gmail poller), newest first. */
+  inboundEmails: Array<{
+    id: string;
+    fromEmail: string;
+    fromName: string | null;
+    subject: string | null;
+    snippet: string | null;
+    bodyText: string | null;
+    receivedAt: string;
+  }>;
 }

--- a/src/app/admin/leads/_components/lead-drawer.tsx
+++ b/src/app/admin/leads/_components/lead-drawer.tsx
@@ -9,6 +9,7 @@ import DrawerHeader from './drawer-header';
 import DrawerSummary from './drawer-summary';
 import DrawerStageActions from './drawer-stage-actions';
 import DrawerFacts from './drawer-facts';
+import DrawerInbound from './drawer-inbound';
 import DrawerTimeline from './drawer-timeline';
 import ReplyComposer from './reply-composer';
 
@@ -113,6 +114,7 @@ export default function LeadDrawer({
               onSnooze={(days) => void snooze(days)}
             />
             <DrawerFacts detail={detail} />
+            <DrawerInbound inboundEmails={detail.inboundEmails} />
 
             <section className="mt-4">
               <h3 className="font-heading font-bold text-sm tracking-[0.1em] uppercase text-gray-500">

--- a/src/app/api/cron/inbound-email/route.ts
+++ b/src/app/api/cron/inbound-email/route.ts
@@ -1,0 +1,39 @@
+/**
+ * GET /api/cron/inbound-email
+ *
+ * Polls the info@ Gmail INBOX every 15 min (vercel.json) and turns
+ * likely-inquiry mail into Lead Flow board cards + stored messages
+ * (src/lib/leads/inbound-email.ts). No-ops (configured:false) until the Gmail
+ * service account + domain-wide delegation are set up — see
+ * docs/inbound-email-setup.md.
+ *
+ * Auth: CRON_SECRET bearer, fail-CLOSED when unset (same as lead-pipeline):
+ * this route reads a mailbox and writes leads, so a misconfigured environment
+ * must not leave it publicly triggerable.
+ */
+import { NextResponse, type NextRequest } from 'next/server';
+import { pollInboundEmails } from '@/lib/leads/inbound-email';
+import { safeErrorMessage } from '@/lib/email/gmail-client';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+export const maxDuration = 300;
+
+const CRON_SECRET = process.env.CRON_SECRET;
+
+export async function GET(req: NextRequest) {
+  const auth = req.headers.get('authorization');
+  if (!CRON_SECRET || auth !== `Bearer ${CRON_SECRET}`) {
+    return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const result = await pollInboundEmails();
+    console.log('[inbound-email cron]', JSON.stringify(result));
+    return NextResponse.json({ ok: true, ...result, at: new Date().toISOString() });
+  } catch (err) {
+    // Message only — the raw Google error carries the signed JWT assertion.
+    console.error('[inbound-email cron] poll failed', safeErrorMessage(err));
+    return NextResponse.json({ ok: false, error: 'poll-failed' }, { status: 500 });
+  }
+}

--- a/src/app/api/v1/admin/leads/[id]/route.ts
+++ b/src/app/api/v1/admin/leads/[id]/route.ts
@@ -71,7 +71,7 @@ export async function GET(
     return NextResponse.json({ success: false, error: 'not_found' }, { status: 404 });
   }
 
-  const [events, followUps, emailLogs, orders, drafts] = await Promise.all([
+  const [events, followUps, emailLogs, orders, drafts, inboundEmails] = await Promise.all([
     prisma.leadEvent.findMany({
       where: { leadId: id },
       orderBy: { occurredAt: 'desc' },
@@ -108,11 +108,25 @@ export async function GET(
           select: { id: true, status: true, total: true, createdAt: true, token: true },
         })
       : Promise.resolve([]),
+    prisma.inboundEmail.findMany({
+      where: { leadId: id },
+      orderBy: { receivedAt: 'desc' },
+      take: 20,
+      select: {
+        id: true,
+        fromEmail: true,
+        fromName: true,
+        subject: true,
+        snippet: true,
+        bodyText: true,
+        receivedAt: true,
+      },
+    }),
   ]);
 
   return NextResponse.json({
     success: true,
-    data: { lead, events, followUps, emailLogs, orders, drafts },
+    data: { lead, events, followUps, emailLogs, orders, drafts, inboundEmails },
   });
 }
 

--- a/src/lib/email/gmail-client.ts
+++ b/src/lib/email/gmail-client.ts
@@ -1,0 +1,75 @@
+/**
+ * Gmail API client for the info@ inbound-email poller.
+ *
+ * Uses a service account with DOMAIN-WIDE DELEGATION: the account impersonates
+ * the mailbox (`subject`) to read its INBOX. That delegation + the
+ * gmail.readonly scope must be authorized in the Google Workspace admin console
+ * before this works (see docs/inbound-email-setup.md) — until then Google 401s
+ * the token request and the caller logs (message only) + no-ops.
+ *
+ * Read-only on Gmail: we never modify labels or mark-as-read. Idempotency is
+ * tracked in our own DB (inbound_emails.gmail_message_id is UNIQUE), so
+ * gmail.readonly is sufficient (least privilege).
+ *
+ * Prefers a DEDICATED Gmail service account (GMAIL_SERVICE_ACCOUNT_EMAIL /
+ * GMAIL_PRIVATE_KEY). Domain-wide delegation is keyed on (client-id, scope),
+ * NOT on the subject — so granting gmail.readonly to the shared analytics
+ * account (GOOGLE_*) would let that key impersonate ANY mailbox in the domain.
+ * A dedicated account keeps that blast radius off the analytics key. Falls back
+ * to GOOGLE_* when the dedicated one isn't set.
+ */
+import { google, type gmail_v1 } from 'googleapis';
+
+const GMAIL_READONLY_SCOPE = 'https://www.googleapis.com/auth/gmail.readonly';
+const DEFAULT_MAILBOX = 'info@partyondelivery.com';
+
+/** Mailbox whose INBOX we ingest. Override with GMAIL_INBOUND_ADDRESS. */
+export function inboundMailbox(): string {
+  return process.env.GMAIL_INBOUND_ADDRESS?.trim() || DEFAULT_MAILBOX;
+}
+
+/** Dedicated Gmail SA if set, else the shared analytics SA. Null if neither. */
+function gmailCredentials(): { email: string; key: string } | null {
+  const email = process.env.GMAIL_SERVICE_ACCOUNT_EMAIL || process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL;
+  const key = process.env.GMAIL_PRIVATE_KEY || process.env.GOOGLE_PRIVATE_KEY;
+  if (!email || !key) return null;
+  // Vercel stores the PEM with escaped newlines — same unescape as the GA4/GSC helper.
+  return { email, key: key.replace(/\\n/g, '\n') };
+}
+
+/** True when the service-account creds needed for Gmail delegation are present. */
+export function isGmailInboundConfigured(): boolean {
+  return gmailCredentials() !== null;
+}
+
+/**
+ * A gmail_v1 client authenticated as the service account impersonating the
+ * inbound mailbox, or null when creds are absent (caller no-ops). The token
+ * request only succeeds once domain-wide delegation is granted in Workspace.
+ */
+export function getGmailClient(): gmail_v1.Gmail | null {
+  const creds = gmailCredentials();
+  if (!creds) return null;
+  const auth = new google.auth.JWT({
+    email: creds.email,
+    key: creds.key,
+    scopes: [GMAIL_READONLY_SCOPE],
+    subject: inboundMailbox(),
+  });
+  return google.gmail({ version: 'v1', auth });
+}
+
+/**
+ * Log-safe description of an error — message + status only, never the raw
+ * object. A Google `GaxiosError` carries `.config` (the request body, which
+ * includes the signed JWT assertion — a bearer-equivalent credential) and
+ * `.response`; Node's console prints those in full, so logging the raw error
+ * would leak the assertion into the log stream (CWE-532). Use this everywhere
+ * a Gmail/Prisma error is logged.
+ */
+export function safeErrorMessage(err: unknown): string {
+  if (!(err instanceof Error)) return String(err);
+  const e = err as Error & { code?: unknown; response?: { status?: unknown } };
+  const status = e.response?.status ?? e.code;
+  return status != null ? `${e.message} (status=${String(status)})` : e.message;
+}

--- a/src/lib/leads/__tests__/inbound-email-parse.test.ts
+++ b/src/lib/leads/__tests__/inbound-email-parse.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Pure inbound-email parsing + noise filtering: address parsing, MIME body
+ * extraction (plain / nested / html-fallback), message parsing, and the
+ * "only likely inquiries" filter (self / automated / bulk / list / auto).
+ */
+import { describe, it, expect } from 'vitest';
+import type { gmail_v1 } from 'googleapis';
+import {
+  extractBodyText,
+  parseAddress,
+  parseGmailMessage,
+  shouldIngestInbound,
+  type ParsedInbound,
+} from '../inbound-email-parse';
+
+const b64 = (s: string): string => Buffer.from(s).toString('base64url');
+
+describe('parseAddress', () => {
+  it('splits quoted name + angle-addr and lowercases the email', () => {
+    expect(parseAddress('"Jane Doe" <Jane@Example.com>')).toEqual({
+      email: 'jane@example.com',
+      name: 'Jane Doe',
+    });
+  });
+  it('handles bare name + angle-addr and bare address', () => {
+    expect(parseAddress('Jane <jane@x.com>')).toEqual({ email: 'jane@x.com', name: 'Jane' });
+    expect(parseAddress('jane@x.com')).toEqual({ email: 'jane@x.com', name: null });
+  });
+  it('rejects junk and null', () => {
+    expect(parseAddress('not an address')).toEqual({ email: null, name: null });
+    expect(parseAddress(null)).toEqual({ email: null, name: null });
+  });
+});
+
+describe('extractBodyText', () => {
+  it('prefers a text/plain part', () => {
+    const payload: gmail_v1.Schema$MessagePart = {
+      mimeType: 'multipart/alternative',
+      parts: [
+        { mimeType: 'text/plain', body: { data: b64('Hello there') } },
+        { mimeType: 'text/html', body: { data: b64('<p>Hello there</p>') } },
+      ],
+    };
+    expect(extractBodyText(payload)).toBe('Hello there');
+  });
+  it('falls back to stripped text/html when no plain part', () => {
+    const payload: gmail_v1.Schema$MessagePart = {
+      mimeType: 'text/html',
+      body: { data: b64('<div>Hi <b>Jane</b>&amp;co</div>') },
+    };
+    expect(extractBodyText(payload)).toBe('Hi Jane &co');
+  });
+  it('reads a single-part plain body and returns null when empty', () => {
+    expect(
+      extractBodyText({ mimeType: 'text/plain', body: { data: b64('just text') } }),
+    ).toBe('just text');
+    expect(extractBodyText({ mimeType: 'text/plain', body: {} })).toBeNull();
+  });
+  it('caps very long bodies', () => {
+    const big = 'x'.repeat(20_000);
+    const out = extractBodyText({ mimeType: 'text/plain', body: { data: b64(big) } });
+    expect(out?.length).toBe(16_000);
+  });
+});
+
+function msg(headers: Array<[string, string]>, over: Partial<gmail_v1.Schema$Message> = {}): gmail_v1.Schema$Message {
+  return {
+    id: 'm1',
+    threadId: 't1',
+    snippet: 'a snippet',
+    internalDate: String(Date.UTC(2026, 6, 14, 12)),
+    payload: {
+      headers: headers.map(([name, value]) => ({ name, value })),
+      mimeType: 'text/plain',
+      body: { data: b64('body here') },
+    },
+    ...over,
+  };
+}
+
+describe('parseGmailMessage', () => {
+  it('extracts the sender, subject, body, and received time', () => {
+    const parsed = parseGmailMessage(
+      msg([
+        ['From', 'Jane Doe <jane@example.com>'],
+        ['To', 'info@partyondelivery.com'],
+        ['Subject', 'Boat party'],
+      ]),
+    );
+    expect(parsed).not.toBeNull();
+    expect(parsed?.fromEmail).toBe('jane@example.com');
+    expect(parsed?.fromName).toBe('Jane Doe');
+    expect(parsed?.subject).toBe('Boat party');
+    expect(parsed?.bodyText).toBe('body here');
+    expect(parsed?.receivedAt.getTime()).toBe(Date.UTC(2026, 6, 14, 12));
+  });
+  it('returns null when there is no parseable sender', () => {
+    expect(parseGmailMessage(msg([['Subject', 'No from']]))).toBeNull();
+    expect(parseGmailMessage({ threadId: 't' })).toBeNull(); // no id
+  });
+});
+
+// --- shouldIngestInbound ---------------------------------------------------
+
+function parsed(over: Partial<ParsedInbound>): ParsedInbound {
+  return {
+    gmailMessageId: 'm1',
+    gmailThreadId: null,
+    fromEmail: 'jane@example.com',
+    fromName: 'Jane',
+    toAddress: 'info@partyondelivery.com',
+    subject: 'Hi',
+    snippet: null,
+    bodyText: null,
+    receivedAt: new Date('2026-07-14T12:00:00Z'),
+    headers: {},
+    ...over,
+  };
+}
+
+describe('shouldIngestInbound', () => {
+  it('keeps a genuine person-to-person inquiry', () => {
+    expect(shouldIngestInbound(parsed({}))).toEqual({ ingest: true });
+  });
+
+  it('skips our own outbound / internal mail', () => {
+    expect(shouldIngestInbound(parsed({ fromEmail: 'allan@partyondelivery.com' })).reason).toBe('self');
+  });
+
+  it('skips automated senders by local-part', () => {
+    for (const addr of [
+      'no-reply@vendor.com',
+      'noreply@vendor.com',
+      'donotreply@vendor.com',
+      'mailer-daemon@x.com',
+      'notifications@app.com',
+      'newsletter@brand.com',
+    ]) {
+      expect(shouldIngestInbound(parsed({ fromEmail: addr })).reason).toBe('automated-sender');
+    }
+  });
+
+  it('keeps real people whose local-part merely starts with an automated-ish token', () => {
+    for (const addr of [
+      'notifyjane@gmail.com',
+      'updateme@gmail.com',
+      'bouncer@x.com',
+      'mailerman@x.com',
+      'alerta@x.com',
+    ]) {
+      expect(shouldIngestInbound(parsed({ fromEmail: addr }))).toEqual({ ingest: true });
+    }
+  });
+
+  it('skips bulk/list mail by header', () => {
+    expect(shouldIngestInbound(parsed({ headers: { 'list-unsubscribe': '<...>' } })).reason).toBe('bulk-list');
+    expect(shouldIngestInbound(parsed({ headers: { 'list-id': 'x' } })).reason).toBe('bulk-list');
+    expect(shouldIngestInbound(parsed({ headers: { precedence: 'bulk' } })).reason).toBe('bulk-precedence');
+  });
+
+  it('skips auto-generated mail but keeps auto-submitted:no', () => {
+    expect(shouldIngestInbound(parsed({ headers: { 'auto-submitted': 'auto-replied' } })).reason).toBe(
+      'auto-submitted',
+    );
+    expect(shouldIngestInbound(parsed({ headers: { 'auto-submitted': 'no' } }))).toEqual({ ingest: true });
+  });
+});

--- a/src/lib/leads/__tests__/inbound-email.test.ts
+++ b/src/lib/leads/__tests__/inbound-email.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Inbound-email ingestion board-attach guard: idempotency (dedupe by Gmail
+ * message id + P2002 race), PARTIAL→SUBMITTED promotion, no downgrade / no
+ * reopen of closed cards (mirrors dashboard-lead — inbound email never sets
+ * trustedSubmit, so it structurally can't reopen WON/LOST), forward-only
+ * recency, and never-throws on board bookkeeping.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Prisma } from '@prisma/client';
+import type { ParsedInbound } from '../inbound-email-parse';
+
+const upsertLead = vi.fn();
+const markLeadStatus = vi.fn();
+const enrollLeadIfEligible = vi.fn();
+const findUnique = vi.fn();
+const create = vi.fn();
+const leadUpdate = vi.fn();
+
+vi.mock('../leadCapture', () => ({
+  upsertLead: (...a: unknown[]) => upsertLead(...a),
+  markLeadStatus: (...a: unknown[]) => markLeadStatus(...a),
+}));
+vi.mock('../pipeline', () => ({
+  enrollLeadIfEligible: (...a: unknown[]) => enrollLeadIfEligible(...a),
+}));
+vi.mock('@/lib/email/gmail-client', () => ({
+  inboundMailbox: () => 'info@partyondelivery.com',
+  safeErrorMessage: (e: unknown) => String(e),
+  isGmailInboundConfigured: () => true,
+  getGmailClient: () => null,
+}));
+vi.mock('@/lib/database/client', () => ({
+  prisma: {
+    inboundEmail: {
+      findUnique: (...a: unknown[]) => findUnique(...a),
+      create: (...a: unknown[]) => create(...a),
+    },
+    lead: { update: (...a: unknown[]) => leadUpdate(...a) },
+  },
+}));
+
+import { ingestInboundEmail } from '../inbound-email';
+
+function parsed(over: Partial<ParsedInbound> = {}): ParsedInbound {
+  return {
+    gmailMessageId: 'm1',
+    gmailThreadId: 't1',
+    fromEmail: 'jane@example.com',
+    fromName: 'Jane Doe',
+    toAddress: 'info@partyondelivery.com',
+    subject: 'Boat party',
+    snippet: 'hi',
+    bodyText: 'hello',
+    receivedAt: new Date('2026-07-14T12:00:00Z'),
+    headers: {},
+    ...over,
+  };
+}
+
+function stubLead(over: Record<string, unknown> = {}) {
+  return { id: 'lead-1', status: 'PARTIAL', sourceWidget: null, metadata: null, lastActivityAt: null, ...over };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  findUnique.mockResolvedValue(null);
+  upsertLead.mockResolvedValue(stubLead());
+  create.mockResolvedValue({});
+  leadUpdate.mockResolvedValue({});
+  markLeadStatus.mockResolvedValue(undefined);
+  enrollLeadIfEligible.mockResolvedValue(true);
+});
+
+describe('ingestInboundEmail', () => {
+  it('new message → stamps INBOUND_EMAIL source, stores it, promotes PARTIAL to a card', async () => {
+    const res = await ingestInboundEmail(parsed());
+    expect(upsertLead).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'jane@example.com', firstName: 'Jane', lastName: 'Doe' }),
+      expect.objectContaining({ sourceWidget: 'INBOUND_EMAIL' }),
+    );
+    expect(create).toHaveBeenCalled();
+    expect(markLeadStatus).toHaveBeenCalledWith('lead-1', 'SUBMITTED');
+    expect(enrollLeadIfEligible).not.toHaveBeenCalled();
+    expect(res).toEqual({ created: true, leadId: 'lead-1' });
+  });
+
+  it('already-seen Gmail id → no-op (no upsert, no store)', async () => {
+    findUnique.mockResolvedValue({ leadId: 'lead-9' });
+    const res = await ingestInboundEmail(parsed());
+    expect(res).toEqual({ created: false, leadId: 'lead-9' });
+    expect(upsertLead).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('a converted/closed lead is never downgraded or reopened — enroll only', async () => {
+    upsertLead.mockResolvedValue(stubLead({ status: 'CONVERTED', sourceWidget: 'CONTACT_FORM' }));
+    await ingestInboundEmail(parsed());
+    expect(markLeadStatus).not.toHaveBeenCalled(); // no downgrade
+    expect(enrollLeadIfEligible).toHaveBeenCalledWith('lead-1'); // no-ops on a staged lead
+  });
+
+  it('loses a create race (P2002) without double-attaching to the board', async () => {
+    create.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError('dup', { code: 'P2002', clientVersion: '6' }),
+    );
+    const res = await ingestInboundEmail(parsed());
+    expect(res.created).toBe(false);
+    expect(leadUpdate).not.toHaveBeenCalled(); // attachToBoard skipped — no double-bump
+    expect(markLeadStatus).not.toHaveBeenCalled();
+  });
+
+  it('never throws when board bookkeeping fails (the message is already stored)', async () => {
+    leadUpdate.mockRejectedValue(new Error('db down'));
+    await expect(ingestInboundEmail(parsed())).resolves.toEqual({ created: true, leadId: 'lead-1' });
+  });
+
+  it('bumps recency forward only — never moves lastActivityAt backwards', async () => {
+    upsertLead.mockResolvedValue(stubLead({ lastActivityAt: new Date('2026-07-20T00:00:00Z') }));
+    await ingestInboundEmail(parsed());
+    const stale = (leadUpdate.mock.calls[0][0] as { data: Record<string, unknown> }).data;
+    expect('lastActivityAt' in stale).toBe(false);
+
+    leadUpdate.mockClear();
+    upsertLead.mockResolvedValue(stubLead({ lastActivityAt: new Date('2026-07-01T00:00:00Z') }));
+    await ingestInboundEmail(parsed());
+    const fresh = (leadUpdate.mock.calls[0][0] as { data: Record<string, unknown> }).data;
+    expect(fresh.lastActivityAt).toEqual(new Date('2026-07-14T12:00:00Z'));
+  });
+});

--- a/src/lib/leads/__tests__/scoring.test.ts
+++ b/src/lib/leads/__tests__/scoring.test.ts
@@ -216,6 +216,7 @@ describe('computeLeadScore — gap-closure sources (2026-07-14)', () => {
       computeLeadScore({ ...base, sourceWidget: w, metadata: {} }).breakdown.sourceQuality;
     expect(q('OPS_INVOICE')).toBe(16);
     expect(q('PARTNER_INQUIRY')).toBe(14);
+    expect(q('INBOUND_EMAIL')).toBe(14);
     expect(q('LEAD_MAGNET')).toBe(6);
     expect(q('EMAIL_SIGNUP')).toBe(2); // unchanged
   });

--- a/src/lib/leads/inbound-email-parse.ts
+++ b/src/lib/leads/inbound-email-parse.ts
@@ -1,0 +1,184 @@
+/**
+ * Pure parsing + noise-filtering for the inbound-email poller. No Prisma, no
+ * network — unit-tested in isolation. Operates on the Gmail message shape
+ * (gmail_v1.Schema$Message) the poller fetches with format=full.
+ *
+ * "Only likely inquiries" (operator decision 2026-07-14): person-to-person mail
+ * boards; no-reply / bulk / list / auto-generated mail is filtered out so the
+ * sales board doesn't fill with vendor spam and newsletters.
+ */
+import type { gmail_v1 } from 'googleapis';
+
+/** Headers we keep — enough to filter noise and show provenance, not the whole blob. */
+const KEPT_HEADERS = [
+  'from',
+  'to',
+  'subject',
+  'date',
+  'reply-to',
+  'list-unsubscribe',
+  'list-id',
+  'precedence',
+  'auto-submitted',
+] as const;
+
+const MAX_BODY_CHARS = 16_000;
+
+export interface ParsedInbound {
+  gmailMessageId: string;
+  gmailThreadId: string | null;
+  fromEmail: string;
+  fromName: string | null;
+  toAddress: string | null;
+  subject: string | null;
+  snippet: string | null;
+  bodyText: string | null;
+  receivedAt: Date;
+  /** Lower-cased whitelist of headers (see KEPT_HEADERS). */
+  headers: Record<string, string>;
+}
+
+function collectHeaders(raw: gmail_v1.Schema$MessagePartHeader[] | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const h of raw ?? []) {
+    const name = h.name?.toLowerCase();
+    if (name && h.value != null && (KEPT_HEADERS as readonly string[]).includes(name)) {
+      out[name] = h.value;
+    }
+  }
+  return out;
+}
+
+/** `"Jane Doe" <jane@x.com>` / `Jane <jane@x.com>` / `jane@x.com` → parts. */
+export function parseAddress(raw: string | null | undefined): { email: string | null; name: string | null } {
+  if (!raw) return { email: null, name: null };
+  const s = raw.trim();
+  const angle = /<([^>]+)>/.exec(s);
+  const email = (angle ? angle[1] : s).trim().toLowerCase();
+  const name = angle ? s.slice(0, angle.index).trim().replace(/^"|"$/g, '').trim() || null : null;
+  const valid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+  return { email: valid ? email : null, name };
+}
+
+function decodeHtmlEntities(s: string): string {
+  return s
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#0*39;|&apos;/gi, "'");
+}
+
+function stripHtml(html: string): string {
+  // Decode entities FIRST, then strip tags. If we stripped first, a body like
+  // `&amp;lt;img onerror=...&gt;` would survive the strip (no literal `<...>`)
+  // and then decode into a literal tag in the stored text — a latent
+  // HTML-injection payload for the planned reply/quote-original feature.
+  return decodeHtmlEntities(html)
+    .replace(/<(script|style)[\s\S]*?<\/\1>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/[ \t]+/g, ' ')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function decodeB64Url(data: string): string {
+  return Buffer.from(data, 'base64url').toString('utf8');
+}
+
+/** First part matching `mime`, walking multipart trees depth-first. */
+function findMimeData(part: gmail_v1.Schema$MessagePart | undefined, mime: string): string | null {
+  if (!part) return null;
+  if (part.mimeType === mime && part.body?.data) return decodeB64Url(part.body.data);
+  for (const child of part.parts ?? []) {
+    const found = findMimeData(child, mime);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** Plaintext body — prefer text/plain, fall back to stripped text/html. Capped. */
+export function extractBodyText(payload: gmail_v1.Schema$MessagePart | undefined): string | null {
+  const plain = findMimeData(payload, 'text/plain');
+  let text: string | null;
+  if (plain) {
+    text = plain;
+  } else {
+    const html = findMimeData(payload, 'text/html');
+    // Root single-part fallback only when it's actually text — never decode a
+    // lone application/* part as utf8. Cap the HTML fed to the regex passes so
+    // a multi-MB body isn't fully processed before the char cap below applies.
+    const rootIsText = payload?.mimeType?.startsWith('text/') ?? false;
+    text = html
+      ? stripHtml(html.slice(0, 4 * MAX_BODY_CHARS))
+      : rootIsText && payload?.body?.data
+        ? decodeB64Url(payload.body.data)
+        : null;
+  }
+  if (!text) return null;
+  const trimmed = text.replace(/\r\n/g, '\n').trim();
+  return trimmed.length > MAX_BODY_CHARS ? trimmed.slice(0, MAX_BODY_CHARS) : trimmed;
+}
+
+/** Parse a Gmail message into our shape, or null if it has no usable sender. */
+export function parseGmailMessage(msg: gmail_v1.Schema$Message): ParsedInbound | null {
+  if (!msg.id) return null;
+  const payload = msg.payload ?? undefined;
+  const headers = collectHeaders(payload?.headers ?? undefined);
+  const from = parseAddress(headers['from']);
+  if (!from.email) return null; // can't anchor a lead or dedupe without a sender
+
+  const fromInternal = msg.internalDate ? new Date(Number(msg.internalDate)) : null;
+  const fromDate = headers['date'] ? new Date(headers['date']) : null;
+  const receivedAt =
+    fromInternal && !Number.isNaN(fromInternal.getTime())
+      ? fromInternal
+      : fromDate && !Number.isNaN(fromDate.getTime())
+        ? fromDate
+        : new Date();
+
+  return {
+    gmailMessageId: msg.id,
+    gmailThreadId: msg.threadId ?? null,
+    fromEmail: from.email,
+    fromName: from.name,
+    toAddress: headers['to'] ?? null,
+    subject: headers['subject'] ?? null,
+    snippet: msg.snippet ? decodeHtmlEntities(msg.snippet).trim() || null : null,
+    bodyText: extractBodyText(payload),
+    receivedAt,
+    headers,
+  };
+}
+
+// Anchored AND boundary-guarded (the token must be the whole local-part or end
+// at a separator/digit) so real people — notifyjane@, updateme@, bouncer@,
+// mailerman@ — aren't dropped. Ambiguous words (notify/updates/alerts) are left
+// to the stronger List-*/Precedence/Auto-Submitted header checks below.
+const AUTOMATED_LOCALPART =
+  /^(no-?reply|do-?not-?reply|donotreply|mailer-daemon|mailer|postmaster|bounces?|notifications?|newsletter|auto-?confirm|automated)(?=$|[._+-]|\d)/i;
+
+/**
+ * Should this inbound email become a lead card? Filters out our own mail and
+ * the automated/bulk/list traffic info@ collects, keeping person-to-person
+ * inquiries. Returns a reason on skip so the poller can log it quietly.
+ */
+export function shouldIngestInbound(parsed: ParsedInbound): { ingest: boolean; reason?: string } {
+  const email = parsed.fromEmail.toLowerCase();
+  if (!email) return { ingest: false, reason: 'no-sender' };
+  if (email.endsWith('@partyondelivery.com')) return { ingest: false, reason: 'self' };
+
+  const localPart = email.split('@')[0] ?? '';
+  if (AUTOMATED_LOCALPART.test(localPart)) return { ingest: false, reason: 'automated-sender' };
+
+  const h = parsed.headers;
+  if (h['list-unsubscribe'] || h['list-id']) return { ingest: false, reason: 'bulk-list' };
+  if (['bulk', 'list', 'junk'].includes((h['precedence'] ?? '').toLowerCase())) {
+    return { ingest: false, reason: 'bulk-precedence' };
+  }
+  const autoSubmitted = (h['auto-submitted'] ?? '').toLowerCase();
+  if (autoSubmitted && autoSubmitted !== 'no') return { ingest: false, reason: 'auto-submitted' };
+
+  return { ingest: true };
+}

--- a/src/lib/leads/inbound-email.ts
+++ b/src/lib/leads/inbound-email.ts
@@ -1,0 +1,208 @@
+/**
+ * Inbound-email ingestion — poll the info@ Gmail INBOX, turn person-to-person
+ * mail into Lead Flow board cards, and store each message so the drawer can
+ * show "what people are emailing us".
+ *
+ * Mirrors the server-stamped lead pattern in dashboard-lead.ts: upsertLead +
+ * enroll, NO trustedSubmit — an inbound email must not reopen a WON/LOST card
+ * (that power stays with the server-zod submit routes). Idempotent by Gmail
+ * message id (inbound_emails.gmail_message_id is UNIQUE), so overlapping polls
+ * never double-insert. Board bookkeeping never throws the caller.
+ */
+import { Prisma, type Lead } from '@prisma/client';
+import { prisma } from '@/lib/database/client';
+import { enrollLeadIfEligible } from './pipeline';
+import { markLeadStatus, upsertLead } from './leadCapture';
+import {
+  getGmailClient,
+  inboundMailbox,
+  isGmailInboundConfigured,
+  safeErrorMessage,
+} from '@/lib/email/gmail-client';
+import { parseGmailMessage, shouldIngestInbound, type ParsedInbound } from './inbound-email-parse';
+
+/** Stop creating new leads past this many per poll — a public inbox is an
+ *  unauthenticated mutation path, so bound abuse and alert on a spike. */
+const MAX_NEW_LEADS_PER_POLL = 30;
+
+function splitName(name: string | null): { firstName: string | null; lastName: string | null } {
+  const n = (name ?? '').trim();
+  if (!n) return { firstName: null, lastName: null };
+  const parts = n.split(/\s+/);
+  return { firstName: parts[0] ?? null, lastName: parts.slice(1).join(' ') || null };
+}
+
+function objectMeta(v: Prisma.JsonValue | null): Record<string, unknown> {
+  return v && typeof v === 'object' && !Array.isArray(v) ? { ...(v as Record<string, unknown>) } : {};
+}
+
+function isUniqueViolation(err: unknown): boolean {
+  return err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002';
+}
+
+/** Link the message to the lead's card: provenance, recency bump, enroll. */
+async function attachToBoard(lead: Lead, parsed: ParsedInbound): Promise<void> {
+  try {
+    const meta = objectMeta(lead.metadata);
+    meta.inboundEmail = {
+      lastSubject: parsed.subject,
+      lastReceivedAt: parsed.receivedAt.toISOString(),
+      gmailThreadId: parsed.gmailThreadId,
+      lastFrom: parsed.fromEmail,
+    };
+    const upgradeWidget = lead.sourceWidget === null || lead.sourceWidget === 'OTHER';
+    // Recency drives needsResponse + the summary chip. Only ever move it
+    // FORWARD — a stale email must not un-freshen a lead that has newer activity.
+    const bumpActivity = lead.lastActivityAt == null || parsed.receivedAt > lead.lastActivityAt;
+    await prisma.lead.update({
+      where: { id: lead.id },
+      data: {
+        metadata: meta as never,
+        ...(upgradeWidget ? { sourceWidget: 'INBOUND_EMAIL' } : {}),
+        ...(bumpActivity ? { lastActivityAt: parsed.receivedAt } : {}),
+      },
+    });
+
+    // Explicit act ⇒ column card. Guarded: promotes PARTIAL/ANONYMOUS to a card,
+    // never downgrades SUBMITTED/CONVERTED and never reopens WON/LOST.
+    if (lead.status === 'PARTIAL' || lead.status === 'ANONYMOUS') {
+      await markLeadStatus(lead.id, 'SUBMITTED');
+    } else {
+      await enrollLeadIfEligible(lead.id);
+    }
+  } catch (err) {
+    console.warn('[inbound-email] board attach failed', safeErrorMessage(err));
+  }
+}
+
+export interface IngestResult {
+  created: boolean;
+  leadId: string | null;
+}
+
+/**
+ * Persist one inbound email and attach it to its lead card. Idempotent: a Gmail
+ * message id we already stored is a no-op.
+ */
+export async function ingestInboundEmail(parsed: ParsedInbound): Promise<IngestResult> {
+  const existing = await prisma.inboundEmail.findUnique({
+    where: { gmailMessageId: parsed.gmailMessageId },
+    select: { leadId: true },
+  });
+  if (existing) return { created: false, leadId: existing.leadId };
+
+  const { firstName, lastName } = splitName(parsed.fromName);
+  const lead = await upsertLead(
+    { email: parsed.fromEmail, firstName, lastName },
+    { sourcePage: `email:${inboundMailbox()}`, sourceWidget: 'INBOUND_EMAIL' },
+  );
+
+  try {
+    await prisma.inboundEmail.create({
+      data: {
+        gmailMessageId: parsed.gmailMessageId,
+        gmailThreadId: parsed.gmailThreadId,
+        leadId: lead?.id ?? null,
+        fromEmail: parsed.fromEmail,
+        fromName: parsed.fromName,
+        toAddress: parsed.toAddress,
+        subject: parsed.subject,
+        snippet: parsed.snippet,
+        bodyText: parsed.bodyText,
+        receivedAt: parsed.receivedAt,
+        metadata: { headers: parsed.headers } as Prisma.InputJsonValue,
+      },
+    });
+  } catch (err) {
+    if (isUniqueViolation(err)) return { created: false, leadId: lead?.id ?? null }; // raced
+    throw err;
+  }
+
+  if (lead) await attachToBoard(lead, parsed);
+  return { created: true, leadId: lead?.id ?? null };
+}
+
+export interface PollResult {
+  configured: boolean;
+  scanned: number;
+  ingested: number;
+  skippedNoise: number;
+  skippedDup: number;
+  errors: number;
+}
+
+/**
+ * Poll the mailbox INBOX for recent mail and ingest the likely-inquiry ones.
+ * No-ops (configured:false) until the Gmail service account + domain-wide
+ * delegation are set up. Safe to run on an interval — dedupes by message id.
+ */
+export async function pollInboundEmails(opts?: {
+  windowDays?: number;
+  maxMessages?: number;
+}): Promise<PollResult> {
+  const result: PollResult = {
+    configured: false,
+    scanned: 0,
+    ingested: 0,
+    skippedNoise: 0,
+    skippedDup: 0,
+    errors: 0,
+  };
+  if (!isGmailInboundConfigured()) return result;
+  const gmail = getGmailClient();
+  if (!gmail) return result;
+  result.configured = true;
+
+  const windowDays = opts?.windowDays ?? 2;
+  const list = await gmail.users.messages.list({
+    userId: 'me',
+    q: `in:inbox newer_than:${windowDays}d`,
+    maxResults: opts?.maxMessages ?? 50,
+  });
+  const ids = (list.data.messages ?? [])
+    .map((m) => m.id)
+    .filter((id): id is string => Boolean(id));
+  result.scanned = ids.length;
+
+  for (const id of ids) {
+    try {
+      const seen = await prisma.inboundEmail.findUnique({
+        where: { gmailMessageId: id },
+        select: { id: true },
+      });
+      if (seen) {
+        result.skippedDup++;
+        continue;
+      }
+      const full = await gmail.users.messages.get({ userId: 'me', id, format: 'full' });
+      const parsed = parseGmailMessage(full.data);
+      if (!parsed) {
+        result.errors++;
+        continue;
+      }
+      const decision = shouldIngestInbound(parsed);
+      if (!decision.ingest) {
+        result.skippedNoise++;
+        // Domain only — never the full sender address (PII) at INFO level.
+        console.log('[inbound-email] skipped', decision.reason, parsed.fromEmail.split('@')[1] ?? '');
+        continue;
+      }
+      const res = await ingestInboundEmail(parsed);
+      if (res.created) {
+        result.ingested++;
+        if (result.ingested >= MAX_NEW_LEADS_PER_POLL) {
+          console.warn(
+            `[inbound-email] hit new-lead cap (${MAX_NEW_LEADS_PER_POLL}) this poll — possible spike; stopping`,
+          );
+          break;
+        }
+      } else {
+        result.skippedDup++;
+      }
+    } catch (err) {
+      result.errors++;
+      console.warn('[inbound-email] message failed', id, safeErrorMessage(err));
+    }
+  }
+  return result;
+}

--- a/src/lib/leads/pipeline.ts
+++ b/src/lib/leads/pipeline.ts
@@ -47,6 +47,9 @@ const INQUIRY_META_KEYS = [
   'partnerInquiry',
   'affiliateApplication',
   'opsInvoice',
+  // A customer who emails info@ IS a party inquiry — a newsletter-only
+  // (EMAIL_SIGNUP) contact who writes in must board, not stay hidden.
+  'inboundEmail',
 ] as const;
 
 const SWEEP_BATCH = 200;

--- a/src/lib/leads/scoring.ts
+++ b/src/lib/leads/scoring.ts
@@ -220,6 +220,7 @@ function sourceQualityPoints(sourceWidget: string | null | undefined, meta: unkn
     case 'PARTNER_FAREHARBOR_WEBHOOK':
     case 'PARTNER_EMAIL_OPTIN':
     case 'PARTNER_INQUIRY':
+    case 'INBOUND_EMAIL': // a customer who emails info@ is a real inquiry
       return 14;
     case 'DRINK_CALCULATOR':
       return 12;

--- a/vercel.json
+++ b/vercel.json
@@ -107,6 +107,10 @@
     {
       "path": "/api/cron/lead-pipeline",
       "schedule": "30 11 * * *"
+    },
+    {
+      "path": "/api/cron/inbound-email",
+      "schedule": "*/15 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## What
When a customer emails **info@partyondelivery.com**, a 15-min cron polls the mailbox, turns each likely-inquiry message into a card on `/admin/leads`, stores the message, and shows it in the card drawer so an operator can read it and reply with the existing composer. Closes the inbound gap flagged in the drawer-enrichment work (#263) — outbound + site activity were already visible; inbound mail was not.

**Chosen approach:** Gmail/Workspace API polling via the existing Google service account (no DNS change), per operator decision. Only likely inquiries board (no-reply/bulk/list/auto-generated senders are filtered and logged, not carded). Ingest + manual reply now; AI/auto-reply is a planned follow-up.

## How
- **Schema** (`db-migration`, additive/idempotent): `inbound_emails` table + `INBOUND_EMAIL` `LeadSourceWidget`.
- **Poller** (`src/lib/leads/inbound-email.ts` + pure `inbound-email-parse.ts`): filter → `upsertLead` → store message → enroll. Mirrors `dashboard-lead.ts` (server-stamped, **no `trustedSubmit`** so inbound can't reopen a WON/LOST card). Idempotent by Gmail message id. Registers `inboundEmail` as an inquiry key so a newsletter-list contact who writes in still boards.
- **Gmail client** (`src/lib/email/gmail-client.ts`): service-account JWT impersonating the mailbox, `gmail.readonly`. Prefers a **dedicated** Gmail SA (falls back to the shared analytics one) to bound domain-wide-delegation blast radius.
- **Cron** `GET /api/cron/inbound-email` (every 15 min, `CRON_SECRET`, fail-closed). Per-poll new-lead cap bounds abuse of a public inbox.
- **Drawer**: `inbox` timeline entries, an "Emailed us Nd ago" summary chip, and a "Messages from them" section (read the body).

Ships **inert** — the cron returns `configured:false` until the Gmail API + domain-wide delegation are set up. Full steps in `docs/inbound-email-setup.md`.

## Reviews (both incorporated)
- **Security** (PII/scope/cron): fixed a HIGH — never log raw Google errors (a `GaxiosError` carries the signed JWT assertion); redacted the skip log to domain-only; dedicated-SA support; per-poll ingestion cap; HTML decoded-before-strip so stored bodies are injection-safe for the future reply feature. Confirmed: cron auth matches the sibling crons, no XSS (React-escaped, no `dangerouslySetInnerHTML`), migrations additive-only.
- **Correctness**: fixed a HIGH — `inboundEmail` was missing from `INQUIRY_META_KEYS`, so a newsletter-list contact who emailed in would be stored but never carded; boundary-guarded the noise filter so real senders (`notifyjane@`, `bouncer@`) aren't dropped; scored `INBOUND_EMAIL` as a real inquiry.

## Tests / gates
- New `inbound-email-parse.test.ts` (address/MIME/filter) + `inbound-email.test.ts` (board-attach guard: idempotency, P2002 race, no-downgrade/no-reopen, forward-only recency, never-throws) + scoring case. Full suite green, `tsc` no new errors, lint clean.

## Out of scope
AI/automated replies (planned next phase); Gmail push/Pub-Sub (polling suffices); attachment ingestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)