### PR TITLE
fix(refunds): clean historical duplicate Refund rows (incl. #197) via hardened reconcile script

### DIFF
--- a/scripts/ops/__tests__/reconcile-refunds-plan.test.mjs
+++ b/scripts/ops/__tests__/reconcile-refunds-plan.test.mjs
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for the pure planner in scripts/ops/reconcile-duplicate-refunds.mjs.
+ *
+ * planOrder() decides which financial Refund rows get permanently deleted, so its
+ * edge cases are pinned here. The script is import-safe (its CLI entrypoint is
+ * guarded by an import.meta check), so importing planOrder does not touch the DB,
+ * Stripe, or the environment.
+ */
+import { describe, it, expect } from 'vitest';
+import { planOrder, WEBHOOK_IDEMPOTENT_SINCE } from '../reconcile-duplicate-refunds.mjs';
+
+const PRE = new Date('2026-05-24T15:03:28.000Z'); // before the #171 idempotency cutover
+const POST = new Date('2026-07-01T00:00:00.000Z'); // after the cutover
+const order = { id: 'order_1', orderNumber: 197 };
+const NONE = new Set();
+
+function row(id, amount, opts = {}) {
+  const { stripeRefundId = null, reason = 'Stripe refund', createdAt = PRE } = opts;
+  return { id, stripeRefundId, amount, reason, processedBy: stripeRefundId ? 'admin' : null, createdAt };
+}
+function sref(id, dollars, status = 'succeeded') {
+  return { id, amountCents: Math.round(dollars * 100), status };
+}
+
+describe('planOrder — refund de-dup planner', () => {
+  it('deletes BOTH dupes for the #197 cumulative-total pattern (pre-cutover)', () => {
+    const dbRows = [
+      row('r_real1', 238.93, { stripeRefundId: 're_a', reason: 'Return: items returned' }),
+      row('r_dup1', 238.93), // same-amount webhook dupe
+      row('r_real2', 295.9, { stripeRefundId: 're_b', reason: 'Return: items returned' }),
+      row('r_cumul', 534.83), // cumulative-total webhook dupe (matches no single Stripe refund)
+    ];
+    const stripeRefunds = [sref('re_a', 238.93), sref('re_b', 295.9)];
+    const plan = planOrder(order, dbRows, stripeRefunds, NONE);
+    expect(plan.ok).toBe(true);
+    expect(plan.merges).toHaveLength(0);
+    expect(plan.deletes.map((d) => d.rowId).sort()).toEqual(['r_cumul', 'r_dup1']);
+  });
+
+  it('deletes a plain same-amount dupe (pre-cutover) and reconciles 1:1', () => {
+    const dbRows = [
+      row('r_real', 90.49, { stripeRefundId: 're_a', reason: 'Order cancelled' }),
+      row('r_dup', 90.49),
+    ];
+    const plan = planOrder(order, dbRows, [sref('re_a', 90.49)], NONE);
+    expect(plan.ok).toBe(true);
+    expect(plan.deletes.map((d) => d.rowId)).toEqual(['r_dup']);
+  });
+
+  it('does NOT delete a same-shaped orphan created AFTER the cutover (race-safety fence)', () => {
+    const dbRows = [
+      row('r_real', 50.0, { stripeRefundId: 're_a', reason: 'Order cancelled', createdAt: POST }),
+      row('r_orphan', 50.0, { createdAt: POST }), // legit-looking null-id 'Stripe refund' post-cutover
+    ];
+    const plan = planOrder(order, dbRows, [sref('re_a', 50.0)], NONE);
+    expect(plan.deletes).toHaveLength(0);
+    expect(plan.ok).toBe(false); // leftover row → post-condition fails → NEEDS-MANUAL
+    expect(plan.notes.join(' ')).toMatch(/after the #171 idempotency cutover/i);
+  });
+
+  it('never deletes when a live Stripe refund has no DB row (missing record)', () => {
+    const plan = planOrder(order, [row('r_dup', 99.99)], [sref('re_a', 40.0)], NONE);
+    expect(plan.deletes).toHaveLength(0);
+    expect(plan.ok).toBe(false);
+    expect(plan.notes.join(' ')).toMatch(/missing record/i);
+  });
+
+  it('merges (stamps) an unstamped orphan that matches a real Stripe refund — never deletes it', () => {
+    const plan = planOrder(order, [row('r_orphan', 8.97)], [sref('pyr_x', 8.97)], NONE);
+    expect(plan.ok).toBe(true);
+    expect(plan.merges).toHaveLength(1);
+    expect(plan.merges[0]).toMatchObject({ rowId: 'r_orphan', stripeRefundId: 'pyr_x' });
+    expect(plan.deletes).toHaveLength(0);
+  });
+
+  it('never deletes an orphan referenced by an OrderAmendment', () => {
+    const dbRows = [
+      row('r_real', 40.0, { stripeRefundId: 're_a', reason: 'Order amendment refund' }),
+      row('r_amend_orphan', 40.0),
+    ];
+    const plan = planOrder(order, dbRows, [sref('re_a', 40.0)], new Set(['r_amend_orphan']));
+    expect(plan.deletes).toHaveLength(0);
+    expect(plan.notes.join(' ')).toMatch(/OrderAmendment/i);
+    expect(plan.ok).toBe(false);
+  });
+
+  it('fails the whole order SAFE when a stamped row references a refund Stripe does not list (ghost)', () => {
+    const dbRows = [
+      row('r_ghost', 40.0, { stripeRefundId: 're_missing', reason: 'Order cancelled' }),
+      row('r_orphan', 40.0),
+    ];
+    const plan = planOrder(order, dbRows, [sref('re_a', 40.0)], NONE);
+    expect(plan.ok).toBe(false);
+    expect(plan.deletes).toHaveLength(0);
+    expect(plan.merges).toHaveLength(0);
+    expect(plan.notes.join(' ')).toMatch(/Stripe does not list/i);
+  });
+
+  it('does not treat a non-webhook orphan (different reason) as a dupe', () => {
+    const dbRows = [
+      row('r_real', 40.0, { stripeRefundId: 're_a', reason: 'Order cancelled' }),
+      row('r_manual', 40.0, { reason: 'Store credit' }), // manual DB-only refund, not a webhook artifact
+    ];
+    const plan = planOrder(order, dbRows, [sref('re_a', 40.0)], NONE);
+    expect(plan.deletes).toHaveLength(0);
+    expect(plan.ok).toBe(false);
+  });
+
+  it('the cutover fence is the documented instant', () => {
+    expect(WEBHOOK_IDEMPOTENT_SINCE.toISOString()).toBe('2026-06-28T00:00:00.000Z');
+  });
+});

--- a/scripts/ops/reconcile-duplicate-refunds.mjs
+++ b/scripts/ops/reconcile-duplicate-refunds.mjs
@@ -18,9 +18,12 @@
  *   - MERGE: a real Stripe refund that has NO stamped row but DOES have a
  *     matching-amount orphan → stamp the orphan with the Stripe refund id
  *     (claim it) rather than deleting + re-creating.
- *   - DELETE: an orphan row (stripeRefundId=NULL AND reason='Stripe refund')
- *     whose amount is already covered by a stamped, Stripe-verified row → the
- *     webhook duplicate. Deleted.
+ *   - DELETE: an orphan row (stripeRefundId=NULL AND reason='Stripe refund') on
+ *     an order whose every live Stripe refund is already represented by a
+ *     stamped, Stripe-verified row → the webhook duplicate. Deleted regardless
+ *     of its amount, so this also removes the pre-#171 "cumulative total" orphan
+ *     the old webhook wrote from charge.amount_refunded (e.g. order #197's
+ *     $534.83 orphan = the running total of two real refunds $238.93 + $295.90).
  *
  * SAFETY — it will only APPLY changes to an order when, AFTER the planned
  * changes, the order's remaining DB refund rows map 1:1 onto Stripe's live
@@ -42,28 +45,36 @@
 
 import { PrismaClient } from '@prisma/client';
 import Stripe from 'stripe';
+import { writeFileSync } from 'fs';
+import os from 'os';
+import path from 'path';
+import { pathToFileURL } from 'url';
 
-// Hard guard: without a LIVE Stripe key, refunds.list() silently returns empty
-// for every order and the script would "reconcile" against nothing — flagging
-// every order needs-manual while looking like it ran. Fail loudly instead.
 const STRIPE_KEY = process.env.STRIPE_SECRET_KEY;
-if (!STRIPE_KEY) {
-  console.error('ERROR: STRIPE_SECRET_KEY is not set. Run: set -a && source .env.local && set +a');
-  process.exit(1);
-}
-if (STRIPE_KEY.startsWith('sk_test_') || STRIPE_KEY.startsWith('rk_test_')) {
-  console.error('ERROR: STRIPE_SECRET_KEY is a TEST key. This reconciles LIVE refund data — refusing to run.');
-  process.exit(1);
-}
 
-const prisma = new PrismaClient();
-const stripe = new Stripe(STRIPE_KEY);
+// The live-key guard, the Prisma/Stripe clients, and main() run ONLY when this
+// file is executed directly as a script (see the entrypoint at the bottom). When
+// it is imported instead — e.g. a unit test exercising the pure planOrder() —
+// nothing here touches the network, the DB, or process.exit, and these stay
+// undefined. Keeping the pure planner import-safe is what lets it be tested.
+let prisma;
+let stripe;
 
 const args = process.argv.slice(2);
 const APPLY = args.includes('--apply');
 const OUT_JSON = args.includes('--json');
 const ONLY_ORDER = num(flag('--order'), 0);
 const CENT_TOLERANCE = 1; // 1 cent of slack on total comparisons
+
+// The instant the charge.refunded webhook became idempotent (PR #171, merged
+// 2026-06-27 21:13 UTC; last observed pre-fix duplicate was 2026-06-26 22:32
+// UTC). We use the next-day boundary as a safe margin past the deploy. This is
+// the hard fence for amount-blind deletion: a null-id 'Stripe refund' row can
+// only be a webhook duplicate if it was written BEFORE this instant. After it,
+// the webhook cannot create such a row, so a matching row is treated as a
+// (possibly legitimate) route create/stamp-race artifact and left for manual
+// review rather than deleted. Exported so tests can pin both sides of the fence.
+export const WEBHOOK_IDEMPOTENT_SINCE = new Date('2026-06-28T00:00:00Z');
 
 function flag(name) {
   const a = args.find((x) => x.startsWith(`${name}=`));
@@ -73,10 +84,10 @@ function num(v, d) {
   const n = Number(v);
   return Number.isFinite(n) ? n : d;
 }
-function cents(decimalLike) {
+export function cents(decimalLike) {
   return Math.round(Number(decimalLike) * 100);
 }
-function usd(c) {
+export function usd(c) {
   return `$${(c / 100).toFixed(2)}`;
 }
 function log(...a) {
@@ -99,7 +110,7 @@ async function liveStripeRefunds(paymentIntentId) {
  * plan.ok === true means the post-change DB state matches Stripe exactly and is
  * safe to apply.
  */
-function planOrder(order, dbRows, stripeRefunds, amendmentRefundIds) {
+export function planOrder(order, dbRows, stripeRefunds, amendmentRefundIds) {
   const merges = []; // { rowId, stripeRefundId, amountCents }
   const deletes = []; // { rowId, amountCents, reason }
   const notes = [];
@@ -140,28 +151,50 @@ function planOrder(order, dbRows, stripeRefunds, amendmentRefundIds) {
     }
   }
 
-  // Pass 2 — DELETE: leftover orphan duplicates. Strict signature: webhook-created
-  // ('Stripe refund'), null id, amount already covered by a stamped real refund.
-  const stampedAmountCounts = new Map(); // amountCents -> count of stamped rows of that amount
-  for (const r of stamped) {
-    const k = cents(r.amount);
-    stampedAmountCounts.set(k, (stampedAmountCounts.get(k) || 0) + 1);
-  }
-  for (const m of merges) {
-    stampedAmountCounts.set(m.amountCents, (stampedAmountCounts.get(m.amountCents) || 0) + 1);
-  }
+  // Pass 2 — DELETE: leftover orphan duplicates. A webhook orphan carries the
+  // literal reason 'Stripe refund' and a null id. No admin/route path writes that
+  // exact reason (verified across src — only handleChargeRefunded does, and in
+  // current code only WITH a stamped id), so it reads as a webhook artifact.
+  //
+  // But that reason is a naming CONVENTION, not a schema guarantee: the admin
+  // refund route accepts free-text reasons and creates its Refund row, THEN stamps
+  // the Stripe id in a separate (non-atomic) step. A crash in that window could
+  // leave a *legitimate* null-id 'Stripe refund' row — indistinguishable by shape
+  // from a webhook dupe. That failure can only occur AFTER the webhook became
+  // idempotent (#171); every genuine webhook dupe was written before it. So the
+  // amount-blind delete is fenced to rows that PREDATE the cutover
+  // (WEBHOOK_IDEMPOTENT_SINCE). A same-shaped row created after the cutover is
+  // flagged for manual review, never swept up.
+  //
+  // A qualifying pre-cutover orphan is deleted when the order's REAL refunds are
+  // already fully represented (every live Stripe refund maps to a stamped/merged
+  // row), regardless of the orphan's amount — this clears both the common
+  // same-amount dupe AND the pre-#171 "cumulative total" orphan the old webhook
+  // derived from charge.amount_refunded (order #197's $534.83 = two real refunds
+  // $238.93 + $295.90, which matches no single Stripe refund amount).
+  //
+  // If a live Stripe refund still lacks a stamped row (a genuinely missing
+  // record), we do NOT guess — orphans are left as-is and the post-condition
+  // below fails the order into NEEDS-MANUAL.
+  const everyStripeRefundCovered =
+    stripeRefunds.length > 0 && stripeRefunds.every((r) => stampedIds.has(r.id));
 
   for (const o of pool) {
     if (o.claimed) continue;
     const amt = cents(o.amount);
     const isWebhookOrphan = o.reason === 'Stripe refund';
-    const coveredByStamped = (stampedAmountCounts.get(amt) || 0) > 0;
     const referencedByAmendment = amendmentRefundIds.has(o.id);
+    const predatesCutover = new Date(o.createdAt) < WEBHOOK_IDEMPOTENT_SINCE;
 
-    if (isWebhookOrphan && coveredByStamped && !referencedByAmendment) {
-      deletes.push({ rowId: o.id, amountCents: amt, reason: o.reason });
-    } else if (referencedByAmendment) {
+    if (referencedByAmendment) {
       notes.push(`orphan ${o.id.slice(0, 8)} (${usd(amt)}) is referenced by an OrderAmendment — left as-is`);
+    } else if (isWebhookOrphan && everyStripeRefundCovered && predatesCutover) {
+      deletes.push({ rowId: o.id, amountCents: amt, reason: o.reason });
+    } else if (isWebhookOrphan && everyStripeRefundCovered && !predatesCutover) {
+      notes.push(
+        `orphan ${o.id.slice(0, 8)} (${usd(amt)}) created ${new Date(o.createdAt).toISOString()}, ` +
+          `AFTER the #171 idempotency cutover — cannot be a webhook dupe by construction; manual review`
+      );
     } else {
       notes.push(`orphan ${o.id.slice(0, 8)} (${usd(amt)}, reason="${o.reason}") not a safe webhook dupe — left as-is`);
     }
@@ -225,6 +258,7 @@ async function main() {
   let totalMerges = 0;
   let needsManual = 0;
   let applied = 0;
+  let applyFailed = 0;
 
   for (const orderId of orderIds) {
     const order = await prisma.order.findUnique({
@@ -302,21 +336,38 @@ async function main() {
     totalDeletes += plan.deletes.length;
 
     if (APPLY) {
-      await prisma.$transaction(async (tx) => {
-        for (const m of plan.merges) {
-          await tx.refund.update({
-            where: { id: m.rowId },
-            data: { stripeRefundId: m.stripeRefundId, status: 'SUCCEEDED' },
-          });
+      try {
+        await prisma.$transaction(async (tx) => {
+          for (const m of plan.merges) {
+            await tx.refund.update({
+              where: { id: m.rowId },
+              data: { stripeRefundId: m.stripeRefundId, status: 'SUCCEEDED' },
+            });
+          }
+          for (const d of plan.deletes) {
+            await tx.refund.delete({ where: { id: d.rowId } });
+          }
+        });
+        // Re-label financialStatus from the reconciled rows. This re-reads
+        // aggregates and runs OUTSIDE the transaction above; a failure here does
+        // not undo the committed row changes, so we record it and keep going
+        // (re-running the script is idempotent and will relabel).
+        try {
+          await recomputeFinancialStatus(order.id);
+        } catch (statusErr) {
+          entry.notes.push('applied; financialStatus relabel failed (safe to re-run): ' + (statusErr?.message || String(statusErr)));
+          log('  ⚠ applied; status relabel failed (re-run to fix)');
         }
-        for (const d of plan.deletes) {
-          await tx.refund.delete({ where: { id: d.rowId } });
-        }
-      });
-      // Re-label financialStatus from the reconciled rows.
-      await recomputeFinancialStatus(order.id);
-      applied++;
-      log('  ✓ applied');
+        applied++;
+        log('  ✓ applied');
+      } catch (applyErr) {
+        // The transaction rolled back — this order's rows are untouched. Record
+        // the failure and continue so one bad order cannot truncate the batch.
+        entry.status = 'apply-failed';
+        entry.notes.push('APPLY failed (transaction rolled back, rows untouched): ' + (applyErr?.message || String(applyErr)));
+        applyFailed++;
+        log('  ✗ apply FAILED (rolled back): ' + (applyErr?.message || String(applyErr)));
+      }
     }
 
     report.push(entry);
@@ -327,8 +378,33 @@ async function main() {
   log(`Rows to MERGE:      ${totalMerges}`);
   log(`Rows to DELETE:     ${totalDeletes}`);
   log(`Needs manual review:${needsManual}`);
-  if (APPLY) log(`Orders applied:     ${applied}`);
-  else log('\n(DRY RUN — re-run with --apply to write these changes.)');
+  if (APPLY) {
+    log(`Orders applied:     ${applied}`);
+    if (applyFailed) log(`Apply FAILURES:     ${applyFailed} (rows untouched — see notes above; safe to re-run)`);
+    // Durable audit trail — an --apply deletes financial rows and is not
+    // reversible from inside the app, so always persist exactly what changed,
+    // independent of the --json flag.
+    const auditPath = path.join(os.tmpdir(), `reconcile-refunds-audit-${new Date().toISOString().replace(/[:.]/g, '-')}.json`);
+    try {
+      writeFileSync(
+        auditPath,
+        JSON.stringify(
+          {
+            appliedAt: new Date().toISOString(),
+            summary: { orders: orderIds.length, merges: totalMerges, deletes: totalDeletes, applied, applyFailed, needsManual },
+            report,
+          },
+          null,
+          2
+        )
+      );
+      log(`Audit trail written: ${auditPath}`);
+    } catch (auditErr) {
+      log(`WARN: failed to write audit file: ${auditErr?.message || String(auditErr)}`);
+    }
+  } else {
+    log('\n(DRY RUN — re-run with --apply to write these changes.)');
+  }
 
   if (OUT_JSON) console.log(JSON.stringify({ mode: APPLY ? 'apply' : 'dry-run', report }, null, 2));
 }
@@ -362,9 +438,33 @@ async function recomputeFinancialStatus(orderId) {
   }
 }
 
-main()
-  .catch((err) => {
-    console.error(err);
-    process.exitCode = 1;
-  })
-  .finally(() => prisma.$disconnect());
+// ---- CLI entrypoint — runs ONLY on direct execution, never on import --------
+// (`import`ing this file, e.g. from a unit test, must not hit the network or exit
+// the process; the live-key guard and client creation therefore live here.)
+// `typeof pathToFileURL === 'function'` also short-circuits under the vitest
+// jsdom environment, where `url` resolves to a browser shim without it — so the
+// import test never enters this block. pathToFileURL (not string interpolation)
+// is required because the repo path contains spaces, which must be %20-encoded
+// to match import.meta.url.
+if (
+  typeof pathToFileURL === 'function' &&
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  if (!STRIPE_KEY) {
+    console.error('ERROR: STRIPE_SECRET_KEY is not set. Run: set -a && source .env.local && set +a');
+    process.exit(1);
+  }
+  if (STRIPE_KEY.startsWith('sk_test_') || STRIPE_KEY.startsWith('rk_test_')) {
+    console.error('ERROR: STRIPE_SECRET_KEY is a TEST key. This reconciles LIVE refund data — refusing to run.');
+    process.exit(1);
+  }
+  prisma = new PrismaClient();
+  stripe = new Stripe(STRIPE_KEY);
+  main()
+    .catch((err) => {
+      console.error(err);
+      process.exitCode = 1;
+    })
+    .finally(() => prisma.$disconnect());
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,13 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./src/__tests__/setup.ts'],
-    include: ['src/**/*.{test,spec}.{js,ts,jsx,tsx}'],
+    include: [
+      'src/**/*.{test,spec}.{js,ts,jsx,tsx}',
+      // Money-critical ops scripts keep colocated unit tests (pure-planner logic
+      // that decides which prod rows get deleted). Scoped to scripts/ops so the
+      // gate stays green and unrelated script trees aren't pulled in.
+      'scripts/ops/**/*.{test,spec}.mjs',
+    ],
     globals: true,
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## What & why

The pre-#171 `charge.refunded` webhook double-recorded every admin refund: one correct stamped row + one null-id `reason='Stripe refund'` **orphan**. Those orphans inflated refund / P&L reporting totals — the all-time DB refund total read **\$12,373.15** vs Stripe's true **\$6,288.59**. (Customer-facing refunds were never affected; Stripe is authoritative there and untouched.)

The webhook has been **idempotent since #171** (2026-06-27) and creates no new orphans — **no runtime code change here**. This PR is (a) the operator-approved cleanup of the historical rows, already applied to prod, and (b) hardening of the operator-gated reconcile script that did it.

## Changes

**`scripts/ops/reconcile-duplicate-refunds.mjs`**
- Generalize the DELETE rule: a null-id `'Stripe refund'` orphan is removed once every live Stripe refund on the order is already represented by a stamped row — regardless of amount. Clears order **#197**'s `$534.83` *cumulative-total* orphan (the old webhook wrote `charge.amount_refunded`, the running total of two real refunds `$238.93 + $295.90`), which matched no single Stripe refund and was previously `NEEDS-MANUAL`.
- **Security review (HIGH)**: fence amount-blind deletion to rows created **before the #171 cutover** (`WEBHOOK_IDEMPOTENT_SINCE = 2026-06-28`). `'Stripe refund'` is a free-text convention, not a schema guarantee; a legitimately-shaped null-id row could only arise *after* the cutover, so post-cutover matches are flagged for manual review, never swept up.
- Make the script **import-safe** (CLI entrypoint guarded by `import.meta`) so the pure planner is unit-testable.
- **(LOW)** per-order try/catch so one failure can't truncate the batch; durable **JSON audit trail** written on every `--apply`.

**`scripts/ops/__tests__/reconcile-refunds-plan.test.mjs`** — new 9-case unit test for the pure planner: #197 pattern, post-cutover safety fence, missing-record, amendment-referenced, ghost-stamped, merge, non-webhook reason.

**`vitest.config.ts`** — include `scripts/ops/**/*.test.mjs` so the planner test is CI-gated.

## Verification
- **Applied to prod** (operator-approved): 35 deletes + 3 merges across 37 orders. DB refund rows now reconcile **1:1 with live Stripe**; #197 left with its two real refunds (`$534.83` = Stripe). Convergence re-run reports **zero** remaining changes.
- `npm run test:run`: **903/903 pass** (incl. 9 new). Lint clean on touched files.
- `security-reviewer` ran; all findings (1 HIGH / 1 MED / 2 LOW) fixed.
- `tsc` has **pre-existing** errors on main (Prisma/Stripe drift in untouched files); not CI-gated; this PR adds zero new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)