### PR TITLE
fix(dev): replace ':suffix*' redirect patterns that crash Next 15.5 dev startup

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -319,13 +319,18 @@ const nextConfig: NextConfig = {
         destination: '/',
         permanent: true,
       },
+      // NOTE: ':suffix(.*)' not ':suffix*' — path-to-regexp bundled with
+      // Next >=15.5 rejects a '*' repeat on a param glued to literal text
+      // ("Can not repeat \"suffix\" without a prefix and suffix"), which
+      // crashed dev startup. The custom-regex form matches the exact same
+      // URLs (zero or more trailing chars).
       {
-        source: '/downloa:suffix*',
+        source: '/downloa:suffix(.*)',
         destination: '/',
         permanent: true,
       },
       {
-        source: '/fast-deliver:suffix*',
+        source: '/fast-deliver:suffix(.*)',
         destination: '/delivery-areas',
         permanent: true,
       },
@@ -342,7 +347,7 @@ const nextConfig: NextConfig = {
 
       // Dead product pages (crawled but no longer in catalog)
       {
-        source: '/products/heb-cage-free-white-extra-l:suffix*',
+        source: '/products/heb-cage-free-white-extra-l:suffix(.*)',
         destination: '/order',
         permanent: true,
       },


### PR DESCRIPTION
## Problem

Local dev (`npm run dev` Turbopack AND `npx next dev` webpack) crashed at startup right after `✓ Starting...` with:

```
[TypeError: Can not repeat "suffix" without a prefix and suffix]
```

Reproduced repo-wide (main checkout + worktrees) since 2026-07-15. Production builds were unaffected — only local dev boot.

## Root cause

`package.json` pins `^15.4.8` but `node_modules` resolves **Next 15.5.20**, whose bundled path-to-regexp rejects a `*` repeat modifier on a route param glued to literal text (not its own path segment). Three redirects in `next.config.ts` used that form (the param is literally named `suffix`, which is what the error names):

- `/downloa:suffix*`
- `/fast-deliver:suffix*`
- `/products/heb-cage-free-white-extra-l:suffix*`

Proven by compiling all 52 config `source:` patterns against `node_modules/next/dist/compiled/path-to-regexp` — exactly these three fail, everything else (middleware matcher, headers, 327 archived-product redirects) compiles clean.

## Fix

Rewrite as `:suffix(.*)` — a custom-regex param instead of a repeat modifier. Matches the identical URL set (zero or more trailing chars, bare truncations included), and the syntax is valid on both old and new path-to-regexp, so it's safe regardless of which Next minor Vercel resolves.

## Verification

- All 52 `source:` patterns compile against the bundled path-to-regexp (was 3 failures)
- `npm run dev` (Turbopack 15.5.20) boots: `✓ Ready in 1518ms`, `GET / 200`
- Redirect behavior unchanged, curl-verified: `/downloa`, `/download-app`, `/downloadxyz` → 308 `/`; `/fast-deliver`, `/fast-delivery-austin` → 308 `/delivery-areas`; `/products/heb-cage-free-white-extra-large-grade-aa-eggs` → 308 `/order`
- Gates: vitest 898/898 pass, lint clean; tsc has only the 3 known pre-existing errors on untouched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)