### PR TITLE
feat(ab-tests): hero headline experiments on all landing pages + scoreboard atop analytics hub

### DIFF
--- a/scripts/experiments/seed-hero-tests.ts
+++ b/scripts/experiments/seed-hero-tests.ts
@@ -1,0 +1,124 @@
+/**
+ * Seed the hero-headline A/B tests (one per landing page) as DRAFT rows.
+ * DRY-RUN BY DEFAULT — pass --apply to write. Operator-gated per house rules.
+ *
+ * - Creates every seed in src/lib/experiments/hero-test-seeds.ts as status
+ *   DRAFT. Allan reviews the copy and presses Start per page in
+ *   /admin/analytics — so startDate (which drives day counts and the
+ *   projected decision date) reflects the real launch, not the deploy.
+ * - Idempotent: a page that already has ANY hero experiment in
+ *   DRAFT/RUNNING/PAUSED is skipped and reported. Never mutates existing
+ *   rows, never touches a RUNNING test. Re-runs are safe.
+ * - Low-traffic seeds (wedding-weekend, ~3 views/mo) are skipped unless
+ *   --include-low-traffic: a test that mathematically can't conclude is
+ *   dashboard noise by default.
+ * - Every seed is validated against the SAME Zod schema the admin create
+ *   route uses (shared experiment-schemas.ts), plus the weights=100 /
+ *   exactly-one-control checks the route enforces.
+ *
+ * Usage:
+ *   set -a && source .env.local && set +a
+ *   npx tsx scripts/experiments/seed-hero-tests.ts                        # dry-run
+ *   npx tsx scripts/experiments/seed-hero-tests.ts --apply                # write
+ *   npx tsx scripts/experiments/seed-hero-tests.ts --apply --include-low-traffic
+ */
+
+import { prisma } from '../../src/lib/database/client';
+import { CreateExperimentSchema } from '../../src/lib/experiments/experiment-schemas';
+import { HERO_TEST_SEEDS, WIRED_ROUTES } from '../../src/lib/experiments/hero-test-seeds';
+
+const APPLY = process.argv.includes('--apply');
+const INCLUDE_LOW_TRAFFIC = process.argv.includes('--include-low-traffic');
+
+async function main(): Promise<void> {
+  console.log(
+    `Hero-test seeder — ${APPLY ? 'APPLY (writing to DB)' : 'DRY RUN (pass --apply to write)'}`
+  );
+
+  // Validate every seed up front — abort entirely on any invalid seed.
+  const wired = new Set<string>(WIRED_ROUTES);
+  for (const seed of HERO_TEST_SEEDS) {
+    const parsed = CreateExperimentSchema.parse(seed);
+    const totalWeight = parsed.variants.reduce((s, v) => s + v.weight, 0);
+    if (totalWeight !== 100) throw new Error(`${seed.page}: weights sum to ${totalWeight}, not 100`);
+    const controls = parsed.variants.filter((v) => v.isControl).length;
+    if (controls !== 1) throw new Error(`${seed.page}: ${controls} control variants, need exactly 1`);
+    if (!wired.has(seed.page)) throw new Error(`${seed.page}: not a wired hero route`);
+  }
+  console.log(`Validated ${HERO_TEST_SEEDS.length} seeds.\n`);
+
+  let created = 0;
+  let skippedExisting = 0;
+  let skippedLowTraffic = 0;
+
+  for (const seed of HERO_TEST_SEEDS) {
+    if (seed.lowTraffic && !INCLUDE_LOW_TRAFFIC) {
+      console.log(`SKIP (low traffic)   ${seed.page} — "${seed.name}" (pass --include-low-traffic to seed)`);
+      skippedLowTraffic++;
+      continue;
+    }
+
+    const existing = await prisma.experiment.findFirst({
+      where: {
+        page: seed.page,
+        elementId: seed.elementId,
+        status: { in: ['DRAFT', 'RUNNING', 'PAUSED'] },
+      },
+      select: { id: true, name: true, status: true },
+    });
+    if (existing) {
+      console.log(
+        `SKIP (exists ${existing.status}) ${seed.page} — already has "${existing.name}" (${existing.id})`
+      );
+      skippedExisting++;
+      continue;
+    }
+
+    if (!APPLY) {
+      console.log(`WOULD CREATE (draft) ${seed.page} — "${seed.name}"`);
+      for (const v of seed.variants) {
+        const copy = v.content && Object.keys(v.content).length > 0
+          ? JSON.stringify(v.content)
+          : '(page default copy)';
+        console.log(`    ${v.isControl ? '[control]' : '         '} ${v.name} ${v.weight}% ${copy}`);
+      }
+      created++;
+      continue;
+    }
+
+    const experiment = await prisma.experiment.create({
+      data: {
+        name: seed.name,
+        description: seed.description,
+        page: seed.page,
+        elementId: seed.elementId,
+        goalMetric: seed.goalMetric,
+        status: 'DRAFT',
+        variants: {
+          create: seed.variants.map((v) => ({
+            name: v.name,
+            isControl: v.isControl,
+            weight: v.weight,
+            content: v.content && Object.keys(v.content).length > 0 ? v.content : undefined,
+          })),
+        },
+      },
+      select: { id: true },
+    });
+    console.log(`CREATED (draft)      ${seed.page} — "${seed.name}" (${experiment.id})`);
+    created++;
+  }
+
+  console.log(
+    `\n${APPLY ? 'Created' : 'Would create'}: ${created} · skipped existing: ${skippedExisting} · skipped low-traffic: ${skippedLowTraffic}`
+  );
+  if (!APPLY) console.log('Dry run only — nothing was written.');
+  else console.log('Next: open /admin/analytics, review each draft, press Start.');
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/__tests__/experiment-planning.test.ts
+++ b/src/__tests__/experiment-planning.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Experiment planning math — sample size, Wilson CIs, decision projection,
+ * and the anti-peeking verdict gate. Expected values are textbook/reference
+ * numbers computed independently of the implementation.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  requiredSampleSizePerVariant,
+  wilsonInterval,
+  projectDecision,
+  deriveVerdict,
+  defaultRelativeMde,
+  resolveBaselineRate,
+  MIN_RUN_DAYS,
+  type DecisionInputs,
+} from '@/lib/analytics/experiment-planning';
+import {
+  computeSignificance,
+  twoProportionZTest,
+  type VariantStat,
+} from '@/lib/analytics/experiment-significance';
+
+const NOW = new Date('2026-07-15T00:00:00Z');
+
+describe('requiredSampleSizePerVariant', () => {
+  it('matches reference values (alpha 0.05, power 0.8)', () => {
+    expect(requiredSampleSizePerVariant(0.1, 0.3)).toBe(1774);
+    expect(requiredSampleSizePerVariant(0.1, 0.2)).toBe(3841);
+    expect(requiredSampleSizePerVariant(0.5, 0.2)).toBe(388); // textbook 0.5→0.6
+    expect(requiredSampleSizePerVariant(0.1, 0.5)).toBe(686);
+    expect(requiredSampleSizePerVariant(0.59, 0.15)).toBe(464); // the /order case
+  });
+
+  it('supports alpha 0.10', () => {
+    expect(requiredSampleSizePerVariant(0.1, 0.3, 0.1)).toBe(1398);
+  });
+
+  it('rejects degenerate inputs', () => {
+    expect(() => requiredSampleSizePerVariant(0, 0.3)).toThrow(RangeError);
+    expect(() => requiredSampleSizePerVariant(1, 0.3)).toThrow(RangeError);
+    expect(() => requiredSampleSizePerVariant(0.1, 0)).toThrow(RangeError);
+    // target rate p2 >= 1
+    expect(() => requiredSampleSizePerVariant(0.7, 0.5)).toThrow(RangeError);
+    // unsupported quantile
+    expect(() => requiredSampleSizePerVariant(0.1, 0.3, 0.037)).toThrow(RangeError);
+  });
+});
+
+describe('wilsonInterval', () => {
+  it('matches reference values at 95%', () => {
+    const a = wilsonInterval(5, 50);
+    expect(a.lo).toBeCloseTo(0.043476, 4);
+    expect(a.hi).toBeCloseTo(0.213602, 4);
+
+    const zero = wilsonInterval(0, 20);
+    expect(zero.lo).toBe(0);
+    expect(zero.hi).toBeCloseTo(0.161125, 4);
+
+    const all = wilsonInterval(20, 20);
+    expect(all.lo).toBeCloseTo(0.838875, 4);
+    expect(all.hi).toBe(1);
+
+    const home = wilsonInterval(65, 661); // realistic homepage hero CTR
+    expect(home.lo).toBeCloseTo(0.077904, 4);
+    expect(home.hi).toBeCloseTo(0.12341, 4);
+  });
+
+  it('returns [0,1] with no data and is symmetric', () => {
+    expect(wilsonInterval(0, 0)).toEqual({ lo: 0, hi: 1 });
+    const a = wilsonInterval(5, 50);
+    const b = wilsonInterval(45, 50);
+    expect(a.lo).toBeCloseTo(1 - b.hi, 12);
+  });
+
+  it('clamps successes > trials instead of returning NaN', () => {
+    // Public counters increment independently — clicks CAN exceed impressions.
+    const over = wilsonInterval(350, 200);
+    expect(Number.isFinite(over.lo)).toBe(true);
+    expect(over.hi).toBe(1);
+  });
+});
+
+describe('projectDecision', () => {
+  it('projects a reachable date', () => {
+    const p = projectDecision(300, 686, 11, NOW);
+    expect(p.remainingDays).toBe(36); // ceil(386/11)
+    expect(p.projectedDecisionDate).toBe('2026-08-20');
+    expect(p.reachable).toBe(true);
+  });
+
+  it('marks long projections unreachable (no date)', () => {
+    const p = projectDecision(300, 1774, 11, NOW);
+    expect(p.remainingDays).toBe(134);
+    expect(p.reachable).toBe(false);
+    expect(p.projectedDecisionDate).toBeNull();
+  });
+
+  it('handles zero traffic', () => {
+    const p = projectDecision(300, 686, 0, NOW);
+    expect(p.remainingDays).toBeNull();
+    expect(p.projectedDecisionDate).toBeNull();
+    expect(p.reachable).toBe(false);
+  });
+
+  it('handles already-sufficient samples', () => {
+    const done = projectDecision(700, 686, 11, NOW);
+    expect(done.remainingDays).toBe(0);
+    expect(done.projectedDecisionDate).toBe('2026-07-15');
+
+    const edge = projectDecision(685, 686, 11, NOW);
+    expect(edge.remainingDays).toBe(1);
+    expect(edge.projectedDecisionDate).toBe('2026-07-16');
+  });
+
+  it('floors the projected date at the MIN_RUN_DAYS horizon', () => {
+    // Sample reached on day 5 — the date must point at day 14, never "today",
+    // or the banner would say "hold until ~today" and invite an early conclude.
+    const fast = projectDecision(700, 686, 50, NOW, 5);
+    expect(fast.remainingDays).toBe(MIN_RUN_DAYS - 5);
+    expect(fast.projectedDecisionDate).toBe('2026-07-24');
+
+    // Sample NOT reached: remaining days also floored at the horizon.
+    const near = projectDecision(680, 686, 50, NOW, 5);
+    expect(near.remainingDays).toBe(MIN_RUN_DAYS - 5);
+
+    // Past the horizon, behavior is unchanged.
+    const past = projectDecision(700, 686, 50, NOW, 20);
+    expect(past.remainingDays).toBe(0);
+    expect(past.projectedDecisionDate).toBe('2026-07-15');
+  });
+});
+
+describe('defaultRelativeMde / resolveBaselineRate', () => {
+  it('steps the MDE by baseline', () => {
+    expect(defaultRelativeMde(0.1)).toBe(0.5);
+    expect(defaultRelativeMde(0.29)).toBe(0.5);
+    expect(defaultRelativeMde(0.3)).toBe(0.15);
+    expect(defaultRelativeMde(0.59)).toBe(0.15);
+  });
+
+  it('uses the prior until 200 impressions, then pools', () => {
+    expect(
+      resolveBaselineRate(
+        [
+          { impressions: 50, successes: 10 },
+          { impressions: 50, successes: 5 },
+        ],
+        0.12
+      )
+    ).toBe(0.12);
+    expect(
+      resolveBaselineRate(
+        [
+          { impressions: 150, successes: 15 },
+          { impressions: 150, successes: 30 },
+        ],
+        0.12
+      )
+    ).toBeCloseTo(0.15, 10);
+    // degenerate priors are clamped to something sane
+    expect(resolveBaselineRate([], 0)).toBe(0.1);
+    expect(resolveBaselineRate([], NaN)).toBe(0.1);
+  });
+});
+
+function makeVariants(
+  control: { imp: number; succ: number },
+  challenger: { imp: number; succ: number }
+): VariantStat[] {
+  return [
+    { id: 'c', name: 'Control', isControl: true, impressions: control.imp, conversions: control.succ },
+    { id: 'v', name: 'Variant B', isControl: false, impressions: challenger.imp, conversions: challenger.succ },
+  ];
+}
+
+function decisionFor(
+  variants: VariantStat[],
+  opts: { required: number; daily: number; daysRunning: number }
+): ReturnType<typeof deriveVerdict> {
+  const minImpressions = Math.min(...variants.map((v) => v.impressions));
+  const inputs: DecisionInputs = {
+    significance: computeSignificance(variants),
+    projection: projectDecision(minImpressions, opts.required, opts.daily, NOW),
+    daysRunning: opts.daysRunning,
+    assumedBaselineRate: 0.1,
+    relativeMde: 0.5,
+  };
+  return deriveVerdict(inputs);
+}
+
+describe('deriveVerdict', () => {
+  it('declares a winner only past the full horizon', () => {
+    // z = 4.70, p ≈ 2.6e-6 — decisive, and sample/horizon both satisfied.
+    const d = decisionFor(
+      makeVariants({ imp: 5000, succ: 500 }, { imp: 5000, succ: 650 }),
+      { required: 1774, daily: 50, daysRunning: 30 }
+    );
+    expect(d.verdict).toBe('winner');
+    expect(d.message).toContain('Variant B');
+  });
+
+  it('anti-peeking: an early 95% crossing is trending, NOT a winner', () => {
+    // 14.0% vs 10.0% at n=1000: p ≈ 0.0059 (conf ≈ 99.4%) but n < 1774.
+    const d = decisionFor(
+      makeVariants({ imp: 1000, succ: 100 }, { imp: 1000, succ: 140 }),
+      { required: 1774, daily: 50, daysRunning: 30 }
+    );
+    expect(d.verdict).toBe('collecting');
+    expect(d.trendingVariantId).toBe('v');
+    expect(d.message).toContain('trending');
+  });
+
+  it('declares no-difference at the horizon without significance', () => {
+    const d = decisionFor(
+      makeVariants({ imp: 5000, succ: 500 }, { imp: 5000, succ: 510 }),
+      { required: 1774, daily: 50, daysRunning: 30 }
+    );
+    expect(d.verdict).toBe('no-difference');
+  });
+
+  it('holds the winner until MIN_RUN_DAYS even with the full sample', () => {
+    const d = decisionFor(
+      makeVariants({ imp: 5000, succ: 500 }, { imp: 5000, succ: 650 }),
+      { required: 1774, daily: 500, daysRunning: MIN_RUN_DAYS - 9 }
+    );
+    expect(d.verdict).toBe('collecting');
+  });
+
+  it('reports underpowered pages honestly', () => {
+    // bachelorette-ish: 1.3 exposures/day/variant against n=1774
+    const d = decisionFor(
+      makeVariants({ imp: 300, succ: 27 }, { imp: 300, succ: 33 }),
+      { required: 1774, daily: 1.3, daysRunning: 30 }
+    );
+    expect(d.verdict).toBe('underpowered');
+    expect(d.message).toContain('bolder');
+  });
+
+  it('reports no-traffic', () => {
+    const d = decisionFor(
+      makeVariants({ imp: 10, succ: 1 }, { imp: 10, succ: 2 }),
+      { required: 1774, daily: 0, daysRunning: 5 }
+    );
+    expect(d.verdict).toBe('no-traffic');
+  });
+
+  it('control-wins message when challenger is significantly worse at horizon', () => {
+    const d = decisionFor(
+      makeVariants({ imp: 5000, succ: 650 }, { imp: 5000, succ: 500 }),
+      { required: 1774, daily: 50, daysRunning: 30 }
+    );
+    expect(d.verdict).toBe('no-difference');
+    expect(d.message).toContain('Control wins');
+  });
+});
+
+describe('regression pins on the existing z-test (file untouched)', () => {
+  it('matches known values', () => {
+    const a = twoProportionZTest(50, 500, 65, 500);
+    expect(Math.abs(a.z)).toBeCloseTo(1.4869, 2);
+    expect(a.pValue).toBeCloseTo(0.1371, 2);
+
+    const b = twoProportionZTest(500, 5000, 650, 5000);
+    expect(b.pValue).toBeLessThan(1e-5);
+  });
+});

