### PR TITLE
feat(finance): import Wells Fargo statements to extend the bank-truth P&L to Jan 2024

### DIFF
--- a/scripts/finance/extract-wf-pdf.py
+++ b/scripts/finance/extract-wf-pdf.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""
+Extract Wells Fargo business-checking PDF statements -> a signed activity CSV in
+the SAME shape as WF's "Download Account Activity" export
+(DATE,DESCRIPTION,AMOUNT,CHECK #,STATUS), which scripts/finance/import-wf-statements.ts
+then imports.
+
+Why this exists: Plaid's history ceiling is 730 days, so the bank-truth P&L can
+only reach ~mid-2024 from the live Plaid item. Everything earlier must come from
+statements WF releases as PDFs (2023 turned out to be unreachable; Jan 2024 is
+the floor). This is the "table extraction" half of that task; the TS importer is
+the DB half.
+
+How it reads the table: WF's "Transaction history" has right-aligned
+Deposits/Credits and Withdrawals/Debits columns plus an Ending-daily-balance
+column. extract_text() flattens them, so we instead bucket each money token by
+its right-edge x-coordinate (the columns are well separated: deposits ~x1=434,
+withdrawals ~502, balance ~566). A deposit is emitted POSITIVE, a withdrawal
+NEGATIVE — matching WF's own CSV convention (the importer flips both to Plaid's).
+
+Verification (the whole point): every statement prints Total Deposits, Total
+Withdrawals, and a Beginning->Ending balance. A statement only PASSES if the
+summed deposits and withdrawals reconcile to the printed totals to the penny AND
+begin + deposits - withdrawals == ending. A single-cent mismatch fails the run
+and nothing is written — so a silent column/sign error can't reach the importer.
+
+Usage:
+  python3 scripts/finance/extract-wf-pdf.py STATEMENT.pdf [MORE.pdf ...] \
+      [--write OUT.csv]
+
+  # e.g. all of Jan-Jun 2024 into one combined CSV:
+  python3 scripts/finance/extract-wf-pdf.py ~/Downloads/_0*.pdf --write ~/Downloads/wf-pdf-2024h1.csv
+"""
+import csv
+import re
+import sys
+import pdfplumber
+
+MONTHS = {
+    'january': 1, 'february': 2, 'march': 3, 'april': 4, 'may': 5, 'june': 6,
+    'july': 7, 'august': 8, 'september': 9, 'october': 10, 'november': 11, 'december': 12,
+}
+DATE_TOK = re.compile(r'^\d{1,2}/\d{1,2}$')          # transaction post date "1/2"
+MONEY_TOK = re.compile(r'^\$?-?[\d,]+\.\d{2}$')      # "3,750.00", "-887.62", "$3,750.00"
+CHECK_TOK = re.compile(r'^\d{3,6}$')                 # check number "100022"
+
+# Column right-edge (x1) centers, overridden per page from the header words.
+DEF = {'dep': 434.0, 'wd': 502.5, 'bal': 566.0}
+TOL = 12.0
+# End-of-transaction-history markers.
+STOP = re.compile(r'^(Totals|Ending balance on|Summary of checks|Overdraft and returned|'
+                  r'Monthly service fee|Account transaction fees)', re.I)
+
+
+def money(tok):
+    return float(tok.replace('$', '').replace(',', ''))
+
+
+def col_of(x1, cols):
+    if abs(x1 - cols['dep']) <= TOL:
+        return 'dep'
+    if abs(x1 - cols['wd']) <= TOL:
+        return 'wd'
+    # Anything right of the withdrawal column is the Ending-daily-balance column
+    # (right-aligned ~566); treat it all as balance so a wider balance number
+    # that lands a few points off can't leak into the description.
+    if x1 > cols['wd'] + TOL:
+        return 'bal'
+    return None  # embedded in the description (e.g. "$3,750.00" mid-text) -> ignore
+
+
+def parse_summary(pages_text):
+    """Pull printed totals + balances + statement period from page 1."""
+    t = pages_text[0]
+
+    def grab(pat):
+        m = re.search(pat, t)
+        return money(m.group(1)) if m else None
+
+    ym = re.search(r'(' + '|'.join(MONTHS) + r')\s+\d{1,2},\s+(\d{4})', t, re.I)
+    return dict(
+        begin=grab(r'Beginning balance on \S+\s+\$?([\d,]+\.\d{2})'),
+        dep=grab(r'Deposits/Credits\s+\$?([\d,]+\.\d{2})'),
+        wd=grab(r'Withdrawals/Debits\s+-?\s*\$?([\d,]+\.\d{2})'),
+        end=grab(r'Ending balance on \S+\s+\$?([\d,]+\.\d{2})'),
+        month=MONTHS[ym.group(1).lower()] if ym else None,
+        year=int(ym.group(2)) if ym else None,
+    )
+
+
+def extract(path):
+    rows = []
+    with pdfplumber.open(path) as pdf:
+        pages_text = [(p.extract_text() or '') for p in pdf.pages]
+        summ = parse_summary(pages_text)
+        if not (summ['year'] and summ['month']):
+            raise ValueError(f'could not read statement period from {path}')
+        for page in pdf.pages:
+            words = page.extract_words(use_text_flow=False, keep_blank_chars=False)
+            if not words:
+                continue
+            byrow = {}
+            for w in words:
+                byrow.setdefault(round(w['top']), []).append(w)
+            cols = dict(DEF)
+            for line in byrow.values():
+                for w in line:
+                    if w['text'] == 'Credits':
+                        cols['dep'] = w['x1']
+                    elif w['text'] == 'Debits':
+                        cols['wd'] = w['x1']
+                    elif w['text'] == 'balance':
+                        cols['bal'] = w['x1']
+            in_history = False
+            cur = None
+            for top in sorted(byrow):
+                line = sorted(byrow[top], key=lambda w: w['x0'])
+                text = ' '.join(w['text'] for w in line)
+                if not in_history:
+                    if 'Ending daily' in text or ('Deposits/' in text and 'Withdrawals/' in text):
+                        in_history = True
+                    continue
+                if STOP.match(text.strip()):
+                    if cur:
+                        rows.append(cur)
+                        cur = None
+                    in_history = False
+                    continue
+                first = line[0]
+                is_new = DATE_TOK.match(first['text']) and first['x0'] < 90
+                if is_new:
+                    if cur:
+                        rows.append(cur)
+                    mm, dd = first['text'].split('/')
+                    cur = dict(date=f'{int(mm):02d}/{int(dd):02d}/{summ["year"]}',
+                               desc=[], amount=None, check='')
+                    body = line[1:]
+                elif cur is not None:
+                    body = line
+                else:
+                    continue
+                for w in body:
+                    tok = w['text']
+                    if MONEY_TOK.match(tok):
+                        c = col_of(w['x1'], cols)
+                        if c in ('dep', 'wd'):
+                            if cur['amount'] is None:  # first column amount wins
+                                cur['amount'] = money(tok) if c == 'dep' else -money(tok)
+                            continue
+                        if c == 'bal':
+                            continue
+                    if CHECK_TOK.match(tok) and 110 < w['x0'] < 148 and not cur['check']:
+                        cur['check'] = tok
+                        continue
+                    cur['desc'].append(tok)
+            if cur:
+                rows.append(cur)
+    return summ, [r for r in rows if r['amount'] is not None]
+
+
+def main():
+    files = [a for a in sys.argv[1:] if a.lower().endswith('.pdf')]
+    if not files:
+        print('usage: extract-wf-pdf.py STATEMENT.pdf [...] [--write OUT.csv]', file=sys.stderr)
+        sys.exit(2)
+    grand = []
+    allpass = True
+    for f in files:
+        summ, rows = extract(f)
+        dep = round(sum(r['amount'] for r in rows if r['amount'] > 0), 2)
+        wd = round(-sum(r['amount'] for r in rows if r['amount'] < 0), 2)
+        chain = round((summ['begin'] or 0) + dep - wd, 2)
+        ok_dep = summ['dep'] is not None and abs(dep - summ['dep']) < 0.005
+        ok_wd = summ['wd'] is not None and abs(wd - summ['wd']) < 0.005
+        ok_chain = summ['end'] is not None and abs(chain - summ['end']) < 0.005
+        ok = ok_dep and ok_wd and ok_chain
+        allpass = allpass and ok
+        print(f'{f.split("/")[-1]}: {summ["year"]}-{summ["month"]:02d} rows={len(rows)} '
+              f'dep={dep:,.2f}/{summ["dep"]:,.2f} {"OK" if ok_dep else "XX"}  '
+              f'wd={wd:,.2f}/{summ["wd"]:,.2f} {"OK" if ok_wd else "XX"}  '
+              f'end={chain:,.2f}/{summ["end"]:,.2f} {"OK" if ok_chain else "XX"}  '
+              f'=> {"PASS" if ok else "FAIL"}')
+        grand.extend(rows)
+    print(f'\nTOTAL rows: {len(grand)}   {"ALL PASS" if allpass else "SOME FAIL — nothing written"}')
+
+    if '--write' in sys.argv:
+        if not allpass:
+            print('Refusing to write: a statement failed reconciliation.', file=sys.stderr)
+            sys.exit(1)
+        out = sys.argv[sys.argv.index('--write') + 1]
+        with open(out, 'w', newline='') as fh:
+            w = csv.writer(fh, quoting=csv.QUOTE_ALL)
+            w.writerow(['DATE', 'DESCRIPTION', 'AMOUNT', 'CHECK #', 'STATUS'])
+            for r in grand:
+                w.writerow([r['date'], ' '.join(r['desc']), f'{r["amount"]:.2f}', r['check'], 'Posted'])
+        print(f'wrote {len(grand)} rows -> {out}')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/finance/import-wf-statements.ts
+++ b/scripts/finance/import-wf-statements.ts
@@ -1,0 +1,346 @@
+/**
+ * Import Wells Fargo statement/activity rows into the bank-truth P&L, extending
+ * it back before Plaid's 730-day ceiling (Jan 2024 floor; 2023 is unreachable).
+ *
+ * WHAT IT DOES
+ *   - Parses the WF "Download Account Activity" CSV and/or a PDF-derived CSV
+ *     (from scripts/finance/extract-wf-pdf.py, same column shape) via the pure
+ *     parser in src/lib/finance/wf-statement-parser.ts.
+ *   - Writes the rows onto a DEDICATED provenance item —
+ *     institutionName 'Wells Fargo (statements)', status 'statement_import' — so
+ *     they are always distinguishable from the live Plaid item's rows AND the
+ *     daily Plaid sync cron (which only touches status active/error) never tries
+ *     to sync a fake token. The item is environment='production' because that is
+ *     the flag the monthly rollup reads to count bank rows.
+ *   - Runs every row through the SAME pipeline as the live sync:
+ *     categorizeBankOutflow (with a descriptor-derived PFC hint the statement
+ *     lacks) for outflows, classifyBankInflow at rollup time for inflows.
+ *
+ * NO DOUBLE-COUNTING (date-range ownership, not content dedup — PDF and CSV
+ * render the same transaction with structurally different descriptors, so a
+ * content key can't reliably collapse them):
+ *   - Plaid owns everything on/after the "seam" = the live item's earliest txn
+ *     date (~2024-07-15). Statement rows on/after the seam are skipped.
+ *   - The PDF-derived CSV owns its full span (Jan–Jun 2024).
+ *   - The activity CSV contributes ONLY dates AFTER the PDFs' last day (the
+ *     pre-seam July gap Plaid misses); its June overlap with the PDFs is dropped.
+ *
+ * SAFETY: dry-run by default (prints the per-month summary for operator review);
+ * --apply writes. Refuses to run unless a LIVE production Plaid item exists (the
+ * prod-DB guard + the source of the seam). Idempotent: the transaction id is a
+ * hash of a deterministic dedupe key, so re-running upserts in place.
+ *
+ * Usage:
+ *   set -a && source .env.local && set +a
+ *   npx tsx scripts/finance/import-wf-statements.ts \
+ *       --pdf-csv ~/Downloads/wf-pdf-2024h1.csv \
+ *       --activity-csv ~/Downloads/Checking.csv          # dry-run
+ *   ... same command with --apply                          # write
+ */
+
+import { readFileSync } from 'fs';
+import { createHash } from 'crypto';
+import { prisma } from '../../src/lib/database/client';
+import {
+  parseWfActivityCsv,
+  type WfStatementRow,
+} from '../../src/lib/finance/wf-statement-parser';
+import {
+  categorizeBankOutflow,
+  isBankExpenseCategory,
+} from '../../src/lib/finance/plaid-category-map';
+import { classifyBankInflow, type BankInflowClass } from '../../src/lib/finance/bank-income-recon';
+import type { CategorySlug } from '../../src/lib/finance/qb-account-map';
+
+/** The dedicated statement-import provenance item. Distinct institutionId from
+ * the live WF item (ins_127991) so the relink cutover never treats it as a
+ * duplicate; status keeps it out of the daily Plaid sync cron. */
+const STMT_ITEM = {
+  itemId: 'wf-statements-import',
+  institutionId: 'wf-statements-import',
+  institutionName: 'Wells Fargo (statements)',
+  environment: 'production',
+  status: 'statement_import',
+  accessToken: 'STATEMENT_IMPORT_NO_TOKEN',
+} as const;
+const STMT_ACCOUNT_ID = 'wf-statements';
+
+interface Args {
+  pdfCsv: string | null;
+  activityCsv: string | null;
+  apply: boolean;
+}
+
+function parseArgs(): Args {
+  const a = process.argv.slice(2);
+  const get = (flag: string): string | null => {
+    const i = a.indexOf(flag);
+    return i >= 0 && a[i + 1] ? a[i + 1] : null;
+  };
+  const args = { pdfCsv: get('--pdf-csv'), activityCsv: get('--activity-csv'), apply: a.includes('--apply') };
+  if (!args.pdfCsv && !args.activityCsv) {
+    throw new Error('provide at least one of --pdf-csv <path> / --activity-csv <path>');
+  }
+  return args;
+}
+
+/** A parsed row plus its provenance + derived classification, ready to upsert. */
+interface StagedRow {
+  row: WfStatementRow;
+  source: 'pdf' | 'activity';
+  transactionId: string;
+  bankDerivedCategory: CategorySlug | null;
+  isBankDerivedExpense: boolean;
+  inflowClass: BankInflowClass | null;
+}
+
+function stage(row: WfStatementRow, source: 'pdf' | 'activity'): StagedRow {
+  const transactionId = `wfstmt:${createHash('sha1').update(row.dedupeKey).digest('hex').slice(0, 24)}`;
+  if (row.isInflow) {
+    return {
+      row,
+      source,
+      transactionId,
+      bankDerivedCategory: null,
+      isBankDerivedExpense: false,
+      inflowClass: classifyBankInflow({ name: row.descriptor, merchantName: null }),
+    };
+  }
+  // Outflow: same categorizer the live sync uses, fed the statement's PFC hint.
+  const slug = categorizeBankOutflow({
+    name: row.descriptor,
+    merchantName: null,
+    personalFinanceCategoryPrimary: row.pfcPrimaryHint,
+    personalFinanceCategoryDetailed: null,
+  });
+  return {
+    row,
+    source,
+    transactionId,
+    bankDerivedCategory: slug,
+    isBankDerivedExpense: isBankExpenseCategory(slug),
+    inflowClass: null,
+  };
+}
+
+/** Load + parse the CSV(s), then apply date-range ownership + the seam cutoff. */
+function loadStaged(args: Args, seamISO: string): { staged: StagedRow[]; skipped: number } {
+  const pdfRows = args.pdfCsv ? parseWfActivityCsv(readFileSync(args.pdfCsv, 'utf8')) : { rows: [], skipped: [] };
+  const actRows = args.activityCsv ? parseWfActivityCsv(readFileSync(args.activityCsv, 'utf8')) : { rows: [], skipped: [] };
+  const skipped = pdfRows.skipped.length + actRows.skipped.length;
+
+  // PDFs own their full span; the activity CSV contributes only dates AFTER the
+  // PDFs' last day (so the PDF↔CSV June overlap is dropped). Everything on/after
+  // the Plaid seam belongs to the live item and is excluded.
+  const pdfMax = pdfRows.rows.reduce<string>((m, r) => (r.dateISO > m ? r.dateISO : m), '');
+  const included: StagedRow[] = [];
+  for (const r of pdfRows.rows) {
+    if (r.dateISO < seamISO) included.push(stage(r, 'pdf'));
+  }
+  for (const r of actRows.rows) {
+    if (r.dateISO < seamISO && (pdfMax === '' || r.dateISO > pdfMax)) included.push(stage(r, 'activity'));
+  }
+
+  // Idempotency + belt-and-suspenders dedupe (keep first per key). With date
+  // ownership above, PDF and CSV never contribute the same date, so this only
+  // collapses exact re-run duplicates.
+  const byKey = new Map<string, StagedRow>();
+  for (const s of included) if (!byKey.has(s.row.dedupeKey)) byKey.set(s.row.dedupeKey, s);
+  return { staged: [...byKey.values()], skipped };
+}
+
+const fmt = (cents: number) => `$${(cents / 100).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+/** Per-month review table + inflow classification + surfaced items. */
+function printSummary(staged: StagedRow[]): void {
+  const months = new Map<string, {
+    deposits: number; withdrawals: number; count: number;
+    ownerCapital: number; loanProceeds: number; vendorRefund: number; salesOther: number;
+    cogs: number; opex: number; nonOp: number;
+  }>();
+  const m = (k: string) => {
+    let v = months.get(k);
+    if (!v) { v = { deposits: 0, withdrawals: 0, count: 0, ownerCapital: 0, loanProceeds: 0, vendorRefund: 0, salesOther: 0, cogs: 0, opex: 0, nonOp: 0 }; months.set(k, v); }
+    return v;
+  };
+  for (const s of staged) {
+    const b = m(s.row.dateISO.slice(0, 7));
+    b.count++;
+    const cents = Math.abs(s.row.plaidAmountCents);
+    if (s.row.isInflow) {
+      b.deposits += cents;
+      if (s.inflowClass === 'owner_capital') b.ownerCapital += cents;
+      else if (s.inflowClass === 'loan_proceeds') b.loanProceeds += cents;
+      else if (s.inflowClass === 'vendor_refund') b.vendorRefund += cents;
+      else b.salesOther += cents;
+    } else {
+      b.withdrawals += cents;
+      if (s.bankDerivedCategory === 'cogs') b.cogs += cents;
+      else if (s.bankDerivedCategory === 'non_operating') b.nonOp += cents;
+      else b.opex += cents;
+    }
+  }
+  console.log('\n=== Per-month summary (Plaid convention: deposits are inflows) ===');
+  console.log('month     rows   deposits      withdrawals    net           | ownerCap    loanProc     COGS         OpEx');
+  for (const key of [...months.keys()].sort()) {
+    const v = months.get(key)!;
+    const net = v.deposits - v.withdrawals;
+    console.log(
+      `${key}  ${String(v.count).padStart(4)}   ${fmt(v.deposits).padStart(12)}  ${fmt(v.withdrawals).padStart(12)}  ` +
+      `${(net >= 0 ? '+' : '') + fmt(net)}`.padStart(13) +
+      `  | ${fmt(v.ownerCapital).padStart(10)}  ${fmt(v.loanProceeds).padStart(11)}  ${fmt(v.cogs).padStart(11)}  ${fmt(v.opex).padStart(11)}`
+    );
+  }
+
+  // Surface the largest sales_or_other inflows — the ones an operator should eyeball
+  // (a non-sales deposit the anchored rules didn't recognize would show up here).
+  const bigOther = staged
+    .filter((s) => s.inflowClass === 'sales_or_other')
+    .sort((a, b) => Math.abs(b.row.plaidAmountCents) - Math.abs(a.row.plaidAmountCents))
+    .slice(0, 12);
+  console.log('\n=== Largest sales/other inflows (verify none are misclassified financing) ===');
+  for (const s of bigOther) {
+    console.log(`  ${s.row.dateISO}  ${fmt(Math.abs(s.row.plaidAmountCents)).padStart(12)}  ${s.row.descriptor.slice(0, 60)}`);
+  }
+  const loanTotal = staged.filter((s) => s.inflowClass === 'loan_proceeds').reduce((t, s) => t + Math.abs(s.row.plaidAmountCents), 0);
+  const ocTotal = staged.filter((s) => s.inflowClass === 'owner_capital').reduce((t, s) => t + Math.abs(s.row.plaidAmountCents), 0);
+  console.log(`\nRecognized financing across all imported rows: owner capital ${fmt(ocTotal)}, loan proceeds ${fmt(loanTotal)}.`);
+
+  // Audit trail for the synthetic PFC hints on OUTFLOWS (owner draws / loan
+  // payments the statement's missing PFC would otherwise miscategorize). Itemized
+  // — like the inflow audit trails — so a misclassified real expense forced to
+  // non_operating is visible BEFORE --apply rather than hidden in an aggregate.
+  const hinted = staged
+    .filter((s) => !s.row.isInflow && s.row.pfcPrimaryHint)
+    .sort((a, b) => b.row.plaidAmountCents - a.row.plaidAmountCents);
+  const hintedTotal = hinted.reduce((t, s) => t + s.row.plaidAmountCents, 0);
+  console.log(`\n=== Outflows given a synthetic non-operating hint (${hinted.length} rows, ${fmt(hintedTotal)}) — verify none are real expenses ===`);
+  for (const s of hinted) {
+    console.log(`  ${s.row.dateISO}  ${fmt(s.row.plaidAmountCents).padStart(12)}  [${s.row.pfcPrimaryHint}→${s.bankDerivedCategory}]  ${s.row.descriptor.slice(0, 48)}`);
+  }
+}
+
+/** Prove the seam cut is clean, WITHOUT a tautology. Two independent, meaningful
+ * checks: (1) every staged row lands strictly before the seam — this exercises
+ * the actual `date < seamISO` inclusion filter, so a regression (e.g. `<=`) would
+ * surface here; (2) query live rows within the staged date range (date ≤ the
+ * latest staged day) and look for a date+amount collision — normally zero because
+ * the seam is the live item's earliest date, but a genuinely non-empty result
+ * (a live row bleeding into the statement range) would be caught, unlike a query
+ * for live rows `< seam` which is empty by construction. */
+async function checkSeam(staged: StagedRow[], liveItemIds: string[], seamISO: string): Promise<void> {
+  const maxStagedISO = staged.reduce<string>((m, s) => (s.row.dateISO > m ? s.row.dateISO : m), '');
+  const pastSeam = staged.filter((s) => s.row.dateISO >= seamISO);
+  const gapDays = maxStagedISO
+    ? Math.round((new Date(`${seamISO}T00:00:00Z`).getTime() - new Date(`${maxStagedISO}T00:00:00Z`).getTime()) / 86_400_000)
+    : NaN;
+
+  // Live rows within the staged date range (≤ latest staged day). Should be
+  // empty because the seam is the live min — but a MEANINGFUL empty (any overlap
+  // would appear), unlike a "< seam" query.
+  const overlapLive = maxStagedISO
+    ? await prisma.plaidTransaction.findMany({
+        where: { plaidItemId: { in: liveItemIds }, date: { lte: new Date(`${maxStagedISO}T00:00:00Z`) }, pending: false },
+        select: { date: true, amount: true },
+      })
+    : [];
+  const liveKeys = new Set(overlapLive.map((l) => `${l.date.toISOString().slice(0, 10)}|${Math.round(Number(l.amount) * 100)}`));
+  const collisions = staged.filter((s) => liveKeys.has(`${s.row.dateISO}|${s.row.plaidAmountCents}`));
+
+  const ok = pastSeam.length === 0 && overlapLive.length === 0 && collisions.length === 0;
+  console.log(
+    `\nSeam check (seam ${seamISO}, latest staged ${maxStagedISO || 'n/a'}, gap ${gapDays}d): ` +
+    `staged rows on/after seam=${pastSeam.length} (want 0), live rows in staged range=${overlapLive.length} (want 0), ` +
+    `date+amount collisions=${collisions.length} (want 0)  ${ok ? '✓ CLEAN' : '⚠️  REVIEW'}`
+  );
+  for (const c of [...pastSeam, ...collisions].slice(0, 10)) {
+    console.log(`   ⚠️  ${c.row.dateISO} ${fmt(c.row.plaidAmountCents)} ${c.row.descriptor.slice(0, 50)}`);
+  }
+}
+
+async function applyRows(staged: StagedRow[]): Promise<void> {
+  const item = await prisma.plaidItem.upsert({
+    where: { itemId: STMT_ITEM.itemId },
+    create: { ...STMT_ITEM },
+    update: { institutionName: STMT_ITEM.institutionName, status: STMT_ITEM.status, environment: STMT_ITEM.environment },
+  });
+  let n = 0;
+  for (const s of staged) {
+    const dollars = (s.row.plaidAmountCents / 100).toFixed(2);
+    const date = new Date(`${s.row.dateISO}T00:00:00Z`);
+    const data = {
+      plaidItemId: item.id,
+      accountId: STMT_ACCOUNT_ID,
+      date,
+      amount: dollars,
+      name: s.row.descriptor,
+      merchantName: null,
+      pending: false,
+      paymentChannel: null,
+      category: [] as string[],
+      personalFinanceCategoryPrimary: s.row.pfcPrimaryHint,
+      personalFinanceCategoryDetailed: null,
+      bankDerivedCategory: s.bankDerivedCategory,
+      isBankDerivedExpense: s.isBankDerivedExpense,
+    };
+    await prisma.plaidTransaction.upsert({
+      where: { transactionId: s.transactionId },
+      create: { transactionId: s.transactionId, ...data },
+      update: data,
+    });
+    n++;
+    if (n % 200 === 0) console.log(`  ...upserted ${n}/${staged.length}`);
+  }
+  console.log(`Applied: item ${item.id} (${STMT_ITEM.institutionName}), ${n} transactions upserted.`);
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+
+  // Prod-DB guard + seam source: there must be a LIVE production Plaid item.
+  // NOTE: this is a heuristic — it asserts a production PlaidItem row exists, not
+  // that DATABASE_URL points at the real prod DB (matches the convention used by
+  // the other finance scripts). It is also currently the only live bank; if a
+  // SECOND production bank is ever connected the seam below should be scoped to
+  // the WF institutionId, else an earlier-history second item would shift it.
+  const liveItems = await prisma.plaidItem.findMany({
+    where: { environment: 'production', itemId: { not: STMT_ITEM.itemId } },
+    select: { id: true, institutionId: true, institutionName: true },
+  });
+  if (liveItems.length === 0) {
+    throw new Error('refusing: no live production Plaid item found — this is not the production DB, or Plaid is not connected.');
+  }
+  const seamRow = await prisma.plaidTransaction.findFirst({
+    where: { plaidItemId: { in: liveItems.map((i) => i.id) }, pending: false },
+    orderBy: { date: 'asc' },
+    select: { date: true },
+  });
+  if (!seamRow) throw new Error('refusing: live Plaid item has no transactions — cannot determine the seam.');
+  const seamISO = seamRow.date.toISOString().slice(0, 10);
+
+  console.log(`Live Plaid item(s): ${liveItems.map((i) => `${i.institutionName ?? '?'} [${i.institutionId ?? '?'}]`).join(', ')}`);
+  console.log(`Plaid seam (earliest live txn): ${seamISO} — importing statement rows strictly BEFORE this.`);
+
+  const { staged, skipped } = loadStaged(args, seamISO);
+  if (skipped) console.log(`Parser skipped ${skipped} malformed/zero rows (see parser output for reasons).`);
+  console.log(`Staged ${staged.length} statement rows to import (after date-range ownership + seam cutoff).`);
+
+  printSummary(staged);
+  await checkSeam(staged, liveItems.map((i) => i.id), seamISO);
+
+  if (!args.apply) {
+    console.log('\nDRY-RUN — no rows written. Re-run with --apply to persist, then rebuild rollups:');
+    console.log('  npx tsx scripts/finance/backfill-monthly-rollups.ts');
+    return;
+  }
+  console.log('\n--apply — writing to the PRODUCTION database...');
+  await applyRows(staged);
+  console.log('Done. Rebuild rollups next: npx tsx scripts/finance/backfill-monthly-rollups.ts');
+}
+
+main()
+  .catch((err) => {
+    console.error('[import-wf-statements] FATAL:', err instanceof Error ? err.message : err);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/finance/verify-wf-backfill.ts
+++ b/scripts/finance/verify-wf-backfill.ts
@@ -1,0 +1,99 @@
+/**
+ * Read-only verification for the Wells Fargo statement backfill
+ * (scripts/finance/import-wf-statements.ts). Run after --apply + a rollup
+ * rebuild to confirm the newly-covered months look right and the 2024-07 Plaid
+ * seam has no duplicate rows. Writes nothing.
+ *
+ * Usage:
+ *   set -a && source .env.local && set +a
+ *   npx tsx scripts/finance/verify-wf-backfill.ts
+ */
+
+import { prisma } from '../../src/lib/database/client';
+import { earliestDataMonth } from '../../src/lib/finance/monthly-rollup';
+
+const STMT_ITEM_ID = 'wf-statements-import';
+const money = (c: number | bigint | null) =>
+  c === null ? 'null' : `$${(Number(c) / 100).toLocaleString('en-US', { maximumFractionDigits: 0 })}`;
+
+async function main(): Promise<void> {
+  const floor = await earliestDataMonth();
+  console.log(`earliestDataMonth(): ${floor.year}-${String(floor.month).padStart(2, '0')} ` +
+    `(rollups already compute from here — no floor change needed for the Jan-2024 statement data)`);
+
+  // --- Statement-import provenance item ------------------------------------
+  const stmtItem = await prisma.plaidItem.findUnique({ where: { itemId: STMT_ITEM_ID }, select: { id: true, institutionName: true, environment: true, status: true } });
+  if (!stmtItem) {
+    console.log('\nNo statement-import item yet — run import-wf-statements.ts --apply first.');
+    await prisma.$disconnect();
+    return;
+  }
+  const stmtTxns = await prisma.plaidTransaction.findMany({
+    where: { plaidItemId: stmtItem.id }, select: { date: true }, orderBy: { date: 'asc' },
+  });
+  const perMonth = new Map<string, number>();
+  for (const t of stmtTxns) {
+    const k = t.date.toISOString().slice(0, 7);
+    perMonth.set(k, (perMonth.get(k) ?? 0) + 1);
+  }
+  console.log(`\nStatement item: "${stmtItem.institutionName}" env=${stmtItem.environment} status=${stmtItem.status}`);
+  console.log(`  ${stmtTxns.length} rows, ${stmtTxns[0]?.date.toISOString().slice(0, 10)} → ${stmtTxns.at(-1)?.date.toISOString().slice(0, 10)}`);
+  console.log('  per-month: ' + [...perMonth].map(([k, n]) => `${k}:${n}`).join('  '));
+
+  // --- Seam integrity (no double-count with the live Plaid item) -----------
+  const liveItems = await prisma.plaidItem.findMany({
+    where: { environment: 'production', itemId: { not: STMT_ITEM_ID } }, select: { id: true },
+  });
+  const liveIds = liveItems.map((i) => i.id);
+  const seamRow = await prisma.plaidTransaction.findFirst({
+    where: { plaidItemId: { in: liveIds }, pending: false }, orderBy: { date: 'asc' }, select: { date: true },
+  });
+  const seam = seamRow!.date;
+  const seamISO = seam.toISOString().slice(0, 10);
+  // (1) statement rows that leaked on/after the seam — non-tautological (would be
+  // >0 if the import filter regressed).
+  const stmtAfterSeam = await prisma.plaidTransaction.count({ where: { plaidItemId: stmtItem.id, date: { gte: seam } } });
+  // (2) date+amount collisions across the two items ANYWHERE they could overlap:
+  // live rows within the statement item's date range (≤ its latest row). A "live
+  // rows < seam" query would be empty by construction (seam IS the live min), so
+  // instead scope to the statement range, where a real overlap would actually show.
+  const stmtMaxRow = await prisma.plaidTransaction.findFirst({ where: { plaidItemId: stmtItem.id }, orderBy: { date: 'desc' }, select: { date: true } });
+  const stmtMax = stmtMaxRow?.date ?? seam;
+  const [stmtRows, liveInRange] = await Promise.all([
+    prisma.plaidTransaction.findMany({ where: { plaidItemId: stmtItem.id }, select: { date: true, amount: true } }),
+    prisma.plaidTransaction.findMany({ where: { plaidItemId: { in: liveIds }, date: { lte: stmtMax }, pending: false }, select: { date: true, amount: true } }),
+  ]);
+  const liveKeys = new Set(liveInRange.map((l) => `${l.date.toISOString().slice(0, 10)}|${Math.round(Number(l.amount) * 100)}`));
+  const collisions = stmtRows.filter((s) => liveKeys.has(`${s.date.toISOString().slice(0, 10)}|${Math.round(Number(s.amount) * 100)}`)).length;
+  const seamOk = stmtAfterSeam === 0 && liveInRange.length === 0 && collisions === 0;
+  console.log(`\nSeam ${seamISO} (statement latest ${stmtMax.toISOString().slice(0, 10)}): statement rows on/after seam=${stmtAfterSeam} (want 0), ` +
+    `live rows within statement range=${liveInRange.length} (want 0), date+amount collisions=${collisions} (want 0)  ${seamOk ? '✓ CLEAN' : '⚠️  REVIEW'}`);
+
+  // --- Newly-covered months' rollups ---------------------------------------
+  const rollups = await prisma.financeMonthlyRollup.findMany({
+    where: { year: 2024, month: { gte: 1, lte: 7 } }, orderBy: [{ year: 'asc' }, { month: 'asc' }],
+    select: { year: true, month: true, revenueCents: true, cogsCents: true, netIncomeCents: true, dataHealth: true },
+  });
+  console.log('\n=== 2024-01 → 2024-07 rollups (the statement-enriched months) ===');
+  console.log('month     revenue    COGS       net        reliable  src   ownerCap   loanProc   otherInc   reconciled');
+  for (const r of rollups) {
+    const h = (r.dataHealth ?? {}) as Record<string, unknown>;
+    console.log(
+      `${r.year}-${String(r.month).padStart(2, '0')}  ${money(r.revenueCents).padStart(9)}  ${money(r.cogsCents).padStart(9)}  ` +
+      `${money(r.netIncomeCents).padStart(9)}  ${String(h.netIncomeReliable).padStart(7)}  ${String(h.expenseSource ?? '-').padStart(4)}  ` +
+      `${money((h.ownerCapitalCents as number) ?? null).padStart(9)}  ${money((h.loanProceedsCents as number) ?? null).padStart(9)}  ` +
+      `${money((h.otherIncomeCents as number) ?? null).padStart(9)}  ${String(h.incomeReconciled)}`
+    );
+  }
+  console.log('\nNote: these months are QB-sourced (2024 QB ≈ $342K), so net income stays QB-based and remains');
+  console.log('unreliable under the Shopify net-of-refund caveat. The statement import adds the DEPOSIT/');
+  console.log('financing picture (owner capital, PeopleFund loan proceeds) + a QB-completeness cross-check.');
+
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  console.error('[verify-wf-backfill] FATAL:', err instanceof Error ? err.message : err);
+  process.exitCode = 1;
+  return prisma.$disconnect();
+});

--- a/src/lib/email/templates/__tests__/finance-monthly-close.test.ts
+++ b/src/lib/email/templates/__tests__/finance-monthly-close.test.ts
@@ -265,6 +265,32 @@ describe('renderFinanceMonthlyCloseEmail', () => {
     expect(html).toContain('financing');
   });
 
+  it('itemizes loan proceeds (PeopleFund advances) and HTML-escapes the descriptor', () => {
+    const html = renderFinanceMonthlyCloseEmail(
+      shapeMonthlyClosePayload({
+        rollup: reliableRollup({
+          dataHealth: {
+            expenseSource: 'bank',
+            netIncomeReliable: true,
+            incomeReconciled: true,
+            otherIncomeCents: 0,
+            loanProceedsCents: 20_166_000,
+            loanProceedsTxns: [{ name: 'Peoplefund Advance 0006957 <Funding> & Working Capital', cents: 20_166_000 }],
+            flags: [],
+          },
+        }),
+        prior: null,
+        generatedAt: GEN,
+      })
+    );
+    expect(html).toContain('Loan proceeds');
+    expect(html).toContain('$201,660');
+    expect(html).toContain('PeopleFund');
+    // Bank descriptor rendered into HTML must be escaped (no raw < > &).
+    expect(html).toContain('&lt;Funding&gt; &amp; Working Capital');
+    expect(html).not.toContain('<Funding>');
+  });
+
   it('does not leak net income via a QB-discrepancy flag (reconstruction chain closed)', () => {
     const html = renderFinanceMonthlyCloseEmail(
       shapeMonthlyClosePayload({ rollup: qbDiscrepancyRollup(), prior: null, generatedAt: GEN })

--- a/src/lib/email/templates/finance-monthly-close.ts
+++ b/src/lib/email/templates/finance-monthly-close.ts
@@ -140,6 +140,17 @@ function reconciliationBlock(d: MonthlyClosePayload): string {
     );
   }
 
+  if (d.loanProceedsCents !== null && d.loanProceedsCents > 0) {
+    const txns = d.loanProceedsTxns
+      .map((t) => `${money(t.cents)} — ${esc(t.name)}`)
+      .join('<br>&nbsp;&nbsp;');
+    rows.push(
+      `Loan proceeds: <strong>${money(d.loanProceedsCents)}</strong> disbursed this month — ` +
+        `PeopleFund advance, classified as financing (debt), excluded from income.` +
+        (txns ? `<br>&nbsp;&nbsp;${txns}` : '')
+    );
+  }
+
   if (d.vendorRefundCents !== null && d.vendorRefundCents > 0) {
     rows.push(
       `Vendor refunds: ${money(d.vendorRefundCents)} in distributor credits — excluded from income.`
@@ -367,6 +378,14 @@ export function renderFinanceMonthlyCloseText(d: MonthlyClosePayload): string {
         `  Owner capital: ${money(d.ownerCapitalCents)} received — financing (equity), excluded from income.`
       );
       for (const t of d.ownerCapitalTxns) {
+        lines.push(`    ${money(t.cents)} — ${t.name}`);
+      }
+    }
+    if (d.loanProceedsCents !== null && d.loanProceedsCents > 0) {
+      lines.push(
+        `  Loan proceeds: ${money(d.loanProceedsCents)} disbursed — PeopleFund advance, financing (debt), excluded from income.`
+      );
+      for (const t of d.loanProceedsTxns) {
         lines.push(`    ${money(t.cents)} — ${t.name}`);
       }
     }

--- a/src/lib/finance/__tests__/bank-income-recon.test.ts
+++ b/src/lib/finance/__tests__/bank-income-recon.test.ts
@@ -26,6 +26,34 @@ describe('classifyBankInflow', () => {
     ).toBe('owner_capital');
   });
 
+  it('classifies PeopleFund advances as loan proceeds (financing, not income)', () => {
+    // Real descriptors from the 2024 statement import (loan #0006957). ~$328K of
+    // these in 2024 H1 alone — must never read as phantom sales.
+    expect(
+      classifyBankInflow({
+        name: 'Peoplefund Advance 0006957 Full and Final Funding; Working Capital',
+        merchantName: null,
+      })
+    ).toBe('loan_proceeds');
+    expect(
+      classifyBankInflow({
+        name: 'Peoplefund Advances 0006957 Partial Funding; Inventory Category to Wc',
+        merchantName: null,
+      })
+    ).toBe('loan_proceeds');
+  });
+
+  it('does NOT sweep a PeopleFund LOAN PAYMENT or a bare mention into loan proceeds', () => {
+    // The outflow payment ("Pymt") is not an inflow class; and the rule requires
+    // BOTH "peoplefund" AND "advance" so an unrelated mention can't false-match.
+    expect(
+      classifyBankInflow({ name: 'Peoplefund Pymt Web Pmts 032124 Party on Delivery', merchantName: null })
+    ).toBe('sales_or_other');
+    expect(classifyBankInflow({ name: 'CASH ADVANCE FROM A CUSTOMER', merchantName: null })).toBe(
+      'sales_or_other'
+    );
+  });
+
   it('classifies credits from COGS merchants as vendor refunds (not sales)', () => {
     expect(
       classifyBankInflow({ name: "Southern Glazer' FINTECHEFT 051826 XXXXX6635", merchantName: null })

--- a/src/lib/finance/__tests__/wf-statement-parser.test.ts
+++ b/src/lib/finance/__tests__/wf-statement-parser.test.ts
@@ -1,0 +1,191 @@
+/**
+ * WF statement CSV parser — the sign flip (WF debit=negative / Plaid outflow=
+ * positive) is the load-bearing correctness property; the descriptor→PFC hints
+ * keep owner draws off the meals line; the dedupe key must be identical for the
+ * same transaction whether it came from a PDF statement or the activity CSV.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseWfActivityCsv,
+  parseCsvLine,
+  toIsoDate,
+  parseWfAmountCents,
+  normalizeDescriptor,
+} from '@/lib/finance/wf-statement-parser';
+
+const HEADER = '"DATE","DESCRIPTION","AMOUNT","CHECK #","STATUS"';
+
+describe('parseCsvLine', () => {
+  it('handles quoted fields with embedded commas', () => {
+    expect(parseCsvLine('"07/17/2026","SQ *CANTRIP, INC gosq.com","-150.00","","Posted"')).toEqual([
+      '07/17/2026',
+      'SQ *CANTRIP, INC gosq.com',
+      '-150.00',
+      '',
+      'Posted',
+    ]);
+  });
+
+  it('handles doubled-quote escapes', () => {
+    expect(parseCsvLine('"a ""b"" c","1.00"')).toEqual(['a "b" c', '1.00']);
+  });
+});
+
+describe('toIsoDate', () => {
+  it('converts MM/DD/YYYY to ISO', () => {
+    expect(toIsoDate('01/02/2024')).toBe('2024-01-02');
+    expect(toIsoDate('7/9/2024')).toBe('2024-07-09');
+  });
+  it('rejects junk', () => {
+    expect(toIsoDate('not a date')).toBeNull();
+    expect(toIsoDate('13/40/2024')).toBeNull();
+  });
+});
+
+describe('parseWfAmountCents', () => {
+  it('parses signed money with commas and $', () => {
+    expect(parseWfAmountCents('-3,750.00')).toBe(-375000);
+    expect(parseWfAmountCents('629.84')).toBe(62984);
+    expect(parseWfAmountCents('$16,959.43')).toBe(1695943);
+  });
+  it('rejects non-money', () => {
+    expect(parseWfAmountCents('CHECK')).toBeNull();
+    expect(parseWfAmountCents('')).toBeNull();
+  });
+});
+
+describe('parseWfActivityCsv — sign convention (the critical mapping)', () => {
+  it('flips WF sign to Plaid convention: deposit (+) → inflow (Plaid −), withdrawal (−) → outflow (Plaid +)', () => {
+    const csv = [
+      HEADER,
+      '"01/03/2024","STRIPE TRANSFER ST-C3O2F7I8Y6T3","667.72","","Posted"', // WF + = deposit
+      '"01/02/2024","PURCHASE RISER BILLING","-30.21","","Posted"', // WF − = withdrawal
+    ].join('\n');
+    const { rows } = parseWfActivityCsv(csv);
+    expect(rows).toHaveLength(2);
+    const deposit = rows.find((r) => r.descriptor.includes('STRIPE'))!;
+    const withdrawal = rows.find((r) => r.descriptor.includes('RISER'))!;
+    expect(deposit.plaidAmountCents).toBe(-66772); // inflow → negative in Plaid
+    expect(deposit.isInflow).toBe(true);
+    expect(withdrawal.plaidAmountCents).toBe(3021); // outflow → positive in Plaid
+    expect(withdrawal.isInflow).toBe(false);
+  });
+});
+
+describe('parseWfActivityCsv — structure', () => {
+  it('skips the header row and blank lines', () => {
+    const csv = [HEADER, '', '"01/02/2024","PURCHASE","-10.00","","Posted"', ''].join('\n');
+    const { rows } = parseWfActivityCsv(csv);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].dateISO).toBe('2024-01-02');
+  });
+
+  it('captures the check number and the ISO date', () => {
+    const csv = [HEADER, '"07/17/2026","CHECK","-392.71","100117","Posted"'].join('\n');
+    const { rows } = parseWfActivityCsv(csv);
+    expect(rows[0].checkNumber).toBe('100117');
+    expect(rows[0].dateISO).toBe('2026-07-17');
+    expect(rows[0].plaidAmountCents).toBe(39271); // outflow
+  });
+
+  it('collects malformed rows in skipped[] instead of throwing', () => {
+    const csv = [
+      HEADER,
+      '"bad-date","PURCHASE","-10.00","","Posted"',
+      '"01/02/2024","ZERO","0.00","","Posted"',
+      '"01/02/2024","PURCHASE","not-money","","Posted"',
+      '"01/03/2024","GOOD","-5.00","","Posted"',
+    ].join('\n');
+    const { rows, skipped } = parseWfActivityCsv(csv);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].descriptor).toBe('GOOD');
+    expect(skipped).toHaveLength(3);
+    expect(skipped.map((s) => s.reason)).toEqual([
+      expect.stringContaining('date'),
+      'zero amount',
+      expect.stringContaining('amount'),
+    ]);
+  });
+});
+
+describe('parseWfActivityCsv — PFC hints for statement rows (no real PFC)', () => {
+  it('hints TRANSFER_OUT for an owner-draw transfer so it is not booked as a meal', () => {
+    // Brian's LLC and Allan's USAA are the owners' known linked accounts.
+    for (const desc of [
+      'Online Transfer to B Hill Entertainment LLC Business Checking',
+      'Online Transfer to USAA Federal Savings Bank Chk xxxxx4514 A. Henslee',
+    ]) {
+      const { rows } = parseWfActivityCsv([HEADER, `"02/14/2024","${desc}","-20000.00","","Posted"`].join('\n'));
+      expect(rows[0].pfcPrimaryHint).toBe('TRANSFER_OUT');
+    }
+  });
+
+  it('does NOT hint a transfer to a NON-owner recipient (a real bill via linked transfer stays an expense)', () => {
+    // The anchored hint must not sweep a genuine vendor payment into non_operating.
+    const csv = [
+      HEADER,
+      '"02/14/2024","Online Transfer to Riverside Property Management LLC Rent","-4500.00","","Posted"',
+    ].join('\n');
+    const { rows } = parseWfActivityCsv(csv);
+    expect(rows[0].pfcPrimaryHint).toBeNull();
+  });
+
+  it('hints LOAN_PAYMENTS for a PeopleFund payment outflow', () => {
+    const csv = [
+      HEADER,
+      '"03/21/2024","Peoplefund Pymt Web Pmts 032124 Party on Delivery","-6178.46","","Posted"',
+    ].join('\n');
+    const { rows } = parseWfActivityCsv(csv);
+    expect(rows[0].pfcPrimaryHint).toBe('LOAN_PAYMENTS');
+  });
+
+  it('does NOT hint on an inflow (inflows are classified by descriptor, not PFC)', () => {
+    // A PeopleFund ADVANCE is an inflow → no PFC hint; classifyBankInflow handles it.
+    const csv = [
+      HEADER,
+      '"02/14/2024","Peoplefund Advance 0006957 Full and Final Funding","201660.00","","Posted"',
+    ].join('\n');
+    const { rows } = parseWfActivityCsv(csv);
+    expect(rows[0].isInflow).toBe(true);
+    expect(rows[0].pfcPrimaryHint).toBeNull();
+  });
+
+  it('leaves an ordinary purchase unhinted', () => {
+    const csv = [HEADER, '"01/02/2024","PURCHASE HEB CURBSIDE","-201.81","","Posted"'].join('\n');
+    const { rows } = parseWfActivityCsv(csv);
+    expect(rows[0].pfcPrimaryHint).toBeNull();
+  });
+});
+
+describe('parseWfActivityCsv — dedupe key stability (PDF ↔ CSV overlap)', () => {
+  it('produces the SAME dedupe key for the same txn from a PDF (Title Case, single spaces) and the CSV (UPPER, padded)', () => {
+    const pdf = [
+      HEADER,
+      '"06/20/2024","Purchase authorized on 06/18 SQ *Cantrip, INC gosq.com MA S384170565898946 Card 9853","-150.00","","Posted"',
+    ].join('\n');
+    const csvPadded = [
+      HEADER,
+      '"06/20/2024","PURCHASE                 AUTHORIZED ON   06/18 SQ *CANTRIP, INC          gosq.com      MA  S384170565898946   CARD 9853","-150.00","","Posted"',
+    ].join('\n');
+    const a = parseWfActivityCsv(pdf).rows[0];
+    const b = parseWfActivityCsv(csvPadded).rows[0];
+    expect(a.dedupeKey).toBe(b.dedupeKey);
+  });
+
+  it('distinguishes two same-day same-amount checks by check number', () => {
+    const csv = [
+      HEADER,
+      '"07/01/2024","CHECK","-3750.00","100117","Posted"',
+      '"07/01/2024","CHECK","-3750.00","100118","Posted"',
+    ].join('\n');
+    const { rows } = parseWfActivityCsv(csv);
+    expect(rows[0].dedupeKey).not.toBe(rows[1].dedupeKey);
+  });
+});
+
+describe('normalizeDescriptor', () => {
+  it('lowercases and collapses whitespace', () => {
+    expect(normalizeDescriptor('  Purchase   AUTHORIZED  on ')).toBe('purchase authorized on');
+  });
+});

--- a/src/lib/finance/bank-income-recon.ts
+++ b/src/lib/finance/bank-income-recon.ts
@@ -60,6 +60,30 @@ export const OWNER_CAPITAL_RULES: readonly RegExp[] = [
 ];
 
 /**
+ * Loan-proceeds (financing) inflow descriptors — the PeopleFund term-loan
+ * DISBURSEMENTS, ANCHORED to the exact shape on the real Wells Fargo feed
+ * (surfaced by the 2024 statement import, operator-confirmed loan #0006957):
+ *
+ *   "Peoplefund Advance 0006957 Full and Final Funding; Working Capital"
+ *   "Peoplefund Advances 0006957 Partial Funding; Inventory Category…"
+ *
+ * These are loan proceeds — financing, never income — and must not trip the
+ * "deposits exceed revenue" flag (2024 H1 alone was ~$328K of PeopleFund
+ * advances, which would otherwise read as phantom sales). The loan PAYMENTS
+ * ("Peoplefund Pymt…") are the matching outflow, already mapped `non_operating`
+ * via the PFC / statement LOAN_PAYMENTS hint.
+ *
+ * Anchored like OWNER_CAPITAL_RULES: PeopleFund is Party On's CDFI lender, not a
+ * customer, and the "advance" wording + loan number pin it to a disbursement —
+ * a real sale (Stripe/Square "ST-…" / Square Inc) can't be laundered as
+ * financing by this rule. If the descriptor drifts, the month re-flags as excess
+ * deposits (see the drift hint) rather than silently misclassifying.
+ */
+export const LOAN_PROCEEDS_RULES: readonly RegExp[] = [
+  /\bpeoplefund\b.*\badvance/i, // "Peoplefund Advance(s) 0006957 … Funding"
+];
+
+/**
  * The distributors' payment-processor stamp that appears on their ACH debits
  * AND their refund credits ("Southern Glazer' FINTECHEFT 051826 …"). A vendor
  * refund must carry it — a Zelle from a person whose name merely contains a
@@ -68,12 +92,17 @@ export const OWNER_CAPITAL_RULES: readonly RegExp[] = [
  */
 const VENDOR_PROCESSOR_STAMP = /fintech/i;
 
-export type BankInflowClass = 'owner_capital' | 'vendor_refund' | 'sales_or_other';
+export type BankInflowClass =
+  | 'owner_capital'
+  | 'loan_proceeds'
+  | 'vendor_refund'
+  | 'sales_or_other';
 
 /**
- * Classify a production bank INFLOW by descriptor. Owner capital and vendor
- * refunds (credits back from a COGS merchant, e.g. a distributor rebate) are
- * excluded from the income reconciliation — neither is sales revenue.
+ * Classify a production bank INFLOW by descriptor. Owner capital, loan proceeds
+ * (PeopleFund advances), and vendor refunds (credits back from a COGS merchant,
+ * e.g. a distributor rebate) are all excluded from the income reconciliation —
+ * none is sales revenue.
  */
 export function classifyBankInflow(txn: {
   name: string;
@@ -82,6 +111,9 @@ export function classifyBankInflow(txn: {
   const text = `${txn.merchantName ?? ''} ${txn.name ?? ''}`.trim();
   for (const re of OWNER_CAPITAL_RULES) {
     if (re.test(text)) return 'owner_capital';
+  }
+  for (const re of LOAN_PROCEEDS_RULES) {
+    if (re.test(text)) return 'loan_proceeds';
   }
   // Vendor refund = COGS-merchant descriptor AND the processor stamp their
   // real credits carry — never a bare name match.
@@ -119,6 +151,10 @@ export interface BankIncomeRecon {
    * disappearing into an aggregate.
    */
   ownerCapitalTxns: Array<{ name: string; cents: number }>;
+  /** Loan proceeds (PeopleFund advances) — financing, excluded from income. */
+  loanProceedsCents: number;
+  /** Per-advance audit trail of what was classified loan proceeds. */
+  loanProceedsTxns: Array<{ name: string; cents: number }>;
   /** Credits back from COGS merchants (distributor refunds) — excluded too. */
   vendorRefundCents: number;
   matchedToStripeCents: number;
@@ -191,6 +227,8 @@ export async function reconcileBankIncome(
       totalDepositsCents: 0,
       ownerCapitalCents: 0,
       ownerCapitalTxns: [],
+      loanProceedsCents: 0,
+      loanProceedsTxns: [],
       vendorRefundCents: 0,
       matchedToStripeCents: 0,
       stripeExplainedCents: 0,
@@ -220,6 +258,8 @@ export async function reconcileBankIncome(
   let totalDepositsCents = 0;
   let ownerCapitalCents = 0;
   const ownerCapitalTxns: Array<{ name: string; cents: number }> = [];
+  let loanProceedsCents = 0;
+  const loanProceedsTxns: Array<{ name: string; cents: number }> = [];
   let vendorRefundCents = 0;
   let salesDepositsCents = 0;
   let matchedToStripeCents = 0;
@@ -230,6 +270,9 @@ export async function reconcileBankIncome(
     if (cls === 'owner_capital') {
       ownerCapitalCents += cents;
       ownerCapitalTxns.push({ name: t.merchantName ?? t.name, cents });
+    } else if (cls === 'loan_proceeds') {
+      loanProceedsCents += cents;
+      loanProceedsTxns.push({ name: t.merchantName ?? t.name, cents });
     } else if (cls === 'vendor_refund') {
       vendorRefundCents += cents;
     } else {
@@ -258,8 +301,8 @@ export async function reconcileBankIncome(
     // (a classifier miss), not a new anomaly — say so, so the operator checks
     // OWNER_CAPITAL_RULES before hunting for missing orders.
     const driftHint =
-      ownerCapitalCents === 0
-        ? ' (no owner-capital transfers recognized this month — if Brian did inject capital, the bank descriptor may have drifted; check OWNER_CAPITAL_RULES)'
+      ownerCapitalCents === 0 && loanProceedsCents === 0
+        ? ' (no owner-capital or loan-proceeds transfers recognized this month — if Brian injected capital or a loan disbursed, the bank descriptor may have drifted; check OWNER_CAPITAL_RULES / LOAN_PROCEEDS_RULES)'
         : '';
     flags.push(
       `$${(otherIncomeCents / 100).toFixed(0)} of bank deposits exceed known Stripe ` +
@@ -273,6 +316,8 @@ export async function reconcileBankIncome(
     totalDepositsCents,
     ownerCapitalCents,
     ownerCapitalTxns,
+    loanProceedsCents,
+    loanProceedsTxns,
     vendorRefundCents,
     matchedToStripeCents,
     stripeExplainedCents,

--- a/src/lib/finance/monthly-close-payload.ts
+++ b/src/lib/finance/monthly-close-payload.ts
@@ -63,6 +63,10 @@ interface RollupDataHealth {
   ownerCapitalCents?: number | null;
   /** Per-transfer audit trail of the owner-capital classification. */
   ownerCapitalTxns?: Array<{ name: string; cents: number }>;
+  /** Loan proceeds (PeopleFund advances) recognized as financing this month. */
+  loanProceedsCents?: number | null;
+  /** Per-advance audit trail of the loan-proceeds classification. */
+  loanProceedsTxns?: Array<{ name: string; cents: number }>;
   /** Distributor refund credits excluded from the income check. */
   vendorRefundCents?: number | null;
   /** Accrual-COGS estimate (cost of what SOLD) + revenue coverage. */
@@ -124,6 +128,10 @@ export interface MonthlyClosePayload {
   ownerCapitalCents: number | null;
   /** Per-transfer audit trail (descriptor + amount) of the owner-capital rows. */
   ownerCapitalTxns: Array<{ name: string; cents: number }>;
+  /** Loan proceeds (PeopleFund advances, financing) recognized this month. */
+  loanProceedsCents: number | null;
+  /** Per-advance audit trail (descriptor + amount) of the loan-proceeds rows. */
+  loanProceedsTxns: Array<{ name: string; cents: number }>;
   /** Distributor refund credits excluded from the income check. */
   vendorRefundCents: number | null;
   // Accrual view (estimate) — cost of what SOLD, vs the cash-basis COGS above.
@@ -190,6 +198,8 @@ export function shapeMonthlyClosePayload(args: {
     otherIncomeCents: health.otherIncomeCents ?? null,
     ownerCapitalCents: health.ownerCapitalCents ?? null,
     ownerCapitalTxns: Array.isArray(health.ownerCapitalTxns) ? health.ownerCapitalTxns : [],
+    loanProceedsCents: health.loanProceedsCents ?? null,
+    loanProceedsTxns: Array.isArray(health.loanProceedsTxns) ? health.loanProceedsTxns : [],
     vendorRefundCents: health.vendorRefundCents ?? null,
     accrualCogsCents: health.accrual?.cogsCents ?? null,
     accrualCoveragePct: health.accrual?.coveragePct ?? null,

--- a/src/lib/finance/monthly-rollup.ts
+++ b/src/lib/finance/monthly-rollup.ts
@@ -601,6 +601,11 @@ function buildDataHealth(h: HealthInput): Record<string, unknown> {
     // in the email instead of vanishing into an aggregate.
     ownerCapitalCents: h.bankIncome.hasProductionBank ? h.bankIncome.ownerCapitalCents : null,
     ownerCapitalTxns: h.bankIncome.hasProductionBank ? h.bankIncome.ownerCapitalTxns : [],
+    // Loan proceeds (PeopleFund advances) recognized this month — financing, not
+    // income; surfaced with a per-advance audit trail like owner capital so a
+    // misclassified disbursement is spot-checkable rather than hidden.
+    loanProceedsCents: h.bankIncome.hasProductionBank ? h.bankIncome.loanProceedsCents : null,
+    loanProceedsTxns: h.bankIncome.hasProductionBank ? h.bankIncome.loanProceedsTxns : [],
     vendorRefundCents: h.bankIncome.hasProductionBank ? h.bankIncome.vendorRefundCents : null,
     // Accrual-COGS estimate (cost of what SOLD, from per-item cost snapshots) —
     // the true product-margin view alongside the lumpy cash-basis COGS.

--- a/src/lib/finance/wf-statement-parser.ts
+++ b/src/lib/finance/wf-statement-parser.ts
@@ -1,0 +1,220 @@
+/**
+ * Pure parser for Wells Fargo "Download Account Activity" CSV rows — used to
+ * extend the bank-truth P&L back before Plaid's 730-day ceiling (Jan 2024, the
+ * earliest WF would release; 2023 is unreachable). See
+ * scripts/finance/import-wf-statements.ts for the operator-gated importer and
+ * scripts/finance/extract-wf-pdf.py for the PDF→CSV step that feeds this the
+ * same column shape.
+ *
+ * The one thing that silently corrupts everything is the SIGN. Wells Fargo's
+ * activity export uses the OPPOSITE convention from Plaid:
+ *   - WF CSV:  debit/outflow = NEGATIVE, credit/inflow = POSITIVE
+ *   - Plaid:   outflow = POSITIVE, inflow = NEGATIVE  (what the rest of the
+ *              finance pipeline — plaid_transactions.amount — expects)
+ * so every amount is flipped here: `plaidAmountCents = -wfAmountCents`.
+ *
+ * Statement rows carry NO Plaid Personal Finance Category, so
+ * categorizeBankOutflow (plaid-category-map.ts) loses its PFC precedence steps
+ * and an owner draw like "Online Transfer to B Hill Entertainment LLC" would
+ * fall through to the /entertainment/ keyword and become a MEALS expense. To
+ * avoid that WITHOUT touching the shared, security-reviewed category rules, this
+ * parser supplies a `pfcPrimaryHint` for two unambiguous financing shapes only —
+ * an owner DRAW out to one of the owners' known linked accounts, and a PeopleFund
+ * loan payment — feeding them into the EXISTING PFC map (TRANSFER_OUT /
+ * LOAN_PAYMENTS → non_operating). The transfer hint is ANCHORED to the specific
+ * owner accounts (mirroring OWNER_CAPITAL_RULES), NOT a bare "Online Transfer
+ * to …": a broad match would sweep a genuine bill paid via a linked recipient
+ * into non_operating and silently drop it from the expense base. Everything else
+ * gets no hint and runs the normal pipeline.
+ *
+ * Pure + dependency-free so it is unit-testable; the importer handles I/O,
+ * hashing the `dedupeKey` into a transaction id, and the DB writes.
+ */
+
+/** Plaid PFC-primary hint the importer stamps so the shared category map can
+ * resolve a statement outflow that has no real PFC. Only the two unambiguous
+ * financing/transfer shapes are hinted; see file header. */
+export type PfcPrimaryHint = 'TRANSFER_OUT' | 'LOAN_PAYMENTS';
+
+export interface WfStatementRow {
+  /** Post date, ISO 'YYYY-MM-DD' (WF activity dates are MM/DD/YYYY). */
+  dateISO: string;
+  /** Cleaned single-line description (whitespace collapsed, original casing). */
+  descriptor: string;
+  /** Check number when the row is a check, else null. */
+  checkNumber: string | null;
+  /**
+   * Amount in Plaid convention (positive = outflow/debit, negative =
+   * inflow/credit) — already sign-flipped from the WF export. Integer cents.
+   */
+  plaidAmountCents: number;
+  /** true when this is a deposit/credit (Plaid-negative); for readability. */
+  isInflow: boolean;
+  /** PFC-primary hint for the shared category map (outflows only), else null. */
+  pfcPrimaryHint: PfcPrimaryHint | null;
+  /**
+   * Deterministic idempotency + cross-source dedupe key:
+   * `dateISO|signedCents|normalizedDescriptor|checkNumber`. Same real
+   * transaction from a PDF statement and from the CSV normalizes to the same
+   * key (WF descriptors carry unique auth/ref codes; checks add their number),
+   * so re-runs and PDF↔CSV overlaps never double-count.
+   */
+  dedupeKey: string;
+}
+
+/**
+ * WF "Online Transfer to …" an OWNER's linked account = an owner draw (money
+ * OUT to the owners' personal / LLC accounts), the mirror of OWNER_CAPITAL_RULES.
+ * ANCHORED to the specific owner accounts observed on the feed — Brian's B Hill
+ * Entertainment LLC and "Hill B" checking, Allan's USAA / A. Henslee — so a
+ * transfer paying a genuine VENDOR via a linked recipient is NOT swept into
+ * non_operating and dropped from the expense base. If a new owner-account
+ * descriptor appears it simply won't be hinted (runs the normal pipeline), which
+ * is the safe direction; extend this list rather than loosening it.
+ */
+const HINT_OWNER_DRAW_OUT =
+  /online\s+transfer\s+to\b.*(b\.?\s*hill\s+entertainment|\bhill\s+b\b|\busaa\b|\bhenslee\b)/i;
+/** Any outflow to the CDFI lender = a loan payment (its name is unique). */
+const HINT_PEOPLEFUND = /\bpeoplefund\b/i;
+
+/** Lowercase + collapse all whitespace runs to one space + trim. */
+export function normalizeDescriptor(s: string): string {
+  return s.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Parse one RFC-4180 CSV line into fields. Handles quoted fields (the WF export
+ * quotes every field) with embedded commas and doubled-quote escapes (`""`).
+ */
+export function parseCsvLine(line: string): string[] {
+  const out: string[] = [];
+  let field = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (line[i + 1] === '"') {
+          field += '"';
+          i++; // skip the escaped quote
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += ch;
+      }
+    } else if (ch === '"') {
+      inQuotes = true;
+    } else if (ch === ',') {
+      out.push(field);
+      field = '';
+    } else {
+      field += ch;
+    }
+  }
+  out.push(field);
+  return out;
+}
+
+/** MM/DD/YYYY → YYYY-MM-DD. Returns null if not a valid date shape. */
+export function toIsoDate(mdy: string): string | null {
+  const m = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/.exec(mdy.trim());
+  if (!m) return null;
+  const month = Number(m[1]);
+  const day = Number(m[2]);
+  const year = Number(m[3]);
+  if (month < 1 || month > 12 || day < 1 || day > 31) return null;
+  return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+}
+
+/** Parse a WF signed amount string ("-3,750.00", "629.84", "$16,959.43") to
+ * cents. Returns null when the token is not a money value. */
+export function parseWfAmountCents(raw: string): number | null {
+  const t = raw.replace(/[$,\s]/g, '');
+  if (!/^-?\d+(\.\d{1,2})?$/.test(t)) return null;
+  return Math.round(parseFloat(t) * 100);
+}
+
+function pfcHintFor(descriptor: string, isInflow: boolean): PfcPrimaryHint | null {
+  // Hints only steer outflow categorization (categorizeBankOutflow); inflows are
+  // classified by descriptor (classifyBankInflow) and ignore PFC.
+  if (isInflow) return null;
+  if (HINT_OWNER_DRAW_OUT.test(descriptor)) return 'TRANSFER_OUT';
+  if (HINT_PEOPLEFUND.test(descriptor)) return 'LOAN_PAYMENTS';
+  return null;
+}
+
+export interface ParseWfCsvResult {
+  rows: WfStatementRow[];
+  /** Non-fatal issues (skipped/malformed lines), for the importer to log. */
+  skipped: Array<{ line: number; reason: string; raw: string }>;
+}
+
+const HEADER_TOKENS = new Set(['DATE', 'DESCRIPTION', 'AMOUNT']);
+
+/**
+ * Parse a full WF activity CSV (Checking.csv or a PDF-derived CSV in the same
+ * DATE,DESCRIPTION,AMOUNT,CHECK #,STATUS shape). Blank lines and the header row
+ * are skipped; malformed rows are collected in `skipped` rather than thrown, so
+ * one bad line never aborts an import.
+ */
+export function parseWfActivityCsv(csvText: string): ParseWfCsvResult {
+  const rows: WfStatementRow[] = [];
+  const skipped: Array<{ line: number; reason: string; raw: string }> = [];
+  const lines = csvText.split(/\r\n|\n|\r/);
+
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i];
+    if (raw.trim() === '') continue;
+    const fields = parseCsvLine(raw);
+    // Expect: DATE, DESCRIPTION, AMOUNT, CHECK #, STATUS (STATUS optional).
+    if (fields.length < 3) {
+      skipped.push({ line: i + 1, reason: 'too few columns', raw });
+      continue;
+    }
+    const [dateRaw, descRaw, amountRaw, checkRaw] = fields;
+    // Skip the header row.
+    if (HEADER_TOKENS.has(dateRaw.trim().toUpperCase())) continue;
+
+    const dateISO = toIsoDate(dateRaw);
+    if (!dateISO) {
+      skipped.push({ line: i + 1, reason: `unparseable date "${dateRaw}"`, raw });
+      continue;
+    }
+    const wfCents = parseWfAmountCents(amountRaw);
+    if (wfCents === null) {
+      skipped.push({ line: i + 1, reason: `unparseable amount "${amountRaw}"`, raw });
+      continue;
+    }
+    if (wfCents === 0) {
+      // A zero-amount activity row carries no ledger effect; skip (rare).
+      skipped.push({ line: i + 1, reason: 'zero amount', raw });
+      continue;
+    }
+
+    const descriptor = descRaw.replace(/\s+/g, ' ').trim();
+    const checkNumber = checkRaw && checkRaw.trim() !== '' ? checkRaw.trim() : null;
+    // Flip WF sign → Plaid convention (outflow positive, inflow negative).
+    const plaidAmountCents = -wfCents;
+    const isInflow = plaidAmountCents < 0;
+    const pfcPrimaryHint = pfcHintFor(descriptor, isInflow);
+    const dedupeKey = [
+      dateISO,
+      plaidAmountCents,
+      normalizeDescriptor(descriptor),
+      checkNumber ?? '',
+    ].join('|');
+
+    rows.push({
+      dateISO,
+      descriptor,
+      checkNumber,
+      plaidAmountCents,
+      isInflow,
+      pfcPrimaryHint,
+      dedupeKey,
+    });
+  }
+
+  return { rows, skipped };
+}


### PR DESCRIPTION
## What & why
Plaid's 730-day history ceiling stops the live Wells Fargo item at **2024-07-15**, so the "bank is the book" P&L couldn't reach earlier. This imports WF statements Allan downloads manually to extend it back. **2023 turned out unreachable** (WF only released ~2 years), so **Jan 2024 is the floor**.

## Pieces
- **`src/lib/finance/wf-statement-parser.ts`** (pure, tested) — WF activity CSV → Plaid shape, flipping WF's sign convention (debit negative) to Plaid's (outflow positive). Supplies an **anchored** descriptor→PFC hint (owner-draw transfers to the owners' known linked accounts + PeopleFund payments → `non_operating`) so a statement — which carries no Plaid PFC — doesn't book an owner draw as a meal, without loosely sweeping a real vendor bill into `non_operating`.
- **`scripts/finance/extract-wf-pdf.py`** — WF PDF statements → the same CSV shape, bucketing deposit/withdrawal columns by x-coordinate and **verifying each statement's totals + balance chain to the penny** (6/6 reconcile) before writing.
- **`scripts/finance/import-wf-statements.ts`** — dry-run default, `--apply` writes. Dedicated provenance item (`Wells Fargo (statements)`, `status=statement_import` so the Plaid sync cron skips it, distinct `institutionId` so cutover never touches it). **Date-range ownership at the 2024-07-15 seam** so no row double-counts the live feed. Per-month review summary with itemized audit trails for financing inflows AND synthetic-hint outflows.
- **`bank-income-recon.ts`** — anchored **`loan_proceeds`** class (PeopleFund advances, ~$328K in 2024 H1) so disbursements read as financing, not phantom sales; surfaced in the monthly-close email like owner capital.
- **`scripts/finance/verify-wf-backfill.ts`** — read-only post-apply verification with a non-tautological seam-collision check.

## Verification (applied to prod)
- PDF extraction: 6/6 statements reconcile to printed totals to the penny.
- Prod dry-run + apply: **597 rows** (Jan-Jun from PDFs + Jul 1-14 gap from CSV), **seam check CLEAN** (0 collisions), **$328K PeopleFund correctly classed as financing**.
- Rollups rebuilt (66/66); 2024-01→07 now carry the deposit/financing layer. Net income stays QB-based + unreliable under the Shopify net-of-refund caveat (expected — QB has ~$342K for 2024).
- Gates: `tsc` clean, `lint` clean, **987 tests pass**.

## Review
Security-reviewer agent + `/code-review` run before merge (money-math). 1 HIGH + 2 MED + 3 LOW all fixed: anchored the transfer-out hint, replaced a tautological seam check with a meaningful one, added false-positive + HTML-escape tests. Sign convention, `loan_proceeds` anchoring, double-count guard, idempotency, PII handling verified clean. No `prisma/schema.prisma` changes.

## Deferred follow-up
The flagged 2025 months (Nov 2025–Feb 2026 deposit excess) are **Shopify Capital $25K (Dec 2025)** + Allan's USAA transfers — proposed as a separate reviewed PR (anchored `shopify capital → loan_proceeds`), pending Allan's decision on the USAA classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)