### PR TITLE
feat(sms-consent): add phone + affirmative SMS opt-in to group-order checkout (A2P 10DLC)

### DIFF
--- a/src/__tests__/group-v2-payments.test.ts
+++ b/src/__tests__/group-v2-payments.test.ts
@@ -21,12 +21,15 @@ const mockPrismaDeliveryTaskCreate = vi.fn();
 const mockPrismaProductVariantFindUnique = vi.fn();
 const mockPrismaProductVariantFindMany = vi.fn();
 const mockPrismaGroupOrderV2FindUnique = vi.fn();
+const mockPrismaParticipantPaymentCreate = vi.fn();
+const mockStripeCheckoutSessionsCreate = vi.fn();
 
 vi.mock('@/lib/database/client', () => ({
   prisma: {
     participantPayment: {
       findFirst: (...args: unknown[]) => mockPrismaParticipantPaymentFindFirst(...args),
       update: (...args: unknown[]) => mockPrismaParticipantPaymentUpdate(...args),
+      create: (...args: unknown[]) => mockPrismaParticipantPaymentCreate(...args),
     },
     groupParticipantV2: {
       findUnique: (...args: unknown[]) => mockPrismaGroupParticipantV2FindUnique(...args),
@@ -79,8 +82,19 @@ vi.mock('@/lib/affiliates/commission-engine', () => ({
 vi.mock('@/lib/affiliates/affiliate-service', () => ({
   getAffiliateByCode: vi.fn().mockResolvedValue(null),
 }));
-vi.mock('./client', () => ({
-  stripe: {},
+// NOTE: the SUT imports `stripe` from '@/lib/stripe/client' (a lazy Proxy that
+// throws without STRIPE_SECRET_KEY). Mock that exact module id — a relative
+// './client' here resolves against the test dir and silently no-ops.
+vi.mock('@/lib/stripe/client', () => ({
+  stripe: {
+    checkout: {
+      sessions: { create: (...args: unknown[]) => mockStripeCheckoutSessionsCreate(...args) },
+    },
+    coupons: { create: vi.fn().mockResolvedValue({ id: 'coupon_test' }) },
+  },
+  getStripe: vi.fn(),
+  STRIPE_PUBLISHABLE_KEY: 'pk_test',
+  STRIPE_WEBHOOK_SECRET: 'whsec_test',
 }));
 vi.mock('@/lib/tax', () => ({
   DEFAULT_TAX_RATE: 0.0825,
@@ -492,5 +506,72 @@ describe('createGroupV2CheckoutSession availability guard', () => {
     await expect(createGroupV2CheckoutSession(baseInput)).rejects.toBeInstanceOf(
       ProductNotPurchasableError
     );
+  });
+});
+
+describe('createGroupV2CheckoutSession — SMS consent metadata (A2P 10DLC)', () => {
+  const purchasableInput = {
+    groupOrderId: 'group-order-id-1',
+    subOrderId: 'sub-order-id-1',
+    participantId: 'participant-id-1',
+    participantName: 'Guest',
+    draftItems: [
+      {
+        id: 'draft-1',
+        productId: 'product-id-1',
+        variantId: 'variant-id-1',
+        title: 'Test Beer Pack',
+        variantTitle: '12 Pack',
+        price: 22.99,
+        imageUrl: null,
+        quantity: 1,
+      },
+    ],
+    successUrl: 'https://example.com/success',
+    cancelUrl: 'https://example.com/cancel',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Product purchasable → availability guard passes → we reach the Stripe call.
+    mockPrismaProductVariantFindMany.mockResolvedValue([
+      {
+        id: 'variant-id-1',
+        availableForSale: true,
+        product: { id: 'product-id-1', status: 'ACTIVE', title: 'Test Beer Pack' },
+      },
+    ]);
+    mockStripeCheckoutSessionsCreate.mockResolvedValue({ id: 'cs_test_x', url: 'https://stripe.test/x' });
+    mockPrismaParticipantPaymentCreate.mockResolvedValue({ id: 'payment-x' });
+  });
+
+  function lastSessionParams(): Stripe.Checkout.SessionCreateParams {
+    return mockStripeCheckoutSessionsCreate.mock.calls[0][0] as Stripe.Checkout.SessionCreateParams;
+  }
+
+  it('omits smsConsent from metadata when no phone was provided (even if consent is true)', async () => {
+    await createGroupV2CheckoutSession({ ...purchasableInput, smsConsent: true });
+    expect(lastSessionParams().metadata).not.toHaveProperty('smsConsent');
+  });
+
+  it("records smsConsent 'false' when a phone is present but the box is unchecked", async () => {
+    await createGroupV2CheckoutSession({
+      ...purchasableInput,
+      participantPhone: '5551234567',
+      smsConsent: false,
+    });
+    expect(lastSessionParams().metadata?.smsConsent).toBe('false');
+  });
+
+  it("records smsConsent 'true' with a phone, and never leaks the raw phone into the session", async () => {
+    await createGroupV2CheckoutSession({
+      ...purchasableInput,
+      participantPhone: '5559998888',
+      smsConsent: true,
+    });
+    const params = lastSessionParams();
+    expect(params.metadata?.smsConsent).toBe('true');
+    // The raw phone must never appear in metadata, custom_text, or anywhere in the params.
+    expect(JSON.stringify(params)).not.toContain('5559998888');
   });
 });

--- a/src/app/api/v2/group-orders/[code]/tabs/[tabId]/checkout-all/route.ts
+++ b/src/app/api/v2/group-orders/[code]/tabs/[tabId]/checkout-all/route.ts
@@ -21,7 +21,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
     const { code, tabId } = await params;
     const body = await request.json();
-    const { participantId, discountCode, tipAmount, email } = body;
+    const { participantId, discountCode, tipAmount, email, phone, smsConsent } = body;
 
     if (!participantId) {
       return NextResponse.json(
@@ -46,6 +46,17 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       return NextResponse.json(
         { success: false, error: 'Participant not found' },
         { status: 404 }
+      );
+    }
+
+    // Authorization: the participant must belong to THIS group. getParticipantById
+    // looks up by id alone, so without this check a shareCode holder could pass
+    // another group's participantId and forge that person's phone / SMS-consent
+    // record (and clobber their delivery contact). Scope it to the URL's group.
+    if (participant.groupOrderId !== group.id) {
+      return NextResponse.json(
+        { success: false, error: 'Participant does not belong to this group' },
+        { status: 403 }
       );
     }
 
@@ -78,6 +89,14 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         console.error('[Group V2] Failed to save participant email:', err);
       }
     }
+
+    // Bound + type-guard the optional phone from the (untrusted) request body.
+    // We deliberately do NOT persist it to the participant here: Stripe collects
+    // the authoritative order phone (phone_number_collection), and writing
+    // guestPhone from this participantId-only path would let one group member set
+    // another member's contact number. cleanPhone is used only to pair the opt-in
+    // with a number and to gate the smsConsent record below.
+    const cleanPhone = typeof phone === 'string' ? phone.trim().slice(0, 40) : '';
 
     // Include delivery fee in checkout if not already paid/waived
     let shouldIncludeDeliveryFee = !tab.deliveryFeeWaived
@@ -126,6 +145,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       subOrderId: tabId,
       participantId,
       participantEmail: effectiveEmail,
+      participantPhone: cleanPhone || participant.guestPhone || undefined,
+      smsConsent: typeof smsConsent === 'boolean' ? smsConsent : undefined,
       participantName: participant.guestName || 'Guest',
       draftItems,
       discountCode,

--- a/src/app/api/v2/group-orders/[code]/tabs/[tabId]/checkout/route.ts
+++ b/src/app/api/v2/group-orders/[code]/tabs/[tabId]/checkout/route.ts
@@ -21,7 +21,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
     const { code, tabId } = await params;
     const body = await request.json();
-    const { participantId, discountCode, tipAmount, email } = body;
+    const { participantId, discountCode, tipAmount, email, phone, smsConsent } = body;
 
     if (!participantId) {
       return NextResponse.json(
@@ -46,6 +46,17 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       return NextResponse.json(
         { success: false, error: 'Participant not found' },
         { status: 404 }
+      );
+    }
+
+    // Authorization: the participant must belong to THIS group. getParticipantById
+    // looks up by id alone, so without this check a shareCode holder could pass
+    // another group's participantId and forge that person's phone / SMS-consent
+    // record (and clobber their delivery contact). Scope it to the URL's group.
+    if (participant.groupOrderId !== group.id) {
+      return NextResponse.json(
+        { success: false, error: 'Participant does not belong to this group' },
+        { status: 403 }
       );
     }
 
@@ -77,6 +88,14 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         console.error('[Group V2] Failed to save participant email:', err);
       }
     }
+
+    // Bound + type-guard the optional phone from the (untrusted) request body.
+    // We deliberately do NOT persist it to the participant here: Stripe collects
+    // the authoritative order phone (phone_number_collection), and writing
+    // guestPhone from this participantId-only path would let one group member set
+    // another member's contact number. cleanPhone is used only to pair the opt-in
+    // with a number and to gate the smsConsent record below.
+    const cleanPhone = typeof phone === 'string' ? phone.trim().slice(0, 40) : '';
 
     // Bundle delivery fee into this checkout if it hasn't already been paid/waived.
     // Mirrors checkout-all/route.ts so participant checkout doesn't drop the fee.
@@ -131,6 +150,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       subOrderId: tabId,
       participantId,
       participantEmail: effectiveEmail,
+      participantPhone: cleanPhone || participant.guestPhone || undefined,
+      smsConsent: typeof smsConsent === 'boolean' ? smsConsent : undefined,
       participantName: participant.guestName || 'Guest',
       draftItems,
       discountCode,

--- a/src/components/dashboard/DashboardCheckoutModal.tsx
+++ b/src/components/dashboard/DashboardCheckoutModal.tsx
@@ -7,6 +7,7 @@ import {
   checkoutAllV2,
   validateGroupDiscount,
 } from '@/lib/group-orders-v2/api-client';
+import SmsConsentCheckbox from '@/components/consent/SmsConsentCheckbox';
 
 interface Props {
   shareCode: string;
@@ -35,6 +36,11 @@ export default function DashboardCheckoutModal({
   const [error, setError] = useState('');
   const [email, setEmail] = useState(participantEmail || '');
   const [emailError, setEmailError] = useState('');
+  const [phone, setPhone] = useState('');
+  // UNCHECKED by default — A2P 10DLC express consent must be an affirmative
+  // user action. Optional: never gates checkout; recorded only when a phone
+  // is provided.
+  const [smsConsent, setSmsConsent] = useState(false);
 
   // ─── Two checkout acknowledgements ────────────────────────────────
   // 1. Substitutions OK — pre-checked, customer can opt out. Lets ops
@@ -132,7 +138,9 @@ export default function DashboardCheckoutModal({
           participantId,
           discountApplied?.code,
           tip,
-          trimmedEmail
+          trimmedEmail,
+          phone.trim() || undefined,
+          smsConsent
         );
         window.location.href = result.checkoutUrl;
       } else {
@@ -142,7 +150,9 @@ export default function DashboardCheckoutModal({
           participantId,
           discountApplied?.code,
           tip,
-          trimmedEmail
+          trimmedEmail,
+          phone.trim() || undefined,
+          smsConsent
         );
         window.location.href = result.checkoutUrl;
       }
@@ -215,6 +225,30 @@ export default function DashboardCheckoutModal({
               <p className="text-xs text-red-600 mt-1">{emailError}</p>
             )}
             <p className="text-xs text-gray-400 mt-1">For order confirmation and updates</p>
+          </div>
+
+          {/* Phone + SMS opt-in — optional. The phone field is paired with an
+              unchecked, affirmative SMS consent checkbox (A2P 10DLC). Neither
+              gates checkout; Stripe still collects the order phone at payment. */}
+          <div>
+            <label htmlFor="checkout-phone" className="block text-sm font-medium text-gray-700 mb-1">
+              Phone <span className="text-gray-400 font-normal">(optional)</span>
+            </label>
+            <input
+              id="checkout-phone"
+              type="tel"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              placeholder="(555) 555-5555"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:border-brand-blue focus:ring-0 transition-all"
+            />
+            <div className="mt-2">
+              <SmsConsentCheckbox
+                id="group-checkout-sms-consent"
+                checked={smsConsent}
+                onChange={setSmsConsent}
+              />
+            </div>
           </div>
 
           {/* Discount code */}

--- a/src/components/group-v2/CheckoutSummaryModal.tsx
+++ b/src/components/group-v2/CheckoutSummaryModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, ReactElement } from 'react';
 import { checkoutParticipantV2, validateGroupDiscount } from '@/lib/group-orders-v2/api-client';
+import SmsConsentCheckbox from '@/components/consent/SmsConsentCheckbox';
 import type { DraftCartItemView, SubOrderFull } from '@/lib/group-orders-v2/types';
 
 interface Props {
@@ -27,6 +28,11 @@ export default function CheckoutSummaryModal({
   const [discountApplied, setDiscountApplied] = useState<{ code: string; type: string; value: number; discountAmount: number; freeShipping?: boolean } | null>(null);
   const [discountError, setDiscountError] = useState('');
   const [applyingDiscount, setApplyingDiscount] = useState(false);
+  const [phone, setPhone] = useState('');
+  // UNCHECKED by default — A2P 10DLC express consent must be an affirmative
+  // user action. Optional: never gates checkout; recorded only when a phone
+  // is provided.
+  const [smsConsent, setSmsConsent] = useState(false);
 
   if (!isOpen) return null;
 
@@ -67,7 +73,11 @@ export default function CheckoutSummaryModal({
         shareCode,
         tab.id,
         participantId,
-        discountApplied?.code || undefined
+        discountApplied?.code || undefined,
+        undefined,
+        undefined,
+        phone.trim() || undefined,
+        smsConsent
       );
       if (!result.checkoutUrl) {
         throw new Error('No checkout URL returned');
@@ -185,6 +195,29 @@ export default function CheckoutSummaryModal({
           {discountError && (
             <p className="text-sm text-red-600 mt-1">{discountError}</p>
           )}
+        </div>
+
+        {/* Phone + SMS opt-in — optional, unchecked (A2P 10DLC express consent).
+            Neither gates checkout; Stripe still collects the order phone. */}
+        <div className="mb-4">
+          <label htmlFor="group-summary-phone" className="block text-sm font-medium text-gray-700 mb-1">
+            Phone <span className="text-gray-400 font-normal">(optional)</span>
+          </label>
+          <input
+            id="group-summary-phone"
+            type="tel"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            placeholder="(555) 555-5555"
+            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm text-gray-900 focus:ring-2 focus:ring-brand-blue"
+          />
+          <div className="mt-2">
+            <SmsConsentCheckbox
+              id="group-summary-sms-consent"
+              checked={smsConsent}
+              onChange={setSmsConsent}
+            />
+          </div>
         </div>
 
         {/* Totals */}

--- a/src/lib/group-orders-v2/api-client.ts
+++ b/src/lib/group-orders-v2/api-client.ts
@@ -256,13 +256,15 @@ export async function checkoutAllV2(
   participantId: string,
   discountCode?: string,
   tipAmount?: number,
-  email?: string
+  email?: string,
+  phone?: string,
+  smsConsent?: boolean
 ): Promise<{ checkoutUrl: string; sessionId: string }> {
   const session = await apiFetch<{ checkoutUrl: string; sessionId: string }>(
     `${API_BASE}/${code}/tabs/${tabId}/checkout-all`,
     {
       method: 'POST',
-      body: JSON.stringify({ participantId, discountCode, tipAmount, email }),
+      body: JSON.stringify({ participantId, discountCode, tipAmount, email, phone, smsConsent }),
     }
   );
   // Checkout is what locks a v2 tab, so this is the lock moment of the funnel.
@@ -277,13 +279,15 @@ export async function checkoutParticipantV2(
   participantId: string,
   discountCode?: string,
   tipAmount?: number,
-  email?: string
+  email?: string,
+  phone?: string,
+  smsConsent?: boolean
 ): Promise<{ checkoutUrl: string; sessionId: string; paymentId: string }> {
   const session = await apiFetch<{ checkoutUrl: string; sessionId: string; paymentId: string }>(
     `${API_BASE}/${code}/tabs/${tabId}/checkout`,
     {
       method: 'POST',
-      body: JSON.stringify({ participantId, discountCode, tipAmount, email }),
+      body: JSON.stringify({ participantId, discountCode, tipAmount, email, phone, smsConsent }),
     }
   );
   trackEvent(ANALYTICS_EVENTS.LOCK_GROUP_ORDER, { share_code: code, scope: 'participant' });

--- a/src/lib/stripe/group-v2-payments.ts
+++ b/src/lib/stripe/group-v2-payments.ts
@@ -48,6 +48,13 @@ interface CreateCheckoutInput {
   subOrderId: string;
   participantId: string;
   participantEmail?: string;
+  /** Optional phone from our checkout modal, used only to pair the SMS opt-in
+   *  with a number and to gate the smsConsent metadata below. Not persisted to
+   *  the participant; Stripe collects the authoritative order phone. */
+  participantPhone?: string;
+  /** A2P 10DLC express SMS opt-in from the modal checkbox. Recorded to Stripe
+   *  metadata only when a phone is present; not enforced yet (deferred). */
+  smsConsent?: boolean;
   participantName: string;
   draftItems: DraftItemForCheckout[];
   discountCode?: string;
@@ -230,12 +237,21 @@ export async function createGroupV2CheckoutSession(input: CreateCheckoutInput) {
           ? { deliveryFee: '0', deliveryFeeWaivedByAffiliate: 'true' }
           : {}),
       ...(input.affiliateCode ? { affiliateCode: input.affiliateCode } : {}),
+      // A2P 10DLC: record express SMS opt-in only when a phone was provided.
+      ...(input.participantPhone && input.smsConsent !== undefined
+        ? { smsConsent: input.smsConsent ? 'true' : 'false' }
+        : {}),
     },
     billing_address_collection: 'required',
     phone_number_collection: { enabled: true },
+    // Transactional order/delivery texts for THIS order shown at the phone
+    // field. Marketing/reminder SMS consent is collected separately via the
+    // explicit, unchecked opt-in checkbox on our checkout modal (A2P 10DLC
+    // express consent) — this disclosure is not the marketing opt-in.
     custom_text: {
       submit: {
-        message: `Payment for your group order items (${draftItems.length} items).`,
+        message:
+          'We may text you order and delivery updates for this order at the number you provide. Msg & data rates may apply. Reply STOP to opt out, HELP for help. See our Privacy Policy at partyondelivery.com/privacy.',
       },
     },
   };


### PR DESCRIPTION
## What & why
Twilio Trust & Safety (A2P 10DLC case **#27953198**, rep Varun) keeps flagging our SMS-consent visibility. The affirmative consent checkbox existed only on `/checkout` and the lead-magnet popup — **not on the main group-order funnel** that `Start Order` (`/order → /dashboard/[code]`) actually lands on. That funnel collected email only and handed the phone off to Stripe with no opt-in. This adds the compliant opt-in to the group funnel so a reviewer (and customer) sees it where they actually check out.

## Changes
- **`DashboardCheckoutModal`** (`/dashboard/[code]`, the primary funnel) and **`CheckoutSummaryModal`** (`/group/[code]/dashboard`, still-reachable secondary): optional **phone field + unchecked, affirmative `SmsConsentCheckbox`** directly beneath it. Never gates checkout (consent is not a condition of purchase).
- Thread `phone` + `smsConsent` through `api-client` → both v2 checkout routes → the Stripe session builder.
- Record `smsConsent` in Stripe metadata **only when a phone is present** (mirrors the shipped `/checkout` pattern). Raw phone is **never** put in metadata/URL/logs.
- Align the group-v2 Stripe `custom_text` transactional SMS disclosure with `checkout.ts`.

## Security (two-round `security-reviewer` pass)
- **Closed a cross-group forgery vector**: scope the participant to the URL's group (`participant.groupOrderId === group.id`) before any consent write — the `participantId` lookup was previously unscoped.
- **Validated the untrusted `phone`** (type-guard + 40-char cap) and **do not persist it** to `participant.guestPhone` — Stripe collects the authoritative order phone, and skipping the write removes a write-once poisoning surface on the `participantId`-only path.
- **Added 3 unit tests** for the `smsConsent` metadata gating (also fixed a pre-existing no-op `vi.mock` that silently skipped the Stripe mock).

### Known limitation (pre-existing — not introduced here)
The unauthenticated group `GET` exposes participant ids/PII and mutating calls trust a client-supplied `participantId`, so a **same-group** member can stamp an **inert** `smsConsent` flag under another member's Stripe session. **Nothing reads that flag today** (SMS-consent enforcement is deferred, `task_26d7819c`). The proper fix (per-participant identity tokens / masking the GET) is architectural and belongs with that enforcement work. Deliberately out of scope here.

## Gates
- `npx tsc --noEmit` clean on touched files (worktree has unrelated pre-existing dep/prisma-drift errors; not a CI gate)
- `npm run lint` clean · `npm run test:run` **907 passing** (incl. 3 new)
- `security-reviewer` ran twice; findings addressed or explicitly deferred above

## After merge (not done yet)
Capture live screenshots of the group-order checkout consent + DOB age gate on prod, then Allan posts the round-4 reply to Twilio case #27953198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
