### PR TITLE
feat(partners): STR lead enrichment — profile dropdown + personalized outreach drafts

### DIFF
--- a/src/components/admin/StrPartnersView.tsx
+++ b/src/components/admin/StrPartnersView.tsx
@@ -15,7 +15,7 @@
  * "Created" with a link to its live page.
  */
 
-import { useMemo, useState, type ReactElement } from 'react';
+import { Fragment, useMemo, useState, type ReactElement } from 'react';
 import Link from 'next/link';
 import prospectsData from '@/data/str-partner-prospects.json';
 
@@ -26,6 +26,39 @@ interface Socials {
   twitter?: string | null;
   youtube?: string | null;
   tiktok?: string | null;
+}
+
+/** Deep-researched sales profile attached to a prospect row. */
+interface Enrichment {
+  enrichedAt: string;
+  management: {
+    ownerName: string | null;
+    ownerNotes: string | null;
+    team: string | null;
+    linkedin: string | null;
+    operatingSince: string | null;
+    entity: string | null;
+  };
+  portfolio: {
+    propertyCount: string;
+    propertyTypes: string;
+    locations: string;
+    maxGroupSize: string | null;
+    notableProperties: { name: string; blurb: string }[];
+  };
+  business: {
+    bookingModel: string;
+    services: string;
+    positioning: string;
+    guestDemographic: string;
+  };
+  reputation: {
+    summary: string;
+    ratings: string | null;
+    praiseThemes: string | null;
+  };
+  partnershipAngles: string[];
+  outreachEmail: { subject: string; body: string };
 }
 
 interface Prospect {
@@ -40,6 +73,8 @@ interface Prospect {
   description: string;
   /** Set once the partner page exists — links the row to /partners/<slug>. */
   partnerSlug?: string | null;
+  /** Deep-researched profile + personalized outreach draft (dropdown). */
+  enrichment?: Enrichment | null;
 }
 
 const SOCIAL_LABELS: [keyof Socials, string][] = [
@@ -55,10 +90,52 @@ function csvEscape(v: string): string {
   return /[",\n]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v;
 }
 
+/**
+ * Master outreach template — the full "everything Party On Delivery does
+ * for STR partners" pitch. Personalized per-lead versions live in each
+ * prospect's enrichment.outreachEmail; this is the base to adapt.
+ */
+const MASTER_OUTREACH = {
+  subject: 'Free guest perk for {{Company}} — stocked fridges, zero work for your team',
+  body: `Hi {{FirstName}},
+
+I'm Brian, founder of Party On Delivery — Austin's premium alcohol delivery and guest-concierge service. We partner with short-term rental companies like {{Company}} to give your guests a five-star arrival experience without adding a single task to your team's plate.
+
+Here's everything a partnership includes:
+
+• FREE DELIVERY FOR YOUR GUESTS — every guest who books through your link gets free alcohol delivery to their rental (a real perk you can advertise on your listings).
+• PRE-ARRIVAL STOCKING — drinks iced, arranged, and waiting when guests walk in. We coordinate timing with your check-ins.
+• YOUR OWN BRANDED PAGE — a co-branded page (your logo, your look) at partyondelivery.com/partners/{{slug}} that you drop into welcome emails, guidebooks, or listing descriptions.
+• A PERSONAL PARTY DASHBOARD FOR EVERY GROUP — one click and each group gets their own private ordering dashboard: everyone in the party adds what they want, splits payment their own way, zero group-text math. Perfect for bachelorette and birthday groups.
+• FULL CATALOG — spirits, beer, wine, seltzers, champagne, cocktail kits, mixers, bulk ice, and cups. Custom item requests honored whenever we can source them.
+• SAME-DAY AND LAST-MINUTE — TABC-licensed, always on time, with money-back on unopened returns (up to 25% of the order) so groups can over-buy risk-free.
+• YOU EARN ON EVERY ORDER — partners earn a commission on every guest order, tracked in your own partner portal where you can see each dashboard your guests create, how engaged they are, and what they ordered.
+• ZERO LIFT — no inventory, no liability, no staff time. You share a link; we do everything else.
+
+We already do this for Austin STR and boat-party operators, and guests consistently call it out in reviews.
+
+Worth a 15-minute call this week? I can have your branded page live the same day.
+
+Brian Hill
+Founder, Party On Delivery
+partyondelivery.com · (737) 371-9700`,
+};
+
 export default function StrPartnersView(): ReactElement {
   const prospects = prospectsData as Prospect[];
   const [search, setSearch] = useState('');
   const [copied, setCopied] = useState(false);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [copiedEmail, setCopiedEmail] = useState<string | null>(null);
+
+  const copyOutreach = async (p: Prospect) => {
+    if (!p.enrichment) return;
+    await navigator.clipboard.writeText(
+      `Subject: ${p.enrichment.outreachEmail.subject}\n\n${p.enrichment.outreachEmail.body}`
+    );
+    setCopiedEmail(p.website);
+    setTimeout(() => setCopiedEmail(null), 2500);
+  };
 
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();
@@ -123,6 +200,32 @@ export default function StrPartnersView(): ReactElement {
         </Link>
       </div>
 
+      {/* Master outreach template */}
+      <details className="mb-4 rounded-lg border border-gray-200 bg-white">
+        <summary className="cursor-pointer p-3 font-bold text-gray-900 text-sm">
+          ✉️ Master outreach template (everything POD does — adapt per lead)
+        </summary>
+        <div className="px-4 pb-4">
+          <p className="text-sm text-gray-700 font-semibold mb-2">
+            Subject: {MASTER_OUTREACH.subject}
+          </p>
+          <pre className="whitespace-pre-wrap text-sm text-gray-700 font-sans bg-gray-50 rounded-lg p-4 border border-gray-100">
+            {MASTER_OUTREACH.body}
+          </pre>
+          <button
+            type="button"
+            onClick={() =>
+              navigator.clipboard.writeText(
+                `Subject: ${MASTER_OUTREACH.subject}\n\n${MASTER_OUTREACH.body}`
+              )
+            }
+            className="mt-2 btn-secondary px-4 py-2 text-sm"
+          >
+            Copy template
+          </button>
+        </div>
+      </details>
+
       <div className="rounded-lg border border-gray-200 overflow-x-auto bg-white">
         <table className="w-full text-sm">
           <thead className="bg-gray-50 text-xs uppercase tracking-wider text-gray-600">
@@ -139,18 +242,42 @@ export default function StrPartnersView(): ReactElement {
           </thead>
           <tbody className="divide-y divide-gray-100 align-top">
             {filtered.map((p) => (
-              <tr key={p.website}>
-                <td className="p-3 min-w-[180px]">
-                  <a
-                    href={p.website}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="font-medium text-brand-blue hover:underline"
-                  >
-                    {p.name}
-                  </a>
-                  <div className="text-xs text-gray-500 break-all">
-                    {p.website.replace(/^https?:\/\/(www\.)?/, '')}
+              <Fragment key={p.website}>
+              <tr>
+                <td className="p-3 min-w-[200px]">
+                  <div className="flex items-start gap-1.5">
+                    {p.enrichment && (
+                      <button
+                        type="button"
+                        onClick={() => setExpanded(expanded === p.website ? null : p.website)}
+                        className="mt-0.5 text-brand-blue font-bold text-sm leading-none"
+                        aria-label={expanded === p.website ? 'Collapse enrichment' : 'Expand enrichment'}
+                      >
+                        {expanded === p.website ? '▾' : '▸'}
+                      </button>
+                    )}
+                    <div>
+                      <a
+                        href={p.website}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="font-medium text-brand-blue hover:underline"
+                      >
+                        {p.name}
+                      </a>
+                      <div className="text-xs text-gray-500 break-all">
+                        {p.website.replace(/^https?:\/\/(www\.)?/, '')}
+                      </div>
+                      {p.enrichment && (
+                        <button
+                          type="button"
+                          onClick={() => setExpanded(expanded === p.website ? null : p.website)}
+                          className="mt-1 inline-block text-xs font-bold text-green-700 bg-green-50 px-1.5 py-0.5 rounded"
+                        >
+                          ✦ Enriched — {expanded === p.website ? 'hide' : 'view'}
+                        </button>
+                      )}
+                    </div>
                   </div>
                 </td>
                 <td className="p-3">
@@ -218,9 +345,124 @@ export default function StrPartnersView(): ReactElement {
                   )}
                 </td>
               </tr>
+              {p.enrichment && expanded === p.website && (
+                <tr className="bg-blue-50/40">
+                  <td colSpan={8} className="p-4 md:p-6">
+                    <EnrichmentPanel
+                      prospect={p}
+                      onCopyEmail={() => copyOutreach(p)}
+                      emailCopied={copiedEmail === p.website}
+                    />
+                  </td>
+                </tr>
+              )}
+              </Fragment>
             ))}
           </tbody>
         </table>
+      </div>
+    </div>
+  );
+}
+
+/** Expanded dropdown: the researched profile + personalized outreach draft. */
+function EnrichmentPanel({
+  prospect,
+  onCopyEmail,
+  emailCopied,
+}: {
+  prospect: Prospect;
+  onCopyEmail: () => void;
+  emailCopied: boolean;
+}): ReactElement {
+  const e = prospect.enrichment!;
+  return (
+    <div className="max-w-5xl">
+      <div className="flex items-baseline justify-between flex-wrap gap-2 mb-4">
+        <h3 className="text-lg font-bold text-gray-900">
+          Enriched profile — {prospect.name}
+        </h3>
+        <span className="text-xs text-gray-500">researched {e.enrichedAt}</span>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+        <div className="bg-white rounded-lg border border-gray-200 p-4">
+          <h4 className="text-sm font-bold text-gray-900 uppercase tracking-wide mb-2">Management</h4>
+          <dl className="text-sm text-gray-700 space-y-1">
+            {e.management.ownerName && <div><span className="font-semibold">Owner:</span> {e.management.ownerName}</div>}
+            {e.management.ownerNotes && <div className="text-gray-600">{e.management.ownerNotes}</div>}
+            {e.management.team && <div><span className="font-semibold">Team:</span> {e.management.team}</div>}
+            {e.management.operatingSince && <div><span className="font-semibold">Operating since:</span> {e.management.operatingSince}</div>}
+            {e.management.entity && <div><span className="font-semibold">Entity:</span> {e.management.entity}</div>}
+            {e.management.linkedin && (
+              <div>
+                <a href={e.management.linkedin} target="_blank" rel="noopener noreferrer" className="text-brand-blue underline">LinkedIn</a>
+              </div>
+            )}
+          </dl>
+        </div>
+
+        <div className="bg-white rounded-lg border border-gray-200 p-4">
+          <h4 className="text-sm font-bold text-gray-900 uppercase tracking-wide mb-2">Portfolio</h4>
+          <dl className="text-sm text-gray-700 space-y-1">
+            <div><span className="font-semibold">Properties:</span> {e.portfolio.propertyCount}</div>
+            <div><span className="font-semibold">Types:</span> {e.portfolio.propertyTypes}</div>
+            <div><span className="font-semibold">Locations:</span> {e.portfolio.locations}</div>
+            {e.portfolio.maxGroupSize && (
+              <div><span className="font-semibold">Largest groups:</span> {e.portfolio.maxGroupSize}</div>
+            )}
+          </dl>
+          {e.portfolio.notableProperties.length > 0 && (
+            <ul className="mt-2 text-sm text-gray-600 list-disc pl-5 space-y-0.5">
+              {e.portfolio.notableProperties.map((np) => (
+                <li key={np.name}><span className="font-medium text-gray-800">{np.name}</span> — {np.blurb}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="bg-white rounded-lg border border-gray-200 p-4">
+          <h4 className="text-sm font-bold text-gray-900 uppercase tracking-wide mb-2">Business</h4>
+          <dl className="text-sm text-gray-700 space-y-1">
+            <div><span className="font-semibold">Booking model:</span> {e.business.bookingModel}</div>
+            <div><span className="font-semibold">Services:</span> {e.business.services}</div>
+            <div><span className="font-semibold">Positioning:</span> {e.business.positioning}</div>
+            <div><span className="font-semibold">Guests:</span> {e.business.guestDemographic}</div>
+          </dl>
+        </div>
+
+        <div className="bg-white rounded-lg border border-gray-200 p-4">
+          <h4 className="text-sm font-bold text-gray-900 uppercase tracking-wide mb-2">Reputation</h4>
+          <p className="text-sm text-gray-700">{e.reputation.summary}</p>
+          {e.reputation.ratings && <p className="text-sm text-gray-600 mt-1">{e.reputation.ratings}</p>}
+          {e.reputation.praiseThemes && (
+            <p className="text-sm text-gray-600 mt-1"><span className="font-semibold text-gray-800">Guests praise:</span> {e.reputation.praiseThemes}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="bg-white rounded-lg border border-gray-200 p-4 mb-4">
+        <h4 className="text-sm font-bold text-gray-900 uppercase tracking-wide mb-2">Partnership angles</h4>
+        <ul className="text-sm text-gray-700 list-disc pl-5 space-y-1">
+          {e.partnershipAngles.map((a) => (
+            <li key={a}>{a}</li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="bg-white rounded-lg border-2 border-brand-blue/30 p-4">
+        <div className="flex items-center justify-between flex-wrap gap-2 mb-2">
+          <h4 className="text-sm font-bold text-gray-900 uppercase tracking-wide">
+            Personalized outreach draft
+          </h4>
+          <button type="button" onClick={onCopyEmail} className="btn-primary px-4 py-2 text-sm">
+            {emailCopied ? 'Copied ✓' : 'Copy email'}
+          </button>
+        </div>
+        <p className="text-sm font-semibold text-gray-800 mb-2">Subject: {e.outreachEmail.subject}</p>
+        <pre className="whitespace-pre-wrap text-sm text-gray-700 font-sans bg-gray-50 rounded-lg p-4 border border-gray-100">
+          {e.outreachEmail.body}
+        </pre>
       </div>
     </div>
   );

--- a/src/data/str-partner-prospects.json
+++ b/src/data/str-partner-prospects.json
@@ -2,7 +2,7 @@
   {
     "name": "Lynn's Lodging",
     "website": "https://www.lynnslodgingatx.com/",
-    "propertiesEstimate": "~34",
+    "propertiesEstimate": "~35-37",
     "contactName": "Lynn",
     "email": "hello@lynnslodging.com",
     "phone": "512-920-3590",
@@ -16,7 +16,69 @@
     },
     "logoUrl": "https://www.lynnslodgingatx.com/i/width=200,dpr=1,format=jpeg?src=https%3A%2F%2Fassets-websites.wander.com%2F637460520617640767%2Flogo-TAcHsUiqn1-vZGHBYDcI2.png",
     "description": "Designer luxury Austin STRs with pools, hot tubs, rooftop spaces; also full-service STR management (Austin + Cedar Park).",
-    "partnerSlug": "lynns-lodging"
+    "partnerSlug": "lynns-lodging",
+    "enrichment": {
+      "enrichedAt": "2026-07-21",
+      "management": {
+        "ownerName": "Lynn (surname not published anywhere public)",
+        "ownerNotes": "Hands-on owner-operator — guests name her personally in reviews ('Lynn was gracious', 'super responsive', gives restaurant recs). She runs both the guest brand and an owner-acquisition funnel (go.lynnslodging.com 'STR Bookings Maximizer Report'), so she is operator + salesperson. One relationship unlocks the whole portfolio.",
+        "team": "No named team; services (24/7 guest comms, cleaning/staging, photography, dynamic pricing) imply a small ops/cleaning crew",
+        "linkedin": null,
+        "operatingSince": "Young, fast-scaling — Facebook page created ~late 2024; Airbtics shows 38-150% YoY listing growth",
+        "entity": "LYNN'S LODGING LLC, Austin TX"
+      },
+      "portfolio": {
+        "propertyCount": "~35-37 (site lists 37; Airbtics counts 35 Airbnb listings)",
+        "propertyTypes": "Designer/luxury homes, 1-11 BR — compounds and event-capable properties with pools (incl. cowboy pools), hot tubs, fire pits, OUTDOOR BARS, game rooms, movie rooms, rooftops, pool tables",
+        "locations": "Central Austin — Rainey Street/downtown, South Congress (1007 S Congress aparthotel cluster), near 6th St and Lady Bird Lake — plus Cedar Park",
+        "maxGroupSize": "Homes sleep 12-16+; an 11-bedroom listing suggests 20+ at the top end",
+        "notableProperties": [
+          {
+            "name": "Huge 5BR Compound",
+            "blurb": "sleeps 16, one block from Rainey Street — flagship big-group party pad"
+          },
+          {
+            "name": "Luxe Rainey DTown Oasis",
+            "blurb": "sleeps 14, private pool + hot tub, walkable to Rainey nightlife"
+          },
+          {
+            "name": "2-Home Event Compound (Cedar Park)",
+            "blurb": "sleeps 16 w/ hot tub, explicitly marketed as an event space"
+          },
+          {
+            "name": "4BR w/ Cowboy Pool, Fire Pit + Pool Table",
+            "blurb": "signature Austin backyard-hangout home, sleeps 8"
+          },
+          {
+            "name": "1007 S Congress cluster",
+            "blurb": "7 designer 2-3BR units sleeping 12-14 each, shared pool/fire pit/outdoor bar, steps from SoCo"
+          }
+        ]
+      },
+      "business": {
+        "bookingModel": "Hybrid — direct-booking site (Wander platform, 'book direct, skip fees') + full OTA spread (Airbnb, Vrbo, Expedia, Klook, Trip.com, Agoda) + owner lead-magnet funnel",
+        "services": "Full-service STR management for owners; promises guests 'concierge-style service and personalized local recommendations' — but has NO beverage/amenity concierge product",
+        "positioning": "Ultra-premium: ~$510 ADR (183% above Austin's ~$180 avg), ~$70.6K revenue/listing (82% above market), 75% occupancy",
+        "guestDemographic": "Group celebrations — bachelorette parties (formal Bach Babes partnership w/ 10% code), girls' trips, SXSW crowds, large friend/family groups; marketing: homes are 'perfect for groups looking to relax and celebrate in style'"
+      },
+      "reputation": {
+        "summary": "Excellent and consistent — guests repeatedly praise Lynn personally; no recurring complaints surfaced anywhere indexed.",
+        "ratings": "Airbnb 5.0 avg (per Airbtics); 4-star aparthotel listings on OTAs",
+        "praiseThemes": "host responsiveness/warmth, local recommendations, cleanliness, no checkout chores, hot tub/game-room fun for bachelorette groups, walkability"
+      },
+      "partnershipAngles": [
+        "She sells the party occasion (outdoor bars, fire pits, cowboy pools, 'celebrate in style') — but nobody stocks the bar. POD is the missing piece of the exact experience she advertises.",
+        "Proven bachelorette referral pipeline: her Bach Babes partnership (10% off for bachelorette groups) is the same playbook POD's partner program runs — she already knows this model works.",
+        "She promises 'concierge-style service' with no in-house product — POD is white-label fulfillment: pre-arrival fridge stocking, cocktail kits, welcome bars.",
+        "Big-group inventory (12-16+ sleepers, event compound in Cedar Park) means every booking clears POD's order minimums — multi-case orders by default; Cedar Park is in the delivery zone.",
+        "$510-ADR guests are experience-hungry and price-insensitive — premium spirits and package upsells fit; commission adds a new revenue line she demonstrably cares about (she runs a revenue-maximizer funnel).",
+        "Owner-led shop with a 5.0 built on responsiveness — one call with Lynn activates all ~37 properties; her co-branded page is ALREADY LIVE at /partners/lynns-lodging."
+      ],
+      "outreachEmail": {
+        "subject": "Lynn — those outdoor bars at your Rainey + SoCo homes? Let us keep them stocked (free delivery for your guests)",
+        "body": "Hi Lynn,\n\nI'm Brian, founder of Party On Delivery — Austin's premium alcohol delivery and guest-concierge service. I've been admiring what you've built: 37 designer homes, a 5.0 rating your guests credit to you personally, and the best big-group inventory near Rainey and SoCo. Your listings promise groups a place to 'relax and celebrate in style' — cowboy pools, fire pits, outdoor bars.\n\nHere's the thing: your guests still have to stock those bars themselves, hauling cases in an Uber on day one.\n\nWe fix that, at zero cost and zero effort to you:\n\n• FREE DELIVERY FOR YOUR GUESTS — spirits, champagne, seltzers, cocktail kits, bulk ice, cups — iced and waiting at check-in, timed to your arrivals. Same-day and last-minute covered, TABC-licensed, money-back on unopened returns so groups can over-buy risk-free.\n\n• A PARTY DASHBOARD FOR EVERY GROUP — one link, and each bachelorette or birthday crew gets a private ordering page: everyone adds their own drinks, payment splits itself, no group-text math. You already saw how well the referral model works with Bach Babes — this is that, for the bar.\n\n• YOUR BRANDED PAGE IS ALREADY LIVE — we built partyondelivery.com/partners/lynns-lodging with your branding. Drop it in welcome emails or your digital guidebook and it just works.\n\n• YOU EARN ON EVERY ORDER — commission on every guest purchase, tracked in your own partner portal (you can watch each group's dashboard, engagement, and order status in real time).\n\nWith homes sleeping 12-16+, your average group is exactly who we built this for — and it makes the 'concierge-style service' your brand already promises tangible from the minute they walk in.\n\nWorth 15 minutes this week? I can walk you through the live page and have your first guest dashboard running on the call.\n\nBrian Hill\nFounder, Party On Delivery\npartyondelivery.com · (737) 371-9700"
+      }
+    }
   },
   {
     "name": "Austin Vacay",


### PR DESCRIPTION
Adds the lead-enrichment layer to the STR Partners tab:

- **Enrichment dropdown** per prospect: management, portfolio, business model, reputation, partnership angles, personalized outreach email with one-click copy
- **Master outreach template** (full POD services pitch) collapsible at the top of the tab
- **First enriched lead: Lynn's Lodging** — deep web research (owner profile, ~37 properties w/ types + neighborhoods + 5 flagship homes, $510 ADR positioning, Bach Babes bachelorette partnership, 5.0 reputation) + a personalized email draft referencing her live `/partners/lynns-lodging` page

Gates: tsc clean, lint clean, 987/987 tests. Admin tab render behind auth not visually verified locally (no JWT_SECRET) — same pattern as existing tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)