--- a/src/__tests__/experiment-transform.test.ts
+++ b/src/__tests__/experiment-transform.test.ts
@@ -1,0 +1,200 @@
+/**
+ * transformExperiment — the pure transform behind GET /api/admin/experiments.
+ * Pins the response shape (significance, decision, per-variant CIs) and the
+ * goal-dependent success counting, using synthetic Prisma-shaped rows.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  transformExperiment,
+  successCount,
+  type TransformableExperiment,
+} from '@/lib/analytics/experiment-transform';
+
+const NOW = new Date('2026-07-15T00:00:00Z');
+
+function makeExperiment(
+  overrides: Partial<TransformableExperiment> = {}
+): TransformableExperiment {
+  return {
+    id: 'exp-1',
+    name: 'Hero test',
+    page: '/boat-parties',
+    elementId: 'hero',
+    status: 'RUNNING',
+    goalMetric: 'cta_click',
+    startDate: new Date('2026-06-15T00:00:00Z'), // 30 days before NOW
+    variants: [
+      {
+        id: 'v-control',
+        name: 'Control',
+        isControl: true,
+        weight: 50,
+        content: null,
+        impressions: 1000,
+        clicks: 100,
+        conversions: 5,
+        revenue: 0,
+      },
+      {
+        id: 'v-b',
+        name: 'Variant B',
+        isControl: false,
+        weight: 50,
+        content: { headline: 'Challenger' },
+        impressions: 1000,
+        clicks: 140,
+        conversions: 3,
+        revenue: 0,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('successCount', () => {
+  it('uses clicks for click-style goals, conversions otherwise', () => {
+    const v = { clicks: 7, conversions: 2 };
+    expect(successCount('cta_click', v)).toBe(7);
+    expect(successCount('scroll_depth', v)).toBe(7);
+    expect(successCount('conversion', v)).toBe(2);
+    expect(successCount('revenue', v)).toBe(2);
+  });
+});
+
+describe('transformExperiment', () => {
+  it('produces the full response shape', () => {
+    const t = transformExperiment(makeExperiment(), NOW);
+
+    expect(t.totalImpressions).toBe(2000);
+    expect(t.daysRunning).toBe(30);
+    expect(t.uplift).toBeCloseTo(40, 1); // 14% vs 10% clicks
+
+    // significance uses clicks for cta_click goal
+    const challenger = t.significance.variants.find((v) => v.id === 'v-b');
+    expect(challenger?.conversionRate).toBeCloseTo(0.14, 10);
+
+    // per-variant rates in percent + Wilson CI in percent
+    const vb = t.variants.find((v) => v.id === 'v-b');
+    expect(vb?.clickRate).toBeCloseTo(14, 5);
+    expect(vb?.goalRateCi.lo).toBeGreaterThan(11);
+    expect(vb?.goalRateCi.hi).toBeLessThan(17);
+
+    // decision block present with the concrete verdict for this fixture
+    // (pooled baseline 12% → required 555/variant; 1000 ≥ 555, day 30 ≥ 14,
+    // 40% lift at ~99.4% confidence → a legitimate winner).
+    expect(t.decision!.verdict).toBe('winner');
+    expect(typeof t.decision!.message).toBe('string');
+    expect(t.decision!.requiredPerVariant).toBeGreaterThan(0);
+  });
+
+  it('is order-independent: challenger listed before control gives the same result', () => {
+    const reversed = makeExperiment();
+    reversed.variants = [...reversed.variants].reverse(); // challenger first
+    const t = transformExperiment(reversed, NOW);
+    expect(t.uplift).toBeCloseTo(40, 1); // control still found by isControl flag
+    expect(t.decision!.verdict).toBe('winner');
+    expect(t.significance.control?.id).toBe('v-control');
+  });
+
+  it('anti-peeking flows through: confident early lead is collecting/trending', () => {
+    // 8% vs 5% at n=1000: ~99.3% confident, but the pooled baseline (6.5%)
+    // requires 1109/variant → short of the horizon → trending, not winner.
+    const early = makeExperiment({
+      variants: makeExperiment().variants.map((v) => ({
+        ...v,
+        clicks: v.id === 'v-control' ? 50 : 80,
+      })),
+    });
+    const t = transformExperiment(early, NOW, new Map(), 7, 0.1);
+    expect(t.decision!.verdict).toBe('collecting');
+    expect(t.decision!.trendingVariantId).toBe('v-b');
+  });
+
+  it('conversion-goal experiments count conversions, not clicks', () => {
+    const t = transformExperiment(makeExperiment({ goalMetric: 'conversion' }), NOW);
+    const control = t.significance.variants.find((v) => v.id === 'v-control');
+    expect(control?.conversionRate).toBeCloseTo(0.005, 10);
+  });
+
+  it('uses trailing exposure counts for the projection when present', () => {
+    const exposures = new Map([
+      ['exp-1:v-control', 70], // 10/day over the 7-day window
+      ['exp-1:v-b', 70],
+    ]);
+    const t = transformExperiment(makeExperiment(), NOW, exposures, 7, 0.1);
+    expect(t.decision!.dailyExposurePerVariant).toBeCloseTo(10, 5);
+  });
+
+  it('falls back to lifetime counters when the event stream is empty', () => {
+    const t = transformExperiment(makeExperiment(), NOW, new Map(), 7, 0.1);
+    // 1000 impressions over 30 days ≈ 33.3/day
+    expect(t.decision!.dailyExposurePerVariant).toBeCloseTo(1000 / 30, 3);
+  });
+
+  it('handles a DRAFT with no startDate and zero data without exploding', () => {
+    const t = transformExperiment(
+      makeExperiment({
+        status: 'DRAFT',
+        startDate: null,
+        variants: makeExperiment().variants.map((v) => ({
+          ...v,
+          impressions: 0,
+          clicks: 0,
+          conversions: 0,
+        })),
+      }),
+      NOW
+    );
+    expect(t.daysRunning).toBe(0);
+    expect(t.decision!.verdict).toBe('no-traffic');
+  });
+
+  it('survives clicks > impressions (public counters are unchecked increments)', () => {
+    // An attacker can POST more click events than impressions; the pooled
+    // baseline would be ≥ 1 and the power formula would throw if unclamped.
+    const t = transformExperiment(
+      makeExperiment({
+        variants: [
+          { id: 'c', name: 'Control', isControl: true, weight: 50, content: null, impressions: 200, clicks: 350, conversions: 0, revenue: 0 },
+          { id: 'v', name: 'Variant B', isControl: false, weight: 50, content: null, impressions: 200, clicks: 180, conversions: 0, revenue: 0 },
+        ],
+      }),
+      NOW
+    );
+    expect(t.decision).toBeDefined();
+    expect(Number.isFinite(t.decision!.requiredPerVariant)).toBe(true);
+  });
+
+  it('survives organic near-100% goal rates without throwing', () => {
+    // e.g. a scroll_depth goal where nearly everyone completes: 99.5% pooled.
+    const t = transformExperiment(
+      makeExperiment({
+        goalMetric: 'scroll_depth',
+        variants: [
+          { id: 'c', name: 'Control', isControl: true, weight: 50, content: null, impressions: 400, clicks: 398, conversions: 0, revenue: 0 },
+          { id: 'v', name: 'Variant B', isControl: false, weight: 50, content: null, impressions: 400, clicks: 399, conversions: 0, revenue: 0 },
+        ],
+      }),
+      NOW
+    );
+    expect(t.decision).toBeDefined();
+    expect(Number.isFinite(t.decision!.requiredPerVariant)).toBe(true);
+  });
+
+  it('caps the MDE for very high baselines instead of throwing', () => {
+    const t = transformExperiment(
+      makeExperiment({
+        variants: [
+          { id: 'c', name: 'Control', isControl: true, weight: 50, content: null, impressions: 500, clicks: 295, conversions: 0, revenue: 0 },
+          { id: 'v', name: 'Variant B', isControl: false, weight: 50, content: null, impressions: 500, clicks: 300, conversions: 0, revenue: 0 },
+        ],
+      }),
+      NOW
+    );
+    // baseline ≈ 0.595 → default MDE 0.15 keeps p2 < 1; must not throw and
+    // must produce a sane requirement.
+    expect(t.decision!.requiredPerVariant).toBeGreaterThan(100);
+    expect(Number.isFinite(t.decision!.requiredPerVariant)).toBe(true);
+  });
+});

--- a/src/__tests__/experiment-transform.test.ts
+++ b/src/__tests__/experiment-transform.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect } from 'vitest';
 import {
   transformExperiment,
   successCount,
+  buildVariantTrends,
   type TransformableExperiment,
 } from '@/lib/analytics/experiment-transform';
 
@@ -59,6 +60,29 @@ describe('successCount', () => {
     expect(successCount('scroll_depth', v)).toBe(7);
     expect(successCount('conversion', v)).toBe(2);
     expect(successCount('revenue', v)).toBe(2);
+  });
+});
+
+describe('buildVariantTrends', () => {
+  it('computes cumulative rates and gap-fills missing days', () => {
+    const rows = [
+      { variantId: 'a', day: '2026-07-10', exposures: 10, clicks: 1 },
+      // 07-11 missing entirely — must be gap-filled with zeros
+      { variantId: 'a', day: '2026-07-12', exposures: 10, clicks: 3 },
+      { variantId: 'b', day: '2026-07-10', exposures: 8, clicks: 2 },
+    ];
+    const trends = buildVariantTrends(rows, ['a', 'b']);
+    expect(trends['a'].map((p) => p.date)).toEqual(['2026-07-10', '2026-07-11', '2026-07-12']);
+    expect(trends['a'][1].exposures).toBe(0); // gap-filled
+    expect(trends['a'][1].cumRate).toBeCloseTo(10, 5); // 1/10 carried forward
+    expect(trends['a'][2].cumRate).toBeCloseTo(20, 5); // 4/20
+    // variant b has no rows after day 1 — cumulative carries forward flat
+    expect(trends['b'][2].cumExposures).toBe(8);
+    expect(trends['b'][2].cumRate).toBeCloseTo(25, 5);
+  });
+
+  it('returns empty for no rows', () => {
+    expect(buildVariantTrends([], ['a'])).toEqual({});
   });
 });
 
@@ -180,6 +204,20 @@ describe('transformExperiment', () => {
     );
     expect(t.decision).toBeDefined();
     expect(Number.isFinite(t.decision!.requiredPerVariant)).toBe(true);
+  });
+
+  it('attaches per-variant trends when series rows are provided', () => {
+    const rows = [
+      { variantId: 'v-control', day: '2026-07-10', exposures: 20, clicks: 2 },
+      { variantId: 'v-b', day: '2026-07-10', exposures: 22, clicks: 3 },
+      { variantId: 'v-control', day: '2026-07-11', exposures: 30, clicks: 3 },
+      { variantId: 'v-b', day: '2026-07-11', exposures: 28, clicks: 5 },
+    ];
+    const t = transformExperiment(makeExperiment(), NOW, new Map(), 7, 0.1, rows);
+    expect(t.trends['v-control']).toHaveLength(2);
+    // cumulative: day2 control = 5/50 = 10%
+    expect(t.trends['v-control'][1].cumRate).toBeCloseTo(10, 5);
+    expect(t.trends['v-b'][1].cumClicks).toBe(8);
   });
 
   it('caps the MDE for very high baselines instead of throwing', () => {

--- a/src/__tests__/hero-copy.test.ts
+++ b/src/__tests__/hero-copy.test.ts
@@ -1,0 +1,167 @@
+/**
+ * resolveHeroCopy precedence matrix — quiz > Brian's registry > System B (DB)
+ * > config default, with the SEO/H1 and bullets rules pinned.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveHeroCopy } from '@/components/landing/heroCopy';
+
+const CONFIG = {
+  heroEyebrow: 'AUSTIN BACHELOR PARTY ALCOHOL DELIVERY',
+  heroHeadline: 'Stocked & Ice-Cold',
+  heroHeadlineAccent: 'Before The Groom Lands.',
+  heroSubhead: 'Default subhead.',
+  heroBullets: ['bullet one', 'bullet two'],
+  ctaText: 'BUILD YOUR BACH PACKAGE →',
+};
+
+const BRIAN_HERO = {
+  eyebrow: 'BRIAN EYEBROW',
+  headline: 'Brian Headline',
+  headlineAccent: 'Brian Accent',
+  subhead: 'Brian subhead',
+};
+
+describe('resolveHeroCopy', () => {
+  it('config defaults when nothing overrides', () => {
+    const r = resolveHeroCopy({ cameFromQuiz: false, dbContent: null, config: CONFIG });
+    expect(r).toEqual({
+      eyebrow: CONFIG.heroEyebrow,
+      headline: CONFIG.heroHeadline,
+      headlineAccent: CONFIG.heroHeadlineAccent,
+      subhead: CONFIG.heroSubhead,
+      showBullets: true,
+      primaryCtaText: CONFIG.ctaText,
+    });
+  });
+
+  it('quiz beats everything (except CTA text)', () => {
+    const r = resolveHeroCopy({
+      cameFromQuiz: true,
+      brianHero: BRIAN_HERO,
+      dbContent: { headline: 'DB Headline', ctaText: 'DB CTA' },
+      config: CONFIG,
+    });
+    expect(r.eyebrow).toBe('WELCOME — STEP 1 OF 2');
+    expect(r.headline).toBe("Step one: Let's get started with");
+    expect(r.headlineAccent).toBe('your drinks.');
+    expect(r.showBullets).toBe(true); // bullets still win (existing behavior)
+    // CTA chain in the quiz branch mirrors the pre-resolver template:
+    // Brian's CTA test > System B > config. (In practice the template skips
+    // System B assignment on quiz arrivals, so dbContent is null there — the
+    // dbContent link matters only for the pure-function contract.)
+    expect(r.primaryCtaText).toBe('DB CTA');
+  });
+
+  it('quiz branch: Brian CTA test still wins the button text', () => {
+    const r = resolveHeroCopy({
+      cameFromQuiz: true,
+      brianCta: { primary: 'BRIAN CTA' },
+      dbContent: { ctaText: 'DB CTA' },
+      config: CONFIG,
+    });
+    expect(r.primaryCtaText).toBe('BRIAN CTA');
+  });
+
+  it('quiz branch: config CTA when no test overrides it', () => {
+    const r = resolveHeroCopy({
+      cameFromQuiz: true,
+      dbContent: null,
+      config: CONFIG,
+    });
+    expect(r.primaryCtaText).toBe(CONFIG.ctaText);
+  });
+
+  it("Brian's running test beats System B on every hero field", () => {
+    const r = resolveHeroCopy({
+      cameFromQuiz: false,
+      brianHero: BRIAN_HERO,
+      dbContent: { headline: 'DB Headline', subhead: 'DB subhead', ctaText: 'DB CTA' },
+      config: CONFIG,
+    });
+    expect(r.eyebrow).toBe('BRIAN EYEBROW');
+    expect(r.headline).toBe('Brian Headline');
+    expect(r.headlineAccent).toBe('Brian Accent');
+    expect(r.subhead).toBe('Brian subhead');
+    // System B never mixes into a Brian-owned hero, not even the CTA.
+    expect(r.primaryCtaText).toBe(CONFIG.ctaText);
+    expect(r.showBullets).toBe(true);
+  });
+
+  it("Brian's CTA test overrides the primary CTA text", () => {
+    const r = resolveHeroCopy({
+      cameFromQuiz: false,
+      brianCta: { primary: 'BRIAN CTA' },
+      dbContent: { ctaText: 'DB CTA' },
+      config: CONFIG,
+    });
+    expect(r.primaryCtaText).toBe('BRIAN CTA');
+  });
+
+  it('System B never overrides the eyebrow (semantic H1 / SEO)', () => {
+    const r = resolveHeroCopy({
+      cameFromQuiz: false,
+      dbContent: { eyebrow: 'SHOULD BE IGNORED', headline: 'DB Headline' },
+      config: CONFIG,
+    });
+    expect(r.eyebrow).toBe(CONFIG.heroEyebrow);
+    expect(r.headline).toBe('DB Headline');
+  });
+
+  it('System B headline WITHOUT accent renders one line (accent empty)', () => {
+    const r = resolveHeroCopy({
+      cameFromQuiz: false,
+      dbContent: { headline: 'One Line Challenger' },
+      config: CONFIG,
+    });
+    expect(r.headline).toBe('One Line Challenger');
+    expect(r.headlineAccent).toBe('');
+  });
+
+  it('System B headline WITH accent renders both lines', () => {
+    const r = resolveHeroCopy({
+      cameFromQuiz: false,
+      dbContent: { headline: 'Line One —', headlineAccent: 'Line Two.' },
+      config: CONFIG,
+    });
+    expect(r.headline).toBe('Line One —');
+    expect(r.headlineAccent).toBe('Line Two.');
+  });
+
+  it('per-field independence: DB accent alone keeps the config headline', () => {
+    const r = resolveHeroCopy({
+      cameFromQuiz: false,
+      dbContent: { headlineAccent: 'New Accent Only.' },
+      config: CONFIG,
+    });
+    expect(r.headline).toBe(CONFIG.heroHeadline);
+    expect(r.headlineAccent).toBe('New Accent Only.');
+  });
+
+  it('System B subhead suppresses bullets; no override keeps them', () => {
+    const withSub = resolveHeroCopy({
+      cameFromQuiz: false,
+      dbContent: { subhead: 'DB subhead override' },
+      config: CONFIG,
+    });
+    expect(withSub.showBullets).toBe(false);
+    expect(withSub.subhead).toBe('DB subhead override');
+
+    const noBullets = resolveHeroCopy({
+      cameFromQuiz: false,
+      dbContent: null,
+      config: { ...CONFIG, heroBullets: [] },
+    });
+    expect(noBullets.showBullets).toBe(false);
+    expect(noBullets.subhead).toBe(CONFIG.heroSubhead);
+  });
+
+  it('CTA chain: DB ctaText wins over config when Brian absent', () => {
+    const r = resolveHeroCopy({
+      cameFromQuiz: false,
+      dbContent: { ctaText: 'DB CTA' },
+      config: CONFIG,
+    });
+    expect(r.primaryCtaText).toBe('DB CTA');
+  });
+});

--- a/src/__tests__/hero-test-seeds.test.ts
+++ b/src/__tests__/hero-test-seeds.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Hero-test seed validity — every seed must pass the same schema the admin
+ * create route enforces, and the homepage seed must survive the legacy
+ * name→content-id mapping (a rename silently renders control on both arms).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { HERO_TEST_SEEDS, WIRED_ROUTES } from '@/lib/experiments/hero-test-seeds';
+import { CreateExperimentSchema } from '@/lib/experiments/experiment-schemas';
+// The REAL mapping (shared by /api/experiments/assign + /track) — the legacy
+// homepage pipeline resolves variant NAMES to hero-variants.ts content ids;
+// anything unrecognized silently falls back to 'control' on both arms.
+import { mapVariantNameToContentId } from '@/lib/experiments/hero-variants';
+
+describe('hero-test seeds', () => {
+  it('every seed passes the create-route schema', () => {
+    for (const seed of HERO_TEST_SEEDS) {
+      expect(() => CreateExperimentSchema.parse(seed)).not.toThrow();
+    }
+  });
+
+  it('exactly 2 variants, weights 100, exactly one control, cta_click goal', () => {
+    for (const seed of HERO_TEST_SEEDS) {
+      expect(seed.variants, seed.page).toHaveLength(2);
+      expect(seed.variants.reduce((s, v) => s + (v.weight ?? 0), 0), seed.page).toBe(100);
+      expect(seed.variants.filter((v) => v.isControl).length, seed.page).toBe(1);
+      expect(seed.goalMetric, seed.page).toBe('cta_click');
+    }
+  });
+
+  it('pages are unique and all wired for hero experiments', () => {
+    const pages = HERO_TEST_SEEDS.map((s) => s.page);
+    expect(new Set(pages).size).toBe(pages.length);
+    const wired = new Set<string>(WIRED_ROUTES);
+    for (const page of pages) expect(wired.has(page), page).toBe(true);
+  });
+
+  it('covers every wired route exactly once', () => {
+    expect(new Set(HERO_TEST_SEEDS.map((s) => s.page))).toEqual(new Set(WIRED_ROUTES));
+  });
+
+  it('controls never carry copy overrides (content empty)', () => {
+    for (const seed of HERO_TEST_SEEDS) {
+      const control = seed.variants.find((v) => v.isControl);
+      expect(Object.keys(control?.content ?? {}), seed.page).toHaveLength(0);
+    }
+  });
+
+  it('homepage variant names resolve through the legacy name mapping to DISTINCT content', () => {
+    const home = HERO_TEST_SEEDS.find((s) => s.page === '/');
+    expect(home).toBeDefined();
+    const ids = home!.variants.map((v) => mapVariantNameToContentId(v.name));
+    // Both must resolve (no silent fallback collision) and differ from each other.
+    expect(new Set(ids).size).toBe(2);
+    expect(ids).toContain('control');
+    // Homepage copy lives in hero-variants.ts — the DB content must stay empty.
+    for (const v of home!.variants) {
+      expect(Object.keys(v.content ?? {})).toHaveLength(0);
+    }
+  });
+
+  it('challenger on the SEO-keyword calculator page keeps the exact-match keyword', () => {
+    const calc = HERO_TEST_SEEDS.find((s) => s.page === '/wedding-drink-calculator');
+    const challenger = calc!.variants.find((v) => !v.isControl);
+    expect(challenger?.content?.headline).toContain('Wedding Drink Calculator');
+  });
+
+  it('template-lander challengers never override the SEO eyebrow', () => {
+    for (const seed of HERO_TEST_SEEDS) {
+      for (const v of seed.variants) {
+        expect(v.content?.eyebrow, `${seed.page} / ${v.name}`).toBeUndefined();
+      }
+    }
+  });
+
+  it('only wedding-weekend is flagged low-traffic', () => {
+    const flagged = HERO_TEST_SEEDS.filter((s) => s.lowTraffic).map((s) => s.page);
+    expect(flagged).toEqual(['/austin-wedding-weekend-delivery']);
+  });
+});

--- a/src/__tests__/use-hero-experiment.test.tsx
+++ b/src/__tests__/use-hero-experiment.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * useHeroExperiment — the skip option is a data-integrity invariant: when a
+ * page opts out (Brian's test running, /order auto-mode, quiz arrivals), the
+ * hook must make NO network calls at all — an assign call records an
+ * impression server-side, which would pollute the experiment sample.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useHeroExperiment } from '@/hooks/useHeroExperiment';
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock);
+  fetchMock.mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      experimentId: null,
+      variantDbId: null,
+      content: null,
+      goalMetric: null,
+    }),
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  fetchMock.mockReset();
+});
+
+describe('useHeroExperiment skip', () => {
+  it('skip: true → ready immediately, NO assign fetch, NO impression', async () => {
+    const { result } = renderHook(() => useHeroExperiment('/order', { skip: true }));
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.content).toBeNull();
+    expect(result.current.experimentId).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('skip omitted → assign fetch fires', async () => {
+    const { result } = renderHook(() => useHeroExperiment('/boat-parties'));
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(fetchMock).toHaveBeenCalled();
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toContain('/api/experiments/assign');
+    expect(url).toContain('page=%2Fboat-parties');
+  });
+
+  it('no active experiment → defaults, and no impression POST', async () => {
+    const { result } = renderHook(() => useHeroExperiment('/boat-parties'));
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.content).toBeNull();
+    // Only the assign GET — no POST /api/experiments/track without a variant.
+    const posts = fetchMock.mock.calls.filter(
+      (c) => (c[1] as RequestInit | undefined)?.method === 'POST'
+    );
+    expect(posts).toHaveLength(0);
+  });
+});

--- a/src/app/admin/analytics/components/CreateHeroTestModal.tsx
+++ b/src/app/admin/analytics/components/CreateHeroTestModal.tsx
@@ -8,6 +8,7 @@ interface VariantForm {
   isControl: boolean;
   eyebrow: string;
   headline: string;
+  headlineAccent: string;
   subhead: string;
   ctaText: string;
 }
@@ -15,6 +16,8 @@ interface VariantForm {
 interface CreateHeroTestModalProps {
   /** Canonical route the experiment is scoped to (e.g. '/weddings'). */
   canonicalPath: string;
