### PR TITLE
fix(finance): keep genuinely-duplicate WF statement rows distinct (extend import to 2023)

### DIFF
--- a/scripts/finance/import-wf-statements.ts
+++ b/scripts/finance/import-wf-statements.ts
@@ -218,6 +218,22 @@ function printSummary(staged: StagedRow[]): void {
   for (const s of hinted) {
     console.log(`  ${s.row.dateISO}  ${fmt(s.row.plaidAmountCents).padStart(12)}  [${s.row.pfcPrimaryHint}→${s.bankDerivedCategory}]  ${s.row.descriptor.slice(0, 48)}`);
   }
+
+  // Content-identical rows kept as DISTINCT (same date+amount+descriptor, no
+  // unique auth code — e.g. two ATM fees for two real withdrawals). These are
+  // the ONLY rows a file-level duplicate could sneak in through, so list every
+  // group for the operator to confirm each is genuinely N real transactions and
+  // not a doubled statement, BEFORE --apply.
+  const groups = new Map<string, StagedRow[]>();
+  for (const s of staged) {
+    const base = s.row.dedupeKey.split('|#')[0];
+    (groups.get(base) ?? groups.set(base, []).get(base)!).push(s);
+  }
+  const dups = [...groups.values()].filter((g) => g.length > 1).sort((a, b) => a[0].row.dateISO.localeCompare(b[0].row.dateISO));
+  console.log(`\n=== Content-identical rows kept as distinct (${dups.length} groups) — confirm each is N REAL transactions, not a doubled statement ===`);
+  for (const g of dups) {
+    console.log(`  x${g.length}  ${g[0].row.dateISO}  ${fmt(g[0].row.plaidAmountCents).padStart(12)}  ${g[0].row.descriptor.slice(0, 52)}`);
+  }
 }
 
 /** Prove the seam cut is clean, WITHOUT a tautology. Two independent, meaningful

--- a/scripts/finance/verify-wf-backfill.ts
+++ b/scripts/finance/verify-wf-backfill.ts
@@ -69,12 +69,13 @@ async function main(): Promise<void> {
   console.log(`\nSeam ${seamISO} (statement latest ${stmtMax.toISOString().slice(0, 10)}): statement rows on/after seam=${stmtAfterSeam} (want 0), ` +
     `live rows within statement range=${liveInRange.length} (want 0), date+amount collisions=${collisions} (want 0)  ${seamOk ? '✓ CLEAN' : '⚠️  REVIEW'}`);
 
-  // --- Newly-covered months' rollups ---------------------------------------
+  // --- Newly-covered months' rollups (Jan 2023 → the Plaid seam month) -------
   const rollups = await prisma.financeMonthlyRollup.findMany({
-    where: { year: 2024, month: { gte: 1, lte: 7 } }, orderBy: [{ year: 'asc' }, { month: 'asc' }],
+    where: { OR: [{ year: 2023 }, { year: 2024, month: { lte: 7 } }] },
+    orderBy: [{ year: 'asc' }, { month: 'asc' }],
     select: { year: true, month: true, revenueCents: true, cogsCents: true, netIncomeCents: true, dataHealth: true },
   });
-  console.log('\n=== 2024-01 → 2024-07 rollups (the statement-enriched months) ===');
+  console.log('\n=== 2023-01 → 2024-07 rollups (the statement-enriched months) ===');
   console.log('month     revenue    COGS       net        reliable  src   ownerCap   loanProc   otherInc   reconciled');
   for (const r of rollups) {
     const h = (r.dataHealth ?? {}) as Record<string, unknown>;

--- a/src/lib/finance/__tests__/wf-statement-parser.test.ts
+++ b/src/lib/finance/__tests__/wf-statement-parser.test.ts
@@ -173,6 +173,23 @@ describe('parseWfActivityCsv — dedupe key stability (PDF ↔ CSV overlap)', ()
     expect(a.dedupeKey).toBe(b.dedupeKey);
   });
 
+  it('keeps two genuinely-identical rows (duplicate ATM fees) as DISTINCT keys, not one', () => {
+    // Older statements have rows with no unique auth code — two $5 ATM fees on
+    // the same day are two real fees and must not collapse (would undercount).
+    const csv = [
+      HEADER,
+      '"09/29/2023","Non-Wells Fargo ATM Transaction Fee","-5.00","","Posted"',
+      '"09/29/2023","Non-Wells Fargo ATM Transaction Fee","-5.00","","Posted"',
+    ].join('\n');
+    const { rows } = parseWfActivityCsv(csv);
+    expect(rows).toHaveLength(2);
+    expect(rows[0].dedupeKey).not.toBe(rows[1].dedupeKey);
+    // First occurrence keeps the BARE key (prior imports stay idempotent); only
+    // the second gets a suffix.
+    expect(rows[0].dedupeKey).not.toContain('|#');
+    expect(rows[1].dedupeKey).toContain('|#1');
+  });
+
   it('distinguishes two same-day same-amount checks by check number', () => {
     const csv = [
       HEADER,

--- a/src/lib/finance/wf-statement-parser.ts
+++ b/src/lib/finance/wf-statement-parser.ts
@@ -1,7 +1,7 @@
 /**
  * Pure parser for Wells Fargo "Download Account Activity" CSV rows — used to
- * extend the bank-truth P&L back before Plaid's 730-day ceiling (Jan 2024, the
- * earliest WF would release; 2023 is unreachable). See
+ * extend the bank-truth P&L back before Plaid's 730-day ceiling, from the
+ * monthly statements Allan downloads (back to at least Jan 2023). See
  * scripts/finance/import-wf-statements.ts for the operator-gated importer and
  * scripts/finance/extract-wf-pdf.py for the PDF→CSV step that feeds this the
  * same column shape.
@@ -54,10 +54,14 @@ export interface WfStatementRow {
   pfcPrimaryHint: PfcPrimaryHint | null;
   /**
    * Deterministic idempotency + cross-source dedupe key:
-   * `dateISO|signedCents|normalizedDescriptor|checkNumber`. Same real
-   * transaction from a PDF statement and from the CSV normalizes to the same
-   * key (WF descriptors carry unique auth/ref codes; checks add their number),
-   * so re-runs and PDF↔CSV overlaps never double-count.
+   * `dateISO|signedCents|normalizedDescriptor|checkNumber`, plus a `|#N` suffix
+   * for the 2nd+ occurrence of an otherwise-identical key WITHIN the file. Most
+   * WF descriptors carry unique auth/ref/check codes so the base key is already
+   * unique; but a handful of older rows don't (e.g. two "Non-Wells Fargo ATM
+   * Transaction Fee" of the same amount on the same day are two real fees), and
+   * without the suffix they would collapse and undercount. The suffix is only
+   * added from the 2nd occurrence on, so single rows keep their bare key and
+   * stay idempotent across re-runs and prior imports.
    */
   dedupeKey: string;
 }
