### PR TITLE
fix(finance): classify Shopify Capital MCA as loan proceeds (financing, not income)

### DIFF
--- a/src/lib/finance/__tests__/bank-income-recon.test.ts
+++ b/src/lib/finance/__tests__/bank-income-recon.test.ts
@@ -54,6 +54,30 @@ describe('classifyBankInflow', () => {
     );
   });
 
+  it('classifies a Shopify Capital advance as loan proceeds (financing, not income)', () => {
+    // Live WF descriptor for the 2025-12-09 merchant cash advance ($25,000).
+    // Shopify Capital is Shopify's lending arm — financing, never sales.
+    expect(
+      classifyBankInflow({
+        name: 'SHOPIFY CAPITAL SHOPIFY 251208 45834452 Premier Conc',
+        merchantName: null,
+      })
+    ).toBe('loan_proceeds');
+  });
+
+  it('does NOT sweep a Shopify sales payout into loan proceeds (anchor requires "capital")', () => {
+    // Regular Shopify settlements never carry the word "capital"; a real sale
+    // must stay IN the income check. The anchor pins the lending product only.
+    expect(
+      classifyBankInflow({ name: 'SHOPIFY PAYMENTS 251208 45834452 Premier Conc', merchantName: null })
+    ).toBe('sales_or_other');
+    // A real Shopify sales payout (the "SHOPIFY TRANSFER … BRIAN HILL" shape seen
+    // on the live feed) must also stay in the check — no "capital" token.
+    expect(
+      classifyBankInflow({ name: 'SHOPIFY TRANSFER 251110 PARTY ON DELIVE BRIAN HILL', merchantName: null })
+    ).toBe('sales_or_other');
+  });
+
   it('classifies credits from COGS merchants as vendor refunds (not sales)', () => {
     expect(
       classifyBankInflow({ name: "Southern Glazer' FINTECHEFT 051826 XXXXX6635", merchantName: null })

--- a/src/lib/finance/bank-income-recon.ts
+++ b/src/lib/finance/bank-income-recon.ts
@@ -60,27 +60,33 @@ export const OWNER_CAPITAL_RULES: readonly RegExp[] = [
 ];
 
 /**
- * Loan-proceeds (financing) inflow descriptors — the PeopleFund term-loan
- * DISBURSEMENTS, ANCHORED to the exact shape on the real Wells Fargo feed
- * (surfaced by the 2024 statement import, operator-confirmed loan #0006957):
+ * Loan-proceeds (financing) inflow descriptors — term-loan / merchant-cash-advance
+ * DISBURSEMENTS, ANCHORED to the exact shapes on the real Wells Fargo feed:
  *
- *   "Peoplefund Advance 0006957 Full and Final Funding; Working Capital"
- *   "Peoplefund Advances 0006957 Partial Funding; Inventory Category…"
+ *   PeopleFund CDFI term loan (#0006957), surfaced by the 2024 statement import:
+ *     "Peoplefund Advance 0006957 Full and Final Funding; Working Capital"
+ *     "Peoplefund Advances 0006957 Partial Funding; Inventory Category…"
  *
- * These are loan proceeds — financing, never income — and must not trip the
- * "deposits exceed revenue" flag (2024 H1 alone was ~$328K of PeopleFund
- * advances, which would otherwise read as phantom sales). The loan PAYMENTS
- * ("Peoplefund Pymt…") are the matching outflow, already mapped `non_operating`
- * via the PFC / statement LOAN_PAYMENTS hint.
+ *   Shopify Capital merchant cash advance ($25,000 on 2025-12-09):
+ *     "SHOPIFY CAPITAL SHOPIFY 251208 45834452 Premier Conc"
  *
- * Anchored like OWNER_CAPITAL_RULES: PeopleFund is Party On's CDFI lender, not a
- * customer, and the "advance" wording + loan number pin it to a disbursement —
- * a real sale (Stripe/Square "ST-…" / Square Inc) can't be laundered as
- * financing by this rule. If the descriptor drifts, the month re-flags as excess
- * deposits (see the drift hint) rather than silently misclassifying.
+ * These are financing proceeds — never income — and must not trip the "deposits
+ * exceed revenue" flag (2024 H1 alone was ~$328K of PeopleFund advances; the
+ * Shopify advance is $25K of Dec-2025 inflows). The matching outflows are the
+ * loan PAYMENTS ("Peoplefund Pymt…") / Shopify Capital remittances, handled on
+ * the expense side.
+ *
+ * Anchored like OWNER_CAPITAL_RULES: each rule pins the LENDER, not a customer.
+ *   - PeopleFund: the "advance" wording + loan number pin it to a disbursement.
+ *   - Shopify Capital: the literal word "capital" is Shopify's lending arm. A
+ *     regular Shopify sales payout never carries it — sales settle via Stripe
+ *     ("ST-…") — so a real sale can't be laundered as financing by this rule.
+ * If a descriptor drifts, the month re-flags as excess deposits (see the drift
+ * hint) rather than silently misclassifying.
  */
 export const LOAN_PROCEEDS_RULES: readonly RegExp[] = [
   /\bpeoplefund\b.*\badvance/i, // "Peoplefund Advance(s) 0006957 … Funding"
+  /\bshopify\s+capital\b/i, // "SHOPIFY CAPITAL SHOPIFY … Premier Conc" — Shopify's MCA arm (sales settle via Stripe "ST-…", never this)
 ];
 
 /**


### PR DESCRIPTION
## What

Adds one anchored rule to `LOAN_PROCEEDS_RULES` in `src/lib/finance/bank-income-recon.ts`:

```
/\bshopify\s+capital\b/i   → loan_proceeds (financing, excluded from the income cross-check)
```

The **2025-12-09 $25,000 Shopify Capital merchant cash advance** (live WF descriptor `SHOPIFY CAPITAL SHOPIFY 251208 45834452 Premier Conc`) was landing in the deposits-vs-Stripe-revenue income cross-check as unexplained "other income", inflating December 2025's excess-deposits flag by $25K (phantom "missing orders"). Shopify Capital is Shopify's lending arm — this is financing/debt, not sales — so it should be recognized like the PeopleFund advances and excluded from the income check, surfaced in the `loanProceeds` audit trail instead.

## Why it's safe (anchoring)

Same convention as the existing PeopleFund / owner-capital rules — anchor on the funding source, never a bare name. The literal word **"capital"** is load-bearing: sales settle via Stripe (`ST-…`), and Shopify sales payouts read `SHOPIFY TRANSFER …` / `SHOPIFY PAYMENTS …` — **never** `SHOPIFY CAPITAL`. So no real sale can be laundered as financing. If the descriptor ever drifts, the month re-flags as excess deposits (with the drift hint) rather than silently misclassifying.

## Effect (dry-run against prod, read-only — no persist)

| Month | Before | After |
|---|---|---|
| **Dec 2025** | $26,718 unexplained excess, loanProceeds $0 | **$1,718** excess, **loanProceeds $25,000** (MCA now in the audit trail) |

**No month flips `netIncomeReliable` on this change alone.** December's residual $1,718 is the $3K USAA transfer (a separate open decision) partially offset; Nov 2025 / Jan / Feb residuals are real Stripe/PayPal sales deposits exceeding *recorded* revenue (a revenue-completeness gap, not financing). Those are tracked separately — no financing rule fixes them.

## Tests / gates

- `+3` unit tests in `__tests__/bank-income-recon.test.ts`: real-descriptor positive + `SHOPIFY PAYMENTS` / `SHOPIFY TRANSFER … BRIAN HILL` adversarial negatives (the latter contains both "SHOPIFY" and "HILL" yet must stay `sales_or_other`).
- Full vitest: **989 passed**. ESLint: **0 errors** (pre-existing `<img>` warnings only). `tsc`: 3 pre-existing errors unrelated to this change (recharts formatters + Stripe API-version string); CI gates on Test & Lint.
- **security-reviewer: SAFE TO MERGE** (0 crit/high/med). 1 pre-existing LOW (field-concatenation footgun affecting all rules) spun off as a separate tech-debt task, not introduced here.

## Post-merge step

Rebuild the finance monthly rollups so prod reflects the reclassification:
```
npx tsx scripts/finance/backfill-monthly-rollups.ts
```

## Not in this PR (open decision)

The **USAA personal-transfer** classification (owner capital vs. income) is a separate operator decision in progress. If excluded as financing, combined with this rule it would flip **December 2025** to `netIncomeReliable=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)