+  /** Routes on this tab that render their own hero — a selector shows when >1. */
+  pathOptions?: string[];
   elementId: string;
   pageLabel: string;
   onClose: () => void;
@@ -22,12 +25,13 @@ interface CreateHeroTestModalProps {
 }
 
 function blankVariant(name: string, isControl: boolean): VariantForm {
-  return { name, weight: 50, isControl, eyebrow: '', headline: '', subhead: '', ctaText: '' };
+  return { name, weight: 50, isControl, eyebrow: '', headline: '', headlineAccent: '', subhead: '', ctaText: '' };
 }
 
-const FIELDS: { key: keyof Pick<VariantForm, 'eyebrow' | 'headline' | 'subhead' | 'ctaText'>; label: string }[] = [
+const FIELDS: { key: keyof Pick<VariantForm, 'eyebrow' | 'headline' | 'headlineAccent' | 'subhead' | 'ctaText'>; label: string }[] = [
   { key: 'eyebrow', label: 'Eyebrow' },
   { key: 'headline', label: 'Headline' },
+  { key: 'headlineAccent', label: 'Headline 2nd line (Austin landers)' },
   { key: 'subhead', label: 'Subhead' },
   { key: 'ctaText', label: 'Button text' },
 ];
@@ -39,12 +43,14 @@ const FIELDS: { key: keyof Pick<VariantForm, 'eyebrow' | 'headline' | 'subhead' 
  */
 export default function CreateHeroTestModal({
   canonicalPath,
+  pathOptions,
   elementId,
   pageLabel,
   onClose,
   onCreated,
 }: CreateHeroTestModalProps): ReactElement {
   const [name, setName] = useState('');
+  const [page, setPage] = useState(canonicalPath);
   const [goalMetric, setGoalMetric] = useState<'cta_click' | 'conversion'>('cta_click');
   const [variants, setVariants] = useState<VariantForm[]>([
     blankVariant('Control', true),
@@ -79,7 +85,7 @@ export default function CreateHeroTestModal({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           name: name.trim(),
-          page: canonicalPath,
+          page,
           elementId,
           goalMetric,
           variants: variants.map((v) => ({
@@ -89,6 +95,7 @@ export default function CreateHeroTestModal({
             content: {
               ...(v.eyebrow.trim() && { eyebrow: v.eyebrow.trim() }),
               ...(v.headline.trim() && { headline: v.headline.trim() }),
+              ...(v.headlineAccent.trim() && { headlineAccent: v.headlineAccent.trim() }),
               ...(v.subhead.trim() && { subhead: v.subhead.trim() }),
               ...(v.ctaText.trim() && { ctaText: v.ctaText.trim() }),
             },
@@ -118,6 +125,17 @@ export default function CreateHeroTestModal({
         <label className="block text-base font-medium text-gray-700 mb-1">Test name</label>
         <input className="input-premium mb-4" value={name} placeholder="e.g. Wedding hero — benefit vs urgency"
           onChange={(e) => setName(e.target.value)} />
+
+        {pathOptions && pathOptions.length > 1 && (
+          <>
+            <label className="block text-base font-medium text-gray-700 mb-1">Which page&apos;s hero?</label>
+            <select className="input-premium mb-4" value={page} onChange={(e) => setPage(e.target.value)}>
+              {pathOptions.map((p) => (
+                <option key={p} value={p}>{p}</option>
+              ))}
+            </select>
+          </>
+        )}
 
         <label className="block text-base font-medium text-gray-700 mb-1">Goal</label>
         <select className="input-premium mb-4" value={goalMetric} onChange={(e) => setGoalMetric(e.target.value as 'cta_click' | 'conversion')}>

--- a/src/app/admin/analytics/components/ExperimentCharts.tsx
+++ b/src/app/admin/analytics/components/ExperimentCharts.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import { ReactElement, useMemo, useState } from 'react';
+import type { VariantRow } from './ExperimentResultCard';
+import type { TrendPoint } from '@/lib/analytics/experiment-transform';
+
+/**
+ * Compact charts for one experiment in the analytics scoreboard.
+ *
+ * Colors: control is deliberately NEUTRAL gray (#6b7280) — it's the baseline,
+ * not a competing identity — and the challenger carries brand-blue (#0B74B8).
+ * CVD separation ΔE≈32 (validated); identity is never color-alone (direct
+ * labels on line ends + the counts below every bar).
+ */
+const CONTROL_COLOR = '#6b7280';
+const VARIANT_COLOR = '#0B74B8';
+
+export function variantColor(isControl: boolean): string {
+  return isControl ? CONTROL_COLOR : VARIANT_COLOR;
+}
+
+const W = 320;
+const H = 96;
+const PAD = { top: 8, right: 64, bottom: 16, left: 30 };
+
+interface TrendProps {
+  variants: VariantRow[];
+  trends: Record<string, TrendPoint[]>;
+}
+
+/**
+ * Cumulative CTR over time, one line per variant. Cumulative — not daily —
+ * because daily rates at this traffic are noise; what an operator can read is
+ * the two lines settling apart (or together) as the sample grows.
+ */
+export function CtrTrendChart({ variants, trends }: TrendProps): ReactElement {
+  const [hoverIdx, setHoverIdx] = useState<number | null>(null);
+
+  const series = useMemo(
+    () =>
+      variants
+        .map((v) => ({ variant: v, points: trends[v.id] ?? [] }))
+        .filter((s) => s.points.length > 0),
+    [variants, trends]
+  );
+  const nDays = series[0]?.points.length ?? 0;
+
+  if (nDays < 2) {
+    return (
+      <div className="flex h-full min-h-[96px] items-center justify-center rounded-lg border border-dashed border-gray-200 px-3 text-center text-sm text-gray-400">
+        CTR trend appears after a couple of days of data
+      </div>
+    );
+  }
+
+  const maxRate = Math.max(5, ...series.flatMap((s) => s.points.map((p) => p.cumRate)));
+  const x = (i: number): number =>
+    PAD.left + (i / Math.max(nDays - 1, 1)) * (W - PAD.left - PAD.right);
+  const y = (rate: number): number =>
+    PAD.top + (1 - rate / maxRate) * (H - PAD.top - PAD.bottom);
+
+  const gridRates = [0, maxRate / 2, maxRate];
+  const hover = hoverIdx != null ? Math.min(hoverIdx, nDays - 1) : null;
+
+  return (
+    <div className="relative h-full">
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        className="h-full w-full"
+        role="img"
+        aria-label="Cumulative click-through rate over time per variant"
+        onMouseMove={(e) => {
+          const rect = e.currentTarget.getBoundingClientRect();
+          const px = ((e.clientX - rect.left) / rect.width) * W;
+          const frac = (px - PAD.left) / (W - PAD.left - PAD.right);
+          setHoverIdx(Math.round(Math.min(1, Math.max(0, frac)) * (nDays - 1)));
+        }}
+        onMouseLeave={() => setHoverIdx(null)}
+      >
+        {gridRates.map((r) => (
+          <g key={r}>
+            <line x1={PAD.left} x2={W - PAD.right} y1={y(r)} y2={y(r)} stroke="#eef0f3" strokeWidth={1} />
+            <text x={PAD.left - 4} y={y(r) + 3} textAnchor="end" fontSize={8} fill="#9aa3af">
+              {r.toFixed(0)}%
+            </text>
+          </g>
+        ))}
+
+        {hover != null && (
+          <line x1={x(hover)} x2={x(hover)} y1={PAD.top} y2={H - PAD.bottom} stroke="#c8cdd4" strokeWidth={1} />
+        )}
+
+        {series.map(({ variant, points }) => {
+          const color = variantColor(variant.isControl);
+          const path = points.map((p, i) => `${i === 0 ? 'M' : 'L'}${x(i)},${y(p.cumRate)}`).join(' ');
+          const last = points[points.length - 1];
+          return (
+            <g key={variant.id}>
+              <path d={path} fill="none" stroke={color} strokeWidth={2} strokeLinejoin="round" />
+              {hover != null && points[hover] && (
+                <circle cx={x(hover)} cy={y(points[hover].cumRate)} r={3} fill={color} stroke="#fff" strokeWidth={1.5} />
+              )}
+              {/* Direct end label — identity is never color-alone */}
+              <text x={W - PAD.right + 5} y={y(last.cumRate) + 3} fontSize={8.5} fill="#4b5563">
+                {variant.name} {last.cumRate.toFixed(1)}%
+              </text>
+            </g>
+          );
+        })}
+        <text x={PAD.left} y={H - 4} fontSize={8} fill="#9aa3af">
+          {series[0].points[0].date.slice(5)}
+        </text>
+        <text x={W - PAD.right} y={H - 4} textAnchor="end" fontSize={8} fill="#9aa3af">
+          {series[0].points[nDays - 1].date.slice(5)}
+        </text>
+      </svg>
+
+      {hover != null && series[0]?.points[hover] && (
+        <div className="pointer-events-none absolute -top-1 left-1/2 z-10 -translate-x-1/2 rounded-md border border-gray-200 bg-white px-2 py-1 text-xs text-gray-700 shadow-sm">
+          <span className="font-medium">{series[0].points[hover].date}</span>
+          {series.map(({ variant, points }) => (
+            <span key={variant.id} className="ml-2 whitespace-nowrap">
+              <span
+                className="mr-1 inline-block h-2 w-2 rounded-full align-middle"
+                style={{ background: variantColor(variant.isControl) }}
+              />
+              {points[hover].cumRate.toFixed(1)}% ({points[hover].cumClicks}/{points[hover].cumExposures})
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface CountsProps {
+  variants: VariantRow[];
+  goalIsClick: boolean;
+}
+
+/**
+ * Current counts as part-to-whole bars: the light track is visitors, the
+ * solid fill is the subset who clicked — so length compares sample sizes
+ * across variants while the fill ratio shows the rate, on one shared scale.
+ */
+export function CountsBars({ variants, goalIsClick }: CountsProps): ReactElement {
+  const maxVisitors = Math.max(1, ...variants.map((v) => v.impressions));
+  return (
+    <div className="flex h-full flex-col justify-center gap-3">
+      {variants.map((v) => {
+        const successes = goalIsClick ? v.clicks : v.conversions;
+        const color = variantColor(v.isControl);
+        const trackPct = (v.impressions / maxVisitors) * 100;
+        const fillPct = v.impressions > 0 ? (successes / v.impressions) * 100 : 0;
+        return (
+          <div key={v.id}>
+            <div className="mb-1 flex items-baseline justify-between gap-2 text-xs">
+              <span className="truncate text-gray-700">
+                <span className="mr-1.5 inline-block h-2 w-2 rounded-full align-middle" style={{ background: color }} />
+                {v.name}
+              </span>
+              <span className="whitespace-nowrap text-gray-500 tabular-nums">
+                {successes.toLocaleString()} {goalIsClick ? 'clicks' : 'orders'} / {v.impressions.toLocaleString()} visitors
+              </span>
+            </div>
+            <div className="h-3.5 rounded" style={{ width: `${trackPct}%`, background: `${color}26`, minWidth: 24 }}>
+              <div className="h-full rounded" style={{ width: `${fillPct}%`, background: color }} />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/admin/analytics/components/ExperimentResultCard.tsx
+++ b/src/app/admin/analytics/components/ExperimentResultCard.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 export interface HeroContent {
   eyebrow?: string;
   headline?: string;
+  headlineAccent?: string;
   subhead?: string;
   ctaText?: string;
 }
@@ -19,24 +20,52 @@ export interface VariantRow {
   conversions: number;
   clickRate: number;
   conversionRate: number;
+  /** Wilson 95% CI on the goal rate, percent units (matches clickRate). */
+  goalRateCi?: { lo: number; hi: number };
   content: HeroContent | null;
 }
-export interface SigVariant { id: string; confidence: number; liftPct: number; pValue: number }
-export interface Significance { variants: SigVariant[]; winner: string | null; hasEnoughData: boolean }
+export interface SigVariant {
+  id: string;
+  name?: string;
+  confidence: number | null;
+  liftPct: number | null;
+  pValue: number | null;
+}
+/** Mirrors SignificanceResult from computeSignificance — winner is the full
+ * variant object (a previous version of this file typed it as a string id,
+ * which made the winner badge silently never match). */
+export interface Significance {
+  variants: SigVariant[];
+  winner: SigVariant | null;
+  hasEnoughData: boolean;
+}
+export interface ExperimentDecision {
+  verdict: 'winner' | 'no-difference' | 'collecting' | 'underpowered' | 'no-traffic';
+  message: string;
+  requiredPerVariant: number;
+  minVariantImpressions: number;
+  remainingDays: number | null;
+  projectedDecisionDate: string | null;
+  dailyExposurePerVariant: number;
+  reachable: boolean;
+  trendingVariantId: string | null;
+  confidenceLevel: number;
+}
 export interface Experiment {
   id: string;
   name: string;
+  /** Route this test runs on (a tab can span several hero routes). */
+  page: string;
   status: 'DRAFT' | 'RUNNING' | 'PAUSED' | 'COMPLETED';
   goalMetric: string;
   winningVariant: string | null;
   winnerReason: string | null;
   daysRunning: number;
   significance: Significance;
+  /** Absent when the server's decision math degraded for this row. */
+  decision?: ExperimentDecision;
   variants: VariantRow[];
 }
-
-/** Matches the per-variant impression floor in computeSignificance. */
-const MIN_SAMPLE = 100;
 
 const STATUS_STYLES: Record<string, string> = {
   DRAFT: 'bg-gray-100 text-gray-700',
@@ -91,7 +120,12 @@ function VariantCard({
       <div className="flex items-end justify-between">
         <div>
           <div className="text-4xl font-bold text-gray-900 leading-none">{rateOf(v, goalIsClick).toFixed(1)}%</div>
-          <div className="text-sm text-gray-500 mt-1">{goalIsClick ? 'click rate' : 'conversion rate'}</div>
+          <div className="text-sm text-gray-500 mt-1">
+            {goalIsClick ? 'click rate' : 'conversion rate'}
+            {v.goalRateCi && v.impressions > 0 && (
+              <span className="text-gray-400"> · likely {v.goalRateCi.lo.toFixed(1)}–{v.goalRateCi.hi.toFixed(1)}%</span>
+            )}
+          </div>
         </div>
         <div className="text-right text-sm text-gray-600">
           <div>{v.impressions.toLocaleString()} views</div>
@@ -114,31 +148,24 @@ export default function ExperimentResultCard({ exp, canonicalPath, onStatus, onD
   const goalIsClick = exp.goalMetric === 'cta_click' || exp.goalMetric === 'scroll_depth';
   const sorted = [...exp.variants].sort((a, b) => rateOf(b, goalIsClick) - rateOf(a, goalIsClick));
   const leaderId = sorted[0]?.id ?? null;
-  const minImpr = exp.variants.length ? Math.min(...exp.variants.map((v) => v.impressions)) : 0;
-  const needViews = Math.max(0, MIN_SAMPLE - minImpr);
-  const nonControlIds = new Set(exp.variants.filter((v) => !v.isControl).map((v) => v.id));
-  const topConf = Math.round(
-    Math.max(0, ...exp.significance.variants.filter((s) => nonControlIds.has(s.id)).map((s) => s.confidence))
-  );
-  const leaderName = exp.variants.find((v) => v.id === leaderId)?.name ?? '—';
 
   function badgeFor(v: VariantRow): 'winner' | 'ahead' | null {
-    if (exp.significance.winner === v.id || exp.winningVariant === v.id) return 'winner';
-    if (!exp.significance.winner && v.id === leaderId && exp.status !== 'DRAFT') return 'ahead';
+    const callable = exp.decision?.verdict === 'winner';
+    if ((callable && exp.significance.winner?.id === v.id) || exp.winningVariant === v.id) return 'winner';
+    if (exp.winningVariant == null && !callable && v.id === leaderId && exp.status !== 'DRAFT') return 'ahead';
     return null;
   }
 
+  // The decision message (verdict + CI + projected call date) is pre-baked
+  // server-side in experiment-planning.ts — this card just renders it.
   let summary: string;
   if (exp.status === 'COMPLETED') {
     const w = exp.variants.find((v) => v.id === exp.winningVariant);
     summary = w ? `Concluded — winner: ${w.name}.` : 'Concluded.';
-  } else if (exp.significance.winner) {
-    summary = `Significant — ${leaderName} wins at ${topConf}% confidence.`;
-  } else if (needViews > 0) {
-    summary = `Not enough data yet — ~${needViews.toLocaleString()} more views on the smaller variant to reach the minimum sample. Confidence ${topConf}% (need 95% to call it).`;
   } else {
-    summary = `${leaderName} ahead, but not conclusive — confidence ${topConf}% (need 95% to call it).`;
+    summary = exp.decision?.message ?? 'Stats temporarily unavailable for this test.';
   }
+  const summaryIsWin = exp.decision?.verdict === 'winner';
 
   return (
     <div className="rounded-lg border border-gray-200 p-4">
@@ -156,7 +183,7 @@ export default function ExperimentResultCard({ exp, canonicalPath, onStatus, onD
         ))}
       </div>
 
-      <p className={`mt-3 text-sm ${exp.significance.winner ? 'text-green-700' : 'text-gray-600'}`}>{summary}</p>
+      <p className={`mt-3 text-sm ${summaryIsWin ? 'text-green-700' : 'text-gray-600'}`}>{summary}</p>
       {exp.status === 'COMPLETED' && exp.winnerReason && (
         <p className="mt-1 text-sm text-gray-600"><span className="font-medium">Why it won:</span> {exp.winnerReason}</p>
       )}

--- a/src/app/admin/analytics/components/ExperimentResultCard.tsx
+++ b/src/app/admin/analytics/components/ExperimentResultCard.tsx
@@ -51,6 +51,14 @@ export interface ExperimentDecision {
   trendingVariantId: string | null;
   confidenceLevel: number;
 }
+export interface TrendPoint {
+  date: string;
+  exposures: number;
+  clicks: number;
+  cumExposures: number;
+  cumClicks: number;
+  cumRate: number;
+}
 export interface Experiment {
   id: string;
   name: string;
@@ -64,6 +72,8 @@ export interface Experiment {
   significance: Significance;
   /** Absent when the server's decision math degraded for this row. */
   decision?: ExperimentDecision;
+  /** Per-variant cumulative CTR trend (event-based, directional). */
+  trends?: Record<string, TrendPoint[]>;
   variants: VariantRow[];
 }
 

--- a/src/app/admin/analytics/components/ExperimentSummaryBanner.tsx
+++ b/src/app/admin/analytics/components/ExperimentSummaryBanner.tsx
@@ -2,6 +2,7 @@
 
 import { ReactElement, useState } from 'react';
 import CreateHeroTestModal from './CreateHeroTestModal';
+import { CtrTrendChart, CountsBars } from './ExperimentCharts';
 import type { Experiment, VariantRow } from './ExperimentResultCard';
 import { experimentPathsFor, type LandingPageDef } from '@/lib/analytics/landing-pages';
 
@@ -131,6 +132,23 @@ function ExperimentScore({
             </div>
           );
         })}
+      </div>
+
+      {/* Charts: cumulative CTR over time + current counts (event-based
+          trend is directional; the decision numbers stay counter-based) */}
+      <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div className="min-h-[104px]">
+          <div className="mb-1 text-xs font-medium uppercase tracking-wide text-gray-400">
+            {goalIsClick ? 'CTR' : 'Conversion'} over time (cumulative)
+          </div>
+          <CtrTrendChart variants={exp.variants} trends={exp.trends ?? {}} />
+        </div>
+        <div className="min-h-[104px]">
+          <div className="mb-1 text-xs font-medium uppercase tracking-wide text-gray-400">
+            Current counts
+          </div>
+          <CountsBars variants={exp.variants} goalIsClick={goalIsClick} />
+        </div>
       </div>
 
       {/* Verdict: confidence + when we can make the call */}

--- a/src/app/admin/analytics/components/ExperimentSummaryBanner.tsx
+++ b/src/app/admin/analytics/components/ExperimentSummaryBanner.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import { ReactElement, useState } from 'react';
+import CreateHeroTestModal from './CreateHeroTestModal';
+import type { Experiment, VariantRow } from './ExperimentResultCard';
+import { experimentPathsFor, type LandingPageDef } from '@/lib/analytics/landing-pages';
+
+interface Props {
+  def: LandingPageDef;
+  experiments: Experiment[];
+  loading: boolean;
+  reload: () => Promise<void>;
+}
+
+const VERDICT_STYLES: Record<string, string> = {
+  winner: 'border-green-300 bg-green-50 text-green-800',
+  'no-difference': 'border-blue-200 bg-blue-50 text-blue-800',
+  collecting: 'border-gray-200 bg-gray-50 text-gray-700',
+  underpowered: 'border-amber-200 bg-amber-50 text-amber-800',
+  'no-traffic': 'border-amber-200 bg-amber-50 text-amber-800',
+};
+
+function goalRate(v: VariantRow, goalIsClick: boolean): number {
+  return goalIsClick ? v.clickRate : v.conversionRate;
+}
+
+/** One live experiment as a compact scoreboard row set. */
+function ExperimentScore({
+  exp,
+  showPath,
+  onStart,
+  starting,
+}: {
+  exp: Experiment;
+  showPath: boolean;
+  onStart: (id: string) => void;
+  starting: boolean;
+}): ReactElement {
+  const goalIsClick = exp.goalMetric === 'cta_click' || exp.goalMetric === 'scroll_depth';
+  const control = exp.variants.find((v) => v.isControl);
+  const controlRate = control ? goalRate(control, goalIsClick) : 0;
+  const maxRate = Math.max(1e-9, ...exp.variants.map((v) => goalRate(v, goalIsClick)));
+
+  if (exp.status === 'DRAFT') {
+    return (
+      <div className="flex items-center justify-between gap-3 rounded-lg border border-dashed border-gray-300 px-4 py-3">
+        <div className="min-w-0">
+          <span className="text-sm font-medium text-gray-900">{exp.name}</span>
+          {showPath && <span className="ml-2 text-sm text-gray-500">{exp.page}</span>}
+          <span className="ml-2 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">DRAFT</span>
+        </div>
+        <button
+          type="button"
+          className="btn-primary text-sm shrink-0 disabled:opacity-50"
+          disabled={starting}
+          onClick={() => onStart(exp.id)}
+        >
+          {starting ? 'Starting…' : 'Start test'}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-gray-200 p-4">
+      <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1">
+        <span className="text-sm font-semibold text-gray-900">{exp.name}</span>
+        {showPath && <span className="text-sm text-gray-500">{exp.page}</span>}
+        <span
+          className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+            exp.status === 'RUNNING' ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800'
+          }`}
+        >
+          {exp.status}
+        </span>
+        <span className="text-sm text-gray-500">
+          day {exp.daysRunning} · goal: {goalIsClick ? 'CTA clicks' : 'purchases'}
+        </span>
+      </div>
+
+      {/* Variant rows: visitors → clicks → CTR (+CI) → lift */}
+      <div className="space-y-2">
+        {exp.variants.map((v) => {
+          const rate = goalRate(v, goalIsClick);
+          const successes = goalIsClick ? v.clicks : v.conversions;
+          const lift = !v.isControl && controlRate > 0 ? ((rate - controlRate) / controlRate) * 100 : null;
+          const isTrending = exp.decision?.trendingVariantId === v.id;
+          const isWinner = exp.decision?.verdict === 'winner' && exp.significance.winner?.id === v.id;
+          return (
+            <div key={v.id} className="grid grid-cols-12 items-center gap-2">
+              <div className="col-span-12 sm:col-span-3 truncate text-sm text-gray-900">
+                {v.name}
+                {v.isControl && <span className="text-gray-400"> · control</span>}
+                {isWinner && <span className="ml-1 text-xs font-semibold text-green-700">★ WINNER</span>}
+                {!isWinner && isTrending && <span className="ml-1 text-xs font-semibold text-blue-700">trending</span>}
+              </div>
+              <div className="col-span-4 sm:col-span-2 text-sm text-gray-600 tabular-nums">
+                {v.impressions.toLocaleString()} <span className="text-gray-400">visitors</span>
+              </div>
+              <div className="col-span-3 sm:col-span-2 text-sm text-gray-600 tabular-nums">
+                {successes.toLocaleString()} <span className="text-gray-400">{goalIsClick ? 'clicks' : 'orders'}</span>
+              </div>
+              <div className="col-span-5 sm:col-span-3">
+                <div className="flex items-center gap-2">
+                  <div className="h-2 flex-1 overflow-hidden rounded bg-gray-100">
+                    <div
+                      className={`h-full rounded ${v.isControl ? 'bg-gray-400' : 'bg-brand-blue'}`}
+                      style={{ width: `${Math.min(100, (rate / maxRate) * 100)}%` }}
+                    />
+                  </div>
+                  <span className="w-24 text-right text-sm font-semibold text-gray-900 tabular-nums">
+                    {rate.toFixed(1)}%
+                    {v.goalRateCi && v.impressions > 0 && (
+                      <span className="block text-xs font-normal text-gray-400">
+                        {v.goalRateCi.lo.toFixed(1)}–{v.goalRateCi.hi.toFixed(1)}%
+                      </span>
+                    )}
+                  </span>
+                </div>
+              </div>
+              <div className="col-span-12 sm:col-span-2 text-right text-sm tabular-nums">
+                {lift != null ? (
+                  <span className={lift >= 0 ? 'text-green-700' : 'text-red-600'}>
+                    {lift >= 0 ? '+' : ''}
+                    {lift.toFixed(0)}% vs control
+                  </span>
+                ) : (
+                  <span className="text-gray-300">—</span>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Verdict: confidence + when we can make the call */}
+      {exp.decision && (
+        <div
+          className={`mt-3 rounded-lg border px-3 py-2 text-sm ${VERDICT_STYLES[exp.decision.verdict] ?? VERDICT_STYLES.collecting}`}
+        >
+          {exp.decision.message}
+          {exp.decision.verdict === 'collecting' && (
+            <span className="text-gray-500">
+              {' '}
+              ({exp.decision.minVariantImpressions.toLocaleString()} of{' '}
+              {exp.decision.requiredPerVariant.toLocaleString()} visitors per variant at{' '}
+              {Math.round(exp.decision.confidenceLevel * 100)}% confidence)
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Top-of-page experiment scoreboard — the first thing on each landing page's
+ * analytics tab. Per variant: visitors, CTA clicks, CTR with its likely range
+ * (Wilson 95% CI), lift vs control; plus the server's verdict line with the
+ * projected "when can we call it" date. Management (pause/conclude/copy
+ * preview) stays in the A/B tests panel below.
+ */
+export default function ExperimentSummaryBanner({ def, experiments, loading, reload }: Props): ReactElement {
+  const [showCreate, setShowCreate] = useState(false);
+  const [startingId, setStartingId] = useState<string | null>(null);
+
+  const active = experiments.filter((e) => e.status !== 'COMPLETED');
+  const pathOptions = experimentPathsFor(def);
+  const showPath = pathOptions.length > 1;
+
+  async function startTest(id: string): Promise<void> {
+    setStartingId(id);
+    try {
+      await fetch(`/api/admin/experiments/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'RUNNING' }),
+      });
+      await reload();
+    } finally {
+      setStartingId(null);
+    }
+  }
+
+  return (
+    <div className="card">
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-gray-900">Hero A/B test</h2>
+        {active.length === 0 && !loading && (
+          <button type="button" className="btn-primary text-sm" onClick={() => setShowCreate(true)}>
+            + New hero test
+          </button>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="h-24 animate-pulse rounded bg-gray-100" />
+      ) : active.length === 0 ? (
+        <p className="py-2 text-sm text-gray-500">
+          No hero test on this page yet — create one to start measuring which headline converts.
+        </p>
+      ) : (
+        <div className="space-y-3">
+          {active.map((exp) => (
+            <ExperimentScore
+              key={exp.id}
+              exp={exp}
+              showPath={showPath}
+              onStart={startTest}
+              starting={startingId === exp.id}
+            />
+          ))}
+        </div>
+      )}
+
+      {showCreate && (
+        <CreateHeroTestModal
+          canonicalPath={def.canonicalPath}
+          pathOptions={pathOptions}
+          elementId={def.defaultExperimentElementId}
+          pageLabel={def.displayName}
+          onClose={() => setShowCreate(false)}
+          onCreated={() => {
+            setShowCreate(false);
+            reload();
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/analytics/components/PageExperimentsPanel.tsx
+++ b/src/app/admin/analytics/components/PageExperimentsPanel.tsx
@@ -1,34 +1,25 @@
 'use client';
 
-import { ReactElement, useCallback, useEffect, useState } from 'react';
+import { ReactElement, useState } from 'react';
 import Link from 'next/link';
 import CreateHeroTestModal from './CreateHeroTestModal';
 import ExperimentResultCard, { type Experiment } from './ExperimentResultCard';
-import type { LandingPageDef } from '@/lib/analytics/landing-pages';
+import { experimentPathsFor, type LandingPageDef } from '@/lib/analytics/landing-pages';
+
+interface Props {
+  def: LandingPageDef;
+  /** Shared with ExperimentSummaryBanner via useExperiments — one fetch per tab. */
+  experiments: Experiment[];
+  loading: boolean;
+  reload: () => Promise<void>;
+}
 
 /** A/B test management for one landing page: list, rich results, create, start/pause/conclude. */
-export default function PageExperimentsPanel({ def }: { def: LandingPageDef }): ReactElement {
-  const [experiments, setExperiments] = useState<Experiment[]>([]);
-  const [loading, setLoading] = useState(true);
+export default function PageExperimentsPanel({ def, experiments, loading, reload }: Props): ReactElement {
   const [showCreate, setShowCreate] = useState(false);
   const [concludingId, setConcludingId] = useState<string | null>(null);
   const [winnerSel, setWinnerSel] = useState('');
   const [reason, setReason] = useState('');
-
-  const load = useCallback(async () => {
-    setLoading(true);
-    try {
-      const res = await fetch(`/api/admin/experiments?page=${encodeURIComponent(def.canonicalPath)}`, { cache: 'no-store' });
-      const json = await res.json();
-      setExperiments(res.ok ? (json.experiments ?? []) : []);
-    } catch {
-      setExperiments([]);
-    } finally {
-      setLoading(false);
-    }
-  }, [def.canonicalPath]);
-
-  useEffect(() => { load(); }, [load]);
 
   async function patch(id: string, body: Record<string, unknown>): Promise<void> {
     await fetch(`/api/admin/experiments/${id}`, {
@@ -36,16 +27,16 @@ export default function PageExperimentsPanel({ def }: { def: LandingPageDef }): 
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     });
-    await load();
+    await reload();
   }
   async function del(id: string): Promise<void> {
     await fetch(`/api/admin/experiments/${id}`, { method: 'DELETE' });
-    await load();
+    await reload();
   }
 
   function startConclude(exp: Experiment): void {
     setConcludingId(exp.id);
-    setWinnerSel(exp.significance.winner ?? exp.variants.find((v) => !v.isControl)?.id ?? '');
+    setWinnerSel(exp.significance.winner?.id ?? exp.variants.find((v) => !v.isControl)?.id ?? '');
     setReason('');
   }
   async function saveConclude(exp: Experiment): Promise<void> {
@@ -71,18 +62,20 @@ export default function PageExperimentsPanel({ def }: { def: LandingPageDef }): 
 
       {isCampaignPage && (
         <div className="mb-4 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-gray-700">
-          This ad page also runs hero/CTA copy tests managed <strong>in code</strong> (Brian&apos;s system).
-          Those results live in{' '}
+          This ad page can also run hero/CTA copy tests managed <strong>in code</strong> (Brian&apos;s system) —
+          those results live in{' '}
           <Link href="/admin/brians-stuff" className="text-brand-blue underline">Brian&apos;s Stuff → Experiments &amp; Funnels</Link>.
-          New tests you create here use the self-serve builder and won&apos;t touch that system.
+          Tests you create here use the self-serve builder; while a Brian&apos;s hero test is running, self-serve
+          hero tests on this page automatically stand down (no copy swap, no data recorded).
         </div>
       )}
 
       {isLegacyHeroPage && (
         <div className="mb-4 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-gray-700">
-          The homepage hero is rendered by the existing <strong>HeroSection</strong> variant system, so a new
-          test here is tracked but won&apos;t swap the homepage copy until that&apos;s migrated to the
-          self-serve builder. Hero copy-swap is live on Weddings, Boat Parties, Corporate &amp; Cocktail Kits.
+          Homepage tests swap copy through the in-code variant registry (<strong>hero-variants.ts</strong>), not
+          the copy fields below — leave them blank. Variant names must stay exactly{' '}
+          <strong>Control / Variant A / Variant B / Variant C</strong> (renaming silently falls back to control
+          copy for both sides). Self-serve copy-swap is live on every other landing page.
         </div>
       )}
 
@@ -98,7 +91,7 @@ export default function PageExperimentsPanel({ def }: { def: LandingPageDef }): 
             <ExperimentResultCard
               key={exp.id}
               exp={exp}
-              canonicalPath={def.canonicalPath}
+              canonicalPath={exp.page || def.canonicalPath}
               onStatus={(status) => patch(exp.id, { status })}
               onDelete={() => del(exp.id)}
               conclude={{
@@ -119,10 +112,11 @@ export default function PageExperimentsPanel({ def }: { def: LandingPageDef }): 
       {showCreate && (
         <CreateHeroTestModal
           canonicalPath={def.canonicalPath}
+          pathOptions={experimentPathsFor(def)}
           elementId={def.defaultExperimentElementId}
           pageLabel={def.displayName}
           onClose={() => setShowCreate(false)}
-          onCreated={() => { setShowCreate(false); load(); }}
+          onCreated={() => { setShowCreate(false); reload(); }}
         />
       )}
     </div>

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -8,6 +8,8 @@ import TrafficPanel from './components/TrafficPanel';
 import CtaClickTable from './components/CtaClickTable';
 import ConversionPanel from './components/ConversionPanel';
 import PageExperimentsPanel from './components/PageExperimentsPanel';
+import ExperimentSummaryBanner from './components/ExperimentSummaryBanner';
+import { useExperiments } from './useExperiments';
 import { isLandingPageKey, landingPageByKey, type LandingPageKey } from '@/lib/analytics/landing-pages';
 import type {
   AnalyticsPeriod,
@@ -69,6 +71,10 @@ function AnalyticsHub(): ReactElement {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // One experiment fetch per tab, shared by the top scoreboard and the
+  // bottom management panel so actions in either refresh both.
+  const experimentsState = useExperiments(activeDef);
+
   const load = useCallback(async () => {
     setLoading(true);
     setError(null);
@@ -118,6 +124,15 @@ function AnalyticsHub(): ReactElement {
 
       {error && <div className="card bg-red-50 border-red-200 text-sm text-red-700">{error}</div>}
 
+      {activeDef && (
+        <ExperimentSummaryBanner
+          def={activeDef}
+          experiments={experimentsState.experiments}
+          loading={experimentsState.loading}
+          reload={experimentsState.reload}
+        />
+      )}
+
       <TrafficPanel
         traffic={data?.traffic ?? EMPTY_TRAFFIC}
         period={period}
@@ -131,15 +146,23 @@ function AnalyticsHub(): ReactElement {
         engagement={data?.engagement ?? EMPTY_ENGAGEMENT}
         loading={loading}
       />
-      {activeDef && <PageExperimentsPanel def={activeDef} />}
+      {activeDef && (
+        <PageExperimentsPanel
+          def={activeDef}
+          experiments={experimentsState.experiments}
+          loading={experimentsState.loading}
+          reload={experimentsState.reload}
+        />
+      )}
     </div>
   );
 }
 
 /**
- * Per-landing-page analytics hub. Top tab bar selects a page; panels show its
- * traffic (GA4), CTA-click breakdown (first-party), and conversion (orders by
- * Order.landingPage). A/B-test management is added in Phase 2.
+ * Per-landing-page analytics hub. Top tab bar selects a page; the experiment
+ * scoreboard (visitors / CTA CTR / confidence / projected decision date per
+ * variant) leads, followed by traffic (GA4), CTA-click breakdown (first-party),
+ * conversion (orders by Order.landingPage), and A/B test management.
  */
 export default function AnalyticsHubPage(): ReactElement {
   return (

--- a/src/app/admin/analytics/useExperiments.ts
+++ b/src/app/admin/analytics/useExperiments.ts
@@ -1,0 +1,60 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { Experiment } from './components/ExperimentResultCard';
+import { experimentPathsFor, type LandingPageDef } from '@/lib/analytics/landing-pages';
+
+export interface UseExperiments {
+  experiments: Experiment[];
+  loading: boolean;
+  reload: () => Promise<void>;
+}
+
+/**
+ * Shared experiment fetch for one analytics tab — consumed by BOTH the
+ * top ExperimentSummaryBanner and the bottom PageExperimentsPanel so a
+ * Start/Pause/Conclude in either immediately refreshes the other.
+ *
+ * Scopes by the tab's experimentPaths (a tab can span several physical
+ * heroes — weddings = service page + calculator + ads lander).
+ */
+export function useExperiments(def: LandingPageDef | undefined): UseExperiments {
+  const [experiments, setExperiments] = useState<Experiment[]>([]);
+  const [loading, setLoading] = useState(true);
+  // Monotonic request id — a slow response for a previous tab must never
+  // overwrite the current tab's data (Start/Pause would then target the
+  // wrong page's experiments).
+  const requestSeq = useRef(0);
+
+  const pathsKey = def ? experimentPathsFor(def).join(',') : '';
+
+  const reload = useCallback(async (): Promise<void> => {
+    const seq = ++requestSeq.current;
+    if (!pathsKey) {
+      setExperiments([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await fetch(
+        `/api/admin/experiments?pages=${encodeURIComponent(pathsKey)}`,
+        { cache: 'no-store' }
+      );
+      const json = await res.json();
+      if (seq !== requestSeq.current) return; // stale response — drop it
+      setExperiments(res.ok ? (json.experiments ?? []) : []);
+    } catch {
+      if (seq !== requestSeq.current) return;
+      setExperiments([]);
+    } finally {
+      if (seq === requestSeq.current) setLoading(false);
+    }
+  }, [pathsKey]);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  return { experiments, loading, reload };
+}

--- a/src/app/api/admin/experiments/[id]/route.ts
+++ b/src/app/api/admin/experiments/[id]/route.ts
@@ -17,7 +17,7 @@ const UpdateExperimentSchema = z.object({
   description: z.string().max(500).optional(),
   status: z.enum(['DRAFT', 'RUNNING', 'PAUSED', 'COMPLETED']).optional(),
   goalMetric: z.enum(['cta_click', 'scroll_depth', 'conversion', 'revenue']).optional(),
-  goalValue: z.string().optional(),
+  goalValue: z.string().max(120).optional(),
   winningVariant: z.string().optional(),
   winnerReason: z.string().max(1000).optional(),
   confidence: z.number().min(0).max(100).optional(),

--- a/src/app/api/admin/experiments/route.ts
+++ b/src/app/api/admin/experiments/route.ts
@@ -10,7 +10,7 @@ import { z } from 'zod';
 import { requireOpsAuth } from '@/lib/auth/ops-session';
 import { CreateExperimentSchema } from '@/lib/experiments/experiment-schemas';
 import { transformExperiment } from '@/lib/analytics/experiment-transform';
-import { getTrailingExposureRates } from '@/lib/analytics/variant-rollup';
+import { getExperimentDailySeries, getTrailingExposureRates } from '@/lib/analytics/variant-rollup';
 
 /**
  * GET /api/admin/experiments
@@ -58,17 +58,27 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     // Trailing 7-day exposure counts feed the projected-decision-date math;
     // the transform falls back to lifetime counters when the stream is empty.
-    const exposureCounts = await getTrailingExposureRates(
-      experiments.map((e) => e.id),
-      7
-    );
+    // Daily series feeds the cumulative CTR trend chart.
+    const experimentIds = experiments.map((e) => e.id);
+    const [exposureCounts, seriesRows] = await Promise.all([
+      getTrailingExposureRates(experimentIds, 7),
+      getExperimentDailySeries(experimentIds),
+    ]);
+    const seriesByExperiment = new Map<string, typeof seriesRows>();
+    for (const row of seriesRows) {
+      const list = seriesByExperiment.get(row.experimentId) ?? [];
+      list.push(row);
+      seriesByExperiment.set(row.experimentId, list);
+    }
 
     // Per-row guard: one pathological row (counters are publicly writable)
     // must degrade to a skipped row, never blank the whole tab.
     const now = new Date();
     const transformedExperiments = experiments.flatMap((exp) => {
       try {
-        return [transformExperiment(exp, now, exposureCounts)];
+        return [
+          transformExperiment(exp, now, exposureCounts, 7, 0.1, seriesByExperiment.get(exp.id) ?? []),
+        ];
       } catch (e) {
         console.error(`experiments GET: transform failed for ${exp.id}:`, e);
         return [];

--- a/src/app/api/admin/experiments/route.ts
+++ b/src/app/api/admin/experiments/route.ts
@@ -8,44 +8,9 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
 import { requireOpsAuth } from '@/lib/auth/ops-session';
-import { computeSignificance, type VariantStat } from '@/lib/analytics/experiment-significance';
-
-// Hero-copy payload an operator can set per variant (all fields optional —
-// an absent field falls back to the page's default copy).
-const VariantContentSchema = z.object({
-  eyebrow: z.string().max(200).optional(),
-  headline: z.string().max(300).optional(),
-  subhead: z.string().max(500).optional(),
-  ctaText: z.string().max(120).optional(),
-});
-
-// Validation schema for creating an experiment
-const CreateExperimentSchema = z.object({
-  name: z.string().min(1, 'Name is required').max(100),
-  description: z.string().max(500).optional(),
-  page: z.string().min(1, 'Page is required'),
-  elementId: z.string().min(1, 'Element ID is required'),
-  goalMetric: z.enum(['cta_click', 'scroll_depth', 'conversion', 'revenue']),
-  goalValue: z.string().optional(),
-  variants: z.array(z.object({
-    name: z.string().min(1),
-    description: z.string().optional(),
-    isControl: z.boolean().default(false),
-    weight: z.number().min(0).max(100).default(50),
-    content: VariantContentSchema.optional(),
-  })).min(2, 'At least 2 variants required'),
-});
-
-/**
- * Per-variant success count for the significance test: for click-style goals the
- * "success" is a click; for conversion/revenue goals it's a recorded conversion.
- */
-function successCount(
-  goalMetric: string,
-  v: { clicks: number; conversions: number }
-): number {
-  return goalMetric === 'cta_click' || goalMetric === 'scroll_depth' ? v.clicks : v.conversions;
-}
+import { CreateExperimentSchema } from '@/lib/experiments/experiment-schemas';
+import { transformExperiment } from '@/lib/analytics/experiment-transform';
+import { getTrailingExposureRates } from '@/lib/analytics/variant-rollup';
 
 /**
  * GET /api/admin/experiments
@@ -59,6 +24,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const { searchParams } = new URL(request.url);
     const status = searchParams.get('status');
     const page = searchParams.get('page');
+    // `pages=` (comma-separated) scopes to a set of routes — the analytics hub
+    // uses it because one tab can span several physical heroes (e.g. weddings
+    // = /weddings + /wedding-drink-calculator + /austin-wedding-weekend-delivery).
+    const pages = searchParams.get('pages');
 
     const where: Record<string, unknown> = {};
 
@@ -66,7 +35,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       where.status = status;
     }
 
-    if (page) {
+    if (pages) {
+      const paths = pages.split(',').map((p) => p.trim()).filter(Boolean);
+      if (paths.length > 0) where.page = { in: paths };
+    } else if (page) {
       where.page = page;
     }
 
@@ -81,54 +53,26 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         { status: 'asc' },
         { createdAt: 'desc' },
       ],
+      take: 100,
     });
 
-    // Transform to include calculated metrics
-    const transformedExperiments = experiments.map((exp) => {
-      const totalImpressions = exp.variants.reduce((sum, v) => sum + v.impressions, 0);
-      const controlVariant = exp.variants.find((v) => v.isControl);
-      const bestVariant = exp.variants.reduce((best, v) => {
-        if (v.isControl) return best;
-        const vRate = v.impressions > 0 ? v.clicks / v.impressions : 0;
-        const bestRate = best && best.impressions > 0 ? best.clicks / best.impressions : 0;
-        return vRate > bestRate ? v : best;
-      }, null as typeof exp.variants[0] | null);
+    // Trailing 7-day exposure counts feed the projected-decision-date math;
+    // the transform falls back to lifetime counters when the stream is empty.
+    const exposureCounts = await getTrailingExposureRates(
+      experiments.map((e) => e.id),
+      7
+    );
 
-      let uplift = 0;
-      if (controlVariant && bestVariant && controlVariant.impressions > 0 && bestVariant.impressions > 0) {
-        const controlRate = controlVariant.clicks / controlVariant.impressions;
-        const bestRate = bestVariant.clicks / bestVariant.impressions;
-        uplift = controlRate > 0 ? ((bestRate - controlRate) / controlRate) * 100 : 0;
+    // Per-row guard: one pathological row (counters are publicly writable)
+    // must degrade to a skipped row, never blank the whole tab.
+    const now = new Date();
+    const transformedExperiments = experiments.flatMap((exp) => {
+      try {
+        return [transformExperiment(exp, now, exposureCounts)];
+      } catch (e) {
+        console.error(`experiments GET: transform failed for ${exp.id}:`, e);
+        return [];
       }
-
-      const startDate = exp.startDate ? new Date(exp.startDate) : null;
-      const daysRunning = startDate
-        ? Math.floor((Date.now() - startDate.getTime()) / (1000 * 60 * 60 * 24))
-        : 0;
-
-      // Two-proportion z-test significance over the variant counters, using the
-      // goal-appropriate success count (clicks for click goals, conversions otherwise).
-      const sigStats: VariantStat[] = exp.variants.map((v) => ({
-        id: v.id,
-        name: v.name,
-        isControl: v.isControl,
-        impressions: v.impressions,
-        conversions: successCount(exp.goalMetric, v),
-      }));
-      const significance = computeSignificance(sigStats);
-
-      return {
-        ...exp,
-        totalImpressions,
-        uplift: Math.round(uplift * 10) / 10,
-        daysRunning,
-        significance,
-        variants: exp.variants.map((v) => ({
-          ...v,
-          clickRate: v.impressions > 0 ? (v.clicks / v.impressions) * 100 : 0,
-          conversionRate: v.impressions > 0 ? (v.conversions / v.impressions) * 100 : 0,
-        })),
-      };
     });
 
     // Group by status for summary

--- a/src/app/api/experiments/assign/route.ts
+++ b/src/app/api/experiments/assign/route.ts
@@ -10,6 +10,7 @@ import {
   getActiveExperiment,
   assignVariantByWeight,
 } from '@/lib/experiments/experiment-service';
+import { mapVariantNameToContentId } from '@/lib/experiments/hero-variants';
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const { searchParams } = new URL(request.url);
@@ -90,19 +91,3 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   }
 }
 
-/**
- * Map variant name from database to hero content ID
- * Database variants are named "Control", "Variant A", "Variant B", etc.
- * Hero content uses IDs like "control", "variant-a", "variant-b", etc.
- */
-function mapVariantNameToContentId(variantName: string): string {
-  const normalized = variantName.toLowerCase().trim();
-
-  if (normalized === 'control') return 'control';
-  if (normalized === 'variant a') return 'variant-a';
-  if (normalized === 'variant b') return 'variant-b';
-  if (normalized === 'variant c') return 'variant-c';
-
-  // Default to control for unknown names
-  return 'control';
-}

--- a/src/app/api/experiments/track/route.ts
+++ b/src/app/api/experiments/track/route.ts
@@ -13,6 +13,8 @@ import {
   recordConversion,
   getExperimentById,
 } from '@/lib/experiments/experiment-service';
+import { checkRateLimit } from '@/lib/security/rate-limit';
+import { mapVariantNameToContentId } from '@/lib/experiments/hero-variants';
 
 // Validation schema for tracking events
 const TrackingEventSchema = z.object({
@@ -20,13 +22,25 @@ const TrackingEventSchema = z.object({
   experimentId: z.string().min(1),
   variantId: z.string().min(1), // This is the content ID (control, variant-a, etc.)
   metadata: z.object({
-    buttonText: z.string().optional(),
-    revenue: z.number().optional(),
+    buttonText: z.string().max(200).optional(),
+    // Bounded — these counters feed the A/B winner readout, so an arbitrary
+    // revenue number from a public endpoint must be clamped.
+    revenue: z.number().finite().min(0).max(10_000).optional(),
   }).optional(),
 });
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   try {
+    // Throttle: unauthenticated write path whose counters drive winner
+    // declarations. A real visitor fires a handful of events per page view;
+    // 60/min per IP is generous headroom while blunting counter-stuffing.
+    const ip =
+      request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+    const allowed = await checkRateLimit('experiment-track', ip, 60, 60);
+    if (!allowed) {
+      return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+    }
+
     const body = await request.json();
     const validatedData = TrackingEventSchema.parse(body);
 
@@ -40,6 +54,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         { error: 'Experiment not found' },
         { status: 404 }
       );
+    }
+
+    // Only RUNNING experiments accept events — pages only fire these after a
+    // live assignment, so anything else is noise or deliberate stuffing.
+    if (experiment.status !== 'RUNNING') {
+      return NextResponse.json({ success: true, warning: 'Experiment not running' });
     }
 
     // Resolve the variant. Self-serve hero tests pass the real DB variant id;
@@ -98,18 +118,4 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       { status: 500 }
     );
   }
-}
-
-/**
- * Map variant name from database to hero content ID
- */
-function mapVariantNameToContentId(variantName: string): string {
-  const normalized = variantName.toLowerCase().trim();
-
-  if (normalized === 'control') return 'control';
-  if (normalized === 'variant a') return 'variant-a';
-  if (normalized === 'variant b') return 'variant-b';
-  if (normalized === 'variant c') return 'variant-c';
-
-  return 'control';
 }

--- a/src/app/order/page.tsx
+++ b/src/app/order/page.tsx
@@ -28,6 +28,8 @@ import { createDashboardOrderV2, createTabV2 } from '@/lib/group-orders-v2/api-c
 import type { PartyType, DashboardSource, DeliveryContextType } from '@/lib/group-orders-v2/types';
 import { getAffiliateOrderDefaults } from '@/lib/affiliates/presets';
 import { trackCTAClick } from '@/lib/analytics/ga4-events';
+import { useHeroExperiment } from '@/hooks/useHeroExperiment';
+import { trackExperimentClick } from '@/hooks/useExperimentVariant';
 import { getAttributionForDashboard } from '@/lib/analytics/attribution';
 import { getEventPreset } from '@/lib/events/event-presets';
 
@@ -101,6 +103,11 @@ function OrderRedirectInner(): ReactElement {
   // a party type). null = still deciding.
   const [autoMode, setAutoMode] = useState<boolean | null>(null);
   const creating = useRef(false);
+
+  // Self-serve hero headline test — ONLY when the chip selector actually
+  // renders. Auto-mode visitors (query-param / affiliate presets) never see
+  // the headline; assigning them would inflate impressions and poison CTR.
+  const hero = useHeroExperiment('/order', { skip: autoMode !== false });
 
   // Pull the URL inputs once -- they don't change across renders.
   const ref = searchParams?.get('ref') ?? null;
@@ -345,17 +352,24 @@ function OrderRedirectInner(): ReactElement {
           className="h-24 md:h-32 w-auto mx-auto mb-8"
         />
         <h1 className="font-heading font-bold text-3xl md:text-5xl tracking-[0.06em] text-gray-900 mb-2">
-          What are we celebrating?
+          {hero.content?.headline ?? 'What are we celebrating?'}
         </h1>
         <p className="font-fraunces italic text-gray-600 text-lg md:text-xl mb-8">
-          {"One tap and we'll set up your order page."}
+          {hero.content?.subhead ?? "One tap and we'll set up your order page."}
         </p>
         <div className="grid grid-cols-2 md:grid-cols-3 gap-3 md:gap-4">
           {CHIPS.map((chip) => (
             <button
               key={chip.partyType}
               type="button"
-              onClick={() => { trackCTAClick(chip.label, '/order', 'party_type_chip'); runCreate(chip.partyType); }}
+              onClick={() => {
+                trackCTAClick(chip.label, '/order', 'party_type_chip', hero.experimentId ?? undefined, hero.variantId ?? undefined);
+                if (hero.experimentId && hero.variantId) {
+                  // Fire-and-forget — must never delay dashboard creation.
+                  void trackExperimentClick(hero.experimentId, hero.variantId, chip.label);
+                }
+                runCreate(chip.partyType);
+              }}
               disabled={busy}
               className="flex flex-col items-center justify-center gap-2 px-4 py-5 md:py-6 bg-white rounded-2xl shadow-warm-sm hover:shadow-warm-md active:bg-cream font-heading font-semibold tracking-[0.04em] text-gray-900 transition-shadow disabled:opacity-50 disabled:cursor-not-allowed"
             >

--- a/src/app/wedding-drink-calculator/sections/CalculatorHero.tsx
+++ b/src/app/wedding-drink-calculator/sections/CalculatorHero.tsx
@@ -4,6 +4,8 @@ import Image from 'next/image';
 import Link from 'next/link';
 import type { ReactElement } from 'react';
 import { trackCTAClick } from '@/lib/analytics/ga4-events';
+import { useHeroExperiment } from '@/hooks/useHeroExperiment';
+import { trackExperimentClick } from '@/hooks/useExperimentVariant';
 
 /**
  * Paid-ad landing hero. Editorial-luxury aesthetic (espresso ground,
@@ -19,8 +21,27 @@ import { trackCTAClick } from '@/lib/analytics/ga4-events';
  *   - Staggered 600ms entrance reads as composed/premium
  */
 export default function CalculatorHero(): ReactElement {
+  // Self-serve hero A/B test (page + elementId='hero' in /admin/analytics).
+  // SEO note for variant copy: the H1 is the exact-match paid keyword —
+  // variants should keep "Wedding Drink Calculator" as a substring.
+  const hero = useHeroExperiment('/wedding-drink-calculator');
+  const ctaLabel = hero.content?.ctaText ?? 'Start the Calculator';
+  // Historical analytics rows use the lowercase-c label — keep the default's
+  // tracked string identical so the CTA-click table doesn't split into two
+  // rows across the deploy. Variant overrides track their own text.
+  const trackedLabel = hero.content?.ctaText ?? 'Start the calculator';
+
   const handleHeroCta = () => {
-    trackCTAClick('Start the calculator', '#calculator', 'wedding_calc_hero');
+    trackCTAClick(
+      trackedLabel,
+      '#calculator',
+      'wedding_calc_hero',
+      hero.experimentId ?? undefined,
+      hero.variantId ?? undefined
+    );
+    if (hero.experimentId && hero.variantId) {
+      void trackExperimentClick(hero.experimentId, hero.variantId, trackedLabel);
+    }
   };
 
   return (
@@ -41,16 +62,20 @@ export default function CalculatorHero(): ReactElement {
         <h1
           className="font-heading text-4xl md:text-5xl lg:text-6xl font-light tracking-tight leading-[1.05] opacity-0 animate-[fadeUp_0.6s_cubic-bezier(0.22,1,0.36,1)_forwards]"
         >
-          Wedding Drink Calculator
+          {hero.content?.headline ?? 'Wedding Drink Calculator'}
         </h1>
 
         <p
           className="mt-6 max-w-xl text-lg md:text-xl text-white/85 font-light leading-relaxed opacity-0 animate-[fadeUp_0.6s_cubic-bezier(0.22,1,0.36,1)_0.2s_forwards]"
         >
-          Get{' '}
-          <span className="font-cormorant italic text-[#C8A96A]">exact</span>{' '}
-          beer, wine, spirits, and bubbly counts for your Austin wedding.
-          Delivered cold to your venue.
+          {hero.content?.subhead ?? (
+            <>
+              Get{' '}
+              <span className="font-cormorant italic text-[#C8A96A]">exact</span>{' '}
+              beer, wine, spirits, and bubbly counts for your Austin wedding.
+              Delivered cold to your venue.
+            </>
+          )}
         </p>
 
         <a
@@ -58,7 +83,7 @@ export default function CalculatorHero(): ReactElement {
           onClick={handleHeroCta}
           className="group mt-8 inline-flex items-center gap-3 bg-[#C8A96A] text-[#1a1410] hover:bg-[#d8b97a] transition-colors duration-300 px-10 py-4 text-sm tracking-[0.25em] uppercase font-medium rounded-lg opacity-0 animate-[fadeUp_0.6s_cubic-bezier(0.22,1,0.36,1)_0.4s_forwards]"
         >
-          Start the Calculator
+          {ctaLabel}
           <span className="transition-transform duration-300 group-hover:translate-y-0.5">
             ↓
           </span>

--- a/src/components/landing/LandingPageTemplate.tsx
+++ b/src/components/landing/LandingPageTemplate.tsx
@@ -19,6 +19,9 @@ import { trackContactClick, trackCTAClick } from '@/lib/analytics/ga4-events';
 import { experimentsForPath, type BachelorHeroPayload, type CtaCopyPayload } from '@/lib/experiments/registry';
 import { useVariant } from '@/lib/experiments/clientAssign';
 import { useFunnelTracker } from '@/lib/experiments/funnelTrack';
+import { useHeroExperiment } from '@/hooks/useHeroExperiment';
+import { trackExperimentClick } from '@/hooks/useExperimentVariant';
+import { resolveHeroCopy } from './heroCopy';
 import { useSearchParams } from 'next/navigation';
 
 // All 4 /austin-*-delivery landing pages. Used to render an "other event
@@ -120,25 +123,34 @@ export default function LandingPageTemplate({
   const ctaVariantPayload = ctaExp?.variants.find((v) => v.key === ctaVariantKey)
     ?.payload as CtaCopyPayload | undefined;
 
-  // Effective copy = variant override OR config default.
-  // ?welcome=1 (set by the /event-quiz redirect) further overrides the
-  // hero copy with the "Step one: drinks → rest of weekend" framing.
+  // ?welcome=1 (the /event-quiz redirect) replaces the hero copy wholesale,
+  // so quiz arrivals must ALSO skip System B below — otherwise they'd be
+  // assigned + counted as impressions while seeing identical quiz copy on
+  // both arms, diluting the test toward a false "no difference".
   const searchParams = useSearchParams();
   const cameFromQuiz = searchParams?.get('welcome') === '1';
 
-  const heroEyebrow = cameFromQuiz
-    ? 'WELCOME — STEP 1 OF 2'
-    : heroVariantPayload?.eyebrow ?? config.heroEyebrow;
-  const heroHeadline = cameFromQuiz
-    ? "Step one: Let's get started with"
-    : heroVariantPayload?.headline ?? config.heroHeadline;
-  const heroHeadlineAccent = cameFromQuiz
-    ? 'your drinks.'
-    : heroVariantPayload?.headlineAccent ?? config.heroHeadlineAccent;
-  const heroSubhead = cameFromQuiz
-    ? "Then we'll plan the rest of your weekend. Pick a package below or build your own — your contact info is already on file so checkout takes 30 seconds."
-    : heroVariantPayload?.subhead ?? config.heroSubhead;
-  const primaryCtaText = ctaVariantPayload?.primary ?? config.ctaText;
+  // System B (DB-backed self-serve hero tests, created from /admin/analytics).
+  // Hard rules: while a Brian's-registry hero test is RUNNING on this path,
+  // System B is skipped entirely — no variant assignment, no impression
+  // recorded — so his data can't be polluted and precedence is unambiguous.
+  // Quiz arrivals are skipped for the data-integrity reason above.
+  const dbHero = useHeroExperiment(pagePath, { skip: !!heroExp || cameFromQuiz });
+
+  const {
+    eyebrow: heroEyebrow,
+    headline: heroHeadline,
+    headlineAccent: heroHeadlineAccent,
+    subhead: heroSubhead,
+    showBullets: heroShowBullets,
+    primaryCtaText,
+  } = resolveHeroCopy({
+    cameFromQuiz,
+    brianHero: heroVariantPayload,
+    brianCta: ctaVariantPayload,
+    dbContent: dbHero.content,
+    config,
+  });
 
   // Funnel tracker — fires LeadEvents stamped with the bachelor-hero key
   // (the most consequential one). The CTA experiment piggybacks via
@@ -294,12 +306,14 @@ export default function LandingPageTemplate({
               style={{ textShadow: '0 2px 12px rgba(0,0,0,0.55)' }}
             >
               {heroHeadline}
-              <span className="block" style={{ color: T.primary }}>
-                {heroHeadlineAccent}
-              </span>
+              {heroHeadlineAccent && (
+                <span className="block" style={{ color: T.primary }}>
+                  {heroHeadlineAccent}
+                </span>
+              )}
             </h2>
 
-            {config.heroBullets && config.heroBullets.length > 0 ? (
+            {heroShowBullets && config.heroBullets && config.heroBullets.length > 0 ? (
               <ul
                 className="text-base sm:text-lg text-white mb-8 max-w-2xl space-y-1.5"
                 style={{ textShadow: '0 1px 6px rgba(0,0,0,0.6)' }}
@@ -329,7 +343,17 @@ export default function LandingPageTemplate({
               <button
                 type="button"
                 onClick={() => {
-                  trackCTAClick(primaryCtaText, '#builder', 'hero');
+                  trackCTAClick(
+                    primaryCtaText,
+                    '#builder',
+                    'hero',
+                    dbHero.experimentId ?? undefined,
+                    dbHero.variantId ?? undefined
+                  );
+                  if (dbHero.experimentId && dbHero.variantId) {
+                    // Fire-and-forget — counter click for the System B test.
+                    void trackExperimentClick(dbHero.experimentId, dbHero.variantId, primaryCtaText);
+                  }
                   openBuilder();
                 }}
                 className="inline-flex items-center justify-center font-bold text-base sm:text-lg px-8 py-5 rounded-lg tracking-[0.08em] transition-colors shadow-xl"

--- a/src/components/landing/heroCopy.ts
+++ b/src/components/landing/heroCopy.ts
@@ -1,0 +1,95 @@
+/**
+ * Hero copy resolver for LandingPageTemplate — folds FOUR copy sources into
+ * the strings the hero actually renders, with a fixed precedence:
+ *
+ *   quiz (?welcome=1)  >  Brian's registry variant  >  System B DB variant  >  config default
+ *
+ * Rules that protect existing behavior:
+ * - The eyebrow is the page's semantic <h1> (keyword-rich SEO) — System B
+ *   content NEVER overrides it. Quiz/Brian keep their existing behavior.
+ * - A System B `headline` without a `headlineAccent` renders as ONE line
+ *   (accent = ''), so a single-line variant doesn't inherit the config's gold
+ *   second line and read as a two-line mashup.
+ * - Bullets vs subhead: today bullets always win when configured; only a
+ *   System B `subhead` override suppresses them (that's the point of testing
+ *   a subhead). Quiz/Brian subheads keep the current bullets-win behavior.
+ */
+
+import type { ReactNode } from 'react';
+import type { BachelorHeroPayload, CtaCopyPayload } from '@/lib/experiments/registry';
+import type { HeroContent } from '@/hooks/useHeroExperiment';
+
+export interface HeroCopyInput {
+  cameFromQuiz: boolean;
+  /** Brian's hero-headline payload — present only when his test is RUNNING. */
+  brianHero?: BachelorHeroPayload;
+  /** Brian's primary-CTA payload — present only when his test is RUNNING. */
+  brianCta?: CtaCopyPayload;
+  /** System B variant content (null = control / no active experiment). */
+  dbContent: HeroContent | null;
+  config: {
+    heroEyebrow: string;
+    heroHeadline: string;
+    heroHeadlineAccent: string;
+    heroSubhead: ReactNode | string;
+    heroBullets?: string[];
+    ctaText: string;
+  };
+}
+
+export interface ResolvedHeroCopy {
+  eyebrow: string;
+  headline: string;
+  headlineAccent: string;
+  subhead: ReactNode | string;
+  showBullets: boolean;
+  primaryCtaText: string;
+}
+
+export function resolveHeroCopy(input: HeroCopyInput): ResolvedHeroCopy {
+  const { cameFromQuiz, brianHero, brianCta, dbContent, config } = input;
+
+  const hasBullets = (config.heroBullets?.length ?? 0) > 0;
+
+  if (cameFromQuiz) {
+    // ?welcome=1 — the /event-quiz redirect frames the page as step 2.
+    // Exact strings preserved from the pre-resolver template.
+    return {
+      eyebrow: 'WELCOME — STEP 1 OF 2',
+      headline: "Step one: Let's get started with",
+      headlineAccent: 'your drinks.',
+      subhead:
+        "Then we'll plan the rest of your weekend. Pick a package below or build your own — your contact info is already on file so checkout takes 30 seconds.",
+      showBullets: hasBullets,
+      primaryCtaText: brianCta?.primary ?? dbContent?.ctaText ?? config.ctaText,
+    };
+  }
+
+  if (brianHero) {
+    // Brian's registry test owns the hero wholesale — System B never mixes in
+    // (the template skips System B assignment entirely while his test runs).
+    return {
+      eyebrow: brianHero.eyebrow,
+      headline: brianHero.headline,
+      headlineAccent: brianHero.headlineAccent,
+      subhead: brianHero.subhead,
+      showBullets: hasBullets,
+      primaryCtaText: brianCta?.primary ?? config.ctaText,
+    };
+  }
+
+  const dbSubheadOverride = dbContent?.subhead != null;
+  const dbOneLineHeadline =
+    dbContent?.headline != null && dbContent.headlineAccent == null;
+
+  return {
+    eyebrow: config.heroEyebrow, // System B never touches the H1
+    headline: dbContent?.headline ?? config.heroHeadline,
+    headlineAccent: dbOneLineHeadline
+      ? ''
+      : (dbContent?.headlineAccent ?? config.heroHeadlineAccent),
+    subhead: dbContent?.subhead ?? config.heroSubhead,
+    showBullets: hasBullets && !dbSubheadOverride,
+    primaryCtaText: brianCta?.primary ?? dbContent?.ctaText ?? config.ctaText,
+  };
+}

--- a/src/hooks/useHeroExperiment.ts
+++ b/src/hooks/useHeroExperiment.ts
@@ -26,6 +26,8 @@ const VISITOR_ID_MAX_AGE = 30 * 24 * 60 * 60; // 30 days
 export interface HeroContent {
   eyebrow?: string;
   headline?: string;
+  /** Gold second line on the LandingPageTemplate landers; other pages ignore it. */
+  headlineAccent?: string;
   subhead?: string;
   ctaText?: string;
 }
@@ -80,11 +82,23 @@ interface AssignResponse {
 /**
  * @param page - canonical landing-page path (e.g. '/weddings'); experiments are
  *   scoped to (page, elementId='hero').
+ * @param opts.skip - when true, no variant is assigned and NO impression is
+ *   recorded (the hook fires an exposure internally on assignment, so this is
+ *   the only clean opt-out). Used when another system owns the hero (Brian's
+ *   registry test running) or the hero isn't shown (/order auto-mode).
  */
-export function useHeroExperiment(page: string): HeroExperiment {
+export function useHeroExperiment(
+  page: string,
+  opts?: { skip?: boolean }
+): HeroExperiment {
+  const skip = opts?.skip === true;
   const [state, setState] = useState<HeroExperiment>(EMPTY);
 
   useEffect(() => {
+    if (skip) {
+      setState({ ...EMPTY, ready: true });
+      return;
+    }
     let cancelled = false;
     const visitorId = getOrCreateVisitorId();
 
@@ -125,7 +139,7 @@ export function useHeroExperiment(page: string): HeroExperiment {
     return () => {
       cancelled = true;
     };
-  }, [page]);
+  }, [page, skip]);
 
   return state;
 }

--- a/src/lib/analytics/experiment-planning.ts
+++ b/src/lib/analytics/experiment-planning.ts
@@ -1,0 +1,347 @@
+/**
+ * A/B test planning + decision layer — sample size, confidence intervals, and
+ * "when can we call it" projections.
+ *
+ * Sits alongside experiment-significance.ts (which stays untouched — Brian's
+ * funnel route imports it). This module answers the PLANNING questions:
+ *   - How many visitors per variant do we need? (two-proportion power formula)
+ *   - What range is each variant's true rate in? (Wilson score interval)
+ *   - When, at current traffic, can we make the call? (projected decision date)
+ *   - What should the operator do right now? (verdict + plain-English message)
+ *
+ * Everything here is pure — no Prisma, no fetch — so it unit-tests against
+ * textbook values.
+ */
+
+import type { SignificanceResult } from './experiment-significance';
+
+/** Every variant must reach the required sample AND the test must run this many
+ * days before a winner is declared. Two full weekly cycles — party traffic is
+ * heavily weekend-skewed, so shorter runs overweight one kind of visitor. */
+export const MIN_RUN_DAYS = 14;
+
+/** Projections beyond this are reported as unreachable — the honest answer is
+ * "this page can't support an A/B test at current traffic". */
+export const UNREACHABLE_DAYS = 90;
+
+/** Winner threshold. Uniform 95% everywhere — one number, one mental model. */
+export const DEFAULT_CONFIDENCE_LEVEL = 0.95;
+
+// Standard normal quantiles Φ⁻¹(p), exact to double precision (R qnorm values).
+// A lookup beats a rational-approximation inverse: the product only ever uses
+// these few points, the values are exact, and there are no magic coefficients.
+const Z_TABLE: ReadonlyArray<readonly [number, number]> = [
+  [0.8, 0.8416212335729143], // power 0.80
+  [0.85, 1.0364333894937898],
+  [0.9, 1.2815515655446004], // power 0.90
+  [0.95, 1.6448536269514722], // alpha 0.10 two-sided
+  [0.975, 1.9599639845400545], // alpha 0.05 two-sided
+  [0.995, 2.5758293035489004], // alpha 0.01 two-sided
+];
+
+function zQuantile(p: number): number {
+  const hit = Z_TABLE.find(([key]) => Math.abs(p - key) < 1e-9);
+  if (!hit) throw new RangeError(`Unsupported quantile ${p}; add it to Z_TABLE`);
+  return hit[1];
+}
+
+/**
+ * Visitors needed PER VARIANT to detect a relative lift over the baseline rate
+ * (two-sided two-proportion z-test — same test family the readout uses, so the
+ * plan and the analysis agree). Fleiss formula without continuity correction.
+ *
+ * @param baselineRate - control's success rate, in (0,1)
+ * @param relativeMde - minimum detectable effect as a relative lift (0.5 = +50%)
+ */
+export function requiredSampleSizePerVariant(
+  baselineRate: number,
+  relativeMde: number,
+  alpha = 0.05,
+  power = 0.8
+): number {
+  if (baselineRate <= 0 || baselineRate >= 1) {
+    throw new RangeError('baselineRate must be in (0,1)');
+  }
+  if (relativeMde <= 0) throw new RangeError('relativeMde must be > 0');
+  const p1 = baselineRate;
+  const p2 = baselineRate * (1 + relativeMde);
+  if (p2 >= 1) throw new RangeError(`target rate ${p2} >= 1 — lower the MDE`);
+  const delta = p2 - p1;
+  const pBar = (p1 + p2) / 2;
+  const zAlpha = zQuantile(1 - alpha / 2);
+  const zBeta = zQuantile(power);
+  const n =
+    Math.pow(
+      zAlpha * Math.sqrt(2 * pBar * (1 - pBar)) +
+        zBeta * Math.sqrt(p1 * (1 - p1) + p2 * (1 - p2)),
+      2
+    ) /
+    (delta * delta);
+  return Math.ceil(n);
+}
+
+/**
+ * Wilson score interval on a proportion. Chosen over Wald because our variants
+ * live at n < 100 for weeks — Wald collapses to zero width at 0 successes and
+ * dips negative at small n; Wilson keeps near-nominal coverage and stays in [0,1].
+ *
+ * NOTE: overlapping per-variant intervals do NOT imply non-significance — the
+ * winner verdict stays driven by the z-test; these are for operator intuition.
+ */
+export function wilsonInterval(
+  successes: number,
+  trials: number,
+  confidenceLevel = 0.95
+): { lo: number; hi: number } {
+  if (trials <= 0) return { lo: 0, hi: 1 };
+  const z = zQuantile(1 - (1 - confidenceLevel) / 2);
+  // Clamp: the counters are independent public increments, so successes CAN
+  // exceed trials — p > 1 would put NaN (sqrt of a negative) into the JSON.
+  const p = Math.min(1, Math.max(0, successes / trials));
+  const z2 = z * z;
+  const denom = 1 + z2 / trials;
+  const center = (p + z2 / (2 * trials)) / denom;
+  const halfWidth =
+    (z / denom) * Math.sqrt((p * (1 - p)) / trials + z2 / (4 * trials * trials));
+  return {
+    // At p̂ = 0 (or 1) the exact Wilson bound is 0 (or 1); float noise can land
+    // an epsilon inside, so pin the boundary cases.
+    lo: p === 0 ? 0 : Math.max(0, center - halfWidth),
+    hi: p === 1 ? 1 : Math.min(1, center + halfWidth),
+  };
+}
+
+/**
+ * Default minimum detectable effect for a new test, from the baseline rate.
+ * At this site's traffic (20–660 views/page/month) only large effects are
+ * fundable, so default to bold: +50% relative on typical ~10% CTRs. For
+ * already-high baselines (e.g. /order's ~59% chip rate) +50% is arithmetically
+ * impossible, so 15% is the honest large-effect analog.
+ */
+export function defaultRelativeMde(baselineRate: number): number {
+  return baselineRate >= 0.3 ? 0.15 : 0.5;
+}
+
+/**
+ * Baseline for the sample-size calc: pooled observed rate once we have real
+ * data (≥200 total impressions), else the caller's prior (page-level CTA rate).
+ */
+export function resolveBaselineRate(
+  variants: Array<{ impressions: number; successes: number }>,
+  prior: number
+): number {
+  const totalImpressions = variants.reduce((s, v) => s + v.impressions, 0);
+  const totalSuccesses = variants.reduce((s, v) => s + v.successes, 0);
+  if (totalImpressions >= 200 && totalSuccesses > 0) {
+    // Clamp the pooled branch too: the counters are independent unchecked
+    // increments (a public track endpoint), so successes CAN exceed
+    // impressions — an unclamped rate ≥ 1 would make the power formula throw.
+    return clampRate(totalSuccesses / totalImpressions);
+  }
+  return clampRate(prior);
+}
+
+function clampRate(rate: number): number {
+  if (!Number.isFinite(rate) || rate <= 0) return 0.1;
+  return Math.min(rate, 0.95);
+}
+
+export interface DecisionProjection {
+  requiredPerVariant: number;
+  /** The laggard variant's impressions — it drives the finish line. */
+  minVariantImpressions: number;
+  /** Trailing exposures/day for the laggard variant. */
+  dailyExposurePerVariant: number;
+  /** Days until the laggard reaches the required sample; null when no traffic. */
+  remainingDays: number | null;
+  /** ISO yyyy-mm-dd; null when unreachable or no traffic. */
+  projectedDecisionDate: string | null;
+  /** remainingDays is known and within UNREACHABLE_DAYS. */
+  reachable: boolean;
+}
+
+function isoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Project when the laggard variant reaches the required sample size.
+ *
+ * @param daysRunning - when provided, the projected date is floored at the
+ *   MIN_RUN_DAYS horizon so a fast test never shows "hold until ~today"
+ *   while the 14-day gate is still closed (which would invite exactly the
+ *   early conclude the gate exists to prevent).
+ */
+export function projectDecision(
+  minVariantImpressions: number,
+  requiredPerVariant: number,
+  dailyExposurePerVariant: number,
+  now: Date,
+  daysRunning?: number
+): DecisionProjection {
+  const minDaysLeft =
+    daysRunning != null ? Math.max(0, MIN_RUN_DAYS - daysRunning) : 0;
+  const remaining = Math.max(0, requiredPerVariant - minVariantImpressions);
+  if (remaining === 0) {
+    const days = minDaysLeft;
+    return {
+      requiredPerVariant,
+      minVariantImpressions,
+      dailyExposurePerVariant,
+      remainingDays: days,
+      projectedDecisionDate: isoDate(new Date(now.getTime() + days * 86_400_000)),
+      reachable: true,
+    };
+  }
+  if (dailyExposurePerVariant <= 0) {
+    return {
+      requiredPerVariant,
+      minVariantImpressions,
+      dailyExposurePerVariant: 0,
+      remainingDays: null,
+      projectedDecisionDate: null,
+      reachable: false,
+    };
+  }
+  const remainingDays = Math.max(
+    Math.ceil(remaining / dailyExposurePerVariant),
+    minDaysLeft
+  );
+  const reachable = remainingDays <= UNREACHABLE_DAYS;
+  const date = new Date(now.getTime() + remainingDays * 86_400_000);
+  return {
+    requiredPerVariant,
+    minVariantImpressions,
+    dailyExposurePerVariant,
+    remainingDays,
+    projectedDecisionDate: reachable ? isoDate(date) : null,
+    reachable,
+  };
+}
+
+export type ExperimentVerdict =
+  | 'winner'
+  | 'no-difference'
+  | 'collecting'
+  | 'underpowered'
+  | 'no-traffic';
+
+export interface ExperimentDecision extends DecisionProjection {
+  verdict: ExperimentVerdict;
+  /** A challenger that crossed the confidence threshold BEFORE the horizon. */
+  trendingVariantId: string | null;
+  assumedBaselineRate: number;
+  relativeMde: number;
+  confidenceLevel: number;
+  /** Plain-English operator guidance, pre-baked server-side. */
+  message: string;
+}
+
+export interface DecisionInputs {
+  significance: SignificanceResult;
+  projection: DecisionProjection;
+  daysRunning: number;
+  confidenceThreshold?: number;
+  assumedBaselineRate: number;
+  relativeMde: number;
+}
+
+/**
+ * Layer the anti-peeking gate on top of computeSignificance:
+ * a WINNER requires the full sample (every variant ≥ requiredPerVariant),
+ * the 14-day minimum run, AND ≥95% confidence. A 95% crossing before the
+ * horizon renders as "trending" — checked daily, an early call at 95% inflates
+ * false positives badly (effective type-I error toward 20-30% over a long test).
+ * This is a fixed-horizon readout, not formal alpha-spending sequential testing.
+ */
+export function deriveVerdict(inputs: DecisionInputs): ExperimentDecision {
+  const {
+    significance,
+    projection,
+    daysRunning,
+    confidenceThreshold = DEFAULT_CONFIDENCE_LEVEL,
+    assumedBaselineRate,
+    relativeMde,
+  } = inputs;
+
+  const base = {
+    ...projection,
+    assumedBaselineRate,
+    relativeMde,
+    confidenceLevel: confidenceThreshold,
+  };
+
+  const horizonReached =
+    projection.minVariantImpressions >= projection.requiredPerVariant &&
+    daysRunning >= MIN_RUN_DAYS;
+
+  const challengers = significance.variants.filter(
+    (v) => significance.control && v.id !== significance.control.id
+  );
+  const confidentChallenger = challengers.find(
+    (v) => v.confidence != null && v.confidence >= confidenceThreshold
+  );
+
+  if (horizonReached) {
+    if (significance.winner) {
+      const w = significance.winner;
+      const lift = w.liftPct != null ? `${w.liftPct >= 0 ? '+' : ''}${w.liftPct.toFixed(0)}%` : '';
+      return {
+        ...base,
+        verdict: 'winner',
+        trendingVariantId: null,
+        message: `${w.name} wins at ${Math.round((w.confidence ?? 0) * 100)}% confidence (${lift} vs control). Safe to conclude.`,
+      };
+    }
+    // Full sample, no winner. A confident challenger BELOW control means the
+    // challenger lost — control wins. Otherwise the difference is just noise.
+    const controlRate = significance.control?.conversionRate ?? 0;
+    const confidentLoser = challengers.find(
+      (v) =>
+        v.confidence != null &&
+        v.confidence >= confidenceThreshold &&
+        v.conversionRate < controlRate
+    );
+    return {
+      ...base,
+      verdict: 'no-difference',
+      trendingVariantId: null,
+      message: confidentLoser
+        ? `Control wins — the challenger performed significantly worse. Keep the current copy and conclude.`
+        : `Sample reached with no significant difference — pick either copy and move to the next test.`,
+    };
+  }
+
+  if (projection.dailyExposurePerVariant <= 0 && projection.remainingDays === null) {
+    return {
+      ...base,
+      verdict: 'no-traffic',
+      trendingVariantId: null,
+      message: 'No recent traffic — can’t project a decision date.',
+    };
+  }
+
+  if (!projection.reachable) {
+    const days = projection.remainingDays;
+    const daysLabel = days != null && days <= 365 ? `~${days} days` : 'over a year';
+    return {
+      ...base,
+      verdict: 'underpowered',
+      trendingVariantId: confidentChallenger?.id ?? null,
+      message: `At current traffic this test needs ${daysLabel} to conclude — this page can’t support an A/B test right now. Consider a bolder variant, or just ship the better copy and watch the trend.`,
+    };
+  }
+
+  const dateLabel = projection.projectedDecisionDate ?? 'soon';
+  const trending = confidentChallenger ?? null;
+  return {
+    ...base,
+    verdict: 'collecting',
+    trendingVariantId: trending?.id ?? null,
+    message: trending
+      ? `${trending.name} trending ahead at ${Math.round((trending.confidence ?? 0) * 100)}% — hold until ~${dateLabel} to call it (early calls inflate false positives).`
+      : projection.remainingDays != null && projection.remainingDays > 45
+        ? `Collecting data — slow at current traffic; decision expected around ${dateLabel} (~${projection.remainingDays} days). More traffic to this page would speed it up.`
+        : `Collecting data — decision expected around ${dateLabel}${projection.remainingDays != null ? ` (~${projection.remainingDays} days)` : ''}.`,
+  };
+}

--- a/src/lib/analytics/experiment-transform.ts
+++ b/src/lib/analytics/experiment-transform.ts
@@ -67,6 +67,74 @@ export function successCount(
     : v.conversions;
 }
 
+export interface TrendPoint {
+  /** ISO yyyy-mm-dd (UTC day). */
+  date: string;
+  exposures: number;
+  clicks: number;
+  cumExposures: number;
+  cumClicks: number;
+  /** Cumulative goal rate up to this day, PERCENT units (matches clickRate). */
+  cumRate: number;
+}
+
+interface TrendInputRow {
+  variantId: string;
+  day: string;
+  exposures: number;
+  clicks: number;
+}
+
+/**
+ * Build per-variant CUMULATIVE CTR trends from daily event counts. Cumulative
+ * (not daily) because at this site's volumes a per-day rate is pure noise —
+ * the converging/diverging cumulative lines are what an operator can read.
+ * Days between the first and last observed day are gap-filled so the x-axis
+ * is linear in time.
+ */
+export function buildVariantTrends(
+  rows: TrendInputRow[],
+  variantIds: string[]
+): Record<string, TrendPoint[]> {
+  const trends: Record<string, TrendPoint[]> = {};
+  if (rows.length === 0) return trends;
+
+  const days = rows.map((r) => r.day).sort();
+  const firstDay = days[0];
+  const lastDay = days[days.length - 1];
+
+  const byKey = new Map<string, TrendInputRow>();
+  for (const r of rows) byKey.set(`${r.variantId}:${r.day}`, r);
+
+  for (const variantId of variantIds) {
+    const points: TrendPoint[] = [];
+    let cumExposures = 0;
+    let cumClicks = 0;
+    for (
+      let t = new Date(`${firstDay}T00:00:00Z`).getTime();
+      t <= new Date(`${lastDay}T00:00:00Z`).getTime();
+      t += 86_400_000
+    ) {
+      const date = new Date(t).toISOString().slice(0, 10);
+      const row = byKey.get(`${variantId}:${date}`);
+      const exposures = row?.exposures ?? 0;
+      const clicks = row?.clicks ?? 0;
+      cumExposures += exposures;
+      cumClicks += clicks;
+      points.push({
+        date,
+        exposures,
+        clicks,
+        cumExposures,
+        cumClicks,
+        cumRate: cumExposures > 0 ? (cumClicks / cumExposures) * 100 : 0,
+      });
+    }
+    trends[variantId] = points;
+  }
+  return trends;
+}
+
 /**
  * Cap the MDE so the target rate stays below 1 (high-baseline pages).
  * resolveBaselineRate clamps baselines to ≤0.95, so the cap here is always
@@ -86,6 +154,8 @@ export type TransformedExperiment = Omit<TransformableExperiment, 'variants'> & 
   significance: ReturnType<typeof computeSignificance>;
   /** Absent when the decision math failed for this row (degraded, not fatal). */
   decision?: ExperimentDecision;
+  /** Per-variant cumulative CTR trend (event-based, directional). */
+  trends: Record<string, TrendPoint[]>;
   variants: TransformedVariant[];
 };
 
@@ -96,13 +166,16 @@ export type TransformedExperiment = Omit<TransformableExperiment, 'variants'> & 
  * @param exposureWindowDays - the window the counts were collected over.
  * @param baselinePrior - page-level prior CTA rate used until the experiment
  *   has ≥200 impressions of its own.
+ * @param seriesRows - this experiment's daily event counts (see
+ *   getExperimentDailySeries); builds the per-variant cumulative CTR trend.
  */
 export function transformExperiment(
   exp: TransformableExperiment,
   now: Date,
   exposureCounts: Map<string, number> = new Map(),
   exposureWindowDays = 7,
-  baselinePrior = 0.1
+  baselinePrior = 0.1,
+  seriesRows: TrendInputRow[] = []
 ): TransformedExperiment {
   const totalImpressions = exp.variants.reduce((sum, v) => sum + v.impressions, 0);
 
@@ -195,6 +268,7 @@ export function transformExperiment(
     daysRunning,
     significance,
     decision,
+    trends: buildVariantTrends(seriesRows, exp.variants.map((v) => v.id)),
     variants: exp.variants.map((v) => {
       const successes = successCount(exp.goalMetric, v);
       const ci = wilsonInterval(successes, v.impressions);

--- a/src/lib/analytics/experiment-transform.ts
+++ b/src/lib/analytics/experiment-transform.ts
@@ -1,0 +1,209 @@
+/**
+ * Pure per-experiment transform for GET /api/admin/experiments.
+ *
+ * Takes a DB experiment row (+ its variants' lifetime counters and trailing
+ * exposure counts) and produces everything the admin UIs render: significance,
+ * per-variant rates + Wilson CIs, and the decision block (verdict, projected
+ * decision date, plain-English message). Pure so the response shape is unit-
+ * testable without a route or database.
+ */
+
+import {
+  computeSignificance,
+  type VariantStat,
+} from './experiment-significance';
+import {
+  deriveVerdict,
+  projectDecision,
+  requiredSampleSizePerVariant,
+  resolveBaselineRate,
+  defaultRelativeMde,
+  wilsonInterval,
+  type ExperimentDecision,
+} from './experiment-planning';
+
+/** Structural type covering the Prisma row shape the route feeds in. */
+export interface TransformableVariant {
+  id: string;
+  name: string;
+  isControl: boolean;
+  weight: number;
+  content: unknown;
+  impressions: number;
+  clicks: number;
+  conversions: number;
+  revenue: number;
+}
+
+export interface TransformableExperiment {
+  id: string;
+  name: string;
+  page: string;
+  elementId: string;
+  status: string;
+  goalMetric: string;
+  startDate: Date | string | null;
+  variants: TransformableVariant[];
+  [key: string]: unknown;
+}
+
+export interface TransformedVariant extends TransformableVariant {
+  clickRate: number;
+  conversionRate: number;
+  /** Wilson 95% CI on the goal rate, in PERCENT units (matches clickRate). */
+  goalRateCi: { lo: number; hi: number };
+}
+
+/**
+ * Per-variant success count for the significance test: for click-style goals
+ * the "success" is a click; for conversion/revenue goals it's a conversion.
+ */
+export function successCount(
+  goalMetric: string,
+  v: { clicks: number; conversions: number }
+): number {
+  return goalMetric === 'cta_click' || goalMetric === 'scroll_depth'
+    ? v.clicks
+    : v.conversions;
+}
+
+/**
+ * Cap the MDE so the target rate stays below 1 (high-baseline pages).
+ * resolveBaselineRate clamps baselines to ≤0.95, so the cap here is always
+ * ≥ ~0.04 — but guard the degenerate region anyway instead of letting a
+ * positive floor override a negative cap (which would push p2 ≥ 1 and throw).
+ */
+function effectiveMde(baselineRate: number, mde: number): number {
+  const cap = 0.99 / baselineRate - 1;
+  if (cap <= 0.01) return Math.max(cap, 0.001);
+  return Math.min(mde, cap);
+}
+
+export type TransformedExperiment = Omit<TransformableExperiment, 'variants'> & {
+  totalImpressions: number;
+  uplift: number;
+  daysRunning: number;
+  significance: ReturnType<typeof computeSignificance>;
+  /** Absent when the decision math failed for this row (degraded, not fatal). */
+  decision?: ExperimentDecision;
+  variants: TransformedVariant[];
+};
+
+/**
+ * @param exposureCounts - trailing-window `experiment_exposure` counts keyed
+ *   `${experimentId}:${variantId}` (see getTrailingExposureRates). Missing
+ *   entries fall back to lifetime counters averaged over the run.
+ * @param exposureWindowDays - the window the counts were collected over.
+ * @param baselinePrior - page-level prior CTA rate used until the experiment
+ *   has ≥200 impressions of its own.
+ */
+export function transformExperiment(
+  exp: TransformableExperiment,
+  now: Date,
+  exposureCounts: Map<string, number> = new Map(),
+  exposureWindowDays = 7,
+  baselinePrior = 0.1
+): TransformedExperiment {
+  const totalImpressions = exp.variants.reduce((sum, v) => sum + v.impressions, 0);
+
+  const controlVariant = exp.variants.find((v) => v.isControl);
+  const bestVariant = exp.variants.reduce<TransformableVariant | null>((best, v) => {
+    if (v.isControl) return best;
+    const vRate = v.impressions > 0 ? v.clicks / v.impressions : 0;
+    const bestRate = best && best.impressions > 0 ? best.clicks / best.impressions : 0;
+    return vRate > bestRate ? v : best;
+  }, null);
+
+  let uplift = 0;
+  if (
+    controlVariant &&
+    bestVariant &&
+    controlVariant.impressions > 0 &&
+    bestVariant.impressions > 0
+  ) {
+    const controlRate = controlVariant.clicks / controlVariant.impressions;
+    const bestRate = bestVariant.clicks / bestVariant.impressions;
+    uplift = controlRate > 0 ? ((bestRate - controlRate) / controlRate) * 100 : 0;
+  }
+
+  const startDate = exp.startDate ? new Date(exp.startDate) : null;
+  const daysRunning = startDate
+    ? Math.floor((now.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24))
+    : 0;
+
+  const sigStats: VariantStat[] = exp.variants.map((v) => ({
+    id: v.id,
+    name: v.name,
+    isControl: v.isControl,
+    impressions: v.impressions,
+    conversions: successCount(exp.goalMetric, v),
+  }));
+  const significance = computeSignificance(sigStats);
+
+  // ── Decision block ────────────────────────────────────────────────
+  // Guarded: the counters behind this math come from a public tracking
+  // endpoint, so treat them as hostile. If anything still throws, this row
+  // ships without a decision instead of 500ing the whole tab.
+  let decision: ExperimentDecision | undefined;
+  try {
+    const baselineRate = resolveBaselineRate(
+      exp.variants.map((v) => ({
+        impressions: v.impressions,
+        successes: successCount(exp.goalMetric, v),
+      })),
+      baselinePrior
+    );
+    const mde = effectiveMde(baselineRate, defaultRelativeMde(baselineRate));
+    const requiredPerVariant = requiredSampleSizePerVariant(baselineRate, mde);
+
+    // Laggard variant drives the finish line; its trailing daily rate drives
+    // the date. Window: min(7, days since start), floored at 1 (cold start).
+    const windowDays = Math.min(exposureWindowDays, Math.max(daysRunning, 1));
+    const perVariantDaily = exp.variants.map((v) => {
+      const trailing = exposureCounts.get(`${exp.id}:${v.id}`);
+      if (trailing != null && trailing > 0) return trailing / windowDays;
+      // Fallback: lifetime counter averaged over the run (covers tracking gaps).
+      return v.impressions > 0 ? v.impressions / Math.max(daysRunning, 1) : 0;
+    });
+    const minVariantImpressions =
+      exp.variants.length > 0 ? Math.min(...exp.variants.map((v) => v.impressions)) : 0;
+    const laggardDaily = perVariantDaily.length > 0 ? Math.min(...perVariantDaily) : 0;
+
+    const projection = projectDecision(
+      minVariantImpressions,
+      requiredPerVariant,
+      laggardDaily,
+      now,
+      daysRunning
+    );
+    decision = deriveVerdict({
+      significance,
+      projection,
+      daysRunning,
+      assumedBaselineRate: baselineRate,
+      relativeMde: mde,
+    });
+  } catch (e) {
+    console.error(`experiment-transform: decision math failed for ${exp.id}:`, e);
+    decision = undefined;
+  }
+
+  return {
+    ...exp,
+    totalImpressions,
+    uplift: Math.round(uplift * 10) / 10,
+    daysRunning,
+    significance,
+    decision,
+    variants: exp.variants.map((v) => {
+      const successes = successCount(exp.goalMetric, v);
+      const ci = wilsonInterval(successes, v.impressions);
+      return {
+        ...v,
+        clickRate: v.impressions > 0 ? (v.clicks / v.impressions) * 100 : 0,
+        conversionRate: v.impressions > 0 ? (v.conversions / v.impressions) * 100 : 0,
+        goalRateCi: { lo: ci.lo * 100, hi: ci.hi * 100 },
+      };
+    }),
+  };
+}

--- a/src/lib/analytics/landing-pages.ts
+++ b/src/lib/analytics/landing-pages.ts
@@ -44,6 +44,14 @@ export interface LandingPageDef {
   ctaSections: CtaSectionDef[];
   /** Pre-fills the "element" field when creating an A/B test for this page. */
   defaultExperimentElementId: string;
+  /**
+   * Routes on this tab that render their OWN hero and can host a hero A/B
+   * test. Defaults to [canonicalPath]. Only set when a tab unions several
+   * physically different pages (weddings: the service page, the calculator,
+   * and the ads lander each have a distinct hero). Redirect-only aliases
+   * (/bach-parties, /corporate) never render a hero and don't belong here.
+   */
+  experimentPaths?: string[];
 }
 
 export const LANDING_PAGES: LandingPageDef[] = [
@@ -82,6 +90,11 @@ export const LANDING_PAGES: LandingPageDef[] = [
       { id: 'final_cta', label: 'Final CTA' },
     ],
     defaultExperimentElementId: 'hero',
+    experimentPaths: [
+      '/weddings',
+      '/wedding-drink-calculator',
+      '/austin-wedding-weekend-delivery',
+    ],
   },
   {
     key: 'boat-parties',
@@ -173,6 +186,11 @@ export function normalizePath(path: string): string {
   const clean = (path.split('?')[0] ?? '').split('#')[0] ?? '';
   if (clean.length > 1 && clean.endsWith('/')) return clean.slice(0, -1);
   return clean || '/';
+}
+
+/** Routes on a tab that can host a hero A/B test (canonical path by default). */
+export function experimentPathsFor(def: LandingPageDef): string[] {
+  return def.experimentPaths ?? [def.canonicalPath];
 }
 
 /** Canonical path + all alias paths for a landing page (empty if key unknown). */

--- a/src/lib/analytics/variant-rollup.ts
+++ b/src/lib/analytics/variant-rollup.ts
@@ -122,6 +122,60 @@ export async function getTrailingExposureRates(
   );
 }
 
+export interface DailySeriesRow {
+  experimentId: string;
+  variantId: string;
+  /** ISO yyyy-mm-dd (UTC day). */
+  day: string;
+  exposures: number;
+  clicks: number;
+}
+
+/**
+ * Per-day, per-variant exposure + hero-CTA click counts for a set of
+ * experiments — feeds the CTR-over-time trend chart in the analytics hub.
+ * Sourced from AnalyticsEvent rows (experiment_exposure / cta_click stamped
+ * with experiment_id + variant_id). NOTE: the trend is directional — the
+ * DECISION numbers stay on the lifetime variant counters, and the two
+ * pipelines can differ slightly (ad blockers, beacon loss).
+ */
+export async function getExperimentDailySeries(
+  experimentIds: string[],
+  maxDays = 90
+): Promise<DailySeriesRow[]> {
+  if (experimentIds.length === 0) return [];
+  const since = new Date();
+  since.setDate(since.getDate() - maxDays);
+
+  const rows = await prisma.$queryRawUnsafe<
+    Array<{ experiment_id: string; variant_id: string; day: Date; exposures: bigint; clicks: bigint }>
+  >(
+    `
+    SELECT experiment_id, variant_id,
+           date_trunc('day', occurred_at)::date AS day,
+           COUNT(*) FILTER (WHERE name = 'experiment_exposure')::bigint AS exposures,
+           COUNT(*) FILTER (WHERE name = 'cta_click')::bigint           AS clicks
+    FROM analytics_events
+    WHERE experiment_id = ANY($1::text[])
+      AND variant_id IS NOT NULL
+      AND name IN ('experiment_exposure', 'cta_click')
+      AND occurred_at >= $2
+    GROUP BY experiment_id, variant_id, day
+    ORDER BY day
+  `,
+    experimentIds,
+    since
+  );
+
+  return rows.map((r) => ({
+    experimentId: r.experiment_id,
+    variantId: r.variant_id,
+    day: r.day.toISOString().slice(0, 10),
+    exposures: Number(r.exposures),
+    clicks: Number(r.clicks),
+  }));
+}
+
 export interface PageEngagement {
   path: string;
   sessions: number;

--- a/src/lib/analytics/variant-rollup.ts
+++ b/src/lib/analytics/variant-rollup.ts
@@ -87,6 +87,41 @@ export async function getExperimentRollup(
   return { experimentId, windowDays, ...sig };
 }
 
+/**
+ * Per-variant trailing exposure counts for a set of experiments — feeds the
+ * "projected decision date" math (experiment-planning.ts). Counts
+ * `experiment_exposure` AnalyticsEvents in the trailing window; the caller
+ * divides by windowDays (and falls back to lifetime counters / daysRunning
+ * when the event stream is empty for an experiment).
+ *
+ * @returns Map keyed `${experimentId}:${variantId}` → exposure count in window.
+ */
+export async function getTrailingExposureRates(
+  experimentIds: string[],
+  windowDays = 7
+): Promise<Map<string, number>> {
+  if (experimentIds.length === 0) return new Map();
+  const since = new Date();
+  since.setDate(since.getDate() - windowDays);
+
+  const rows = await prisma.analyticsEvent.groupBy({
+    by: ['experimentId', 'variantId'],
+    where: {
+      experimentId: { in: experimentIds },
+      name: 'experiment_exposure',
+      occurredAt: { gte: since },
+      variantId: { not: null },
+    },
+    _count: { _all: true },
+  });
+
+  return new Map(
+    rows
+      .filter((r) => r.experimentId && r.variantId)
+      .map((r) => [`${r.experimentId}:${r.variantId}`, r._count._all])
+  );
+}
+
 export interface PageEngagement {
   path: string;
   sessions: number;

--- a/src/lib/experiments/experiment-schemas.ts
+++ b/src/lib/experiments/experiment-schemas.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared Zod schemas for the DB-backed experiment system (System B).
+ *
+ * Single source of truth for what a variant's hero-copy payload may contain —
+ * consumed by the admin create route AND the seed script, so the two can never
+ * drift. (Brian's code-registry system has its own types; untouched.)
+ */
+
+import { z } from 'zod';
+
+/**
+ * Hero-copy payload an operator can set per variant. All fields optional —
+ * an absent field falls back to the page's default copy.
+ * `headlineAccent` is the gold second line on the LandingPageTemplate landers
+ * (bachelor/bachelorette/corporate/wedding-weekend); other pages ignore it.
+ */
+export const VariantContentSchema = z.object({
+  eyebrow: z.string().max(200).optional(),
+  headline: z.string().max(300).optional(),
+  headlineAccent: z.string().max(200).optional(),
+  subhead: z.string().max(500).optional(),
+  ctaText: z.string().max(120).optional(),
+});
+
+export type VariantContent = z.infer<typeof VariantContentSchema>;
+
+/** Validation schema for creating an experiment. */
+export const CreateExperimentSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(100),
+  description: z.string().max(500).optional(),
+  page: z.string().min(1, 'Page is required'),
+  elementId: z.string().min(1, 'Element ID is required'),
+  goalMetric: z.enum(['cta_click', 'scroll_depth', 'conversion', 'revenue']),
+  goalValue: z.string().max(120).optional(),
+  variants: z
+    .array(
+      z.object({
+        name: z.string().min(1),
+        description: z.string().optional(),
+        isControl: z.boolean().default(false),
+        weight: z.number().min(0).max(100).default(50),
+        content: VariantContentSchema.optional(),
+      })
+    )
+    .min(2, 'At least 2 variants required'),
+});
+
+export type CreateExperimentInput = z.infer<typeof CreateExperimentSchema>;

--- a/src/lib/experiments/hero-test-seeds.ts
+++ b/src/lib/experiments/hero-test-seeds.ts
@@ -1,0 +1,172 @@
+/**
+ * Hero-headline A/B test seeds — one 2-variant test per landing page.
+ *
+ * Copy follows the Hormozi headline framework (dream outcome + timeframe +
+ * effort/risk minimizer) with BOLD swings: at this site's traffic (20–660
+ * views/page/month) only large effects can reach significance, so challengers
+ * change the angle, not a word. Control is ALWAYS the current live copy
+ * (content: {} = render the page's defaults).
+ *
+ * Rules encoded here (enforced by src/__tests__/hero-test-seeds.test.ts):
+ * - Exactly 2 variants per test, 50/50, exactly one control. Headline-only —
+ *   CTA text unchanged so the test measures the headline.
+ * - Template landers (/austin-*): challenger sets headline + headlineAccent;
+ *   the SEO eyebrow (H1) is never varied (and the resolver ignores it anyway).
+ * - Homepage: variant names MUST be exactly 'Control' / 'Variant C' — the
+ *   legacy homepage pipeline maps names → hero-variants.ts content, and any
+ *   other name silently falls back to control copy on both arms. Copy fields
+ *   stay empty; Variant C ("Austin's Premium / Alcohol Delivery" + luxury
+ *   imagery) lives in code. Note: it changes images too, so the homepage test
+ *   reads as a premium-positioning test, not a pure copy test.
+ * - /wedding-drink-calculator: the H1 is the exact-match paid keyword — the
+ *   challenger keeps "Wedding Drink Calculator" as a substring.
+ */
+
+import type { CreateExperimentInput } from './experiment-schemas';
+
+export interface HeroTestSeed extends CreateExperimentInput {
+  /** Under ~5 views/month — seeded only with --include-low-traffic. */
+  lowTraffic?: boolean;
+}
+
+/** Routes with a working hero-experiment integration (System B or legacy). */
+export const WIRED_ROUTES = [
+  '/',
+  '/weddings',
+  '/boat-parties',
+  '/cocktail-kits',
+  '/austin-bachelor-party-delivery',
+  '/austin-bachelorette-party-delivery',
+  '/austin-corporate-event-delivery',
+  '/austin-wedding-weekend-delivery',
+  '/wedding-drink-calculator',
+  '/order',
+] as const;
+
+function twoVariants(
+  challenger: Record<string, string>
+): CreateExperimentInput['variants'] {
+  return [
+    { name: 'Control', isControl: true, weight: 50, content: {} },
+    { name: 'Variant B', isControl: false, weight: 50, content: challenger },
+  ];
+}
+
+export const HERO_TEST_SEEDS: HeroTestSeed[] = [
+  {
+    name: 'Home hero — animated control vs premium positioning (v1)',
+    description:
+      'Legacy in-code variants: Control = animated hero; Variant C = static "Austin\'s Premium / Alcohol Delivery" + luxury imagery. Positioning test (copy + images swap together).',
+    page: '/',
+    elementId: 'hero',
+    goalMetric: 'cta_click',
+    variants: [
+      { name: 'Control', isControl: true, weight: 50, content: {} },
+      { name: 'Variant C', isControl: false, weight: 50, content: {} },
+    ],
+  },
+  {
+    name: 'Weddings hero — quality claim vs vendor-relief (v1)',
+    description:
+      'Control: "Your Austin Wedding, PERFECTLY SERVED". Challenger reframes as risk/effort relief for an overwhelmed couple.',
+    page: '/weddings',
+    elementId: 'hero',
+    goalMetric: 'cta_click',
+    variants: twoVariants({
+      headline: 'One Less Wedding Vendor To Worry About',
+    }),
+  },
+  {
+    name: 'Boat hero — product attribute vs timeframe (v1)',
+    description:
+      'Control: "Cold Drinks to Your BOAT—ON TIME". Challenger sells the moment it matters: stocked before departure.',
+    page: '/boat-parties',
+    elementId: 'hero',
+    goalMetric: 'cta_click',
+    variants: twoVariants({
+      headline: 'Stocked Before You Leave the Marina',
+    }),
+  },
+  {
+    name: 'Cocktail kits hero — product name vs outcome (v1)',
+    description:
+      'Control: "Premium Cocktail Kits, Delivered to Your Door". Challenger leads with the outcome + effort eliminated.',
+    page: '/cocktail-kits',
+    elementId: 'hero',
+    goalMetric: 'cta_click',
+    variants: twoVariants({
+      headline: 'Bar-Quality Cocktails at Home — No Bartender Needed',
+    }),
+  },
+  {
+    name: 'Bachelor hero — timeframe vs one-link effort (v1)',
+    description:
+      'Control: "Stocked & Ice-Cold / Before The Groom Lands." Challenger sells the split-pay, one-link organizer relief.',
+    page: '/austin-bachelor-party-delivery',
+    elementId: 'hero',
+    goalMetric: 'cta_click',
+    variants: twoVariants({
+      headline: "The Whole Weekend's Alcohol —",
+      headlineAccent: 'One Link. Split Pay. Done.',
+    }),
+  },
+  {
+    name: 'Bachelorette hero — timeframe vs vivid outcome (v1)',
+    description:
+      'Control: "Champagne Popped / Before The Bride Lands." Challenger paints the arrival moment for the MOH.',
+    page: '/austin-bachelorette-party-delivery',
+    elementId: 'hero',
+    goalMetric: 'cta_click',
+    variants: twoVariants({
+      headline: 'The Airbnb Is Stocked —',
+      headlineAccent: 'Girls, Just Show Up.',
+    }),
+  },
+  {
+    name: 'Corporate hero — premium claim vs planner risk-relief (v1)',
+    description:
+      'Control: "Premium Bar Service. / Delivered To Your Boardroom." Challenger de-risks the event planner\'s job.',
+    page: '/austin-corporate-event-delivery',
+    elementId: 'hero',
+    goalMetric: 'cta_click',
+    variants: twoVariants({
+      headline: 'Your Event, Fully Stocked —',
+      headlineAccent: 'Invoiced, Insured, On Time.',
+    }),
+  },
+  {
+    name: 'Wedding-weekend hero — abstraction vs specificity (v1)',
+    description:
+      'Control: "Every Toast Of The Weekend." Challenger makes the scope concrete: five events, one coordinator. LOW TRAFFIC (~3 views/mo).',
+    page: '/austin-wedding-weekend-delivery',
+    elementId: 'hero',
+    goalMetric: 'cta_click',
+    lowTraffic: true,
+    variants: twoVariants({
+      headline: 'Five Events. One Coordinator.',
+      headlineAccent: 'Zero Bar Runs All Weekend.',
+    }),
+  },
+  {
+    name: 'Calculator hero — keyword vs keyword+benefit (v1)',
+    description:
+      'Control: "Wedding Drink Calculator" (exact-match paid keyword — challenger must keep it as a substring).',
+    page: '/wedding-drink-calculator',
+    elementId: 'hero',
+    goalMetric: 'cta_click',
+    variants: twoVariants({
+      headline: 'Wedding Drink Calculator — Exact Counts in 2 Minutes',
+    }),
+  },
+  {
+    name: 'Order chips — question vs action framing (v1)',
+    description:
+      'Control: "What are we celebrating?" Challenger tells the visitor exactly what happens next.',
+    page: '/order',
+    elementId: 'hero',
+    goalMetric: 'cta_click',
+    variants: twoVariants({
+      headline: "Pick the party — we'll stock the bar.",
+    }),
+  },
+];

--- a/src/lib/experiments/hero-variants.ts
+++ b/src/lib/experiments/hero-variants.ts
@@ -134,6 +134,27 @@ export const heroVariantRegistry: Record<string, HeroVariantContent> = {
 };
 
 /**
+ * Map a DB variant NAME to a hero content id in this registry — the legacy
+ * homepage pipeline stores copy here (not in ExperimentVariant.content) and
+ * resolves it by name. Unknown names fall back to 'control', which silently
+ * renders control copy on BOTH arms of a test — so homepage experiment
+ * variants must be named exactly Control / Variant A / Variant B / Variant C.
+ * Single source of truth for /api/experiments/assign, /api/experiments/track,
+ * and the seed-validity tests.
+ */
+export function mapVariantNameToContentId(variantName: string): string {
+  const normalized = variantName.toLowerCase().trim();
+
+  if (normalized === 'control') return 'control';
+  if (normalized === 'variant a') return 'variant-a';
+  if (normalized === 'variant b') return 'variant-b';
+  if (normalized === 'variant c') return 'variant-c';
+
+  // Default to control for unknown names
+  return 'control';
+}
+
+/**
  * Get variant content by ID
  * Falls back to control if variant not found
  */


### PR DESCRIPTION
## What

Launches the A/B testing program: a hero-headline test is ready on **every landing page** (incl. homepage), and each `/admin/analytics` tab now leads with an **experiment scoreboard** — per variant: visitors, CTA clicks, CTR with a Wilson 95% range, lift vs control, and a plain-English verdict with the **projected decision date** ("when can we make the call").

## How it works

- **Pages**: `useHeroExperiment` now covers the 4 LandingPageTemplate landers (via a pure `resolveHeroCopy` precedence resolver: quiz > Brian's registry > System B > config), `/wedding-drink-calculator`, and `/order` — joining the already-wired `/weddings`, `/boat-parties`, `/cocktail-kits`. Homepage stays on its legacy variant pipeline (seed variant names map to `hero-variants.ts`).
- **Data integrity**: Brian's running registry tests AND `?welcome=1` quiz arrivals hard-skip System B (no assignment, no impression). `/order` auto-mode visitors skip too. Brian's files + `experiment-significance.ts` are byte-identical.
- **Stats** (`experiment-planning.ts`): two-proportion power formula for required sample size, Wilson CIs, 7-day-trailing exposure → projected decision date, and an **anti-peeking gate**: WINNER requires full sample AND ≥14 days AND ≥95% confidence; early 95% crossings render as "trending — hold until ~date". Underpowered pages say so honestly.
- **API**: `GET /api/admin/experiments` gains `pages=` (weddings tab spans 3 physical heroes) + additive `decision`/`goalRateCi` fields via a unit-tested pure transform with per-row degradation. Legacy `/admin/experiments` consumers unaffected (verified field-by-field).
- **Seeds**: `npx tsx scripts/experiments/seed-hero-tests.ts` (dry-run default, `--apply`, idempotent) creates 9 DRAFT tests — Allan reviews copy and presses **Start** per page, so day counts anchor to the real launch.

## Security review (run, findings fixed)

`security-reviewer` agent + adversarial 3-lens review workflow (16 agents, findings mutation-verified). Fixed: baseline/Wilson clamps against counter abuse (public `/api/experiments/track` can send clicks>impressions), per-row transform degradation (one bad row can't 500 a tab), rate limit + revenue clamp + RUNNING-only writes on the track route, quiz-visitor sample pollution, stale-response race in the shared hub hook, `MIN_RUN_DAYS`-floored projection dates, deduped `mapVariantNameToContentId`.

**Residual risk (accepted, documented):** the track endpoint remains unauthenticated by design (public tracking); within rate limits a determined actor could still inflate counters. Mitigation: winner declaration is human-in-the-loop (Allan sees absolute counts before concluding). A signed-nonce scheme is a possible follow-up.

## Gates

- `npm run test:run`: **954 passed** (99 new across 6 suites: planning math vs textbook values, transform shape + order-independence, resolver precedence matrix, seed validity incl. homepage name-mapping guard, hook skip behavior)
- `npm run lint`: 0 errors
- `npx tsc --noEmit`: clean on all touched files (3 pre-existing main errors untouched)
- Seed dry-run verified against prod DB (9 would-create, wedding-weekend low-traffic-skipped)

## Not verified locally

Browser copy-swap flow — local dev server is broken repo-wide (pre-existing `path-to-regexp` crash at startup, also on main; tracked separately). Post-merge: verify the swap on prod with a short-lived throwaway test on the bachelor lander (July-4 QA playbook), then seed.

## Post-merge plan

1. Deploy → throwaway RUNNING test on `/austin-bachelor-party-delivery`, verify swap + counters, delete it.
2. `seed-hero-tests.ts` dry-run → `--apply` (9 DRAFTs).
3. Allan reviews copy per tab and presses Start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)