### PR TITLE
feat(partners): STR Partners prospect tab — 54 researched Austin STR companies

### DIFF
--- a/src/app/admin/brians-stuff/BriansStuffTabs.tsx
+++ b/src/app/admin/brians-stuff/BriansStuffTabs.tsx
@@ -29,7 +29,8 @@ type TabKey =
   | 'seo'
   | 'pathways'
   | 'logic'
-  | 'docs';
+  | 'docs'
+  | 'str';
 
 export default function BriansStuffTabs({
   playbook,
@@ -42,6 +43,7 @@ export default function BriansStuffTabs({
   pathways,
   logic,
   docs,
+  str,
   initialTab = 'playbook',
 }: {
   playbook: ReactNode;
@@ -54,6 +56,7 @@ export default function BriansStuffTabs({
   pathways: ReactNode;
   logic: ReactNode;
   docs: ReactNode;
+  str: ReactNode;
   initialTab?: TabKey;
 }) {
   const [tab, setTab] = useState<TabKey>(initialTab);
@@ -104,6 +107,9 @@ export default function BriansStuffTabs({
           <TabButton active={tab === 'docs'} onClick={() => setTab('docs')}>
             📚 Enrichment Docs
           </TabButton>
+          <TabButton active={tab === 'str'} onClick={() => setTab('str')}>
+            🏡 STR Partners
+          </TabButton>
         </div>
       </div>
 
@@ -139,6 +145,9 @@ export default function BriansStuffTabs({
       </div>
       <div hidden={tab !== 'docs'} className="px-6 md:px-10 py-8">
         <TabErrorBoundary tabName="Enrichment Docs">{docs}</TabErrorBoundary>
+      </div>
+      <div hidden={tab !== 'str'} className="px-6 md:px-10 py-8">
+        <TabErrorBoundary tabName="STR Partners">{str}</TabErrorBoundary>
       </div>
     </div>
   );

--- a/src/app/admin/brians-stuff/page.tsx
+++ b/src/app/admin/brians-stuff/page.tsx
@@ -9,6 +9,7 @@ import SeoIntelligenceView from '@/components/admin/SeoIntelligenceView';
 import OrderPathwaysView from '@/components/admin/OrderPathwaysView';
 import RecommendationLogicView from '@/components/admin/RecommendationLogicView';
 import EnrichmentDocsView from '@/components/admin/EnrichmentDocsView';
+import StrPartnersView from '@/components/admin/StrPartnersView';
 import BriansStuffTabs from './BriansStuffTabs';
 
 export const metadata: Metadata = {
@@ -42,6 +43,7 @@ export default async function Page({ searchParams }: { searchParams: SP }) {
     'pathways',
     'logic',
     'docs',
+    'str',
   ] as const;
   const initialTab = (
     (VALID_TABS as readonly string[]).includes(params.tab ?? '')
@@ -62,6 +64,7 @@ export default async function Page({ searchParams }: { searchParams: SP }) {
       pathways={<OrderPathwaysView />}
       logic={<RecommendationLogicView />}
       docs={<EnrichmentDocsView />}
+      str={<StrPartnersView />}
     />
   );
 }

--- a/src/components/admin/StrPartnersView.tsx
+++ b/src/components/admin/StrPartnersView.tsx
@@ -1,0 +1,227 @@
+'use client';
+
+/**
+ * Brian's Stuff → STR Partners tab
+ *
+ * Prospect list of Austin short-term-rental companies (5+ homes) with
+ * everything needed to create their partner page and reach out: website,
+ * contact, email, phone, socials, and scraped logo. Data lives in
+ * src/data/str-partner-prospects.json (compiled by research, logos
+ * resolved via src/lib/partners/logo-scraper.ts).
+ *
+ * Workflow: review here → create partner pages via
+ * /admin/affiliates/bulk-import (the "Copy CSV" button emits rows in the
+ * exact import format) → the `partnerSlug` field flips a row to
+ * "Created" with a link to its live page.
+ */
+
+import { useMemo, useState, type ReactElement } from 'react';
+import Link from 'next/link';
+import prospectsData from '@/data/str-partner-prospects.json';
+
+interface Socials {
+  instagram?: string | null;
+  facebook?: string | null;
+  linkedin?: string | null;
+  twitter?: string | null;
+  youtube?: string | null;
+  tiktok?: string | null;
+}
+
+interface Prospect {
+  name: string;
+  website: string;
+  propertiesEstimate: string;
+  contactName: string | null;
+  email: string | null;
+  phone: string | null;
+  socials: Socials;
+  logoUrl: string | null;
+  description: string;
+  /** Set once the partner page exists — links the row to /partners/<slug>. */
+  partnerSlug?: string | null;
+}
+
+const SOCIAL_LABELS: [keyof Socials, string][] = [
+  ['instagram', 'IG'],
+  ['facebook', 'FB'],
+  ['linkedin', 'LI'],
+  ['twitter', 'X'],
+  ['youtube', 'YT'],
+  ['tiktok', 'TT'],
+];
+
+function csvEscape(v: string): string {
+  return /[",\n]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v;
+}
+
+export default function StrPartnersView(): ReactElement {
+  const prospects = prospectsData as Prospect[];
+  const [search, setSearch] = useState('');
+  const [copied, setCopied] = useState(false);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return prospects;
+    return prospects.filter(
+      (p) =>
+        p.name.toLowerCase().includes(q) ||
+        p.website.toLowerCase().includes(q) ||
+        (p.contactName ?? '').toLowerCase().includes(q) ||
+        (p.email ?? '').toLowerCase().includes(q)
+    );
+  }, [prospects, search]);
+
+  const withContact = prospects.filter((p) => p.email || p.phone).length;
+  const withLogo = prospects.filter((p) => p.logoUrl).length;
+  const created = prospects.filter((p) => p.partnerSlug).length;
+
+  const copyBulkImportCsv = async () => {
+    const header = 'business_name,website,category,commission_percent,contact_name,email,phone';
+    const rows = filtered
+      .filter((p) => !p.partnerSlug)
+      .map((p) =>
+        [
+          csvEscape(p.name),
+          csvEscape(p.website),
+          'LODGING',
+          '10',
+          csvEscape(p.contactName ?? ''),
+          csvEscape(p.email ?? ''),
+          csvEscape(p.phone ?? ''),
+        ].join(',')
+      );
+    await navigator.clipboard.writeText([header, ...rows].join('\n'));
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2500);
+  };
+
+  return (
+    <div className="max-w-7xl mx-auto">
+      <div className="mb-6">
+        <h2 className="text-2xl font-bold text-gray-900">STR Partners — Austin prospect list</h2>
+        <p className="text-sm text-gray-600 mt-1 max-w-3xl">
+          Austin short-term-rental companies (~5+ homes) with everything needed to build
+          their partner page and reach out. {prospects.length} companies · {withContact} with
+          direct contact info · {withLogo} logos scraped · {created} partner page{created === 1 ? '' : 's'} created.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3 mb-4">
+        <input
+          type="search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search company, website, contact, email…"
+          className="flex-1 min-w-[240px] rounded-lg border-2 border-gray-200 px-4 py-2.5 text-base focus:border-brand-blue focus:outline-none"
+        />
+        <button type="button" onClick={copyBulkImportCsv} className="btn-primary px-4 py-2.5 text-sm">
+          {copied ? 'Copied ✓' : 'Copy CSV for Bulk Import'}
+        </button>
+        <Link href="/admin/affiliates/bulk-import" className="btn-secondary px-4 py-2.5 text-sm">
+          Open Bulk Import
+        </Link>
+      </div>
+
+      <div className="rounded-lg border border-gray-200 overflow-x-auto bg-white">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50 text-xs uppercase tracking-wider text-gray-600">
+            <tr>
+              <th className="text-left p-3">Company</th>
+              <th className="text-left p-3">Logo</th>
+              <th className="text-left p-3">Homes</th>
+              <th className="text-left p-3">Contact</th>
+              <th className="text-left p-3">Email / phone</th>
+              <th className="text-left p-3">Socials</th>
+              <th className="text-left p-3">About</th>
+              <th className="text-left p-3">Partner page</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100 align-top">
+            {filtered.map((p) => (
+              <tr key={p.website}>
+                <td className="p-3 min-w-[180px]">
+                  <a
+                    href={p.website}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-medium text-brand-blue hover:underline"
+                  >
+                    {p.name}
+                  </a>
+                  <div className="text-xs text-gray-500 break-all">
+                    {p.website.replace(/^https?:\/\/(www\.)?/, '')}
+                  </div>
+                </td>
+                <td className="p-3">
+                  {p.logoUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element -- tiny external thumbnails, optimizer proxying not wanted
+                    <img
+                      src={p.logoUrl}
+                      alt={`${p.name} logo`}
+                      className="h-10 w-16 object-contain bg-gray-50 rounded"
+                      loading="lazy"
+                    />
+                  ) : (
+                    <span className="text-xs text-gray-400">wordmark</span>
+                  )}
+                </td>
+                <td className="p-3 text-gray-700 whitespace-nowrap">{p.propertiesEstimate}</td>
+                <td className="p-3 text-gray-700 min-w-[110px]">{p.contactName ?? '—'}</td>
+                <td className="p-3 min-w-[180px]">
+                  {p.email ? (
+                    <a href={`mailto:${p.email}`} className="text-brand-blue hover:underline break-all">
+                      {p.email}
+                    </a>
+                  ) : (
+                    <span className="text-gray-400">no email</span>
+                  )}
+                  <div>
+                    {p.phone ? (
+                      <a href={`tel:${p.phone}`} className="text-gray-700 hover:underline">
+                        {p.phone}
+                      </a>
+                    ) : (
+                      <span className="text-xs text-gray-400">no phone</span>
+                    )}
+                  </div>
+                </td>
+                <td className="p-3 whitespace-nowrap">
+                  {SOCIAL_LABELS.filter(([key]) => p.socials?.[key]).map(([key, label]) => (
+                    <a
+                      key={key}
+                      href={p.socials[key] as string}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-block mr-1.5 text-xs font-bold text-brand-blue hover:underline"
+                    >
+                      {label}
+                    </a>
+                  ))}
+                  {!SOCIAL_LABELS.some(([key]) => p.socials?.[key]) && (
+                    <span className="text-xs text-gray-400">—</span>
+                  )}
+                </td>
+                <td className="p-3 text-gray-600 max-w-[280px]">{p.description}</td>
+                <td className="p-3 whitespace-nowrap">
+                  {p.partnerSlug ? (
+                    <a
+                      href={`/partners/${p.partnerSlug}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs font-bold text-green-700 hover:underline"
+                    >
+                      ✓ /partners/{p.partnerSlug}
+                    </a>
+                  ) : (
+                    <span className="text-xs text-gray-400">not created</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/data/str-partner-prospects.json
+++ b/src/data/str-partner-prospects.json
@@ -1,0 +1,1028 @@
+[
+  {
+    "name": "Lynn's Lodging",
+    "website": "https://www.lynnslodgingatx.com/",
+    "propertiesEstimate": "~34",
+    "contactName": "Lynn",
+    "email": "hello@lynnslodging.com",
+    "phone": "512-920-3590",
+    "socials": {
+      "instagram": null,
+      "facebook": "https://www.facebook.com/p/Lynns-Lodging-61567370241281/",
+      "linkedin": null,
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://www.lynnslodgingatx.com/i/width=200,dpr=1,format=jpeg?src=https%3A%2F%2Fassets-websites.wander.com%2F637460520617640767%2Flogo-TAcHsUiqn1-vZGHBYDcI2.png",
+    "description": "Designer luxury Austin STRs with pools, hot tubs, rooftop spaces; also full-service STR management (Austin + Cedar Park).",
+    "partnerSlug": "lynns-lodging"
+  },
+  {
+    "name": "Austin Vacay",
+    "website": "https://www.austinvacay.com/",
+    "propertiesEstimate": "~203",
+    "contactName": null,
+    "email": "info@austinvacay.com",
+    "phone": "844-646-8766",
+    "socials": {
+      "instagram": "https://www.instagram.com/austinvacay",
+      "facebook": "https://www.facebook.com/AustinVacays",
+      "linkedin": null,
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://bookingenginecdn-2.hostaway.com/43003-logoUrl.jpg?width=3840&quality=70&format=webp&v=2",
+    "description": "Self-described 'Austin's Largest Vacation Rental Manager' — locally hosted rentals across Austin, Lake Travis, Marfa. Booking arm of STR Management.",
+    "partnerSlug": null
+  },
+  {
+    "name": "STR Management, LLC",
+    "website": "https://www.strmanagement.com/",
+    "propertiesEstimate": "~170",
+    "contactName": "James (team lead)",
+    "email": "info@strmanagement.com",
+    "phone": "844-646-8787",
+    "socials": {
+      "instagram": null,
+      "facebook": "https://www.facebook.com/austinstrmanagement/",
+      "linkedin": "https://www.linkedin.com/company/str-management/",
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://www.strmanagement.com/wp-content/uploads/2019/06/STR-Management-logo-WEB-50.png",
+    "description": "One of Austin's largest local STR managers (since 2014), Austin + Lakeway, in-house cleaning and revenue management.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Vacasa (Austin)",
+    "website": "https://www.vacasa.com/property-management/tx/austin",
+    "propertiesEstimate": "~106-192 in Austin",
+    "contactName": null,
+    "email": null,
+    "phone": "512-991-9338",
+    "socials": {
+      "instagram": "https://www.instagram.com/vacasa/",
+      "facebook": "https://www.facebook.com/vacasa",
+      "linkedin": "https://www.linkedin.com/company/vacasa",
+      "twitter": "https://twitter.com/vacasarentals",
+      "youtube": "https://www.youtube.com/channel/UCgZXkw4UVFCChoAmPzXNZbA",
+      "tiktok": null
+    },
+    "logoUrl": "https://cms-assets.boise.vacasa.com/svg/vacasa_casago_lockup_extra-wide-white.b0c31f473733.svg",
+    "description": "North America's largest vacation rental manager with a local Austin team (absorbed Austin-founded TurnKey).",
+    "partnerSlug": null
+  },
+  {
+    "name": "NomadSTR",
+    "website": "https://www.nomadstr.rentals/",
+    "propertiesEstimate": "100+",
+    "contactName": null,
+    "email": "contact@nomadstr.net",
+    "phone": "407-765-2482",
+    "socials": {
+      "instagram": "https://www.instagram.com/nomad.str/",
+      "facebook": "https://www.facebook.com/nomadstr",
+      "linkedin": "https://www.linkedin.com/company/nomadstr",
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://static.wixstatic.com/media/bad19e_c10dc5385f5644cda9ee247750b31dca%7Emv2.jpg/v1/fill/w_180%2Ch_180%2Clg_1%2Cusm_0.66_1.00_0.01/bad19e_c10dc5385f5644cda9ee247750b31dca%7Emv2.jpg",
+    "description": "Austin-based full-service STR manager for Austin + Hill Country; recently acquired KOZE Vacation Rentals.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Hill Country Premier Lodging",
+    "website": "https://www.hillcountrypremier.com/",
+    "propertiesEstimate": "100+",
+    "contactName": null,
+    "email": "info@hillcountrypremier.com",
+    "phone": "512-847-7460",
+    "socials": {
+      "instagram": "https://www.instagram.com/hcplvacations/",
+      "facebook": "https://www.facebook.com/HCPLvacations/",
+      "linkedin": "https://www.linkedin.com/company/hill-country-premier-lodging/",
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://www.hillcountrypremier.com/wp-content/uploads/2024/03/hcpl-logo.png",
+    "description": "Regional Hill Country heavyweight (20,000 reservations in 2024) — Wimberley, Dripping Springs, Canyon Lake, greater Austin.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Renters Club",
+    "website": "https://www.renters-club.com/",
+    "propertiesEstimate": "~40-90",
+    "contactName": null,
+    "email": null,
+    "phone": "512-952-9113",
+    "socials": {
+      "instagram": "https://www.instagram.com/rentersclub",
+      "facebook": "https://www.facebook.com/therentersclub",
+      "linkedin": null,
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://www.renters-club.com/wp-content/uploads/2023/02/2.png",
+    "description": "Membership-style curated luxury vacation home collection in Austin (S Lamar HQ) with concierge support.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Vivant Stays",
+    "website": "https://vivantstays.com/",
+    "propertiesEstimate": "~85",
+    "contactName": null,
+    "email": null,
+    "phone": "512-571-3602",
+    "socials": {
+      "instagram": "https://www.instagram.com/vivantstays/",
+      "facebook": "https://www.facebook.com/Vivant-Stays-104596691219200",
+      "linkedin": null,
+      "twitter": "https://twitter.com/vivantstays",
+      "youtube": "https://www.youtube.com/channel/UC1T7BRLSZRy5s30k4I4UoEQ",
+      "tiktok": null
+    },
+    "logoUrl": "https://vivantstays.com/wp-content/uploads/2022/07/vivant_logo.svg",
+    "description": "Austin operator of designer STRs, corporate housing, and furnished mid-term stays with data-backed revenue management.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Evolve (Austin)",
+    "website": "https://evolve.com/vacation-rentals/us/tx/austin",
+    "propertiesEstimate": "~58 in Austin",
+    "contactName": null,
+    "email": null,
+    "phone": null,
+    "socials": {
+      "instagram": "https://www.instagram.com/evolvevacationrental/",
+      "facebook": "https://www.facebook.com/evolvevacationrental/",
+      "linkedin": "https://linkedin.com/company/evolve-vacation-rental",
+      "twitter": "https://twitter.com/evolvevr",
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": null,
+    "description": "National light-touch vacation rental platform (10-15% fee) with dozens of Austin properties.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Vacay Hill Country",
+    "website": "https://vacayhillcountry.com/",
+    "propertiesEstimate": "~50+",
+    "contactName": null,
+    "email": null,
+    "phone": "830-730-5921",
+    "socials": {
+      "instagram": "https://www.instagram.com/vacayhillcountry/",
+      "facebook": "https://www.facebook.com/VacayHillCountry/",
+      "linkedin": null,
+      "twitter": "https://twitter.com/vacaytexashill",
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://vacayhillcountry.com/wp-content/uploads/2021/12/Vacayhill-country-fixed.png",
+    "description": "Local Hill Country company (~50+ homes) in Wimberley, Canyon Lake, New Braunfels; 92% owner retention.",
+    "partnerSlug": null
+  },
+  {
+    "name": "GuestSpaces",
+    "website": "https://guestspaces.com/",
+    "propertiesEstimate": "~45",
+    "contactName": null,
+    "email": "info@guestspaces.com",
+    "phone": "512-956-9977",
+    "socials": {
+      "instagram": "https://www.instagram.com/guestspaces",
+      "facebook": "https://www.facebook.com/guestspaces",
+      "linkedin": null,
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://guestspaces.com/wp-content/uploads/2021/02/cropped-cropped-guestspaces_logo_-_light_background-4-250x67.jpg",
+    "description": "Award-winning boutique manager of luxury STR homes and lake houses — Austin, Dripping Springs, Texas lake communities.",
+    "partnerSlug": null
+  },
+  {
+    "name": "AvantStay (Austin)",
+    "website": "https://avantstay.com/austin-vacation-rental-management",
+    "propertiesEstimate": "~34 in Austin",
+    "contactName": null,
+    "email": null,
+    "phone": "415-246-5723",
+    "socials": {
+      "instagram": "https://www.instagram.com/avantstay",
+      "facebook": "https://www.facebook.com/avantstay",
+      "linkedin": "https://www.linkedin.com/company/avantstay",
+      "twitter": null,
+      "youtube": null,
+      "tiktok": "https://www.tiktok.com/@avantstay"
+    },
+    "logoUrl": "https://avantstay.com/apple-touch-icon.png",
+    "description": "National luxury/group STR brand with a dedicated Austin portfolio and local ops team — big bachelorette-group inventory.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Walker Luxury Vacation Rentals",
+    "website": "https://www.walkervr.com/",
+    "propertiesEstimate": "~30",
+    "contactName": null,
+    "email": null,
+    "phone": "512-501-3580",
+    "socials": {
+      "instagram": "https://www.instagram.com/walkerluxuryvacationrentals/",
+      "facebook": "https://www.facebook.com/WalkerLuxuryVacationRentals/",
+      "linkedin": "https://www.linkedin.com/company/walker-luxury-vacation-rentals",
+      "twitter": null,
+      "youtube": null,
+      "tiktok": "https://www.tiktok.com/@walkerluxury"
+    },
+    "logoUrl": "https://www.walkervr.com/wp-content/uploads/2024/11/logo-walkervr.png",
+    "description": "Austin's first boutique property manager focused exclusively on high-end luxury vacation homes incl. Lake Austin waterfront.",
+    "partnerSlug": null
+  },
+  {
+    "name": "North Shore Vacation Rentals",
+    "website": "https://www.theislandonlaketravis.com/",
+    "propertiesEstimate": "30+",
+    "contactName": null,
+    "email": null,
+    "phone": "512-267-4887",
+    "socials": {
+      "instagram": null,
+      "facebook": "https://www.facebook.com/NSVRentals/",
+      "linkedin": null,
+      "twitter": "https://twitter.com/NSVRentals",
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://www.theislandonlaketravis.com/wp-content/uploads/2025/09/north-shore-vacation-rentals-logo-188x50.png",
+    "description": "Manages 30+ privately owned condos and homes on Lake Travis's North Shore (Island Resort, The Hollows, Point Venture).",
+    "partnerSlug": null
+  },
+  {
+    "name": "ABOVE Vacation Residences",
+    "website": "https://www.bookabove.com/",
+    "propertiesEstimate": "~25-27 in Austin area",
+    "contactName": null,
+    "email": "reservations@bookabove.com",
+    "phone": "800-424-1927",
+    "socials": {
+      "instagram": "https://www.instagram.com/bookabove/",
+      "facebook": "https://www.facebook.com/abovevacationresidences/",
+      "linkedin": null,
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://www.bookabove.com/sites/natx/files/styles/ngt_logo/public/natx/ngt_logo/AboveAustin-23.png",
+    "description": "Austin-HQ'd (Bee Cave) luxury estate rental brand with concierge managers and house valets — Lake Austin, Lake Travis, Lake LBJ.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Five Star Vacation Home Rentals",
+    "website": "https://www.fivestarvhr.com/",
+    "propertiesEstimate": "unknown (15,000+ guests hosted)",
+    "contactName": "Lucas Piper (owner); Ryan Leake (GM Austin)",
+    "email": null,
+    "phone": "512-501-2735",
+    "socials": {
+      "instagram": "https://www.instagram.com/fivestarvhr/",
+      "facebook": "https://www.facebook.com/fivestarvhr/",
+      "linkedin": null,
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://cdn.prod.website-files.com/61ef18a9db64b07a0eae8a06/69d33e741eacef5c3179de12_61f2b39b0638949d51645a64_Five%2520Star%2520White%2520Hor.webp",
+    "description": "Top-rated luxury STR manager in Central Texas (Austin, Lake Austin, Hill Country, San Antonio); 3,000+ five-star reviews.",
+    "partnerSlug": null
+  },
+  {
+    "name": "SkyRun Austin",
+    "website": "https://skyrun.com/austin/",
+    "propertiesEstimate": "unknown (Lake Travis + South Austin)",
+    "contactName": "Michael Munson (owner)",
+    "email": "austin@skyrun.com",
+    "phone": "512-900-4766",
+    "socials": {
+      "instagram": "https://www.instagram.com/skyrunvr/",
+      "facebook": "https://www.facebook.com/skyrunvr/",
+      "linkedin": "https://www.linkedin.com/company/skyrunvr/",
+      "twitter": "https://twitter.com/SkyRunVR",
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://cdn.skyrun.com/wp-content/uploads/2023/04/12205314/logo.svg",
+    "description": "Locally owned SkyRun franchise managing vacation homes, condos, and townhomes across Austin and Lake Travis.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Grand Welcome Austin",
+    "website": "https://www.austinmanagement.com/",
+    "propertiesEstimate": "unknown (Austin + Highland Lakes)",
+    "contactName": "Steven Brown & Alex Buchanan (owners); Tatum Heiliger (BD)",
+    "email": "hello@austinmanagement.com",
+    "phone": "737-260-0092",
+    "socials": {
+      "instagram": "https://www.instagram.com/grandwelcomebnbs",
+      "facebook": "https://www.facebook.com/profile.php?id=100092287778741",
+      "linkedin": null,
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://cdn.prod.website-files.com/64b95f5eb93062069a6a0f1d/64b95f5eb93062069a6a0f59_grand-welcome-256.png",
+    "description": "Locally owned boutique franchise for Austin + Highland Lakes; already partners with Bach Babes on bachelorette homes.",
+    "partnerSlug": null
+  },
+  {
+    "name": "512 Retreat",
+    "website": "https://512retreat.com/",
+    "propertiesEstimate": "unknown (multi-home luxury portfolio)",
+    "contactName": null,
+    "email": "reservations@512retreat.com",
+    "phone": "512-851-1143",
+    "socials": {
+      "instagram": "https://www.instagram.com/512retreat/",
+      "facebook": "https://www.facebook.com/512RetreatLuxuryVacation/",
+      "linkedin": null,
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://512retreat.com/wp-content/uploads/2022/04/512Retreat_NewLogo-e1650569324429.png",
+    "description": "Locally grown luxury Austin vacation rental company with concierge services (chefs, event planning, yachts) and a bachelorette collection.",
+    "partnerSlug": null
+  },
+  {
+    "name": "BacheloretteStays",
+    "website": "https://www.bachelorettestays.com/",
+    "propertiesEstimate": "unknown (multiple themed homes incl. The Pink House ATX)",
+    "contactName": null,
+    "email": "hello@bachelorettestays.com",
+    "phone": null,
+    "socials": {
+      "instagram": "https://www.instagram.com/bachelorettestays/",
+      "facebook": null,
+      "linkedin": "https://www.linkedin.com/company/bachelorettestays/",
+      "twitter": null,
+      "youtube": null,
+      "tiktok": "https://www.tiktok.com/@bachelorettestays"
+    },
+    "logoUrl": "https://www.bachelorettestays.com/images/instagram-logo.avif",
+    "description": "Themed party rentals (flower walls, neon murals) for bachelorette/birthday/girls' trips with Austin properties — perfect ICP overlap.",
+    "partnerSlug": null
+  },
+  {
+    "name": "SPRKhost",
+    "website": "https://sprkhost.com/",
+    "propertiesEstimate": "unknown (downtown, Lake Travis, Hill Country)",
+    "contactName": "Rachel & Joe (co-founders)",
+    "email": "support@sprkhost.com",
+    "phone": null,
+    "socials": {
+      "instagram": "https://www.instagram.com/sprkhost_vacations/",
+      "facebook": "https://www.facebook.com/sprkhostvacations/",
+      "linkedin": null,
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": null,
+    "description": "Husband-and-wife Austin luxury vacation rental brand with pool/lakefront homes, direct booking, concierge service.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Stay Local Austin",
+    "website": "https://austinvacationrentals.com/",
+    "propertiesEstimate": "unknown (Austin, Dripping Springs, Lakeway, Lake Travis)",
+    "contactName": null,
+    "email": "stay@staylocalatx.com",
+    "phone": "512-426-5485",
+    "socials": {
+      "instagram": "https://www.instagram.com/staylocalaustintx/",
+      "facebook": "https://www.facebook.com/StayLocalATX/",
+      "linkedin": null,
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://austinvacationrentals.com/wp-content/uploads/2025/11/StayAustin-rgb-cropped.svg",
+    "description": "Local vacation rental manager (Portoro-affiliated) covering downtown Austin to Hill Country and Lake Travis.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Guest Haus",
+    "website": "https://guesthausrentals.com/",
+    "propertiesEstimate": "unknown",
+    "contactName": null,
+    "email": "info@guesthausrentals.com",
+    "phone": "512-823-1286",
+    "socials": {
+      "instagram": "https://www.instagram.com/guesthauspm/",
+      "facebook": "https://www.facebook.com/guesthauspm/",
+      "linkedin": "https://www.linkedin.com/company/guest-haus/",
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://guesthausrentals.com/wp-content/uploads/2024/02/Austin-Texas-Keep-the-shadow-transparend-background-768x768.webp",
+    "description": "Austin-local STR/mid-term manager with net-revenue-share pricing and STR permit/compliance handling.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Barclé Group",
+    "website": "https://barclegroup.com/",
+    "propertiesEstimate": "unknown",
+    "contactName": null,
+    "email": "support@barclegroup.com",
+    "phone": "888-855-7418",
+    "socials": {
+      "instagram": "https://www.instagram.com/barclegroup/",
+      "facebook": "https://www.facebook.com/barclegroup",
+      "linkedin": "https://www.linkedin.com/company/barclegroup/about/",
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://barclegroup.com/wp-content/uploads/2025/05/logo-barcle-club.png",
+    "description": "Premium Austin STR management firm — marketing, guest screening, dynamic pricing, luxury interior design.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Surge",
+    "website": "https://www.gowithsurge.com/",
+    "propertiesEstimate": "unknown (12 markets; Austin home base)",
+    "contactName": "Humberto Marquez (founder)",
+    "email": "hello@gowithsurge.com",
+    "phone": "888-616-8149",
+    "socials": {
+      "instagram": "https://www.instagram.com/gowithsurge/",
+      "facebook": "https://www.facebook.com/gowithsurge",
+      "linkedin": "https://www.linkedin.com/company/gowithsurge/",
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://www.gowithsurge.com/surge-logo-teal.png",
+    "description": "Austin-rooted full-service STR company (management, brokerage, interior design) at a 15% fee; 4.9 Superhost rating.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Oberg Properties",
+    "website": "https://www.obergproperties.com/",
+    "propertiesEstimate": "unknown (Lake Travis since 1984)",
+    "contactName": null,
+    "email": null,
+    "phone": "512-263-5200",
+    "socials": {
+      "instagram": "https://www.instagram.com/obergproperties",
+      "facebook": "https://www.facebook.com/obergproperties",
+      "linkedin": null,
+      "twitter": null,
+      "youtube": "https://www.youtube.com/user/ObergProperties",
+      "tiktok": null
+    },
+    "logoUrl": "https://lirp.cdn-website.com/cdcd1caf/dms3rep/multi/opt/white-logo-icon-1920w.png",
+    "description": "Lakeway/Lake Travis property management firm operating vacation rentals since 1984.",
+    "partnerSlug": null
+  },
+  {
+    "name": "MOD Property Management",
+    "website": "https://modpmco.com/",
+    "propertiesEstimate": "unknown",
+    "contactName": null,
+    "email": null,
+    "phone": "512-956-6364",
+    "socials": {
+      "instagram": "https://www.instagram.com/modpmco/",
+      "facebook": "https://www.facebook.com/modpmco",
+      "linkedin": null,
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://modpmco.com/wp-content/uploads/2020/09/MOD1.png",
+    "description": "Austin-based Airbnb management and hosting company covering Greater Austin and the Hill Country.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Hill Country Lakes Rentals",
+    "website": "https://www.hillcountrylakesrentals.com/",
+    "propertiesEstimate": "~15+",
+    "contactName": "Bill (property manager)",
+    "email": null,
+    "phone": "512-267-7000",
+    "socials": {
+      "instagram": null,
+      "facebook": "https://www.facebook.com/Hollows-Vacation-Rentals-208284062690759/",
+      "linkedin": null,
+      "twitter": "https://twitter.com/HollowsVacation",
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://www.hillcountrylakesrentals.com/wp-content/uploads/2025/09/cropped-hclc-logo-1-220x55.png",
+    "description": "Local manager of privately owned vacation homes on Lake Travis's North Shore (Hollows Resort, Jonestown area).",
+    "partnerSlug": null
+  },
+  {
+    "name": "Management With Love",
+    "website": "https://www.managementwithlove.com/",
+    "propertiesEstimate": "~10",
+    "contactName": null,
+    "email": "managementwithlove@gmail.com",
+    "phone": "512-966-9701",
+    "socials": {
+      "instagram": null,
+      "facebook": null,
+      "linkedin": null,
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": null,
+    "description": "Boutique manager of ~10 lakeside vacation homes in Point Venture on Lake Travis's north shore.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Bach Bros Properties",
+    "website": "https://www.bachbrosproperties.com/",
+    "propertiesEstimate": "unknown (Fredericksburg, Austin, Round Rock)",
+    "contactName": "Joe & Max Bachmeier (founders)",
+    "email": "info@bachbrosproperties.com",
+    "phone": "830-355-2598",
+    "socials": {
+      "instagram": "https://www.instagram.com/bachbrosproperties/",
+      "facebook": "https://www.facebook.com/people/bachbrosproperties/100089914865506/",
+      "linkedin": null,
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://le-de.cdn-website.com/08ade2e0ba474aa58a76e4d7bad4d58f/dms3rep/multi/opt/Bach-Bros-Logos--286-29-320w.png",
+    "description": "Family-owned Hill Country STR manager with Austin inventory; AirDNA #1 US property manager for 2025.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Lazy H Retreats",
+    "website": "https://www.lazyhretreats.com/",
+    "propertiesEstimate": "unknown",
+    "contactName": null,
+    "email": "stay@lazyhretreats.com",
+    "phone": "830-308-7202",
+    "socials": {
+      "instagram": "https://www.instagram.com/lazyhretreats/",
+      "facebook": "https://www.facebook.com/Lazy-H-Retreats-105649469097634/",
+      "linkedin": null,
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://www.lazyhretreats.com/wp-content/uploads/2024/12/LHR-circle-logo-transparent-color-1-e1733850393429.png",
+    "description": "Hill Country vacation rental manager whose service area includes Austin, Kyle, Canyon Lake, New Braunfels.",
+    "partnerSlug": null
+  },
+  {
+    "name": "One Fine BnB",
+    "website": "https://onefinebnb.com/",
+    "propertiesEstimate": "unknown (Austin HQ; global portfolio)",
+    "contactName": null,
+    "email": null,
+    "phone": "512-566-3800",
+    "socials": {
+      "instagram": null,
+      "facebook": null,
+      "linkedin": null,
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://onefinebnb.com/wp-content/uploads/2024/09/Join-the-One-Fine-Bnb-Family-and-Start-Growing-Your-Business-Today-.webp",
+    "description": "Austin-headquartered flat 10%-fee Airbnb management company using AI-driven optimization across 50+ platforms.",
+    "partnerSlug": null
+  },
+  {
+    "name": "MasterHost (Austin)",
+    "website": "https://masterhost.ca/airbnb-management-austin/",
+    "propertiesEstimate": "300+ claimed in Austin",
+    "contactName": null,
+    "email": null,
+    "phone": null,
+    "socials": {
+      "instagram": "https://www.instagram.com/masterhost.ca",
+      "facebook": "https://www.facebook.com/masterhost.ca",
+      "linkedin": "https://www.linkedin.com/company/masterhost",
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": null,
+    "description": "International Airbnb management company (est. 2015) with a large claimed Austin portfolio; contact via web form.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Twinity Properties",
+    "website": "https://twinityproperties.com/",
+    "propertiesEstimate": "unknown (Austin, Houston, San Antonio, Galveston)",
+    "contactName": null,
+    "email": null,
+    "phone": "832-281-4528",
+    "socials": {
+      "instagram": "https://www.instagram.com/twinityproperties",
+      "facebook": null,
+      "linkedin": null,
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://twinityproperties.com/wp-content/uploads/2023/05/tp-logo-primary.svg",
+    "description": "Texas STR management firm handling housekeeping, pricing, permits, and tax remittance for Austin owners.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Guestable",
+    "website": "https://www.guestable.com/austin-vacation-rental-property-management/",
+    "propertiesEstimate": "unknown",
+    "contactName": null,
+    "email": null,
+    "phone": "800-710-7839",
+    "socials": {
+      "instagram": "https://www.instagram.com/guestablehomes/",
+      "facebook": null,
+      "linkedin": "https://www.linkedin.com/company/guestable/",
+      "twitter": "https://twitter.com/guestablehomes",
+      "youtube": "https://www.youtube.com/channel/UCn7V_dD5KlotiMZf1Rz4JYA",
+      "tiktok": null
+    },
+    "logoUrl": "https://www.guestable.com/wp-content/uploads/2018/07/Guestable_Logo.svg",
+    "description": "Data-driven multi-city Airbnb management company with a dedicated Austin operation (HQ Toronto — verify local team).",
+    "partnerSlug": null
+  },
+  {
+    "name": "Nest Vacation Rentals",
+    "website": "https://www.nestvr.com/",
+    "propertiesEstimate": "unknown (boutique luxury collection)",
+    "contactName": null,
+    "email": null,
+    "phone": "512-887-8076",
+    "socials": {
+      "instagram": null,
+      "facebook": "https://www.facebook.com/pages/Nest-Vacation-Rentals/825218760873305",
+      "linkedin": null,
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://www.nestvr.com/wp-content/uploads/2016/02/logo-254x122-300x157-215x113.jpg",
+    "description": "Boutique luxury Austin vacation rental company — downtown bungalows to Hill Country estates.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Casago Austin",
+    "website": "https://casago.com/austin/",
+    "propertiesEstimate": "unknown (Natiivo Austin condos + area homes)",
+    "contactName": "Andy Ross (local franchise owner)",
+    "email": null,
+    "phone": "512-996-3353",
+    "socials": {
+      "instagram": "https://www.instagram.com/casago",
+      "facebook": "https://www.facebook.com/casago.properties",
+      "linkedin": "https://www.linkedin.com/company/casagoproperties",
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://casago.com/images/logos/casago-logo.svg",
+    "description": "Locally owned Casago franchise offering full-service vacation rental management in Austin/Round Rock.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Awning",
+    "website": "https://awning.com/vacation-rental-property-management/austin-texas",
+    "propertiesEstimate": "unknown for Austin (20,000+ nationwide)",
+    "contactName": null,
+    "email": "hello@awning.com",
+    "phone": "415-612-5985",
+    "socials": {
+      "instagram": null,
+      "facebook": "https://www.facebook.com/tryawning",
+      "linkedin": null,
+      "twitter": "https://twitter.com/tryawning",
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://cdn.prod.website-files.com/6124d988b927e9bf3788a541/6391252247a38f08f0fabb25_awning-logo-new.svg",
+    "description": "Tech-enabled nationwide Airbnb/STR management company (from 10% of revenue) with Austin operators.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Locale Hospitality",
+    "website": "https://www.locale.com/city/austin",
+    "propertiesEstimate": "multiple Austin buildings (Rainey St, SoCo, Domain, East Austin)",
+    "contactName": null,
+    "email": "partners@locale.com",
+    "phone": null,
+    "socials": {
+      "instagram": null,
+      "facebook": "https://www.facebook.com/staywithlocale/",
+      "linkedin": "https://www.linkedin.com/company/localehospitality",
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": null,
+    "description": "Austin-founded (2016) tech-forward hospitality company operating furnished apartments/extended stays across Austin.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Restoration 43",
+    "website": "https://restoration43.com/",
+    "propertiesEstimate": "unknown",
+    "contactName": null,
+    "email": "team@restoration43.com",
+    "phone": "972-210-3743",
+    "socials": {
+      "instagram": "https://www.instagram.com/restoration43llc",
+      "facebook": "https://www.facebook.com/Restore437",
+      "linkedin": null,
+      "twitter": null,
+      "youtube": "https://www.youtube.com/channel/UC3-ywUWqOJer_MHscqvr5yg",
+      "tiktok": null
+    },
+    "logoUrl": "https://static.wixstatic.com/media/7be61d_c78818483e0c45ed8edaad2ccaa48a62~mv2.png/v1/fill/w_141,h_98,al_c,q_85,usm_0.66_1.00_0.01,enc_avif,quality_auto/Website%20Logo.png",
+    "description": "TREC-registered short/mid-term rental management team in Austin, Houston, and Dallas with 24/7 support.",
+    "partnerSlug": null
+  },
+  {
+    "name": "HostStarter",
+    "website": "https://hoststarter.net/austin/",
+    "propertiesEstimate": "unknown (33+ markets incl. Austin)",
+    "contactName": null,
+    "email": "hoststarterhelp@gmail.com",
+    "phone": "469-324-0864",
+    "socials": {
+      "instagram": null,
+      "facebook": null,
+      "linkedin": null,
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://hoststarter.net/wp-content/uploads/2026/04/hoststarter-logo-v2.png",
+    "description": "Flat-fee (12.5%) full-service STR management with a dedicated Austin market incl. licensing support.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Clear Stay Properties",
+    "website": "https://clearstayproperties.com/",
+    "propertiesEstimate": "unknown (boutique)",
+    "contactName": null,
+    "email": null,
+    "phone": null,
+    "socials": {
+      "instagram": null,
+      "facebook": null,
+      "linkedin": null,
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://images.squarespace-cdn.com/content/v1/637f7dd1f0e600118df48095/f17acbf7-f349-45b9-baf4-22072ccf0c7c/CS_Logo_RGB_03.png?format=1500w",
+    "description": "Boutique design-driven STR management serving Austin, Dripping Springs, and the Hill Country (contact via discovery-call form).",
+    "partnerSlug": null
+  },
+  {
+    "name": "JW Properties (Lake Travis)",
+    "website": "https://laketravisrental.net/",
+    "propertiesEstimate": "~5-15 waterfront",
+    "contactName": "Jacqueline Wittmuss (broker/owner)",
+    "email": "info@laketravisrental.net",
+    "phone": "512-917-1717",
+    "socials": {
+      "instagram": null,
+      "facebook": null,
+      "linkedin": null,
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://laketravisrental.net/website/agent_zseries_files/3939/logo.png",
+    "description": "Owner-operated luxury waterfront vacation rental + real estate company on Lake Travis and Lake Austin.",
+    "partnerSlug": null
+  },
+  {
+    "name": "iTrip Vacations Austin",
+    "website": "https://austin.itrip.co",
+    "propertiesEstimate": "~20-40",
+    "contactName": "Josh Meisel (owner)",
+    "email": null,
+    "phone": "888-304-2668",
+    "socials": {
+      "instagram": "https://www.instagram.com/itripaustin/",
+      "facebook": "https://www.facebook.com/itripaustin",
+      "linkedin": "https://www.linkedin.com/in/joshmeisel/",
+      "twitter": "https://twitter.com/itripaustin",
+      "youtube": null,
+      "tiktok": "https://www.tiktok.com/@itrip.austin"
+    },
+    "logoUrl": "http://pittsburgh.itrip.co/wp-content/uploads/sites/149/2025/08/Vrbo-Logo.png",
+    "description": "Locally owned iTrip franchise managing vacation rentals across greater Austin (Round Rock, Lago Vista, Lakeway, Dripping Springs) on 80+ channels.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Via Luxury Rentals",
+    "website": "https://vialuxuryrentals.com",
+    "propertiesEstimate": "~10",
+    "contactName": "Kyle (co-founder)",
+    "email": "kyle@vialuxuryrentals.com",
+    "phone": "512-900-9747",
+    "socials": {
+      "instagram": "https://www.instagram.com/via_luxuryrentals",
+      "facebook": "https://www.facebook.com/Via-Luxury-Rentals",
+      "linkedin": "https://www.linkedin.com/company/via-luxury-rentals-property-management",
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://vialuxuryrentals.com/wp-content/uploads/2025/12/cropped-Via-Luxury-Rentals-Logo-512x512-1-180x180.png",
+    "description": "Boutique Austin luxury STR manager founded by ex-Airbnb Superhosts (East Austin HQ).",
+    "partnerSlug": null
+  },
+  {
+    "name": "Austin BNB Management",
+    "website": "https://www.austinbnbmanagement.com",
+    "propertiesEstimate": "~15-20",
+    "contactName": null,
+    "email": null,
+    "phone": "512-660-7531",
+    "socials": {
+      "instagram": null,
+      "facebook": null,
+      "linkedin": null,
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://4b11d1dded.clvaw-cdnwnd.com/a9bbcea42d0a88d79a3d1da2f40e472e/200000019-7c5207c523/Correct_Area_logo-01-01.PNG?ph=4b11d1dded",
+    "description": "Local '100% hands-off' STR manager (W 10th St); claims $3.1M+ earned for clients, Superhost status on all properties.",
+    "partnerSlug": null
+  },
+  {
+    "name": "PMI ATX Properties",
+    "website": "https://www.austinpropertymanagementinc.com",
+    "propertiesEstimate": "unknown (likely 10+)",
+    "contactName": null,
+    "email": "info@pmiatxproperties.com",
+    "phone": "512-651-4255",
+    "socials": {
+      "instagram": "https://www.instagram.com/str_property_management_expert/",
+      "facebook": "https://www.facebook.com/pmiatxproperties/",
+      "linkedin": "https://www.linkedin.com/company/pmi-atx-properties",
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://pmi-resources.nesthub.com/images/logos/PMI-ATX-Properties.png",
+    "description": "Locally owned PMI franchise managing STR vacation rentals + residential properties in Austin.",
+    "partnerSlug": null
+  },
+  {
+    "name": "ATX Luxury Rentals",
+    "website": "https://atxluxuryrentals.com",
+    "propertiesEstimate": "~6",
+    "contactName": "Stephen",
+    "email": "contact@atxluxuryrentals.com",
+    "phone": "512-402-5172",
+    "socials": {
+      "instagram": null,
+      "facebook": null,
+      "linkedin": null,
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://atxluxuryrentals.com/wp-content/uploads/2025/03/045-431259-16012-Canard-Circle20221119_0066_12020489.webp",
+    "description": "Austin Airbnb management specialist — furnishing, revenue optimization, STR licensing, cleaning, maintenance.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Placemakr (Austin)",
+    "website": "https://www.placemakr.com/locations/austin",
+    "propertiesEstimate": "2 buildings, dozens of units",
+    "contactName": null,
+    "email": "info@placemakr.com",
+    "phone": null,
+    "socials": {
+      "instagram": "https://www.instagram.com/placemakr/",
+      "facebook": "https://www.facebook.com/placemakr/",
+      "linkedin": "https://www.linkedin.com/company/placemakr/",
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://www.placemakr.com/hubfs/logo.svg",
+    "description": "Apartment-hotel operator with flexible furnished stays in downtown Austin (Placemakr Downtown + Littlefield Lofts); corporate/group housing arm.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Kasa (Austin)",
+    "website": "https://kasa.com/locations/austin-tx",
+    "propertiesEstimate": "5 Austin buildings (multi-unit)",
+    "contactName": null,
+    "email": null,
+    "phone": null,
+    "socials": {
+      "instagram": "https://www.instagram.com/staykasa/",
+      "facebook": "https://www.facebook.com/StayKasa",
+      "linkedin": "https://www.linkedin.com/company/kasa-living",
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://kasa.com/favicons/apple-icon-180x180.png",
+    "description": "Tech-enabled flexible-stay operator running furnished apartment-hotels in Austin incl. Kasa Downtown Austin.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Mint House (Austin)",
+    "website": "https://minthouse.com",
+    "propertiesEstimate": "25 units (South Congress)",
+    "contactName": null,
+    "email": null,
+    "phone": null,
+    "socials": {
+      "instagram": "https://www.instagram.com/minthouse/",
+      "facebook": "https://www.facebook.com/minthousehq",
+      "linkedin": "https://www.linkedin.com/company/mint-house",
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://framerusercontent.com/images/FB6WD3lPzOcxWjBGCgbTjOIj0.jpg",
+    "description": "Apartment-hotel brand with a 25-unit South Congress property (1007 S Congress Ave).",
+    "partnerSlug": null
+  },
+  {
+    "name": "Log Country Cove",
+    "website": "https://logcountrycove.com",
+    "propertiesEstimate": "37 (32 cabins + 5 lake homes)",
+    "contactName": null,
+    "email": null,
+    "phone": "512-756-9132",
+    "socials": {
+      "instagram": "https://www.instagram.com/logcountrycove/",
+      "facebook": "https://www.facebook.com/logcountrycove/",
+      "linkedin": null,
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": "https://logcountrycove.com/wp-content/uploads/2020/05/LCC-2020-Logo-003-e1589429010608.png",
+    "description": "Waterfront cabin resort on Lake LBJ (Burnet) — 37 furnished units, popular Austin group-getaway destination.",
+    "partnerSlug": null
+  },
+  {
+    "name": "Blueground (Austin)",
+    "website": "https://www.theblueground.com/furnished-apartments-austin-tx",
+    "propertiesEstimate": "16+ Austin apartments",
+    "contactName": null,
+    "email": null,
+    "phone": null,
+    "socials": {
+      "instagram": "https://www.instagram.com/bluegroundhomes/",
+      "facebook": "https://www.facebook.com/theblueground/",
+      "linkedin": "https://www.linkedin.com/company/blueground-co/",
+      "twitter": "https://twitter.com/theblueground",
+      "youtube": "https://www.youtube.com/channel/UC-82kDB6nRWUBSguDHw6-bg",
+      "tiktok": null
+    },
+    "logoUrl": "https://cdn.theblueground.com/website/static/img/logo-icon-wordmark-blue-main.e8343518eda1a7cc3f03.svg",
+    "description": "Global furnished-apartment operator with premium month-to-month stays across Austin (corporate/mid-term skew).",
+    "partnerSlug": null
+  },
+  {
+    "name": "Limestone Country Properties",
+    "website": "https://www.limestone-country.com",
+    "propertiesEstimate": "unknown (Canyon Lake / New Braunfels)",
+    "contactName": null,
+    "email": null,
+    "phone": "830-253-0018",
+    "socials": {
+      "instagram": null,
+      "facebook": null,
+      "linkedin": null,
+      "twitter": null,
+      "youtube": null,
+      "tiktok": null
+    },
+    "logoUrl": null,
+    "description": "Hill Country property manager covering vacation + residential rentals in Canyon Lake and New Braunfels.",
+    "partnerSlug": null
+  }
+]

--- a/src/lib/partners/logo-scraper.ts
+++ b/src/lib/partners/logo-scraper.ts
@@ -71,7 +71,8 @@ export async function urlServesImage(url: string): Promise<boolean> {
 
 /** Resolve a possibly-relative src against the page URL; null if unusable. */
 function absolutize(src: string, pageUrl: string): string | null {
-  const trimmed = src.trim();
+  // srcs come from raw HTML attributes — unescape entities like &amp;
+  const trimmed = src.trim().replaceAll('&amp;', '&');
   if (!trimmed || trimmed.startsWith('data:')) return null;
   try {
     return new URL(trimmed, pageUrl).toString();


### PR DESCRIPTION
## What

New **STR Partners** tab in Brian's Stuff (`/admin/brians-stuff?tab=str`):

- **54 Austin/Hill Country STR companies** (targeting 5+ homes) researched via parallel web sweeps, deduped by domain. Each row: hyperlinked company site, scraped+fetch-validated logo (48/54), homes estimate, contact name, mailto/tel links (48/54 with direct contact), social profiles (IG/FB/LI/X/YT/TT), one-line description, and partner-page status.
- **Copy CSV for Bulk Import** button emits pending rows in the exact `/admin/affiliates/bulk-import` format (LODGING, 10% default) — the intended path to mass-create their partner pages.
- **Lynn's Lodging** ('Lens Lodgings' as originally heard) created as the first real partner: DRAFT affiliate, `/partners/lynns-lodging`, logo set from their site.
- logo-scraper: unescape HTML entities in candidate URLs (found via a real `&amp;` case).

## Verification
- tsc fully clean, lint clean, 872/872 tests pass (npm install fixed the stale local deps — plaid test files now run)
- Logos fetch-validated during scraping (only URLs that actually serve images stored)
- NOT verified: authenticated visual render of the admin tab (local env lacks JWT_SECRET for ops login) — component follows the identical pattern of the 10 existing tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)