### PR TITLE
feat(hq): CRM crossover link in the HQ shell nav

### DIFF
--- a/src/components/backend/shell/MoreSheet.tsx
+++ b/src/components/backend/shell/MoreSheet.tsx
@@ -24,6 +24,20 @@ function Tile({
 }): ReactElement {
   const count =
     dest.badge === 'recs' ? badges.recsOpen : dest.badge === 'leads' ? badges.leadsHot : 0;
+  if (dest.external) {
+    return (
+      <a
+        href={dest.href}
+        target="_blank"
+        rel="noreferrer"
+        onClick={onNavigate}
+        className="relative flex flex-col items-center justify-center gap-1.5 min-h-[74px] rounded-xl border border-gray-200 bg-gray-50 hover:bg-gray-100 text-gray-700 transition-colors touch-manipulation"
+      >
+        <HqIcon name={dest.icon} size={22} />
+        <span className="text-xs font-semibold text-center leading-tight px-1">{dest.label}</span>
+      </a>
+    );
+  }
   return (
     <Link
       href={dest.href}

--- a/src/components/backend/shell/SidebarNav.tsx
+++ b/src/components/backend/shell/SidebarNav.tsx
@@ -32,6 +32,19 @@ function SidebarItem({
         : dest.badge === 'leads'
           ? badges.leadsHot
           : 0;
+  if (dest.external) {
+    return (
+      <a
+        href={dest.href}
+        target="_blank"
+        rel="noreferrer"
+        className="flex items-center gap-3 px-4 min-h-[40px] text-sm font-medium border-l-[3px] border-transparent text-[#B7C4D0] hover:text-white hover:bg-white/5 transition-colors"
+      >
+        <HqIcon name={dest.icon} size={18} />
+        <span className="flex-1">{dest.label}</span>
+      </a>
+    );
+  }
   return (
     <Link
       href={dest.href}

--- a/src/components/backend/shell/icons.tsx
+++ b/src/components/backend/shell/icons.tsx
@@ -16,6 +16,7 @@ export type HqIconName =
   | 'analytics'
   | 'customers'
   | 'leads'
+  | 'crm'
   | 'email'
   | 'recs'
   | 'money'
@@ -111,6 +112,13 @@ const PATHS: Record<HqIconName, ReactElement> = {
   leads: (
     // Funnel — leads flow in wide, convert narrow.
     <path d="M3 4h18l-7 8v6l-4 2v-8L3 4z" />
+  ),
+  crm: (
+    // Paired chat bubbles — the communications hub.
+    <>
+      <path d="M14 9a2 2 0 01-2 2H6l-4 4V4a2 2 0 012-2h8a2 2 0 012 2z" />
+      <path d="M18 9h2a2 2 0 012 2v11l-4-4h-6a2 2 0 01-2-2v-1" />
+    </>
   ),
   reports: (
     <>

--- a/src/components/backend/shell/nav-config.ts
+++ b/src/components/backend/shell/nav-config.ts
@@ -18,6 +18,8 @@ export interface NavDest {
   /** Roles that see this destination. Omitted = everyone. */
   roles?: StaffRole[];
   badge?: BadgeKey;
+  /** Absolute URL to another app — renders a plain <a target="_blank">. */
+  external?: boolean;
 }
 
 /** The four route tabs; the fifth tab (More) is shell chrome, not a route. */
@@ -50,6 +52,7 @@ export const BUSINESS_DESTS: NavDest[] = [
   { href: '/admin/analytics', label: 'Analytics', icon: 'analytics', match: ['/admin/analytics'], roles: ['admin'] },
   { href: '/admin/customers', label: 'Customers', icon: 'customers', match: ['/admin/customers'], roles: ['admin'] },
   { href: '/admin/leads', label: 'Leads', icon: 'leads', match: ['/admin/leads'], roles: ['admin'], badge: 'leads' },
+  { href: 'https://crm.partyondelivery.com', label: 'CRM', icon: 'crm', match: [], roles: ['admin'], external: true },
   { href: '/admin/emails', label: 'Email', icon: 'email', match: ['/admin/emails', '/admin/email-signups'], roles: ['admin'] },
   { href: '/admin/recommendations', label: 'Recs', icon: 'recs', match: ['/admin/recommendations'], roles: ['admin'], badge: 'recs' },
   { href: '/admin/finance', label: 'Money', icon: 'money', match: ['/admin/finance'], roles: ['admin'] },


### PR DESCRIPTION
Adds an admin-only **CRM** item to the HQ shell nav (desktop sidebar BUSINESS group + mobile More sheet) linking to **https://crm.partyondelivery.com** — the CoreLinq CRM stood up today (own Supabase, shadow mode, per ADR-0007).

- New optional `NavDest.external` flag → renders a plain `<a target="_blank" rel="noreferrer">` (external app in its own tab; excluded from active-state matching; no badge).
- New `crm` icon (paired chat bubbles, matching the local Lucide-style set).
- The subdomain is attached to the `partyon-crm` Vercel project; DNS (TXT verify + CNAME) being added at GoDaddy — the link 404s only until those records land.

Gates: `npx tsc --noEmit` exit 0 · `npm run lint` exit 0 · `npm run test:run` 966/966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)