### PR TITLE
feat(partners): bulk partner-page creation + per-partner dashboard engagement analytics

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -85,6 +85,12 @@ const nextConfig: NextConfig = {
         hostname: 'lirp.cdn-website.com',
         pathname: '/**',
       },
+      // Partner logos for bulk-imported affiliates (Affiliate.logoUrl)
+      {
+        protocol: 'https',
+        hostname: 'logo.clearbit.com',
+        pathname: '/**',
+      },
       {
         protocol: 'https',
         hostname: '**.cdn-website.com',

--- a/prisma/migrations/manual/2026-07-14-affiliate-logo-url-dashboard-engagement.sql
+++ b/prisma/migrations/manual/2026-07-14-affiliate-logo-url-dashboard-engagement.sql
@@ -1,0 +1,26 @@
+-- 2026-07-14 · Bulk partner pages + dashboard engagement analytics
+--
+-- (1) affiliates.logo_url — remote logo URL for bulk-created partners.
+--     Committed-to-repo logos (public/images/partners/<slug>-logo.png)
+--     still win when present; this is the runtime fallback so CSV bulk
+--     creation never needs a code deploy.
+--
+-- (2) dashboard_views.last_seen_at + active_seconds — powers
+--     time-on-dashboard analytics. A heartbeat endpoint bumps
+--     last_seen_at and increments active_seconds per (share_code,
+--     visitor_hash) row while the customer has the dashboard open.
+--
+-- Additive + idempotent. Old code ignores all three columns.
+
+BEGIN;
+
+ALTER TABLE affiliates
+  ADD COLUMN IF NOT EXISTS logo_url TEXT;
+
+ALTER TABLE dashboard_views
+  ADD COLUMN IF NOT EXISTS last_seen_at TIMESTAMPTZ;
+
+ALTER TABLE dashboard_views
+  ADD COLUMN IF NOT EXISTS active_seconds INTEGER NOT NULL DEFAULT 0;
+
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2302,6 +2302,12 @@ model Affiliate {
   categoryRateOverride   Decimal? @map("category_rate_override") @db.Decimal(5, 4)
   customerPerk           String   @default("Free Delivery") @map("customer_perk")
 
+  /// Remote logo URL for bulk-created partners (e.g. Clearbit). The
+  /// committed file at public/images/partners/<slug>-logo.png still
+  /// wins when present; this is the runtime fallback so CSV bulk
+  /// creation never needs a code deploy.
+  logoUrl String? @map("logo_url")
+
   payoutMethod  String? @map("payout_method")
   payoutDetails Json?   @map("payout_details")
 
@@ -2378,6 +2384,10 @@ model DashboardView {
   shareCode   String   @map("share_code")
   visitorHash String   @map("visitor_hash")
   viewedAt    DateTime @default(now()) @map("viewed_at")
+  /// Heartbeat: last time this visitor had the dashboard open.
+  lastSeenAt  DateTime? @map("last_seen_at")
+  /// Heartbeat: accumulated seconds this visitor spent on the dashboard.
+  activeSeconds Int @default(0) @map("active_seconds")
 
   @@unique([shareCode, visitorHash])
   @@index([shareCode])

--- a/src/app/admin/affiliates/bulk-import/page.tsx
+++ b/src/app/admin/affiliates/bulk-import/page.tsx
@@ -1,0 +1,312 @@
+'use client';
+
+/**
+ * /admin/affiliates/bulk-import
+ *
+ * Bulk partner creation: paste CSV rows or upload a .csv file, preview
+ * the parsed rows, create them all in one call, and get per-row results
+ * with ready-to-share partner-page links.
+ *
+ * CSV columns (header row required, order-insensitive):
+ *   business_name, website, category, commission_percent, contact_name, email, phone
+ * category ∈ BARTENDER | BOAT | VENUE | LODGING | PLANNER | OTHER
+ *
+ * Parsing happens client-side (no server multipart handling, no new
+ * deps); the API receives clean JSON rows.
+ */
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+
+const CATEGORIES = ['BARTENDER', 'BOAT', 'VENUE', 'LODGING', 'PLANNER', 'OTHER'];
+
+type ParsedRow = {
+  businessName: string;
+  website: string;
+  category: string;
+  commissionPercent: number | null;
+  contactName: string;
+  email: string | null;
+  phone: string | null;
+  problem: string | null;
+};
+
+type RowResult = {
+  businessName: string;
+  ok: boolean;
+  error?: string;
+  slug?: string;
+  code?: string;
+  partnerUrl?: string;
+  logoUrl?: string | null;
+  placeholderEmail?: boolean;
+};
+
+/** Minimal CSV parser — handles quoted fields + commas inside quotes. */
+function parseCsv(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = '';
+  let inQuotes = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (inQuotes) {
+      if (ch === '"' && text[i + 1] === '"') { field += '"'; i++; }
+      else if (ch === '"') inQuotes = false;
+      else field += ch;
+    } else if (ch === '"') inQuotes = true;
+    else if (ch === ',') { row.push(field); field = ''; }
+    else if (ch === '\n' || ch === '\r') {
+      if (ch === '\r' && text[i + 1] === '\n') i++;
+      row.push(field); field = '';
+      if (row.some((c) => c.trim() !== '')) rows.push(row);
+      row = [];
+    } else field += ch;
+  }
+  row.push(field);
+  if (row.some((c) => c.trim() !== '')) rows.push(row);
+  return rows;
+}
+
+function toRows(text: string): ParsedRow[] {
+  const grid = parseCsv(text.trim());
+  if (grid.length < 2) return [];
+  const header = grid[0].map((h) => h.trim().toLowerCase().replace(/\s+/g, '_'));
+  const idx = (name: string) => header.indexOf(name);
+  const iBiz = idx('business_name') >= 0 ? idx('business_name') : idx('company_name');
+  const iWeb = idx('website');
+  const iCat = idx('category') >= 0 ? idx('category') : idx('type');
+  const iCom = idx('commission_percent') >= 0 ? idx('commission_percent') : idx('commission');
+  const iName = idx('contact_name');
+  const iEmail = idx('email');
+  const iPhone = idx('phone');
+
+  return grid.slice(1).map((cells) => {
+    const get = (i: number) => (i >= 0 ? (cells[i] ?? '').trim() : '');
+    const businessName = get(iBiz);
+    const category = get(iCat).toUpperCase();
+    const commissionRaw = get(iCom).replace('%', '');
+    const commissionPercent = commissionRaw ? Number(commissionRaw) : null;
+    const email = get(iEmail) || null;
+    let problem: string | null = null;
+    if (!businessName) problem = 'missing business name';
+    else if (!CATEGORIES.includes(category)) problem = `bad category "${category || '—'}"`;
+    else if (commissionPercent != null && (Number.isNaN(commissionPercent) || commissionPercent < 0 || commissionPercent > 50))
+      problem = 'commission must be 0–50';
+    else if (email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) problem = 'bad email';
+    return {
+      businessName,
+      website: get(iWeb),
+      category,
+      commissionPercent,
+      contactName: get(iName),
+      email,
+      phone: get(iPhone) || null,
+      problem,
+    };
+  });
+}
+
+export default function BulkImportPage() {
+  const [csvText, setCsvText] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [results, setResults] = useState<RowResult[] | null>(null);
+  const [apiError, setApiError] = useState<string | null>(null);
+
+  const rows = useMemo(() => toRows(csvText), [csvText]);
+  const valid = rows.filter((r) => !r.problem);
+
+  async function onFile(f: File | null) {
+    if (!f) return;
+    setCsvText(await f.text());
+  }
+
+  async function submit() {
+    if (valid.length === 0 || submitting) return;
+    setSubmitting(true);
+    setApiError(null);
+    setResults(null);
+    try {
+      const res = await fetch('/api/admin/affiliates/bulk-import', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          rows: valid.map((r) => ({
+            businessName: r.businessName,
+            website: r.website,
+            category: r.category,
+            commissionPercent: r.commissionPercent,
+            contactName: r.contactName,
+            email: r.email,
+            phone: r.phone,
+          })),
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        setApiError(json.error || `HTTP ${res.status}`);
+      } else {
+        setResults(json.results as RowResult[]);
+      }
+    } catch (err) {
+      setApiError(err instanceof Error ? err.message : 'network error');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto p-6 md:p-8">
+      <div className="mb-6">
+        <Link href="/admin/affiliates" className="text-sm text-brand-blue underline">
+          ← Affiliates
+        </Link>
+        <h1 className="text-2xl font-bold text-gray-900 mt-2">Bulk partner import</h1>
+        <p className="text-sm text-gray-600 mt-1 max-w-2xl">
+          Paste CSV or upload a file. Each row becomes a DRAFT affiliate +
+          live partner page at <code className="bg-gray-100 px-1 rounded">/partners/&lt;slug&gt;</code>{' '}
+          with the logo auto-fetched from the company website. Activate each
+          partner by sending the welcome email from the affiliate detail page.
+        </p>
+        <p className="text-xs text-gray-500 mt-2 font-mono">
+          business_name, website, category, commission_percent, contact_name, email, phone
+        </p>
+        <p className="text-xs text-gray-500 font-mono">
+          category: BARTENDER · BOAT · VENUE · LODGING · PLANNER · OTHER
+        </p>
+      </div>
+
+      <div className="flex items-center gap-3 mb-2">
+        <input
+          type="file"
+          accept=".csv,text/csv"
+          onChange={(e) => onFile(e.target.files?.[0] ?? null)}
+          className="text-sm"
+        />
+        <button
+          type="button"
+          onClick={() =>
+            setCsvText(
+              'business_name,website,category,commission_percent,contact_name,email,phone\nATX Craft Bartending,atxcraftbartending.com,BARTENDER,10,Jamie Smith,jamie@atxcraftbartending.com,5125551000\nLakeside Boat Co,lakesideboats.com,BOAT,12,,,',
+            )
+          }
+          className="text-xs underline text-gray-500"
+        >
+          Load example
+        </button>
+      </div>
+
+      <textarea
+        value={csvText}
+        onChange={(e) => setCsvText(e.target.value)}
+        rows={8}
+        placeholder="Paste CSV here (header row first)…"
+        className="w-full rounded-lg border-2 border-gray-200 p-3 font-mono text-sm focus:border-brand-blue focus:outline-none"
+      />
+
+      {rows.length > 0 && (
+        <div className="mt-4 rounded-lg border border-gray-200 overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 text-xs uppercase tracking-wider text-gray-600">
+              <tr>
+                <th className="text-left p-2">Business</th>
+                <th className="text-left p-2">Website</th>
+                <th className="text-left p-2">Category</th>
+                <th className="text-right p-2">Commission</th>
+                <th className="text-left p-2">Email</th>
+                <th className="text-left p-2">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {rows.map((r, i) => (
+                <tr key={i} className={r.problem ? 'bg-red-50' : ''}>
+                  <td className="p-2 font-medium">{r.businessName || '—'}</td>
+                  <td className="p-2 text-gray-600">{r.website || '—'}</td>
+                  <td className="p-2">{r.category || '—'}</td>
+                  <td className="p-2 text-right">{r.commissionPercent != null ? `${r.commissionPercent}%` : 'default'}</td>
+                  <td className="p-2 text-gray-600">{r.email || <span className="text-amber-600">placeholder</span>}</td>
+                  <td className="p-2">
+                    {r.problem ? (
+                      <span className="text-red-700 text-xs font-bold">✗ {r.problem}</span>
+                    ) : (
+                      <span className="text-green-700 text-xs font-bold">✓ ready</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div className="mt-4 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={submit}
+          disabled={valid.length === 0 || submitting}
+          className="btn-primary px-5 py-2.5 disabled:opacity-50"
+        >
+          {submitting ? 'Creating…' : `Create ${valid.length} partner${valid.length === 1 ? '' : 's'}`}
+        </button>
+        {rows.length > valid.length && (
+          <span className="text-xs text-red-700">
+            {rows.length - valid.length} row(s) have problems and will be skipped.
+          </span>
+        )}
+      </div>
+
+      {apiError && (
+        <div className="mt-4 rounded-lg bg-red-50 border border-red-200 p-3 text-sm text-red-800">
+          {apiError}
+        </div>
+      )}
+
+      {results && (
+        <div className="mt-6">
+          <h2 className="text-lg font-bold text-gray-900 mb-2">
+            Results — {results.filter((r) => r.ok).length} created,{' '}
+            {results.filter((r) => !r.ok).length} failed
+          </h2>
+          <div className="rounded-lg border border-gray-200 overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50 text-xs uppercase tracking-wider text-gray-600">
+                <tr>
+                  <th className="text-left p-2">Business</th>
+                  <th className="text-left p-2">Result</th>
+                  <th className="text-left p-2">Partner page</th>
+                  <th className="text-left p-2">Referral code</th>
+                  <th className="text-left p-2">Notes</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {results.map((r, i) => (
+                  <tr key={i} className={r.ok ? '' : 'bg-red-50'}>
+                    <td className="p-2 font-medium">{r.businessName}</td>
+                    <td className="p-2">
+                      {r.ok ? (
+                        <span className="text-green-700 font-bold text-xs">✓ created (DRAFT)</span>
+                      ) : (
+                        <span className="text-red-700 text-xs font-bold">✗ {r.error}</span>
+                      )}
+                    </td>
+                    <td className="p-2">
+                      {r.partnerUrl ? (
+                        <a href={r.partnerUrl} target="_blank" rel="noopener noreferrer" className="text-brand-blue underline text-xs">
+                          {r.partnerUrl.replace('https://', '')}
+                        </a>
+                      ) : '—'}
+                    </td>
+                    <td className="p-2 font-mono text-xs">{r.code ?? '—'}</td>
+                    <td className="p-2 text-xs text-amber-700">
+                      {r.placeholderEmail ? 'placeholder email — set the real one before activating' : ''}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/affiliates/bulk-import/page.tsx
+++ b/src/app/admin/affiliates/bulk-import/page.tsx
@@ -165,8 +165,11 @@ export default function BulkImportPage() {
         <p className="text-sm text-gray-600 mt-1 max-w-2xl">
           Paste CSV or upload a file. Each row becomes a DRAFT affiliate +
           live partner page at <code className="bg-gray-100 px-1 rounded">/partners/&lt;slug&gt;</code>{' '}
-          with the logo auto-fetched from the company website. Activate each
-          partner by sending the welcome email from the affiliate detail page.
+          with the logo extracted from the company website (verified to load;
+          if no usable logo is found the page shows the business name as an
+          all-caps wordmark, so every page is ready to send immediately).
+          Activate each partner by sending the welcome email from the
+          affiliate detail page.
         </p>
         <p className="text-xs text-gray-500 mt-2 font-mono">
           business_name, website, category, commission_percent, contact_name, email, phone
@@ -275,6 +278,7 @@ export default function BulkImportPage() {
                   <th className="text-left p-2">Result</th>
                   <th className="text-left p-2">Partner page</th>
                   <th className="text-left p-2">Referral code</th>
+                  <th className="text-left p-2">Logo</th>
                   <th className="text-left p-2">Notes</th>
                 </tr>
               </thead>
@@ -297,6 +301,17 @@ export default function BulkImportPage() {
                       ) : '—'}
                     </td>
                     <td className="p-2 font-mono text-xs">{r.code ?? '—'}</td>
+                    <td className="p-2 text-xs">
+                      {!r.ok ? (
+                        '—'
+                      ) : r.logoUrl ? (
+                        <a href={r.logoUrl} target="_blank" rel="noopener noreferrer" className="text-green-700 underline">
+                          found
+                        </a>
+                      ) : (
+                        <span className="text-gray-600">name wordmark</span>
+                      )}
+                    </td>
                     <td className="p-2 text-xs text-amber-700">
                       {r.placeholderEmail ? 'placeholder email — set the real one before activating' : ''}
                     </td>

--- a/src/app/admin/affiliates/dashboards/page.tsx
+++ b/src/app/admin/affiliates/dashboards/page.tsx
@@ -1,0 +1,280 @@
+'use client';
+
+/**
+ * /admin/affiliates/dashboards
+ *
+ * POD-admin roster of every client dashboard (GroupOrderV2) across all
+ * partners: searchable by host/name/code, filterable by partner, party
+ * type, and lifecycle, with engagement (views, time-on-dashboard, group
+ * size, cart) and payment status per row.
+ */
+
+import { useCallback, useEffect, useState, type ReactElement } from 'react';
+import Link from 'next/link';
+
+interface DashboardRow {
+  id: string;
+  name: string;
+  hostName: string;
+  hostEmail: string | null;
+  shareCode: string;
+  partyType: string | null;
+  source: string;
+  partner: { id: string; businessName: string; partnerSlug: string | null } | null;
+  createdAt: string;
+  deliveryDate: string | null;
+  lifecycleStatus: 'draft' | 'in_progress' | 'paid' | 'completed';
+  totalCents: number;
+  cartItemCount: number;
+  viewCount: number;
+  activeSeconds: number;
+  lastActivityAt: string | null;
+  participantCount: number;
+}
+
+interface Filters {
+  partners: { id: string; businessName: string }[];
+  partyTypes: string[];
+  lifecycles: string[];
+}
+
+const STATUS_BADGE: Record<string, string> = {
+  draft: 'bg-gray-100 text-gray-700',
+  in_progress: 'bg-blue-100 text-blue-700',
+  paid: 'bg-green-100 text-green-700',
+  completed: 'bg-gray-100 text-gray-600',
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  draft: 'Draft',
+  in_progress: 'In Progress',
+  paid: 'Paid',
+  completed: 'Completed',
+};
+
+const cents = (c: number) =>
+  `$${(c / 100).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+const activeTime = (seconds: number): string => {
+  if (seconds < 60) return `${seconds}s`;
+  const mins = Math.round(seconds / 60);
+  if (mins < 60) return `${mins}m`;
+  return `${Math.floor(mins / 60)}h ${mins % 60}m`;
+};
+
+export default function PartnerDashboardsPage(): ReactElement {
+  const [rows, setRows] = useState<DashboardRow[]>([]);
+  const [filters, setFilters] = useState<Filters | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [search, setSearch] = useState('');
+  const [partnerId, setPartnerId] = useState('');
+  const [partyType, setPartyType] = useState('');
+  const [lifecycle, setLifecycle] = useState('');
+  const [page, setPage] = useState(1);
+  const [pages, setPages] = useState(1);
+  const [total, setTotal] = useState(0);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const params = new URLSearchParams();
+    if (search.trim()) params.set('search', search.trim());
+    if (partnerId) params.set('affiliateId', partnerId);
+    if (partyType) params.set('partyType', partyType);
+    if (lifecycle) params.set('lifecycle', lifecycle);
+    params.set('page', String(page));
+    try {
+      const res = await fetch(`/api/v1/admin/partner-dashboards?${params}`);
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error || 'Failed to load');
+      setRows(json.data.dashboards);
+      setFilters(json.data.filters);
+      setPages(json.data.pagination.pages);
+      setTotal(json.data.pagination.total);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load');
+    } finally {
+      setLoading(false);
+    }
+  }, [search, partnerId, partyType, lifecycle, page]);
+
+  // Debounce reloads so typing in search doesn't fire per keystroke
+  useEffect(() => {
+    const t = setTimeout(load, 300);
+    return () => clearTimeout(t);
+  }, [load]);
+
+  const resetPage = () => setPage(1);
+
+  return (
+    <div className="max-w-7xl mx-auto p-6 md:p-8">
+      <div className="mb-6 flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <Link href="/admin/affiliates" className="text-sm text-brand-blue underline">
+            ← Partners
+          </Link>
+          <h1 className="text-2xl font-bold text-gray-900 mt-2">Client dashboards</h1>
+          <p className="text-sm text-gray-600 mt-1">
+            Every dashboard created by partner clients — {total} total. Search, filter by
+            partner, and see how far each group has gotten toward checkout.
+          </p>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-3 mb-4">
+        <input
+          type="search"
+          value={search}
+          onChange={(e) => { setSearch(e.target.value); resetPage(); }}
+          placeholder="Search host, dashboard name, email, or code…"
+          className="flex-1 min-w-[240px] rounded-lg border-2 border-gray-200 px-4 py-2.5 text-base focus:border-brand-blue focus:outline-none"
+        />
+        <select
+          value={partnerId}
+          onChange={(e) => { setPartnerId(e.target.value); resetPage(); }}
+          className="rounded-lg border-2 border-gray-200 px-3 py-2.5 text-base bg-white focus:border-brand-blue focus:outline-none"
+        >
+          <option value="">All partners</option>
+          {filters?.partners.map((p) => (
+            <option key={p.id} value={p.id}>{p.businessName}</option>
+          ))}
+        </select>
+        <select
+          value={partyType}
+          onChange={(e) => { setPartyType(e.target.value); resetPage(); }}
+          className="rounded-lg border-2 border-gray-200 px-3 py-2.5 text-base bg-white focus:border-brand-blue focus:outline-none"
+        >
+          <option value="">All party types</option>
+          {filters?.partyTypes.map((t) => (
+            <option key={t} value={t}>{t.replaceAll('_', ' ')}</option>
+          ))}
+        </select>
+        <select
+          value={lifecycle}
+          onChange={(e) => { setLifecycle(e.target.value); resetPage(); }}
+          className="rounded-lg border-2 border-gray-200 px-3 py-2.5 text-base bg-white focus:border-brand-blue focus:outline-none"
+        >
+          <option value="">All statuses</option>
+          {filters?.lifecycles.map((l) => (
+            <option key={l} value={l}>{STATUS_LABEL[l] ?? l}</option>
+          ))}
+        </select>
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-lg bg-red-50 border border-red-200 p-3 text-sm text-red-800">
+          {error}
+        </div>
+      )}
+
+      <div className="rounded-lg border border-gray-200 overflow-x-auto bg-white">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50 text-xs uppercase tracking-wider text-gray-600">
+            <tr>
+              <th className="text-left p-3">Host / dashboard</th>
+              <th className="text-left p-3">Partner</th>
+              <th className="text-left p-3">Party type</th>
+              <th className="text-left p-3">Created</th>
+              <th className="text-left p-3">Delivery</th>
+              <th className="text-left p-3">Engagement</th>
+              <th className="text-right p-3">Paid total</th>
+              <th className="text-center p-3">Status</th>
+              <th className="p-3"></th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {loading && rows.length === 0 ? (
+              <tr><td colSpan={9} className="p-8 text-center text-gray-500">Loading…</td></tr>
+            ) : rows.length === 0 ? (
+              <tr><td colSpan={9} className="p-8 text-center text-gray-500">No dashboards match.</td></tr>
+            ) : (
+              rows.map((r) => (
+                <tr key={r.id} className={loading ? 'opacity-50' : ''}>
+                  <td className="p-3">
+                    <div className="font-medium text-gray-900">{r.hostName}</div>
+                    <div className="text-xs text-gray-500">{r.name}</div>
+                  </td>
+                  <td className="p-3">
+                    {r.partner ? (
+                      <span className="text-gray-800">{r.partner.businessName}</span>
+                    ) : (
+                      <span className="text-gray-400">Direct</span>
+                    )}
+                  </td>
+                  <td className="p-3 text-gray-600">
+                    {r.partyType ? r.partyType.replaceAll('_', ' ') : '--'}
+                  </td>
+                  <td className="p-3 text-gray-600 whitespace-nowrap">
+                    {new Date(r.createdAt).toLocaleDateString()}
+                  </td>
+                  <td className="p-3 text-gray-600 whitespace-nowrap">
+                    {r.deliveryDate
+                      ? new Date(r.deliveryDate).toLocaleDateString('en-US', { timeZone: 'UTC' })
+                      : '--'}
+                  </td>
+                  <td className="p-3">
+                    <div className="text-gray-700 whitespace-nowrap">
+                      {r.viewCount} view{r.viewCount === 1 ? '' : 's'}
+                      {r.activeSeconds > 0 && <> · {activeTime(r.activeSeconds)}</>}
+                    </div>
+                    <div className="text-xs text-gray-500 whitespace-nowrap">
+                      {r.participantCount} in group
+                      {r.cartItemCount > 0 && <> · {r.cartItemCount} in cart</>}
+                      {r.lastActivityAt && (
+                        <> · seen {new Date(r.lastActivityAt).toLocaleDateString()}</>
+                      )}
+                    </div>
+                  </td>
+                  <td className="p-3 text-right font-medium text-gray-900">
+                    {r.totalCents > 0 ? cents(r.totalCents) : '--'}
+                  </td>
+                  <td className="p-3 text-center">
+                    <span className={`text-xs font-medium px-2 py-1 rounded-full ${STATUS_BADGE[r.lifecycleStatus]}`}>
+                      {STATUS_LABEL[r.lifecycleStatus]}
+                    </span>
+                  </td>
+                  <td className="p-3 text-right">
+                    <a
+                      href={`/dashboard/${r.shareCode}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sm text-brand-blue hover:underline font-medium"
+                    >
+                      Open
+                    </a>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      {pages > 1 && (
+        <div className="mt-4 flex items-center gap-3 text-sm">
+          <button
+            type="button"
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page <= 1 || loading}
+            className="btn-secondary px-4 py-2 disabled:opacity-40"
+          >
+            Previous
+          </button>
+          <span className="text-gray-600">Page {page} of {pages}</span>
+          <button
+            type="button"
+            onClick={() => setPage((p) => Math.min(pages, p + 1))}
+            disabled={page >= pages || loading}
+            className="btn-secondary px-4 py-2 disabled:opacity-40"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/affiliates/page.tsx
+++ b/src/app/admin/affiliates/page.tsx
@@ -170,7 +170,19 @@ export default function AffiliatesPage(): ReactElement {
       <div className="max-w-7xl mx-auto px-4 py-6">
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-4">
         <h1 className="font-heading font-bold text-2xl sm:text-3xl tracking-[0.06em] uppercase text-gray-900">Affiliates</h1>
-        <div className="flex gap-2">
+        <div className="flex gap-2 flex-wrap">
+          <Link
+            href="/admin/affiliates/dashboards"
+            className="px-4 py-2 text-sm font-semibold text-white bg-gray-800 rounded-lg hover:bg-gray-900 transition-all shadow-sm"
+          >
+            Client Dashboards
+          </Link>
+          <Link
+            href="/admin/affiliates/bulk-import"
+            className="px-4 py-2 text-sm font-semibold text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 transition-all shadow-sm"
+          >
+            Bulk Import
+          </Link>
           <Link
             href="/admin/affiliates/payouts"
             className="px-4 py-2 text-sm font-semibold text-white bg-emerald-600 rounded-lg hover:bg-emerald-700 transition-all shadow-sm"

--- a/src/app/affiliate/dashboard/components/OrdersTab.tsx
+++ b/src/app/affiliate/dashboard/components/OrdersTab.tsx
@@ -15,6 +15,12 @@ interface ClientOrder {
   lifecycleStatus: 'draft' | 'in_progress' | 'paid' | 'completed';
   dashboardUrl: string;
   shareCode: string;
+  // Engagement analytics (optional — older API payloads omit them)
+  viewCount?: number;
+  activeSeconds?: number;
+  lastActivityAt?: string | null;
+  participantCount?: number;
+  cartItemCount?: number;
 }
 
 interface CommissionOrder {
@@ -42,6 +48,13 @@ interface UnifiedOrder {
   commissionCents: number | null;
   lifecycleStatus: 'draft' | 'in_progress' | 'paid' | 'completed';
   dashboardUrl: string | null;
+  engagement: {
+    viewCount: number;
+    activeSeconds: number;
+    lastActivityAt: string | null;
+    participantCount: number;
+    cartItemCount: number;
+  } | null;
 }
 
 interface OrdersTabProps {
@@ -90,6 +103,14 @@ const statusLabel = (status: string) => {
 const cents = (c: number) =>
   `$${(c / 100).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 
+/** "45s", "12m", "1h 20m" — compact time-on-dashboard label. */
+const activeTime = (seconds: number): string => {
+  if (seconds < 60) return `${seconds}s`;
+  const mins = Math.round(seconds / 60);
+  if (mins < 60) return `${mins}m`;
+  return `${Math.floor(mins / 60)}h ${mins % 60}m`;
+};
+
 const sourceBadge = (source: 'referral' | 'dashboard') => {
   if (source === 'referral') return 'bg-purple-50 text-purple-700';
   return 'bg-blue-50 text-blue-700';
@@ -102,6 +123,7 @@ export default function OrdersTab({
 }: OrdersTabProps): ReactElement {
   const [activeSubTab, setActiveSubTab] = useState<SubTab>('all');
   const [cancellingId, setCancellingId] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
 
   const handleCancel = async (id: string) => {
     if (!onCancelClientOrder) return;
@@ -130,6 +152,7 @@ export default function OrdersTab({
       commissionCents: o.commissionCents,
       lifecycleStatus: mapCommissionStatus(o.status),
       dashboardUrl: null,
+      engagement: null,
     })),
     ...clientOrders.map((o): UnifiedOrder => ({
       id: o.id,
@@ -142,6 +165,13 @@ export default function OrdersTab({
       commissionCents: null,
       lifecycleStatus: o.lifecycleStatus,
       dashboardUrl: `/dashboard/${o.shareCode}`,
+      engagement: {
+        viewCount: o.viewCount ?? 0,
+        activeSeconds: o.activeSeconds ?? 0,
+        lastActivityAt: o.lastActivityAt ?? null,
+        participantCount: o.participantCount ?? 0,
+        cartItemCount: o.cartItemCount ?? 0,
+      },
     })),
   ].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
 
@@ -153,9 +183,19 @@ export default function OrdersTab({
     completed: unified.filter((o) => o.lifecycleStatus === 'completed').length,
   };
 
+  const query = search.trim().toLowerCase();
+  const searched = query
+    ? unified.filter(
+        (o) =>
+          o.customerName.toLowerCase().includes(query) ||
+          o.label.toLowerCase().includes(query) ||
+          (o.dashboardUrl ?? '').toLowerCase().includes(query)
+      )
+    : unified;
+
   const filtered = activeSubTab === 'all'
-    ? unified
-    : unified.filter((o) => o.lifecycleStatus === activeSubTab);
+    ? searched
+    : searched.filter((o) => o.lifecycleStatus === activeSubTab);
 
   const emptyMessages: Record<SubTab, string> = {
     all: 'No orders yet. Share your referral link to get started!',
@@ -167,6 +207,15 @@ export default function OrdersTab({
 
   return (
     <div className="space-y-4">
+      {/* Search */}
+      <input
+        type="search"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Search by client name, order name, or dashboard code…"
+        className="w-full md:max-w-md rounded-lg border-2 border-gray-200 px-4 py-2.5 text-base focus:border-brand-blue focus:outline-none"
+      />
+
       {/* Sub-tab bar */}
       <div className="flex gap-2 flex-wrap">
         {SUB_TABS.map((tab) => (
@@ -210,6 +259,7 @@ export default function OrdersTab({
                   <th className="px-4 py-3 text-left font-medium text-gray-600">Date</th>
                   <th className="px-4 py-3 text-left font-medium text-gray-600">Delivery</th>
                   <th className="px-4 py-3 text-right font-medium text-gray-600">Total</th>
+                  <th className="px-4 py-3 text-left font-medium text-gray-600">Engagement</th>
                   <th className="px-4 py-3 text-right font-medium text-gray-600">Commission</th>
                   <th className="px-4 py-3 text-center font-medium text-gray-600">Status</th>
                   <th className="px-4 py-3 text-right font-medium text-gray-600"></th>
@@ -237,6 +287,29 @@ export default function OrdersTab({
                     </td>
                     <td className="px-4 py-3 text-right text-gray-900 font-medium">
                       {order.totalCents > 0 ? cents(order.totalCents) : '--'}
+                    </td>
+                    <td className="px-4 py-3">
+                      {order.engagement ? (
+                        <div className="text-sm text-gray-700 whitespace-nowrap">
+                          <div>
+                            {order.engagement.viewCount} view{order.engagement.viewCount === 1 ? '' : 's'}
+                            {order.engagement.activeSeconds > 0 && (
+                              <> · {activeTime(order.engagement.activeSeconds)}</>
+                            )}
+                          </div>
+                          <div className="text-xs text-gray-500">
+                            {order.engagement.participantCount} in group
+                            {order.engagement.cartItemCount > 0 && (
+                              <> · {order.engagement.cartItemCount} in cart</>
+                            )}
+                            {order.engagement.lastActivityAt && (
+                              <> · seen {new Date(order.engagement.lastActivityAt).toLocaleDateString()}</>
+                            )}
+                          </div>
+                        </div>
+                      ) : (
+                        <span className="text-sm text-gray-400">--</span>
+                      )}
                     </td>
                     <td className="px-4 py-3 text-right text-green-700 font-medium">
                       {order.commissionCents != null ? cents(order.commissionCents) : '--'}
@@ -315,6 +388,14 @@ export default function OrdersTab({
                     </div>
                   )}
                 </div>
+                {order.engagement && (
+                  <div className="text-sm text-gray-600 border-t border-gray-100 pt-2 mb-3">
+                    {order.engagement.viewCount} view{order.engagement.viewCount === 1 ? '' : 's'}
+                    {order.engagement.activeSeconds > 0 && <> · {activeTime(order.engagement.activeSeconds)}</>}
+                    {' · '}{order.engagement.participantCount} in group
+                    {order.engagement.cartItemCount > 0 && <> · {order.engagement.cartItemCount} in cart</>}
+                  </div>
+                )}
                 {order.dashboardUrl && (
                   <Link
                     href={order.dashboardUrl}

--- a/src/app/api/admin/affiliates/[id]/dashboard/route.ts
+++ b/src/app/api/admin/affiliates/[id]/dashboard/route.ts
@@ -8,6 +8,7 @@ import { prisma } from '@/lib/database/client';
 import { requireOpsAuth } from '@/lib/auth/ops-session';
 import { CommissionStatus, GroupV2PaymentStatus } from '@prisma/client';
 import { getTierLabel, getTierProgress, getAnniversaryYearStart } from '@/lib/affiliates/commission-engine';
+import { getDashboardEngagement } from '@/lib/group-orders-v2/view-tracking';
 
 export async function GET(
   _request: NextRequest,
@@ -98,6 +99,7 @@ export async function GET(
               payments: true,
             },
           },
+          _count: { select: { participants: true } },
         },
       }),
       // Recent commissions for monthly stats
@@ -145,6 +147,7 @@ export async function GET(
     });
 
     // Build clientOrders (same format as /api/v1/affiliate/me/client-orders)
+    const engagement = await getDashboardEngagement(dashboardOrders.map((o) => o.shareCode));
     const now = new Date();
     const clientOrders = dashboardOrders.map((order) => {
       const hasPaidPayment = order.tabs.some((tab) =>
@@ -172,6 +175,12 @@ export async function GET(
         0
       );
 
+      const cartItemCount = order.tabs.reduce(
+        (sum, tab) => sum + tab.draftItems.reduce((s, item) => s + item.quantity, 0),
+        0
+      );
+      const eng = engagement.get(order.shareCode);
+
       return {
         id: order.id,
         type: 'dashboard' as const,
@@ -184,6 +193,12 @@ export async function GET(
         lifecycleStatus,
         dashboardUrl: `${appUrl}/dashboard/${order.shareCode}`,
         shareCode: order.shareCode,
+        // Engagement analytics
+        viewCount: eng?.uniqueVisitors ?? order.viewCount,
+        activeSeconds: eng?.totalActiveSeconds ?? 0,
+        lastActivityAt: eng?.lastActivityAt?.toISOString() ?? null,
+        participantCount: order._count.participants,
+        cartItemCount,
       };
     });
 

--- a/src/app/api/admin/affiliates/bulk-import/route.ts
+++ b/src/app/api/admin/affiliates/bulk-import/route.ts
@@ -11,11 +11,15 @@
  * Per row:
  *   - slug from business name (deduped with -2, -3 … suffixes)
  *   - referral code via the shared generateReferralCode()
- *   - logoUrl: explicit value, else Clearbit derived from the website
- *     domain (https://logo.clearbit.com/<domain>). The partner page
- *     prefers a committed file at public/images/partners/<slug>-logo.png
- *     when one exists; logoUrl is the runtime fallback so bulk creation
- *     never needs a code deploy.
+ *   - logoUrl: resolved by src/lib/partners/logo-scraper.ts — explicit
+ *     CSV value, else scraped from the partner's own homepage (logo
+ *     <img> / apple-touch-icon / og:image), else validated Clearbit.
+ *     Every candidate is verified to actually serve an image; when
+ *     nothing validates the partner page renders an all-caps
+ *     business-name wordmark, so the page always looks finished. The
+ *     partner page prefers a committed file at
+ *     public/images/partners/<slug>-logo.png when one exists; logoUrl
+ *     is the runtime fallback so bulk creation never needs a deploy.
  *   - commissionPercent → Affiliate.commissionRateOverride (e.g. 10 → 0.10)
  *   - email optional: placeholder partners+<slug>@partyondelivery.com
  *     until the real contact is known (portal magic-links need a real
@@ -32,10 +36,13 @@ import { z } from 'zod';
 import { requireAdminRole } from '@/lib/auth/ops-session';
 import { prisma } from '@/lib/database/client';
 import { generateReferralCode } from '@/lib/affiliates/affiliate-service';
+import { resolveLogoUrl } from '@/lib/partners/logo-scraper';
 import { AffiliateCategory, AffiliateStatus } from '@prisma/client';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
+// Logo scraping fetches each partner's homepage — allow time for big CSVs
+export const maxDuration = 120;
 
 const CATEGORIES = ['BARTENDER', 'BOAT', 'VENUE', 'LODGING', 'PLANNER', 'OTHER'] as const;
 
@@ -62,18 +69,6 @@ function slugify(s: string): string {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
     .slice(0, 60);
-}
-
-function domainFrom(website: string): string | null {
-  if (!website.trim()) return null;
-  try {
-    const url = new URL(
-      website.startsWith('http') ? website : `https://${website.trim()}`,
-    );
-    return url.hostname.replace(/^www\./, '');
-  } catch {
-    return null;
-  }
 }
 
 type RowResult = {
@@ -104,7 +99,16 @@ export async function POST(request: NextRequest) {
   const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://partyondelivery.com';
   const results: RowResult[] = [];
 
-  for (const row of body.rows) {
+  // Resolve all logos up front, in parallel — each resolution may fetch
+  // the partner's homepage plus a few image candidates, so doing this
+  // inside the sequential DB loop would make big CSVs crawl.
+  const resolvedLogos = await Promise.all(
+    body.rows.map((row) =>
+      resolveLogoUrl(row.website, row.logoUrl).catch(() => null)
+    )
+  );
+
+  for (const [rowIndex, row] of body.rows.entries()) {
     try {
       // ── Slug: derive + dedupe ─────────────────────────────────
       const baseSlug = slugify(row.businessName);
@@ -132,10 +136,10 @@ export async function POST(request: NextRequest) {
         continue;
       }
 
-      // ── Logo: explicit > Clearbit-from-domain > none ──────────
-      const domain = domainFrom(row.website);
-      const logoUrl =
-        row.logoUrl ?? (domain ? `https://logo.clearbit.com/${domain}` : null);
+      // ── Logo: explicit > scraped-from-site > Clearbit > none ──
+      // (all validated to actually serve an image; null falls back to
+      // the all-caps business-name wordmark on the partner page)
+      const logoUrl = resolvedLogos[rowIndex];
 
       // ── Code + create (same objects as the single-create flow) ─
       const code = generateReferralCode(row.businessName);
@@ -195,7 +199,11 @@ export async function POST(request: NextRequest) {
         placeholderEmail,
       });
     } catch (err) {
-      console.error('[bulk-import] row failed:', row.businessName, err);
+      console.error(
+        '[bulk-import] row failed:',
+        row.businessName,
+        err instanceof Error ? err.message : 'unknown error'
+      );
       results.push({
         businessName: row.businessName,
         ok: false,

--- a/src/app/api/admin/affiliates/bulk-import/route.ts
+++ b/src/app/api/admin/affiliates/bulk-import/route.ts
@@ -1,0 +1,214 @@
+/**
+ * POST /api/admin/affiliates/bulk-import
+ *
+ * Bulk partner creation. Admin uploads a CSV (parsed client-side) or
+ * enters rows in the bulk form; this endpoint creates one Affiliate +
+ * matching FREE_SHIPPING Discount per row — the exact same objects the
+ * one-at-a-time flow (create-and-send / scripts/ops/create-affiliate.mjs)
+ * produces, so downstream systems (partner pages, portal auth,
+ * commissions, dashboards) work unchanged.
+ *
+ * Per row:
+ *   - slug from business name (deduped with -2, -3 … suffixes)
+ *   - referral code via the shared generateReferralCode()
+ *   - logoUrl: explicit value, else Clearbit derived from the website
+ *     domain (https://logo.clearbit.com/<domain>). The partner page
+ *     prefers a committed file at public/images/partners/<slug>-logo.png
+ *     when one exists; logoUrl is the runtime fallback so bulk creation
+ *     never needs a code deploy.
+ *   - commissionPercent → Affiliate.commissionRateOverride (e.g. 10 → 0.10)
+ *   - email optional: placeholder partners+<slug>@partyondelivery.com
+ *     until the real contact is known (portal magic-links need a real
+ *     one — flagged in the per-row result)
+ *   - status DRAFT (same as the script) — admin activates by sending
+ *     the welcome email from /ops/affiliates or /admin/affiliates
+ *
+ * Response: per-row results (ok/error + slug, code, partnerUrl) so the
+ * admin UI can render a review table. Rows are processed independently —
+ * one bad row never blocks the rest.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireAdminRole } from '@/lib/auth/ops-session';
+import { prisma } from '@/lib/database/client';
+import { generateReferralCode } from '@/lib/affiliates/affiliate-service';
+import { AffiliateCategory, AffiliateStatus } from '@prisma/client';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const CATEGORIES = ['BARTENDER', 'BOAT', 'VENUE', 'LODGING', 'PLANNER', 'OTHER'] as const;
+
+const rowSchema = z.object({
+  businessName: z.string().min(2).max(120),
+  website: z.string().max(300).optional().default(''),
+  category: z.enum(CATEGORIES),
+  /** Commission as a percentage, e.g. 10 = 10%. Optional — omitted rows
+   *  fall back to the category default rate. */
+  commissionPercent: z.number().min(0).max(50).optional().nullable(),
+  contactName: z.string().max(120).optional().default(''),
+  email: z.string().email().max(200).optional().nullable(),
+  phone: z.string().max(40).optional().nullable(),
+  logoUrl: z.string().url().max(500).optional().nullable(),
+});
+
+const bodySchema = z.object({
+  rows: z.array(rowSchema).min(1).max(100),
+});
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60);
+}
+
+function domainFrom(website: string): string | null {
+  if (!website.trim()) return null;
+  try {
+    const url = new URL(
+      website.startsWith('http') ? website : `https://${website.trim()}`,
+    );
+    return url.hostname.replace(/^www\./, '');
+  } catch {
+    return null;
+  }
+}
+
+type RowResult = {
+  businessName: string;
+  ok: boolean;
+  error?: string;
+  slug?: string;
+  code?: string;
+  partnerUrl?: string;
+  logoUrl?: string | null;
+  placeholderEmail?: boolean;
+};
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAdminRole();
+  if (auth instanceof NextResponse) return auth;
+
+  let body: z.infer<typeof bodySchema>;
+  try {
+    body = bodySchema.parse(await request.json());
+  } catch (err) {
+    return NextResponse.json(
+      { success: false, error: 'invalid_body', detail: String(err) },
+      { status: 400 },
+    );
+  }
+
+  const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://partyondelivery.com';
+  const results: RowResult[] = [];
+
+  for (const row of body.rows) {
+    try {
+      // ── Slug: derive + dedupe ─────────────────────────────────
+      const baseSlug = slugify(row.businessName);
+      if (!baseSlug) {
+        results.push({ businessName: row.businessName, ok: false, error: 'unusable business name' });
+        continue;
+      }
+      let slug = baseSlug;
+      for (let i = 2; i <= 20; i++) {
+        const taken = await prisma.affiliate.findUnique({ where: { partnerSlug: slug } });
+        if (!taken) break;
+        slug = `${baseSlug}-${i}`;
+      }
+
+      // ── Email: real or placeholder ────────────────────────────
+      const placeholderEmail = !row.email;
+      const email = (row.email ?? `partners+${slug}@partyondelivery.com`).toLowerCase();
+      const emailTaken = await prisma.affiliate.findUnique({ where: { email } });
+      if (emailTaken) {
+        results.push({
+          businessName: row.businessName,
+          ok: false,
+          error: `email already used by affiliate "${emailTaken.businessName}"`,
+        });
+        continue;
+      }
+
+      // ── Logo: explicit > Clearbit-from-domain > none ──────────
+      const domain = domainFrom(row.website);
+      const logoUrl =
+        row.logoUrl ?? (domain ? `https://logo.clearbit.com/${domain}` : null);
+
+      // ── Code + create (same objects as the single-create flow) ─
+      const code = generateReferralCode(row.businessName);
+      const affiliate = await prisma.affiliate.create({
+        data: {
+          code,
+          partnerSlug: slug,
+          contactName: row.contactName || row.businessName,
+          businessName: row.businessName,
+          email,
+          phone: row.phone ?? null,
+          category: row.category as AffiliateCategory,
+          status: AffiliateStatus.DRAFT,
+          logoUrl,
+          commissionRateOverride:
+            row.commissionPercent != null ? row.commissionPercent / 100 : null,
+          internalNotes: [
+            `Bulk-imported ${new Date().toISOString().slice(0, 10)}.`,
+            row.website ? `Website: ${row.website}` : '',
+            placeholderEmail ? 'PLACEHOLDER EMAIL — replace before sending welcome/magic links.' : '',
+          ]
+            .filter(Boolean)
+            .join(' '),
+        },
+      });
+
+      // ── Matching discount (mirrors create-affiliate.mjs) ──────
+      const discountCode = affiliate.code.toUpperCase();
+      const existingDiscount = await prisma.discount.findUnique({
+        where: { code: discountCode },
+      });
+      if (!existingDiscount) {
+        await prisma.discount.create({
+          data: {
+            code: discountCode,
+            name: discountCode,
+            type: 'FREE_SHIPPING',
+            value: '0',
+            appliesToAll: true,
+            applicableProducts: [],
+            applicableCategories: [],
+            minOrderAmount: '0.01',
+            isActive: true,
+            combinable: false,
+            freeShipping: false,
+          },
+        });
+      }
+
+      results.push({
+        businessName: row.businessName,
+        ok: true,
+        slug,
+        code: affiliate.code,
+        partnerUrl: `${BASE_URL}/partners/${slug}`,
+        logoUrl,
+        placeholderEmail,
+      });
+    } catch (err) {
+      console.error('[bulk-import] row failed:', row.businessName, err);
+      results.push({
+        businessName: row.businessName,
+        ok: false,
+        error: err instanceof Error ? err.message : 'unknown error',
+      });
+    }
+  }
+
+  const created = results.filter((r) => r.ok).length;
+  return NextResponse.json({
+    success: true,
+    created,
+    failed: results.length - created,
+    results,
+  });
+}

--- a/src/app/api/v1/admin/partner-dashboards/route.ts
+++ b/src/app/api/v1/admin/partner-dashboards/route.ts
@@ -1,0 +1,160 @@
+/**
+ * GET /api/v1/admin/partner-dashboards
+ *
+ * POD-admin roster of ALL client dashboards (GroupOrderV2), searchable
+ * and filterable across every partner — the management-side counterpart
+ * of each partner's own "active dashboards" list.
+ *
+ * Auth: middleware requires a valid ops session for /api/v1/admin/*.
+ *
+ * Query params:
+ *   search    — host name, dashboard name, or share code (insensitive)
+ *   affiliateId — only dashboards attributed to this partner
+ *   partyType — PartyType enum value
+ *   lifecycle — draft | in_progress | paid | completed
+ *   page/limit — pagination (limit ≤ 100)
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/database/client';
+import { getDashboardEngagement } from '@/lib/group-orders-v2/view-tracking';
+import { GroupV2PaymentStatus, PartyType, Prisma } from '@prisma/client';
+
+type Lifecycle = 'draft' | 'in_progress' | 'paid' | 'completed';
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const sp = request.nextUrl.searchParams;
+    const search = sp.get('search')?.trim() || undefined;
+    const affiliateId = sp.get('affiliateId') || undefined;
+    const partyType = sp.get('partyType') || undefined;
+    const lifecycle = (sp.get('lifecycle') as Lifecycle) || undefined;
+    const page = Math.max(parseInt(sp.get('page') || '1'), 1);
+    const limit = Math.min(Math.max(parseInt(sp.get('limit') || '25'), 1), 100);
+
+    const where: Prisma.GroupOrderV2WhereInput = {};
+    if (search) {
+      where.OR = [
+        { hostName: { contains: search, mode: 'insensitive' } },
+        { name: { contains: search, mode: 'insensitive' } },
+        { shareCode: { contains: search, mode: 'insensitive' } },
+        { hostEmail: { contains: search, mode: 'insensitive' } },
+      ];
+    }
+    if (affiliateId) where.affiliateId = affiliateId;
+    if (partyType && (Object.values(PartyType) as string[]).includes(partyType)) {
+      where.partyType = partyType as PartyType;
+    }
+
+    // Lifecycle is derived (payments + views), so filter after mapping.
+    // Over-fetch when a lifecycle filter is on so a page still fills up.
+    const fetchLimit = lifecycle ? limit * 4 : limit;
+
+    const [total, groups, affiliates] = await Promise.all([
+      prisma.groupOrderV2.count({ where }),
+      prisma.groupOrderV2.findMany({
+        where,
+        orderBy: { createdAt: 'desc' },
+        skip: (page - 1) * limit,
+        take: fetchLimit,
+        include: {
+          affiliate: { select: { id: true, businessName: true, partnerSlug: true } },
+          tabs: {
+            include: {
+              draftItems: { select: { quantity: true } },
+              purchasedItems: { select: { price: true, quantity: true } },
+              payments: { select: { status: true } },
+            },
+          },
+          _count: { select: { participants: true } },
+        },
+      }),
+      // Partner filter dropdown options
+      prisma.affiliate.findMany({
+        where: { groupOrdersV2: { some: {} } },
+        select: { id: true, businessName: true },
+        orderBy: { businessName: 'asc' },
+      }),
+    ]);
+
+    const engagement = await getDashboardEngagement(groups.map((g) => g.shareCode));
+    const now = new Date();
+
+    let rows = groups.map((g) => {
+      const hasPaidPayment = g.tabs.some((tab) =>
+        tab.payments.some((p) => p.status === GroupV2PaymentStatus.PAID)
+      );
+      const firstTab = [...g.tabs].sort((a, b) => a.position - b.position)[0];
+      const deliveryDate = firstTab?.deliveryDate ?? null;
+
+      let lifecycleStatus: Lifecycle;
+      if (hasPaidPayment) {
+        lifecycleStatus = deliveryDate && deliveryDate < now ? 'completed' : 'paid';
+      } else if (g.viewCount > 0) {
+        lifecycleStatus = 'in_progress';
+      } else {
+        lifecycleStatus = 'draft';
+      }
+
+      const totalCents = g.tabs.reduce(
+        (sum, tab) =>
+          sum +
+          tab.purchasedItems.reduce(
+            (s, item) => s + Math.round(Number(item.price) * item.quantity * 100),
+            0
+          ),
+        0
+      );
+      const cartItemCount = g.tabs.reduce(
+        (sum, tab) => sum + tab.draftItems.reduce((s, item) => s + item.quantity, 0),
+        0
+      );
+      const eng = engagement.get(g.shareCode);
+
+      return {
+        id: g.id,
+        name: g.name,
+        hostName: g.hostName,
+        hostEmail: g.hostEmail,
+        shareCode: g.shareCode,
+        partyType: g.partyType,
+        source: g.source,
+        partner: g.affiliate
+          ? { id: g.affiliate.id, businessName: g.affiliate.businessName, partnerSlug: g.affiliate.partnerSlug }
+          : null,
+        createdAt: g.createdAt.toISOString(),
+        deliveryDate: deliveryDate?.toISOString() ?? null,
+        lifecycleStatus,
+        totalCents,
+        cartItemCount,
+        viewCount: eng?.uniqueVisitors ?? g.viewCount,
+        activeSeconds: eng?.totalActiveSeconds ?? 0,
+        lastActivityAt: eng?.lastActivityAt?.toISOString() ?? null,
+        participantCount: g._count.participants,
+      };
+    });
+
+    if (lifecycle) {
+      rows = rows.filter((r) => r.lifecycleStatus === lifecycle).slice(0, limit);
+    }
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        dashboards: rows,
+        pagination: { page, limit, total, pages: Math.ceil(total / limit) },
+        filters: {
+          partners: affiliates,
+          partyTypes: Object.values(PartyType),
+          lifecycles: ['draft', 'in_progress', 'paid', 'completed'],
+        },
+      },
+    });
+  } catch (error) {
+    console.error('[Admin Partner Dashboards API] Error:', error);
+    return NextResponse.json(
+      { success: false, error: 'Failed to fetch dashboards' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/v1/affiliate/me/client-orders/route.ts
+++ b/src/app/api/v1/affiliate/me/client-orders/route.ts
@@ -6,6 +6,7 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/database/client';
 import { getAffiliateSession } from '@/lib/affiliates/affiliate-session';
+import { getDashboardEngagement } from '@/lib/group-orders-v2/view-tracking';
 import { GroupV2PaymentStatus } from '@prisma/client';
 
 type LifecycleStatus = 'draft' | 'in_progress' | 'paid' | 'completed';
@@ -23,13 +24,16 @@ export async function GET(): Promise<NextResponse> {
       include: {
         tabs: {
           include: {
+            draftItems: { select: { quantity: true } },
             purchasedItems: true,
             payments: true,
           },
         },
+        _count: { select: { participants: true } },
       },
     });
 
+    const engagement = await getDashboardEngagement(orders.map((o) => o.shareCode));
     const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://partyondelivery.com';
     const now = new Date();
 
@@ -65,6 +69,12 @@ export async function GET(): Promise<NextResponse> {
         0
       );
 
+      const cartItemCount = order.tabs.reduce(
+        (sum, tab) => sum + tab.draftItems.reduce((s, item) => s + item.quantity, 0),
+        0
+      );
+      const eng = engagement.get(order.shareCode);
+
       return {
         id: order.id,
         type: 'dashboard' as const,
@@ -77,6 +87,12 @@ export async function GET(): Promise<NextResponse> {
         lifecycleStatus,
         dashboardUrl: `${appUrl}/dashboard/${order.shareCode}`,
         shareCode: order.shareCode,
+        // Engagement analytics
+        viewCount: eng?.uniqueVisitors ?? order.viewCount,
+        activeSeconds: eng?.totalActiveSeconds ?? 0,
+        lastActivityAt: eng?.lastActivityAt?.toISOString() ?? null,
+        participantCount: order._count.participants,
+        cartItemCount,
       };
     });
 

--- a/src/app/api/v2/group-orders/[code]/heartbeat/route.ts
+++ b/src/app/api/v2/group-orders/[code]/heartbeat/route.ts
@@ -3,11 +3,18 @@
  * Public endpoint — accumulates time-on-dashboard for engagement
  * analytics. The dashboard pings this every 30s while visible; each
  * ping bumps lastSeenAt and adds `seconds` (server-capped) to the
- * visitor's activeSeconds.
+ * visitor's activeSeconds. Writes are rejected for unknown share codes
+ * and throttled server-side (min 20s between credited heartbeats per
+ * visitor), so replay/forgery cannot inflate the metrics or grow the
+ * table unbounded.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { recordDashboardHeartbeat } from '@/lib/group-orders-v2/view-tracking';
+import {
+  recordDashboardHeartbeat,
+  shareCodeExists,
+} from '@/lib/group-orders-v2/view-tracking';
+import { clientIpFrom } from '@/lib/group-orders-v2/client-ip';
 
 export async function POST(
   request: NextRequest,
@@ -16,8 +23,9 @@ export async function POST(
   try {
     const { code } = await params;
 
-    const forwarded = request.headers.get('x-forwarded-for');
-    const ip = forwarded?.split(',')[0]?.trim() || 'unknown';
+    if (!(await shareCodeExists(code))) {
+      return NextResponse.json({ success: false }, { status: 404 });
+    }
 
     let seconds = 30;
     try {
@@ -29,7 +37,7 @@ export async function POST(
 
     // Awaited on purpose: un-awaited writes get killed by the serverless
     // freeze when the response returns.
-    await recordDashboardHeartbeat(code, ip, seconds);
+    await recordDashboardHeartbeat(code, clientIpFrom(request), seconds);
 
     return NextResponse.json({ success: true });
   } catch (err) {

--- a/src/app/api/v2/group-orders/[code]/heartbeat/route.ts
+++ b/src/app/api/v2/group-orders/[code]/heartbeat/route.ts
@@ -1,0 +1,39 @@
+/**
+ * POST /api/v2/group-orders/[code]/heartbeat
+ * Public endpoint — accumulates time-on-dashboard for engagement
+ * analytics. The dashboard pings this every 30s while visible; each
+ * ping bumps lastSeenAt and adds `seconds` (server-capped) to the
+ * visitor's activeSeconds.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { recordDashboardHeartbeat } from '@/lib/group-orders-v2/view-tracking';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ code: string }> }
+): Promise<NextResponse> {
+  try {
+    const { code } = await params;
+
+    const forwarded = request.headers.get('x-forwarded-for');
+    const ip = forwarded?.split(',')[0]?.trim() || 'unknown';
+
+    let seconds = 30;
+    try {
+      const body = await request.json();
+      if (typeof body?.seconds === 'number') seconds = body.seconds;
+    } catch {
+      // sendBeacon may post an empty body — use the default interval
+    }
+
+    // Awaited on purpose: un-awaited writes get killed by the serverless
+    // freeze when the response returns.
+    await recordDashboardHeartbeat(code, ip, seconds);
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error('[Heartbeat] Error:', err);
+    return NextResponse.json({ success: true }); // tracking is best-effort
+  }
+}

--- a/src/app/api/v2/group-orders/[code]/track-view/route.ts
+++ b/src/app/api/v2/group-orders/[code]/track-view/route.ts
@@ -1,10 +1,15 @@
 /**
  * POST /api/v2/group-orders/[code]/track-view
- * Public endpoint -- tracks unique dashboard visitors.
+ * Public endpoint -- tracks unique dashboard visitors. Rejects unknown
+ * share codes so arbitrary strings can't create garbage rows.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { trackDashboardView } from '@/lib/group-orders-v2/view-tracking';
+import {
+  trackDashboardView,
+  shareCodeExists,
+} from '@/lib/group-orders-v2/view-tracking';
+import { clientIpFrom } from '@/lib/group-orders-v2/client-ip';
 
 export async function POST(
   request: NextRequest,
@@ -13,12 +18,13 @@ export async function POST(
   try {
     const { code } = await params;
 
-    const forwarded = request.headers.get('x-forwarded-for');
-    const ip = forwarded?.split(',')[0]?.trim() || 'unknown';
+    if (!(await shareCodeExists(code))) {
+      return NextResponse.json({ success: false }, { status: 404 });
+    }
 
     // Awaited on purpose: un-awaited writes get killed by the serverless
     // freeze when the response returns (same bug as the lead mirrors).
-    await trackDashboardView(code, ip).catch((err) => {
+    await trackDashboardView(code, clientIpFrom(request)).catch((err) => {
       console.error('[Track View] Error:', err);
     });
 

--- a/src/app/api/v2/group-orders/[code]/track-view/route.ts
+++ b/src/app/api/v2/group-orders/[code]/track-view/route.ts
@@ -16,8 +16,9 @@ export async function POST(
     const forwarded = request.headers.get('x-forwarded-for');
     const ip = forwarded?.split(',')[0]?.trim() || 'unknown';
 
-    // Fire-and-forget -- don't block the response on DB write
-    trackDashboardView(code, ip).catch((err) => {
+    // Awaited on purpose: un-awaited writes get killed by the serverless
+    // freeze when the response returns (same bug as the lead mirrors).
+    await trackDashboardView(code, ip).catch((err) => {
       console.error('[Track View] Error:', err);
     });
 

--- a/src/app/dashboard/[code]/page.tsx
+++ b/src/app/dashboard/[code]/page.tsx
@@ -184,6 +184,24 @@ export default function DashboardPage(): ReactElement {
     fetch(`/api/v2/group-orders/${code}/track-view`, { method: 'POST' }).catch(() => {});
   }, [code]);
 
+  // Engagement heartbeat: every 30s while the tab is visible, credit
+  // 30s of active time so partners/admin can see time-on-dashboard.
+  useEffect(() => {
+    if (!code) return;
+    const HEARTBEAT_SECONDS = 30;
+    const ping = () => {
+      if (document.visibilityState !== 'visible') return;
+      fetch(`/api/v2/group-orders/${code}/heartbeat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ seconds: HEARTBEAT_SECONDS }),
+        keepalive: true,
+      }).catch(() => {});
+    };
+    const interval = setInterval(ping, HEARTBEAT_SECONDS * 1000);
+    return () => clearInterval(interval);
+  }, [code]);
+
   // Auto-load affiliate from cookie (with confetti on first apply)
   useEffect(() => {
     if (!code || !participantId) return;

--- a/src/app/partners/[slug]/page.tsx
+++ b/src/app/partners/[slug]/page.tsx
@@ -93,10 +93,14 @@ export default async function DynamicPartnerPage({ params }: Props) {
     notFound();
   }
 
-  const { logo: partnerLogo, heroImage: partnerHeroImage } = findPartnerData(
+  const { logo: diskLogo, heroImage: partnerHeroImage } = findPartnerData(
     affiliate.businessName,
     affiliate.partnerSlug ?? slug
   );
+  // Committed logo files win; Affiliate.logoUrl (set by bulk import,
+  // usually a Clearbit URL) is the runtime fallback so bulk-created
+  // partners get a logo without a code deploy.
+  const partnerLogo = diskLogo ?? affiliate.logoUrl ?? null;
   const CategoryTemplate = getCategoryTemplate(affiliate.category);
 
   // For PLANNER partners, build a hero carousel: [partnerHero, ...sharedPlannerHeros]

--- a/src/components/partners/PartnerLogo.tsx
+++ b/src/components/partners/PartnerLogo.tsx
@@ -1,0 +1,60 @@
+import type { ReactElement } from 'react';
+import Image from 'next/image';
+
+interface PartnerLogoProps {
+  /** Logo URL — committed /images path or remote (bulk-import) URL. */
+  logo: string | null;
+  businessName: string;
+  /** Classes applied to the logo <Image> (sizing per template). */
+  imgClassName: string;
+  /** Wrap the logo in a white chip (light-background logos on dark heros). */
+  lightChip?: boolean;
+}
+
+/**
+ * Partner-page masthead: the partner's logo when we have one, otherwise
+ * an all-caps business-name wordmark so a freshly bulk-created page
+ * always looks finished and is safe to send to clients immediately.
+ *
+ * Remote logos (Affiliate.logoUrl — scraped from the partner site or
+ * Clearbit) render with `unoptimized` so next/image serves them
+ * directly instead of proxying arbitrary hosts through the image
+ * optimizer (no remotePatterns entry needed, no server-side fetch).
+ */
+export default function PartnerLogo({
+  logo,
+  businessName,
+  imgClassName,
+  lightChip = false,
+}: PartnerLogoProps): ReactElement {
+  if (!logo) {
+    return (
+      <div className="mb-6">
+        <span className="block font-heading uppercase text-white text-4xl md:text-5xl tracking-[0.1em] leading-tight drop-shadow-2xl">
+          {businessName}
+        </span>
+      </div>
+    );
+  }
+
+  const img = (
+    <Image
+      src={logo}
+      alt={`${businessName} logo`}
+      width={240}
+      height={240}
+      className={imgClassName}
+      unoptimized={logo.startsWith('http')}
+    />
+  );
+
+  return (
+    <div className="mb-6">
+      {lightChip ? (
+        <div className="inline-block bg-white rounded-2xl p-4 md:p-5 shadow-xl">{img}</div>
+      ) : (
+        img
+      )}
+    </div>
+  );
+}

--- a/src/components/partners/templates/BoatTemplate.tsx
+++ b/src/components/partners/templates/BoatTemplate.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import Navigation from '@/components/Navigation';
 import Footer from '@/components/Footer';
 import type { CategoryTemplateProps } from './template-types';
+import PartnerLogo from '@/components/partners/PartnerLogo';
 
 type BoatTemplateProps = CategoryTemplateProps & {
   /** Override the default "Free Drink Delivery for {business}" H1 (co-branded partner headline). */
@@ -112,29 +113,16 @@ export function BoatTemplate({ affiliate, partnerLogo, partnerHeroImage, headlin
         <div className="relative z-10 max-w-7xl mx-auto px-6 md:px-12 pt-24 md:pt-28 pb-16 md:pb-20">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-10 md:gap-12 items-center">
             <div className="order-1 text-center">
-              {partnerLogo && (
-                <div className="mb-6">
-                  {logoLightChip ? (
-                    <div className="inline-block bg-white rounded-2xl p-4 md:p-5 shadow-xl">
-                      <Image
-                        src={partnerLogo}
-                        alt={`${businessName} logo`}
-                        width={240}
-                        height={240}
-                        className="h-28 md:h-36 w-auto object-contain mx-auto"
-                      />
-                    </div>
-                  ) : (
-                    <Image
-                      src={partnerLogo}
-                      alt={`${businessName} logo`}
-                      width={240}
-                      height={240}
-                      className="h-40 md:h-48 w-auto object-contain mx-auto drop-shadow-[0_0_15px_rgba(255,255,255,0.3)] brightness-110"
-                    />
-                  )}
-                </div>
-              )}
+              <PartnerLogo
+                logo={partnerLogo}
+                businessName={businessName}
+                lightChip={!!partnerLogo && !!logoLightChip}
+                imgClassName={
+                  logoLightChip
+                    ? 'h-28 md:h-36 w-auto object-contain mx-auto'
+                    : 'h-40 md:h-48 w-auto object-contain mx-auto drop-shadow-[0_0_15px_rgba(255,255,255,0.3)] brightness-110'
+                }
+              />
 
               <h1 className="font-heading text-3xl sm:text-4xl md:text-5xl text-white mb-4 tracking-wide leading-tight">
                 {headline ?? (

--- a/src/components/partners/templates/DefaultTemplate.tsx
+++ b/src/components/partners/templates/DefaultTemplate.tsx
@@ -6,6 +6,7 @@ import HeroCarousel from '@/components/partners/HeroCarousel';
 import type { CategoryTemplateProps } from './template-types';
 import { getStrPartnerBySlug } from '@/lib/partners/str-partners';
 import StrStartOrderButton from '@/components/partners/StrStartOrderButton';
+import PartnerLogo from '@/components/partners/PartnerLogo';
 
 interface CategoryConfig {
   heroSubtitle: (name: string) => string;
@@ -200,16 +201,12 @@ export function DefaultTemplate({ affiliate, partnerLogo, partnerHeroImage, hero
         <div className="relative z-10 max-w-7xl mx-auto px-6 md:px-12 pt-24 md:pt-28 pb-16 md:pb-20">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-10 md:gap-12 items-center">
             <div className="order-1 text-center">
-              {partnerLogo && !strConfig && (
-                <div className="mb-6">
-                  <Image
-                    src={partnerLogo}
-                    alt={`${businessName} logo`}
-                    width={240}
-                    height={240}
-                    className="h-60 md:h-72 w-auto object-contain mx-auto drop-shadow-2xl"
-                  />
-                </div>
+              {!strConfig && (
+                <PartnerLogo
+                  logo={partnerLogo}
+                  businessName={businessName}
+                  imgClassName="h-60 md:h-72 w-auto object-contain mx-auto drop-shadow-2xl"
+                />
               )}
 
               <h1 className="font-heading text-3xl sm:text-4xl md:text-5xl text-white mb-4 tracking-wide leading-tight">

--- a/src/lib/group-orders-v2/client-ip.ts
+++ b/src/lib/group-orders-v2/client-ip.ts
@@ -1,0 +1,19 @@
+/**
+ * Client IP resolution for the public dashboard-tracking endpoints.
+ *
+ * Prefers platform-set headers (Vercel writes x-real-ip and
+ * x-vercel-forwarded-for at the edge) over the client-suppliable
+ * x-forwarded-for, so rotating a forged XFF header can't mint unlimited
+ * "unique visitors".
+ */
+import type { NextRequest } from 'next/server';
+
+/** Resolve the caller's IP from the most trustworthy header available. */
+export function clientIpFrom(request: NextRequest): string {
+  return (
+    request.headers.get('x-real-ip')?.trim() ||
+    request.headers.get('x-vercel-forwarded-for')?.split(',')[0]?.trim() ||
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    'unknown'
+  );
+}

--- a/src/lib/group-orders-v2/view-tracking.ts
+++ b/src/lib/group-orders-v2/view-tracking.ts
@@ -36,3 +36,74 @@ export async function trackDashboardView(
     `;
   }
 }
+
+/** Max seconds a single heartbeat may credit — the client pings every
+ *  30s, so anything larger is a replayed/forged request. */
+const MAX_HEARTBEAT_SECONDS = 120;
+
+/**
+ * Record a dashboard heartbeat: bump lastSeenAt and accumulate active
+ * time on this visitor's view row. Creates the row if the initial
+ * track-view call was missed (e.g. ad blocker raced it).
+ */
+export async function recordDashboardHeartbeat(
+  shareCode: string,
+  ip: string,
+  seconds: number
+): Promise<void> {
+  const credit = Math.min(Math.max(Math.round(seconds), 0), MAX_HEARTBEAT_SECONDS);
+  const visitorHash = createHash('sha256')
+    .update(ip + shareCode)
+    .digest('hex')
+    .slice(0, 32);
+
+  await prisma.$executeRaw`
+    INSERT INTO dashboard_views (id, share_code, visitor_hash, viewed_at, last_seen_at, active_seconds)
+    VALUES (gen_random_uuid(), ${shareCode}, ${visitorHash}, NOW(), NOW(), ${credit})
+    ON CONFLICT (share_code, visitor_hash) DO UPDATE
+    SET last_seen_at = NOW(),
+        active_seconds = dashboard_views.active_seconds + ${credit}
+  `;
+}
+
+export interface DashboardEngagement {
+  uniqueVisitors: number;
+  totalActiveSeconds: number;
+  lastActivityAt: Date | null;
+}
+
+/**
+ * Aggregate engagement (unique visitors, total active seconds, most
+ * recent activity) for a set of dashboards in one query. Returns a map
+ * keyed by shareCode; codes with no views are absent.
+ */
+export async function getDashboardEngagement(
+  shareCodes: string[]
+): Promise<Map<string, DashboardEngagement>> {
+  const map = new Map<string, DashboardEngagement>();
+  if (shareCodes.length === 0) return map;
+
+  const rows = await prisma.dashboardView.groupBy({
+    by: ['shareCode'],
+    where: { shareCode: { in: shareCodes } },
+    _count: { _all: true },
+    _sum: { activeSeconds: true },
+    _max: { lastSeenAt: true, viewedAt: true },
+  });
+
+  for (const row of rows) {
+    const lastSeen = row._max.lastSeenAt;
+    const lastViewed = row._max.viewedAt;
+    map.set(row.shareCode, {
+      uniqueVisitors: row._count._all,
+      totalActiveSeconds: row._sum.activeSeconds ?? 0,
+      lastActivityAt:
+        lastSeen && lastViewed
+          ? lastSeen > lastViewed
+            ? lastSeen
+            : lastViewed
+          : (lastSeen ?? lastViewed ?? null),
+    });
+  }
+  return map;
+}

--- a/src/lib/group-orders-v2/view-tracking.ts
+++ b/src/lib/group-orders-v2/view-tracking.ts
@@ -42,9 +42,27 @@ export async function trackDashboardView(
 const MAX_HEARTBEAT_SECONDS = 120;
 
 /**
+ * Guard for the public tracking endpoints: true only when the share
+ * code belongs to a real GroupOrderV2. Prevents unbounded garbage-row
+ * writes for arbitrary codes (dashboard_views.share_code has no FK).
+ */
+export async function shareCodeExists(shareCode: string): Promise<boolean> {
+  if (!shareCode || shareCode.length > 64) return false;
+  const group = await prisma.groupOrderV2.findUnique({
+    where: { shareCode },
+    select: { id: true },
+  });
+  return group !== null;
+}
+
+/**
  * Record a dashboard heartbeat: bump lastSeenAt and accumulate active
  * time on this visitor's view row. Creates the row if the initial
  * track-view call was missed (e.g. ad blocker raced it).
+ *
+ * Rate limit: the SQL only credits time when the previous heartbeat is
+ * at least 20s old, so replaying requests faster than the 30s client
+ * interval cannot inflate active_seconds beyond real elapsed time.
  */
 export async function recordDashboardHeartbeat(
   shareCode: string,
@@ -63,6 +81,8 @@ export async function recordDashboardHeartbeat(
     ON CONFLICT (share_code, visitor_hash) DO UPDATE
     SET last_seen_at = NOW(),
         active_seconds = dashboard_views.active_seconds + ${credit}
+    WHERE dashboard_views.last_seen_at IS NULL
+       OR dashboard_views.last_seen_at < NOW() - INTERVAL '20 seconds'
   `;
 }
 

--- a/src/lib/partners/logo-scraper.ts
+++ b/src/lib/partners/logo-scraper.ts
@@ -1,0 +1,167 @@
+/**
+ * Partner logo extraction — used by the bulk-import flow so a freshly
+ * created partner page has a real logo without a code deploy.
+ *
+ * Resolution order (first candidate that actually serves an image wins):
+ *   1. Explicit logoUrl from the CSV row
+ *   2. The partner site's own markup, best-first:
+ *      <img> whose src/class/alt/id mentions "logo" → apple-touch-icon
+ *      → og:image → large <link rel="icon"> (png/svg)
+ *   3. Clearbit (https://logo.clearbit.com/<domain>) — validated, since
+ *      Clearbit 404s for unknown domains
+ *
+ * Every candidate is verified with a real fetch (status 200 + image/*
+ * content-type) so we never store a URL that renders as a broken image
+ * on the partner page. All fetches are tightly time-boxed and restricted
+ * to public https hosts (no private ranges — basic SSRF hygiene even
+ * though the input is admin-gated).
+ */
+
+const PAGE_TIMEOUT_MS = 6000;
+const IMAGE_TIMEOUT_MS = 4000;
+const USER_AGENT =
+  'Mozilla/5.0 (compatible; PartyOnDelivery-LogoBot/1.0; +https://partyondelivery.com)';
+
+/** Reject non-public hosts: localhost, raw private/link-local IPs, .local. */
+function isPublicHttpUrl(raw: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') return false;
+  const host = url.hostname.toLowerCase();
+  if (host === 'localhost' || host.endsWith('.local') || host.endsWith('.internal')) return false;
+  if (/^\d+\.\d+\.\d+\.\d+$/.test(host)) {
+    const [a, b] = host.split('.').map(Number);
+    if (a === 10 || a === 127 || a === 0 || (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168) || (a === 169 && b === 254)) {
+      return false;
+    }
+  }
+  if (host.includes(':')) return false; // IPv6 literals — skip entirely
+  return true;
+}
+
+async function fetchWithTimeout(url: string, timeoutMs: number): Promise<Response | null> {
+  if (!isPublicHttpUrl(url)) return null;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, {
+      signal: controller.signal,
+      redirect: 'follow',
+      headers: { 'User-Agent': USER_AGENT, Accept: 'text/html,image/*,*/*' },
+    });
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** True when the URL serves an actual image we can render. */
+export async function urlServesImage(url: string): Promise<boolean> {
+  const res = await fetchWithTimeout(url, IMAGE_TIMEOUT_MS);
+  if (!res || !res.ok) return false;
+  const type = res.headers.get('content-type') ?? '';
+  // .ico favicons are too small to use as a page logo
+  return type.startsWith('image/') && !type.includes('image/vnd.microsoft.icon') && !type.includes('image/x-icon');
+}
+
+/** Resolve a possibly-relative src against the page URL; null if unusable. */
+function absolutize(src: string, pageUrl: string): string | null {
+  const trimmed = src.trim();
+  if (!trimmed || trimmed.startsWith('data:')) return null;
+  try {
+    return new URL(trimmed, pageUrl).toString();
+  } catch {
+    return null;
+  }
+}
+
+/** Pull logo candidate URLs out of homepage HTML, best-first. */
+export function extractLogoCandidates(html: string, pageUrl: string): string[] {
+  const candidates: string[] = [];
+  const push = (src: string | undefined) => {
+    if (!src) return;
+    const abs = absolutize(src, pageUrl);
+    if (abs && !candidates.includes(abs)) candidates.push(abs);
+  };
+
+  // 1. <img> tags that look like a logo (src, class, alt, or id says so)
+  const imgTags = html.match(/<img\b[^>]*>/gi) ?? [];
+  for (const tag of imgTags) {
+    if (!/logo/i.test(tag)) continue;
+    const src =
+      tag.match(/\bsrc=["']([^"']+)["']/i)?.[1] ??
+      tag.match(/\bdata-src=["']([^"']+)["']/i)?.[1];
+    push(src);
+    if (candidates.length >= 3) break; // first few logo-ish imgs are enough
+  }
+
+  // 2. apple-touch-icon — usually a clean square brand mark
+  for (const tag of html.match(/<link\b[^>]*rel=["']apple-touch-icon[^"']*["'][^>]*>/gi) ?? []) {
+    push(tag.match(/\bhref=["']([^"']+)["']/i)?.[1]);
+  }
+
+  // 3. og:image (often a hero photo, so it ranks below the real logos)
+  push(
+    html.match(
+      /<meta\b[^>]*property=["']og:image["'][^>]*content=["']([^"']+)["']/i
+    )?.[1] ??
+      html.match(
+        /<meta\b[^>]*content=["']([^"']+)["'][^>]*property=["']og:image["']/i
+      )?.[1]
+  );
+
+  // 4. png/svg favicons (skip .ico — too small)
+  for (const tag of html.match(/<link\b[^>]*rel=["'](?:shortcut )?icon["'][^>]*>/gi) ?? []) {
+    const href = tag.match(/\bhref=["']([^"']+)["']/i)?.[1];
+    if (href && /\.(png|svg)(\?|$)/i.test(href)) push(href);
+  }
+
+  return candidates;
+}
+
+/** Normalize a CSV "website" value to a fetchable homepage URL. */
+export function websiteToUrl(website: string): string | null {
+  const trimmed = website.trim();
+  if (!trimmed) return null;
+  const withProto = trimmed.startsWith('http') ? trimmed : `https://${trimmed}`;
+  return isPublicHttpUrl(withProto) ? withProto : null;
+}
+
+/**
+ * Find the best working logo URL for a partner.
+ * Returns null when nothing validates — the partner page then renders
+ * the all-caps business-name wordmark instead.
+ */
+export async function resolveLogoUrl(
+  website: string,
+  explicitLogoUrl?: string | null
+): Promise<string | null> {
+  // Explicit CSV value wins when it actually serves an image
+  if (explicitLogoUrl && (await urlServesImage(explicitLogoUrl))) {
+    return explicitLogoUrl;
+  }
+
+  const pageUrl = websiteToUrl(website);
+  if (!pageUrl) return null;
+
+  // Scrape the partner's homepage for its own logo
+  const res = await fetchWithTimeout(pageUrl, PAGE_TIMEOUT_MS);
+  if (res?.ok) {
+    const html = (await res.text()).slice(0, 500_000);
+    for (const candidate of extractLogoCandidates(html, res.url || pageUrl).slice(0, 5)) {
+      if (await urlServesImage(candidate)) return candidate;
+    }
+  }
+
+  // Clearbit fallback — validated, since it 404s for unknown domains
+  const domain = new URL(pageUrl).hostname.replace(/^www\./, '');
+  const clearbit = `https://logo.clearbit.com/${domain}`;
+  if (await urlServesImage(clearbit)) return clearbit;
+
+  return null;
+}


### PR DESCRIPTION
## What

**Bulk partner creation** — `/admin/affiliates/bulk-import`: paste/upload CSV → one DRAFT affiliate + referral code + FREE_SHIPPING discount + live `/partners/<slug>` page per row. Same objects as the single-create flow, so commissions/portal/dashboards work unchanged.

**Reliable logos** — new `logo-scraper.ts` resolves each partner's logo: explicit CSV URL → scraped from their homepage (logo `<img>` / apple-touch-icon / og:image / png-svg favicon) → validated Clearbit. Every candidate is fetch-verified to serve a real image. When nothing validates, the partner page renders an all-caps business-name wordmark, so every page is send-ready immediately. Remote logos render `unoptimized` (no image-optimizer proxying of arbitrary hosts).

**Dashboard engagement analytics** — 30s visibility-gated heartbeat from `/dashboard/[code]` → `DashboardView.lastSeenAt/activeSeconds` (manual additive migration, already applied to prod + verified). Partner portal + admin affiliate view rosters now show views, time-on-dashboard, group size, cart items, last activity, plus a search box.

**Global admin roster** — `/admin/affiliates/dashboards`: every client dashboard across all partners, searchable by host/name/email/code, filterable by partner / party type / lifecycle status.

**Tracking hardening (security-reviewer findings)** — heartbeat/track-view 404 unknown share codes, SQL-level heartbeat throttle (min 20s between credits), platform IP headers preferred over spoofable XFF, track-view freeze-bug fix (awaited write).

## Verification
- `npx tsc --noEmit` clean (excluding pre-existing missing-dep errors: plaid/dnd-kit/clarity)
- `npm run lint` clean (one pre-existing warning in untouched file)
- `npm run test:run`: 855/855 pass (2 test files fail to import locally-missing `plaid` — pre-existing)
- Logo scraper live-tested (premierpartycruises.com → real logo; unknown domain → wordmark fallback)
- security-reviewer agent ran on the diff; both HIGH findings fixed in-branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)