@@ -162,6 +166,9 @@ export function parseWfActivityCsv(csvText: string): ParseWfCsvResult {
   const rows: WfStatementRow[] = [];
   const skipped: Array<{ line: number; reason: string; raw: string }> = [];
   const lines = csvText.split(/\r\n|\n|\r/);
+  // Occurrence counter per base key, so two genuinely-distinct rows that share
+  // date+amount+descriptor+check (e.g. duplicate ATM fees) get distinct keys.
+  const keyCounts = new Map<string, number>();
 
   for (let i = 0; i < lines.length; i++) {
     const raw = lines[i];
@@ -198,12 +205,17 @@ export function parseWfActivityCsv(csvText: string): ParseWfCsvResult {
     const plaidAmountCents = -wfCents;
     const isInflow = plaidAmountCents < 0;
     const pfcPrimaryHint = pfcHintFor(descriptor, isInflow);
-    const dedupeKey = [
+    const baseKey = [
       dateISO,
       plaidAmountCents,
       normalizeDescriptor(descriptor),
       checkNumber ?? '',
     ].join('|');
+    const occ = keyCounts.get(baseKey) ?? 0;
+    keyCounts.set(baseKey, occ + 1);
+    // Bare key for the first occurrence (keeps prior imports idempotent); a
+    // suffix only for genuine duplicates.
+    const dedupeKey = occ === 0 ? baseKey : `${baseKey}|#${occ}`;
 
     rows.push({
       dateISO,


### PR DESCRIPTION
## What & why
Follow-up to the WF statement importer (#279). Extending the bank-truth P&L back to **full-year 2023** (the 2023 statements turned out reachable after all) surfaced a dedupe undercount.

Older WF statements contain genuinely-distinct rows with **no unique auth code** — e.g. two `$5.00 Non-Wells Fargo ATM Transaction Fee` on 2023-09-29 (two real Munich ATM withdrawals, distinct ATM IDs) and two `$0.31 International Purchase Transaction Fee` on 2023-10-02 (two different purchases). They share date+amount+descriptor, so the content dedupe key collapsed them → **$5.31 undercounted across 2023**. 2024 never hit this (every row carried a unique auth/ref/check code).

## Fix
Append a `|#N` occurrence suffix to the dedupe key for the 2nd+ identical row **within a file**. The first occurrence keeps its bare key, so:
- single rows — **all of the already-imported 2024 data** — keep their exact `transactionId` and re-import idempotently (verified: statement item held at exactly 1029 rows after re-apply, no duplication);
- only true duplicates get a distinct key.

After the fix, every 2023 month reconciles to the statement's printed totals **to the penny**.

## Also in this PR
- `import-wf-statements.ts`: the dry-run now lists every content-identical group kept as distinct, so the operator confirms each is N real transactions (not a doubled statement) before `--apply`.
- `verify-wf-backfill.ts`: verification range extended to 2023-01 → 2024-07.
- Docstring: corrected the stale "2023 is unreachable" note.

## Applied to prod
Re-ran the importer with the combined 2023+2024 set: **1029 rows** (2023-01-03 → 2024-07-12), seam CLEAN (0 collisions), rollups rebuilt (66/66). 2023 now carries the deposit/financing layer (~$74K owner capital recognized; USAA/other deposits surfaced for the still-open owner-capital decision). Net income stays QB-based + unreliable under the Shopify caveat, as before.

## Review
security-reviewer (money-correctness) — SAFE TO MERGE: idempotency of the 597 prior 2024 rows confirmed (base key starts with dateISO → no cross-year collision), determinism confirmed (file-order iteration). Its MEDIUM (surface suffixed rows) is addressed above. Gates: lint clean, **996 tests pass**. (tsc has pre-existing errors on main from #280/#281, none in these files; tsc isn't the CI gate.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)