### PR TITLE
fix(leads): filter role-address + vendor-domain automated mail from inbound

### DIFF
--- a/src/lib/leads/__tests__/inbound-email-parse.test.ts
+++ b/src/lib/leads/__tests__/inbound-email-parse.test.ts
@@ -127,7 +127,7 @@ describe('shouldIngestInbound', () => {
     expect(shouldIngestInbound(parsed({ fromEmail: 'allan@partyondelivery.com' })).reason).toBe('self');
   });
 
-  it('skips automated senders by local-part', () => {
+  it('skips automated / role-address senders by local-part', () => {
     for (const addr of [
       'no-reply@vendor.com',
       'noreply@vendor.com',
@@ -135,9 +135,22 @@ describe('shouldIngestInbound', () => {
       'mailer-daemon@x.com',
       'notifications@app.com',
       'newsletter@brand.com',
+      'support@acme.com',
+      'help@acme.com',
+      'billing@acme.com',
+      'team@acme.com',
+      'marketing@acme.com',
+      'security@acme.com',
     ]) {
       expect(shouldIngestInbound(parsed({ fromEmail: addr })).reason).toBe('automated-sender');
     }
+  });
+
+  it('skips known vendor/SaaS domains (checked before local-part)', () => {
+    // The exact sender that slipped through in production — automated LeadGenJay
+    // mail from help@leadgenjay.com. Domain rule fires first.
+    expect(shouldIngestInbound(parsed({ fromEmail: 'help@leadgenjay.com' })).reason).toBe('vendor-domain');
+    expect(shouldIngestInbound(parsed({ fromEmail: 'jane@leadgenjay.com' })).reason).toBe('vendor-domain');
   });
 
   it('keeps real people whose local-part merely starts with an automated-ish token', () => {
@@ -147,6 +160,9 @@ describe('shouldIngestInbound', () => {
       'bouncer@x.com',
       'mailerman@x.com',
       'alerta@x.com',
+      'helpful@gmail.com',
+      'teamsters@gmail.com',
+      'salesperson@gmail.com',
     ]) {
       expect(shouldIngestInbound(parsed({ fromEmail: addr }))).toEqual({ ingest: true });
     }

--- a/src/lib/leads/inbound-email-parse.ts
+++ b/src/lib/leads/inbound-email-parse.ts
@@ -152,12 +152,22 @@ export function parseGmailMessage(msg: gmail_v1.Schema$Message): ParsedInbound |
   };
 }
 
-// Anchored AND boundary-guarded (the token must be the whole local-part or end
-// at a separator/digit) so real people — notifyjane@, updateme@, bouncer@,
-// mailerman@ — aren't dropped. Ambiguous words (notify/updates/alerts) are left
-// to the stronger List-*/Precedence/Auto-Submitted header checks below.
+// Role / automated local-parts. A real party inquiry comes from a person's own
+// address; mail FROM a role address (support@, help@, billing@ of some vendor)
+// to our info@ is almost always automated/transactional (login codes, receipts,
+// account reports) that carries none of the bulk/list headers below. Anchored
+// AND boundary-guarded (token must be the whole local-part or end at a
+// separator/digit) so real people — notifyjane@, updateme@, bouncer@,
+// mailerman@, helpful@ — aren't dropped.
 const AUTOMATED_LOCALPART =
-  /^(no-?reply|do-?not-?reply|donotreply|mailer-daemon|mailer|postmaster|bounces?|notifications?|newsletter|auto-?confirm|automated)(?=$|[._+-]|\d)/i;
+  /^(no-?reply|do-?not-?reply|donotreply|mailer-daemon|mailer|postmaster|bounces?|notifications?|notify|newsletter|auto-?confirm|automated|support|help|hello|team|billing|accounts?|security|system|marketing|sales|alerts?|updates?)(?=$|[._+-]|\d)/i;
+
+/**
+ * Vendor / SaaS domains whose mail is never a customer inquiry — a precise
+ * complement to the local-part heuristic (catches e.g. transactional mail from
+ * a non-role address). Grow as new tools surface in the skipped-mail logs.
+ */
+const NOISE_SENDER_DOMAINS: ReadonlySet<string> = new Set(['leadgenjay.com']);
 
 /**
  * Should this inbound email become a lead card? Filters out our own mail and
@@ -170,6 +180,8 @@ export function shouldIngestInbound(parsed: ParsedInbound): { ingest: boolean; r
   if (email.endsWith('@partyondelivery.com')) return { ingest: false, reason: 'self' };
 
   const localPart = email.split('@')[0] ?? '';
+  const domain = email.split('@')[1] ?? '';
+  if (NOISE_SENDER_DOMAINS.has(domain)) return { ingest: false, reason: 'vendor-domain' };
   if (AUTOMATED_LOCALPART.test(localPart)) return { ingest: false, reason: 'automated-sender' };
 
   const h = parsed.headers;


### PR DESCRIPTION
## What
Tightens the inbound-email noise filter after live data (from #265) showed automated **transactional** vendor mail reaching the board — a LeadGenJay weekly account summary and a login OTP, both from `help@leadgenjay.com`. That class carries none of the bulk/`List-*`/`Precedence` headers the filter keyed on, and `help@` wasn't a recognized automated local-part.

## Change (`shouldIngestInbound`, `inbound-email-parse.ts`)
- **Role-address local-parts** added: `support/help/hello/team/billing/accounts/security/system/marketing/sales/notify/alerts/updates`. Still boundary-guarded, so real people (`helpful@`, `teamsters@`, `salesperson@`, `notifyjane@`) are **not** dropped.
- **Vendor-domain denylist** (`NOISE_SENDER_DOMAINS`, seeded with `leadgenjay.com`), checked first — a precise complement that also catches transactional mail from non-role addresses. Grow it as new tools show up in the skipped-mail logs.

Skipped mail is still just logged (domain only), never lost — it stays in Gmail.

## Tests
Extended `inbound-email-parse.test.ts`: role addresses skip as `automated-sender`, `*@leadgenjay.com` (incl. the exact `help@leadgenjay.com` that slipped) skips as `vendor-domain`, and `helpful@`/`teamsters@`/`salesperson@` still ingest. Full suite green, tsc no new errors, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)