### PR TITLE
feat(partners): exact same-origin mirror of Premier's /quote page in the boat tab

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -180,6 +180,26 @@ const nextConfig: NextConfig = {
   },
 
   // 301 Redirects for SEO (from SEMrush audit - January 2025)
+  async rewrites() {
+    return [
+      // Same-origin proxy for the Premier Party Cruises quote-page mirror
+      // (public/partners-embed/premier-quote.html — Brian's own site,
+      // mirrored per his direction). Premier's Vite build references
+      // /assets/* + /attached_assets/* root-relative, and their CDN sends
+      // no CORS headers, so <base>-loading the module scripts cross-origin
+      // fails. Proxying through our origin sidesteps CORS entirely.
+      // Neither path exists in POD (public/ has no assets/attached_assets).
+      {
+        source: '/assets/:path*',
+        destination: 'https://premierpartycruises.com/assets/:path*',
+      },
+      {
+        source: '/attached_assets/:path*',
+        destination: 'https://premierpartycruises.com/attached_assets/:path*',
+      },
+    ];
+  },
+
   async redirects() {
     return [
       // 2026-06-10 archived + orphaned product URL sweep — see
@@ -566,12 +586,39 @@ const nextConfig: NextConfig = {
       // rule above would cause browsers to block embedding). Modern
       // browsers honor CSP `frame-ancestors *` instead.
       {
-        source: '/:path((?!admin|ops).*)',
+        source: '/:path((?!admin|ops|partners-embed).*)',
         headers: [
           ...commonSecurityHeaders,
           {
             key: 'Content-Security-Policy',
             value: [...baseCspDirectives, 'frame-ancestors *'].join('; '),
+          },
+        ],
+      },
+      // ─── PARTNER EMBED MIRRORS — /partners-embed/* ─────────────────
+      // Same-origin mirrors of partner booking pages (e.g. Premier Party
+      // Cruises' /quote incl. its Xola checkout), shown inside the
+      // two-tab partner pages. These run the partner's own scripts via a
+      // <base> tag pointing at their origin, so they need a relaxed CSP
+      // scoped to this path only. noindex; only POD may frame them.
+      {
+        source: '/partners-embed/:path*',
+        headers: [
+          ...commonSecurityHeaders,
+          { key: 'X-Robots-Tag', value: 'noindex, nofollow' },
+          {
+            key: 'Content-Security-Policy',
+            value: [
+              "default-src 'self' https:",
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https:",
+              "style-src 'self' 'unsafe-inline' https:",
+              "img-src 'self' data: blob: https:",
+              "font-src 'self' data: https:",
+              "connect-src 'self' https: wss:",
+              "frame-src https:",
+              "base-uri 'self' https://premierpartycruises.com",
+              "frame-ancestors 'self'",
+            ].join('; '),
           },
         ],
       },

--- a/public/partners-embed/premier-quote.html
+++ b/public/partners-embed/premier-quote.html
@@ -1,0 +1,5258 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head><script>try{history.replaceState(null,"","/quote")}catch(e){}</script><meta name="robots" content="noindex,nofollow">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    
+    <!-- PAGESPEED: Only preconnect to fonts (critical for render) - defer third-party scripts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <!-- INSTANT QUOTE WIDGET: Preconnect to booking domain for zero-delay /chat page -->
+    <link rel="preconnect" href="https://booking.premierpartycruises.com" crossorigin>
+    <link rel="dns-prefetch" href="https://booking.premierpartycruises.com">
+    
+    <!-- DNS prefetch for non-critical resources (much lighter than preconnect) -->
+    <link rel="dns-prefetch" href="https://xola.com">
+    <link rel="dns-prefetch" href="https://www.googletagmanager.com">
+    
+    <!-- PAGESPEED: Preload LCP image (hero poster) - most critical for LCP score -->
+    <link rel="preload" as="image" href="/attached_assets/bachelor-party-group-guys-mobile.webp" 
+          media="(max-width: 768px)" fetchpriority="high" type="image/webp" />
+    <link rel="preload" as="image" href="/attached_assets/bachelor-party-group-guys-hero-compressed.webp" 
+          media="(min-width: 769px)" fetchpriority="high" type="image/webp" />
+    
+    <!-- PAGESPEED: Preconnect to critical third-party domains -->
+    <link rel="preconnect" href="https://js.stripe.com" crossorigin>
+    <link rel="dns-prefetch" href="https://js.stripe.com">
+    
+    <!-- MOBILE PAGESPEED: Preload 140x140 logo for mobile retina (7KB vs 26KB) -->
+    <link rel="preload" as="image" href="/attached_assets/PPC-Logo-140x140.webp" 
+          media="(max-width: 768px)" fetchpriority="high" type="image/webp" />
+    <link rel="preload" as="image" href="/attached_assets/PPC-Logo-280x280.webp" 
+          media="(min-width: 769px)" fetchpriority="high" type="image/webp" />
+    
+    
+    <!-- FALLBACK SEO TAGS (overridden by React Helmet) -->
+    <title>Austin Party Boat Rentals on Lake Travis</title>
+    <meta name="description" content="Austin's longest-running Lake Travis party boat fleet — 15+ years, 150,000+ guests, zero incidents. Private charters from $200/hour, ATX Disco Cruise from $85/$95/$105 per person (base rates, plus tax + 20% gratuity). BYOB + Party On Delivery." />
+    <meta name="keywords" content="austin party boat rentals, lake travis party boat, party boat austin, lake travis boat rental" />
+    
+    <!-- AI & Search Engine Indexing - Explicitly allow all crawlers -->
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+
+    <!-- Open Graph Fallback -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://premierpartycruises.com" />
+    <meta property="og:title" content="Austin Party Boat Rentals on Lake Travis" />
+    <meta property="og:description" content="Austin's longest-running Lake Travis party boat fleet — 15+ years, 150,000+ guests, zero incidents. Private charters from $200/hour, ATX Disco Cruise from $85/$95/$105 per person (base rates, plus tax + 20% gratuity). BYOB + Party On Delivery." />
+    <meta property="og:image" content="https://premierpartycruises.com/og-default.jpg" />
+    <meta property="og:site_name" content="Premier Party Cruises" />
+
+    <!-- Twitter Card Fallback -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Austin Party Boat Rentals on Lake Travis" />
+    <meta name="twitter:description" content="Austin's longest-running Lake Travis party boat fleet — 15+ years, 150,000+ guests, zero incidents. Private charters from $200/hour, ATX Disco Cruise from $85/$95/$105 per person (base rates, plus tax + 20% gratuity). BYOB + Party On Delivery." />
+    <meta name="twitter:image" content="https://premierpartycruises.com/og-default.jpg" />
+
+    <!-- FAQ Schema and other structured data injected by React Helmet per page for unique SEO -->
+
+    <!-- Branding & Theme - Premier Party Cruises Favicon (v2 = Feb 2026 logo update) -->
+    <link rel="icon" type="image/x-icon" href="/favicon.ico?v=2" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png?v=2" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=2" />
+    <link rel="icon" type="image/png" sizes="192x192" href="/icon-192.png?v=2" />
+    <link rel="icon" type="image/png" sizes="512x512" href="/icon-512.png?v=2" />
+    <meta name="theme-color" content="#00d4ff" />
+    
+    <!-- PAGESPEED: Non-blocking font loading using media="print" pattern (most reliable) -->
+    
+    <noscript><link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;600;700&family=Bebas+Neue&family=Candal&family=Unbounded:wght@400;500;600;700;800&display=swap" onload="this.onload=null;this.rel='stylesheet'">
+    <noscript></noscript></noscript>
+    
+    <!-- Inline critical CSS for instant layout stability (prevents CLS) -->
+    <style>
+      /* Critical layout stability - applied immediately before any content renders */
+      html, body {
+        margin: 0;
+        padding: 0;
+        min-height: 100vh;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+      }
+      
+      #root {
+        min-height: 0;
+        background: transparent;
+      }
+      
+      /* PAGESPEED: Critical above-the-fold styles for hero section - FIXED HEIGHT prevents CLS */
+      #hero, .hero-section, section[id="hero"] {
+        min-height: clamp(600px, 100vh, 1200px);
+        background: #111827;
+        position: relative;
+        contain: layout paint;
+        overflow: hidden;
+      }
+      
+      /* Navigation bar critical styles - target ONLY header nav, not mobile bottom nav */
+      header nav,
+      nav[data-testid="main-nav"] {
+        position: fixed;
+        top: 0;
+        width: 100%;
+        z-index: 50;
+        background: rgba(255, 255, 255, 0.95);
+        -webkit-backdrop-filter: blur(10px);
+                backdrop-filter: blur(10px);
+      }
+      
+      /* Ensure mobile bottom nav stays at bottom */
+      nav[data-testid="mobile-bottom-nav"] {
+        position: fixed !important;
+        top: auto !important;
+        bottom: 0 !important;
+      }
+      
+      /* Hero content critical styles to prevent CLS */
+      .hero-content {
+        position: relative;
+        z-index: 10;
+        color: white;
+        text-align: center;
+        padding: 2rem 1rem;
+      }
+      
+      /* SSR content will be hidden by inline script after this */
+      .ssr-content {
+        /* Visible to crawlers until JS loads */
+      }
+    </style>
+    
+    
+  
+  <link rel="canonical" href="https://premierpartycruises.com/" />
+  <style id="critical-css">:root{--primary:hsl(208 100% 50%);--secondary:hsl(51 100% 50%);--background:#fff;--foreground:#000}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:"DM Sans",system-ui,sans-serif;-webkit-font-smoothing:antialiased;background:#fff;color:#000;line-height:1.5}
+h1,h2,h3{font-family:"Bebas Neue",system-ui,sans-serif;font-weight:700;letter-spacing:0.1em}
+h1{font-size:clamp(1.5rem,4vw,3.5rem);line-height:1.2}
+.relative{position:relative}
+.absolute{position:absolute}
+.inset-0{top:0;right:0;bottom:0;left:0}
+.z-0{z-index:0}
+.z-10{z-index:10}
+.w-full{width:100%}
+.h-full{height:100%}
+.min-h-screen{min-height:100vh}
+.object-cover{object-fit:cover}
+.text-white{color:#fff}
+.text-center{text-align:center}
+.mx-auto{margin-left:auto;margin-right:auto}
+.container{width:100%;max-width:1280px;margin:0 auto;padding:0 1rem}
+.flex{display:flex}
+.items-center{align-items:center}
+.justify-center{justify-content:center}
+.overflow-hidden{overflow:hidden}
+.bg-gradient-to-r{background-image:linear-gradient(to right,var(--tw-gradient-stops))}
+@media(min-width:768px){
+  h1{font-size:clamp(2.5rem,5vw,3.5rem)}
+  .md\:text-2xl{font-size:1.5rem}
+  .md\:text-4xl{font-size:2.25rem}
+  .md\:h-24{height:6rem}
+}
+@media(min-width:1024px){
+  .lg\:text-6xl{font-size:3.75rem}
+}</style>
+
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "@id": "https://premierpartycruises.com/#website",
+  "url": "https://premierpartycruises.com/",
+  "name": "Premier Party Cruises",
+  "description": "Austin's premier party boat cruises and private charters on Lake Travis",
+  "publisher": {
+    "@id": "https://premierpartycruises.com/#organization"
+  },
+  "potentialAction": {
+    "@type": "SearchAction",
+    "target": {
+      "@type": "EntryPoint",
+      "urlTemplate": "https://premierpartycruises.com/search?q={search_term_string}"
+    },
+    "query-input": "required name=search_term_string"
+  }
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": [
+    "Organization",
+    "LocalBusiness"
+  ],
+  "@id": "https://premierpartycruises.com/#organization",
+  "name": "Premier Party Cruises",
+  "legalName": "B Hill Entertainment LLC",
+  "url": "https://premierpartycruises.com/",
+  "logo": "https://premierpartycruises.com/media/schema/ppc-logo.png",
+  "image": [
+    "https://premierpartycruises.com/media/schema/hero-boat-1.jpg",
+    "https://premierpartycruises.com/media/schema/hero-boat-2.jpg",
+    "https://premierpartycruises.com/media/schema/disco-dance-floor.jpg",
+    "https://premierpartycruises.com/media/schema/group-swimming-lilypad.jpg"
+  ],
+  "description": "Austin’s original Lake Travis party boat company offering private cruises, the ATX Disco Cruise, and full‑service planning for bachelor/bachelorette, corporate, birthday, and family events.",
+  "foundingDate": "2009",
+  "slogan": "Creating the perfect party cruise experience on Lake Travis",
+  "founder": {
+    "@type": "Person",
+    "name": "Brian Hill",
+    "alumniOf": "University of Texas at Austin",
+    "jobTitle": "Owner & Experience Optimization Engineer"
+  },
+  "sameAs": [
+    "https://www.instagram.com/premierpartycruises",
+    "https://www.tiktok.com/@premierpartycruisesatx",
+    "https://www.facebook.com/premierpartycruises",
+    "https://share.google/oLFqmN5TGvXpnlX6i"
+  ],
+  "address": {
+    "@type": "PostalAddress",
+    "streetAddress": "13993 FM 2769",
+    "addressLocality": "Leander",
+    "addressRegion": "TX",
+    "postalCode": "78641",
+    "addressCountry": "US"
+  },
+  "geo": {
+    "@type": "GeoCoordinates",
+    "latitude": 30.432167,
+    "longitude": -97.881167
+  },
+  "contactPoint": [
+    {
+      "@type": "ContactPoint",
+      "contactType": "customer support",
+      "telephone": "+1-512-488-5892",
+      "email": "clientservices@premierpartycruises.com",
+      "availableLanguage": [
+        "en",
+        "es"
+      ]
+    }
+  ],
+  "openingHoursSpecification": [
+    {
+      "@type": "OpeningHoursSpecification",
+      "dayOfWeek": [
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday"
+      ],
+      "opens": "09:00",
+      "closes": "21:00"
+    }
+  ],
+  "areaServed": [
+    "Austin TX",
+    "Texas",
+    "United States"
+  ],
+  "priceRange": "$",
+  "aggregateRating": {
+    "@type": "AggregateRating",
+    "ratingValue": 4.9,
+    "reviewCount": 500,
+    "bestRating": 5,
+    "worstRating": 1
+  }
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What types of party boat rentals do you offer?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "We offer two main types of party boat experiences: Private Charters (exclusive boat rental for your group of 14-75 guests, starting at $200/hour with 4-hour minimum) and the ATX Disco Cruise (join other groups on our signature party cruise with DJ, photographer, and all amenities included, three time slots available from $85-$105 per person). Perfect for bachelor parties, bachelorette parties, corporate events, birthdays, weddings, and any special celebration."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How much does it cost to rent a party boat on Lake Travis?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Private charters start at $200 per hour with a 4-hour minimum. We have three boats available: Day Tripper (14 people), Meeseeks and The Irony (18-25 people), and Clever Girl (30-50 people with 14 disco balls). ATX Disco Cruise has three time slots: Friday 12-4pm at $95/person, Saturday 11am-3pm at $105/person, and Saturday 3:30-7:30pm at $85/person (prices include DJ, photographer, floats, and all amenities)."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can we bring food and drinks on the boat?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes! All cruises are fully BYOB friendly (21+ with valid ID required). You can bring your own beer, wine, seltzers, and non-alcoholic beverages in cans or plastic containers - no glass allowed for safety. We provide large coolers with ice. You can also bring snacks and meals, or we can coordinate alcohol delivery directly to the boat for your convenience."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Where do you depart from on Lake Travis?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "We depart from Anderson Mill Marina at 13993 FM 2769, Leander, TX 78641. We're the closest marina to downtown Austin, approximately 30 minutes away, making us convenient for all your guests."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What's included with the ATX Disco Cruise?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Every ATX Disco Cruise includes a professional DJ playing all day, professional photographer with photo delivery, giant unicorn floats, multiple lily pad floats, disco dance floor, party supplies and mixers, ice water stations, clean restroom facilities, and an unforgettable party atmosphere with multiple bachelor and bachelorette groups celebrating together."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What makes Premier Party Cruises different from other Lake Travis boat rentals?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "With 14+ years of experience and over 125,000 satisfied customers, we are Austin's longest-running and most trusted party cruise company. We maintain a perfect safety record with Coast Guard certified captains, operate the newest fleet in Austin, and provide full-service experiences with professional crew and premium sound systems. We're the only company offering the signature ATX Disco Cruise party experience."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can you accommodate corporate events and team building activities?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Absolutely! We specialize in corporate events and team building on Lake Travis. Our fleet accommodates groups from 14 to 75+ guests with professional service and premium amenities. Customizable packages include catering coordination, AV equipment, and dedicated event planning to ensure your corporate event is a complete success."
+      }
+    }
+  ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  "name": "Premier Party Cruises - Lake Travis Party Boats",
+  "description": "Experience Austin's premier party boat cruises on Lake Travis. Watch our walkthrough of the Clever Girl, our flagship 75-passenger disco party boat with 14 disco balls, premium sound system, and spectacular lake views. Perfect for bachelor parties, bachelorette parties, corporate events, and special celebrations.",
+  "thumbnailUrl": "https://premierpartycruises.com/gallery-optimized/_capitalcityshots-46.webp",
+  "uploadDate": "2024-01-15",
+  "duration": "PT2M30S",
+  "contentUrl": "https://premierpartycruises.com/attached_assets/Boat_Video_Walkthrough_Generated_1761209219959.mp4",
+  "embedUrl": "https://premierpartycruises.com/",
+  "publisher": {
+    "@type": "Organization",
+    "name": "Premier Party Cruises",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://premierpartycruises.com/gallery-optimized/_capitalcityshots-6.webp"
+    }
+  },
+  "potentialAction": {
+    "@type": "WatchAction",
+    "target": "https://premierpartycruises.com/"
+  }
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Service",
+  "@id": "https://premierpartycruises.com/#private-charters",
+  "name": "Private Party Boat Charters on Lake Travis",
+  "serviceType": "Private Boat Charter",
+  "provider": {
+    "@id": "https://premierpartycruises.com/#organization"
+  },
+  "areaServed": [
+    "Austin TX",
+    "Lake Travis",
+    "Texas",
+    "United States"
+  ],
+  "description": "Choose from our fleet of premium party boats for your exclusive celebration: Day Tripper (14 people), Meeseeks (18-25 people), or flagship Clever Girl (30-50 people) with giant Texas flag and 14 disco balls. Every private charter includes licensed captains, premium Bluetooth sound systems, large coolers with ice, and all the amenities for an unforgettable celebration. Perfect for weddings, corporate events, birthdays, and any special celebration. Pricing from $200-$350 per hour with a 4-hour minimum. Fully customizable packages to match your event needs.",
+  "offers": {
+    "@type": "AggregateOffer",
+    "priceCurrency": "USD",
+    "lowPrice": "200",
+    "highPrice": "350",
+    "priceValidUntil": "2099-12-31",
+    "availability": "https://schema.org/InStock",
+    "url": "https://premierpartycruises.com/chat"
+  },
+  "hasOfferCatalog": {
+    "@type": "OfferCatalog",
+    "name": "Party Boat Fleet",
+    "itemListElement": [
+      {
+        "@type": "OfferCatalog",
+        "name": "Day Tripper - 14 Person Boat",
+        "itemListElement": [
+          {
+            "@type": "Offer",
+            "itemOffered": {
+              "@id": "https://premierpartycruises.com/#service-daytripper"
+            }
+          }
+        ]
+      },
+      {
+        "@type": "OfferCatalog",
+        "name": "Meeseeks - 25 Person Boat",
+        "itemListElement": [
+          {
+            "@type": "Offer",
+            "itemOffered": {
+              "@id": "https://premierpartycruises.com/#service-meeseeks"
+            }
+          }
+        ]
+      },
+      {
+        "@type": "OfferCatalog",
+        "name": "Clever Girl - 50 Person Flagship",
+        "itemListElement": [
+          {
+            "@type": "Offer",
+            "itemOffered": {
+              "@id": "https://premierpartycruises.com/#service-clevergirl"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "additionalProperty": [
+    {
+      "@type": "PropertyValue",
+      "name": "Minimum Duration",
+      "value": "4 hours"
+    },
+    {
+      "@type": "PropertyValue",
+      "name": "BYOB Friendly",
+      "value": "Yes (21+ with ID)"
+    },
+    {
+      "@type": "PropertyValue",
+      "name": "Licensed Captains",
+      "value": "Coast Guard Certified"
+    }
+  ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Service",
+  "@id": "https://premierpartycruises.com/#atx-disco-cruise",
+  "name": "ATX Disco Cruise - Lake Travis Party Boat Experience",
+  "serviceType": "Party Cruise Event",
+  "provider": {
+    "@id": "https://premierpartycruises.com/#organization"
+  },
+  "areaServed": [
+    "Austin TX",
+    "Lake Travis",
+    "Texas",
+    "United States"
+  ],
+  "description": "Join the BEST party on Lake Travis! Our signature ATX Disco Cruise features a professional DJ, photographer, disco dance floor, giant floats, and an incredible party atmosphere. Three time slots available with different pricing options to fit your schedule. Every disco cruise includes professional entertainment, photo delivery, party supplies, and an unforgettable experience with multiple bachelor and bachelorette groups celebrating together.",
+  "offers": [
+    {
+      "@type": "Offer",
+      "name": "Friday 12-4pm Time Slot",
+      "price": "95.00",
+      "priceCurrency": "USD",
+      "priceValidUntil": "2099-12-31",
+      "availability": "https://schema.org/InStock",
+      "url": "https://premierpartycruises.com/atx-disco-cruise",
+      "description": "$95 per person ($124.88 with tax and gratuity). Includes all cruise amenities, DJ, photographer, and party atmosphere"
+    },
+    {
+      "@type": "Offer",
+      "name": "Saturday 11am-3pm Time Slot - BEST",
+      "price": "105.00",
+      "priceCurrency": "USD",
+      "priceValidUntil": "2099-12-31",
+      "availability": "https://schema.org/InStock",
+      "url": "https://premierpartycruises.com/atx-disco-cruise",
+      "description": "$105 per person ($137.81 with tax and gratuity). Most popular time slot with all amenities"
+    },
+    {
+      "@type": "Offer",
+      "name": "Saturday 3:30-7:30pm Time Slot - FUN!",
+      "price": "85.00",
+      "priceCurrency": "USD",
+      "priceValidUntil": "2099-12-31",
+      "availability": "https://schema.org/InStock",
+      "url": "https://premierpartycruises.com/atx-disco-cruise",
+      "description": "$85 per person ($111.56 with tax and gratuity). Evening party atmosphere with all amenities"
+    }
+  ],
+  "additionalProperty": [
+    {
+      "@type": "PropertyValue",
+      "name": "Professional DJ",
+      "value": "Included - Playing all day"
+    },
+    {
+      "@type": "PropertyValue",
+      "name": "Professional Photographer",
+      "value": "Included - Photo delivery provided"
+    },
+    {
+      "@type": "PropertyValue",
+      "name": "Party Floats",
+      "value": "Giant unicorn floats and lily pads included"
+    }
+  ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Service",
+  "@id": "https://premierpartycruises.com/#service-daytripper",
+  "name": "Day Tripper - 14 Person Party Boat Charter",
+  "serviceType": "Boat Charter Service",
+  "description": "Intimate 14-person party boat perfect for small celebrations and private groups on Lake Travis. Features professional captain, premium sound system, coolers with ice, and comfortable seating for up to 14 passengers.",
+  "provider": {
+    "@id": "https://premierpartycruises.com/#organization"
+  },
+  "areaServed": {
+    "@type": "GeoCircle",
+    "@id": "https://premierpartycruises.com/#service-area",
+    "geoMidpoint": {
+      "@type": "GeoCoordinates",
+      "latitude": 30.432167,
+      "longitude": -97.881167
+    },
+    "geoRadius": "50 miles",
+    "address": {
+      "@type": "PostalAddress",
+      "addressLocality": "Austin",
+      "addressRegion": "TX",
+      "addressCountry": "US"
+    }
+  },
+  "termsOfService": "https://premierpartycruises.com/terms",
+  "category": "Party Boat Charter",
+  "availableChannel": {
+    "@type": "ServiceChannel",
+    "serviceUrl": "https://premierpartycruises.com/chat",
+    "servicePhone": "+1-512-488-5892"
+  },
+  "additionalProperty": [
+    {
+      "@type": "PropertyValue",
+      "name": "Capacity",
+      "value": "14 passengers"
+    },
+    {
+      "@type": "PropertyValue",
+      "name": "Minimum Duration",
+      "value": "4 hours"
+    },
+    {
+      "@type": "PropertyValue",
+      "name": "Starting Price",
+      "value": "$200 per hour"
+    }
+  ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Service",
+  "@id": "https://premierpartycruises.com/#service-meeseeks",
+  "name": "Meeseeks - 25 Person Party Boat Charter",
+  "serviceType": "Boat Charter Service",
+  "description": "Mid-sized 25-person party boat ideal for medium celebrations and group outings on Lake Travis. Features professional captain, premium sound system, coolers with ice, and spacious deck for up to 25 passengers.",
+  "provider": {
+    "@id": "https://premierpartycruises.com/#organization"
+  },
+  "areaServed": {
+    "@type": "GeoCircle",
+    "@id": "https://premierpartycruises.com/#service-area",
+    "geoMidpoint": {
+      "@type": "GeoCoordinates",
+      "latitude": 30.432167,
+      "longitude": -97.881167
+    },
+    "geoRadius": "50 miles",
+    "address": {
+      "@type": "PostalAddress",
+      "addressLocality": "Austin",
+      "addressRegion": "TX",
+      "addressCountry": "US"
+    }
+  },
+  "termsOfService": "https://premierpartycruises.com/terms",
+  "category": "Party Boat Charter",
+  "availableChannel": {
+    "@type": "ServiceChannel",
+    "serviceUrl": "https://premierpartycruises.com/chat",
+    "servicePhone": "+1-512-488-5892"
+  },
+  "additionalProperty": [
+    {
+      "@type": "PropertyValue",
+      "name": "Capacity",
+      "value": "25 passengers"
+    },
+    {
+      "@type": "PropertyValue",
+      "name": "Minimum Duration",
+      "value": "4 hours"
+    },
+    {
+      "@type": "PropertyValue",
+      "name": "Starting Price",
+      "value": "$250 per hour"
+    }
+  ]
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Service",
+  "@id": "https://premierpartycruises.com/#service-clevergirl",
+  "name": "Clever Girl - 50 Person Party Boat Charter",
+  "serviceType": "Boat Charter Service",
+  "description": "Premier 50-person party boat perfect for large celebrations and corporate events on Lake Travis. Features professional captain, premium sound system, multiple deck levels, coolers with ice, and spacious accommodations for up to 50 passengers.",
+  "provider": {
+    "@id": "https://premierpartycruises.com/#organization"
+  },
+  "areaServed": {
+    "@type": "GeoCircle",
+    "@id": "https://premierpartycruises.com/#service-area",
+    "geoMidpoint": {
+      "@type": "GeoCoordinates",
+      "latitude": 30.432167,
+      "longitude": -97.881167
+    },
+    "geoRadius": "50 miles",
+    "address": {
+      "@type": "PostalAddress",
+      "addressLocality": "Austin",
+      "addressRegion": "TX",
+      "addressCountry": "US"
+    }
+  },
+  "termsOfService": "https://premierpartycruises.com/terms",
+  "category": "Party Boat Charter",
+  "availableChannel": {
+    "@type": "ServiceChannel",
+    "serviceUrl": "https://premierpartycruises.com/chat",
+    "servicePhone": "+1-512-488-5892"
+  },
+  "additionalProperty": [
+    {
+      "@type": "PropertyValue",
+      "name": "Capacity",
+      "value": "50 passengers"
+    },
+    {
+      "@type": "PropertyValue",
+      "name": "Minimum Duration",
+      "value": "4 hours"
+    },
+    {
+      "@type": "PropertyValue",
+      "name": "Starting Price",
+      "value": "$350 per hour"
+    }
+  ]
+}
+  </script>
+    <meta name="author" content="Premier Party Cruises" />
+    <meta property="article:author" content="Premier Party Cruises" />
+    <meta property="article:modified_time" content="2026-06-10T04:15:09.416Z" />
+    <meta name="last-modified" content="2026-06-10" />
+      
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  <link rel="alternate" type="application/rss+xml" title="Lake Travis Party Boat Blog" href="/rss.xml" />
+      
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;600;700&family=Bebas+Neue&family=Candal&family=Unbounded:wght@400;500;600;700;800&display=swap" media="print" onload="this.media='all'">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;600;700&family=Bebas+Neue&family=Candal&family=Unbounded:wght@400;500;600;700;800&display=swap">
+    <link rel="modulepreload" crossorigin href="/assets/pdf-vendor-u7RKwMPe.js">
+    <link rel="modulepreload" crossorigin href="/assets/react-vendor-a70FWiba.js">
+    <link rel="modulepreload" crossorigin href="/assets/query-vendor-DRq91Ri2.js">
+    <link rel="modulepreload" crossorigin href="/assets/icons-vendor-D7ZOfHka.js">
+    <link rel="modulepreload" crossorigin href="/assets/radix-vendor-UvTqZ5Sk.js">
+    <link rel="modulepreload" crossorigin href="/assets/utils-vendor-CeJt2ZsY.js">
+    <link rel="stylesheet" crossorigin href="/assets/index-CAn9k3cP.css">
+    <script type="module" crossorigin src="/assets/index-sIVm4zWm.js"></script>
+    
+  <script type="application/ld+json" data-breadcrumb="auto">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Premier Party Cruises","item":"https://premierpartycruises.com/"}]}</script>
+  
+    <script type="application/ld+json" data-event="halloween">{"@context":"https://schema.org","@type":"Event","name":"Halloween Haunted Party Cruise","description":"Halloween-themed haunted party cruise on Lake Travis — costume contest, themed lighting, BYOB. 21+ public sailings plus private charters.","image":["https://premierpartycruises.com/attached_assets/hero-fallback.jpg"],"startDate":"2026-10-25","endDate":"2026-10-31","eventStatus":"https://schema.org/EventScheduled","eventAttendanceMode":"https://schema.org/OfflineEventAttendanceMode","location":{"@type":"Place","name":"Anderson Mill Marina","address":{"@type":"PostalAddress","streetAddress":"13993 FM 2769","addressLocality":"Leander","addressRegion":"TX","postalCode":"78641","addressCountry":"US"}},"organizer":{"@type":"Organization","name":"Premier Party Cruises"},"performer":{"@type":"Organization","name":"Premier Party Cruises"},"offers":{"@type":"AggregateOffer","priceCurrency":"USD","lowPrice":"85","highPrice":"250","availability":"https://schema.org/InStock","url":"https://premierpartycruises.com/","validFrom":"2026-01-01"}}</script>
+    <script type="application/ld+json" data-event="nye">{"@context":"https://schema.org","@type":"Event","name":"New Year's Eve Cruise","description":"Ring in the new year on Lake Travis with Premier Party Cruises — countdown, champagne toast, and skyline views from Anderson Mill Marina.","image":["https://premierpartycruises.com/attached_assets/hero-fallback.jpg"],"startDate":"2026-12-31","endDate":"2026-12-31","eventStatus":"https://schema.org/EventScheduled","eventAttendanceMode":"https://schema.org/OfflineEventAttendanceMode","location":{"@type":"Place","name":"Anderson Mill Marina","address":{"@type":"PostalAddress","streetAddress":"13993 FM 2769","addressLocality":"Leander","addressRegion":"TX","postalCode":"78641","addressCountry":"US"}},"organizer":{"@type":"Organization","name":"Premier Party Cruises"},"performer":{"@type":"Organization","name":"Premier Party Cruises"},"offers":{"@type":"AggregateOffer","priceCurrency":"USD","lowPrice":"85","highPrice":"250","availability":"https://schema.org/InStock","url":"https://premierpartycruises.com/","validFrom":"2026-01-01"}}</script>
+    <script type="application/ld+json" data-event="july4">{"@context":"https://schema.org","@type":"Event","name":"July 4th Fireworks Cruise","description":"Watch Lake Travis Independence Day fireworks from the water aboard a Premier party boat — captain anchors at the prime viewing cove.","image":["https://premierpartycruises.com/attached_assets/hero-fallback.jpg"],"startDate":"2026-07-04","endDate":"2026-07-04","eventStatus":"https://schema.org/EventScheduled","eventAttendanceMode":"https://schema.org/OfflineEventAttendanceMode","location":{"@type":"Place","name":"Anderson Mill Marina","address":{"@type":"PostalAddress","streetAddress":"13993 FM 2769","addressLocality":"Leander","addressRegion":"TX","postalCode":"78641","addressCountry":"US"}},"organizer":{"@type":"Organization","name":"Premier Party Cruises"},"performer":{"@type":"Organization","name":"Premier Party Cruises"},"offers":{"@type":"AggregateOffer","priceCurrency":"USD","lowPrice":"85","highPrice":"250","availability":"https://schema.org/InStock","url":"https://premierpartycruises.com/","validFrom":"2026-01-01"}}</script>
+    <script type="application/ld+json" data-event="spring-break">{"@context":"https://schema.org","@type":"Event","name":"Spring Break Party Cruise","description":"Spring Break party cruises on Lake Travis — daily public 21+ sailings on Clever Girl and private charters across the fleet.","image":["https://premierpartycruises.com/attached_assets/hero-fallback.jpg"],"startDate":"2027-03-13","endDate":"2027-03-22","eventStatus":"https://schema.org/EventScheduled","eventAttendanceMode":"https://schema.org/OfflineEventAttendanceMode","location":{"@type":"Place","name":"Anderson Mill Marina","address":{"@type":"PostalAddress","streetAddress":"13993 FM 2769","addressLocality":"Leander","addressRegion":"TX","postalCode":"78641","addressCountry":"US"}},"organizer":{"@type":"Organization","name":"Premier Party Cruises"},"performer":{"@type":"Organization","name":"Premier Party Cruises"},"offers":{"@type":"AggregateOffer","priceCurrency":"USD","lowPrice":"85","highPrice":"250","availability":"https://schema.org/InStock","url":"https://premierpartycruises.com/","validFrom":"2026-01-01"}}</script>
+    <script type="application/ld+json" data-press="auto">{"@context":"https://schema.org","@type":"Organization","@id":"https://premierpartycruises.com/#organization","subjectOf":[{"@type":"CreativeWork","name":"KXAN Austin Coverage","url":"https://www.kxan.com/"},{"@type":"CreativeWork","name":"Austin360 Lake Travis Feature","url":"https://www.austin360.com/"},{"@type":"CreativeWork","name":"Texas Highways Magazine","url":"https://texashighways.com/"}]}</script>
+    <script type="application/ld+json" data-video="auto">{"@context":"https://schema.org","@type":"VideoObject","name":"Premier Party Cruises — Lake Travis Walkthrough","description":"On-water walkthrough of Premier Party Cruises' Lake Travis fleet — Day Tripper (14), Meeseeks (25), The Irony (25-30), Clever Girl (75-guest flagship). Anderson Mill Marina, 25 minutes from downtown Austin.","thumbnailUrl":"https://premierpartycruises.com/attached_assets/hero-fallback.jpg","uploadDate":"2025-10-23","contentUrl":"https://premierpartycruises.com/attached_assets/Boat_Video_Walkthrough_Generated_1761209219959.mp4","embedUrl":"https://premierpartycruises.com/","duration":"PT45S","publisher":{"@id":"https://premierpartycruises.com/#organization"}}</script>
+    <script type="application/ld+json" data-imageobject="hero">{"@context":"https://schema.org","@type":"ImageObject","name":"Premier Party Cruises — Lake Travis Hero Image","contentUrl":"https://premierpartycruises.com/attached_assets/hero-fallback.jpg","thumbnailUrl":"https://premierpartycruises.com/attached_assets/hero-fallback.jpg","caption":"Lake Travis party boat at sunset — Premier Party Cruises Anderson Mill Marina","creditText":"Premier Party Cruises","copyrightNotice":"Premier Party Cruises (B Hill Entertainment, LLC)","license":"https://premierpartycruises.com/"}</script>
+  </head>
+  <body>
+    <div id="root"></div><div class="ssr-content">
+  <nav aria-label="Main navigation" style="background: #f8fafc; padding: 1rem 2rem; border-bottom: 1px solid #e2e8f0;">
+    <div style="max-width: 1200px; margin: 0 auto; display: flex; flex-wrap: wrap; gap: 1rem; align-items: center; justify-content: space-between;">
+      <a href="/" style="font-weight: 700; font-size: 1.25rem; color: #1e40af; text-decoration: none;">Premier Party Cruises</a>
+      <ul style="display: flex; flex-wrap: wrap; gap: 1.5rem; list-style: none; margin: 0; padding: 0;">
+        <li><a href="/" style="color: #374151; text-decoration: none;">Home</a></li>
+        <li><a href="/atx-disco-cruise" style="color: #374151; text-decoration: none;">ATX Disco Cruise</a></li>
+        <li><a href="/bachelor-party-austin" style="color: #374151; text-decoration: none;">Bachelor Party</a></li>
+        <li><a href="/bachelorette-party-austin" style="color: #374151; text-decoration: none;">Bachelorette Party</a></li>
+        <li><a href="/private-cruises" style="color: #374151; text-decoration: none;">Private Cruises</a></li>
+        <li><a href="/gallery" style="color: #374151; text-decoration: none;">Gallery</a></li>
+        <li><a href="/testimonials-faq" style="color: #374151; text-decoration: none;">Reviews & FAQ</a></li>
+        <li><a href="/contact" style="color: #374151; text-decoration: none;">Contact</a></li>
+      </ul>
+    </div>
+  </nav>
+    <div class="ssr-content" style="padding: 2rem; max-width: 1200px; margin: 0 auto; font-family: system-ui, sans-serif;">
+      
+      <h1 style="font-size: 2.5rem; font-weight: bold; margin-bottom: 1.5rem; color: #000; line-height: 1.2;">Austin Party Boat Rentals on Lake Travis — Private Charters &amp; the ATX Disco Cruise</h1>
+      <p style="font-size: 1.125rem; line-height: 1.75; color: #374151; margin-bottom: 2rem;">Experience the ultimate party cruise on Lake Travis with Austin's premier boat rental company. Choose from <a href="/private-cruises" style="color: #1e40af; text-decoration: underline;">Private Boat Rentals</a>, the <a href="/atx-disco-cruise" style="color: #1e40af; text-decoration: underline;">ATX Disco Cruise</a>, <a href="/bachelor-party-austin" style="color: #1e40af; text-decoration: underline;">Bachelor Party Cruises</a>, <a href="/bachelorette-party-austin" style="color: #1e40af; text-decoration: underline;">Bachelorette Party Cruises</a>, <a href="/corporate-events" style="color: #1e40af; text-decoration: underline;">Corporate Events</a>, and more. Professional crew, premium amenities, and unforgettable celebrations await.</p>
+  
+      <section style="margin-bottom: 2.5rem;">
+        <h2 style="font-size: 2rem; font-weight: 600; margin-bottom: 1rem; color: #000;">Private Charters - Your Exclusive Boat Experience</h2>
+    <p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">Choose from our fleet of premium party boats: "Day Tripper" (1-14 people), "Meeseeks / The Irony" (15-30 people), or flagship "Clever Girl" (31-75 people) with giant Texas flag and 14 disco balls. Every <a href="/private-cruises" style="color: #1e40af; text-decoration: underline;">Private Boat Rentals</a> includes licensed captains, premium Bluetooth sound systems, large coolers with ice, and all the amenities for an unforgettable celebration.</p>
+<p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">Perfect for <a href="/wedding-parties" style="color: #1e40af; text-decoration: underline;">Wedding Party Boats</a>, <a href="/corporate-events" style="color: #1e40af; text-decoration: underline;">Corporate Events</a>, <a href="/birthday-parties" style="color: #1e40af; text-decoration: underline;">Birthday Parties</a>, and any special celebration. Starting at $200 per hour with a 4-hour minimum. Fully customizable packages to match your event needs.</p>
+<h3 style="font-size: 1.25rem; font-weight: 600; margin-top: 1.5rem; margin-bottom: 0.75rem; color: #111827;">Private Charter Features</h3>
+<ul style="list-style-type: disc; margin-left: 1.5rem; margin-bottom: 1rem;">
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Licensed captains & professional crew</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Premium Bluetooth sound systems</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Large coolers with ice provided</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Lily pads & floaties available</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">BYOB friendly (21+ with ID)</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Customizable routes on Lake Travis</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Perfect for groups of 14-75 guests</li>
+</ul>
+</section>
+
+      <section style="margin-bottom: 2.5rem;">
+        <h2 style="font-size: 2rem; font-weight: 600; margin-bottom: 1rem; color: #000;">ATX Disco Cruise - The Ultimate Party Experience</h2>
+    <p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">Join the BEST party on Lake Travis! Our signature <a href="/atx-disco-cruise" style="color: #1e40af; text-decoration: underline;">ATX Disco Cruise</a> features a professional DJ, photographer, disco dance floor, giant floats, and an incredible party atmosphere. Choose from three time slots: Friday 12-4pm ($95), Saturday 11am-3pm ($105 - most popular!), or Saturday 3:30-7:30pm ($85). Prices include tax and gratuity.</p>
+<p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">Every disco cruise includes professional entertainment, photo delivery, party supplies, and an unforgettable experience with multiple <a href="/bachelor-party-austin" style="color: #1e40af; text-decoration: underline;">Bachelor Party Cruises</a> and <a href="/bachelorette-party-austin" style="color: #1e40af; text-decoration: underline;">Bachelorette Party Cruises</a> groups celebrating together.</p>
+<h3 style="font-size: 1.25rem; font-weight: 600; margin-top: 1.5rem; margin-bottom: 0.75rem; color: #111827;">Disco Cruise Includes</h3>
+<ul style="list-style-type: disc; margin-left: 1.5rem; margin-bottom: 1rem;">
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Professional DJ playing all day</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Professional photographer</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Giant unicorn floats</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Multiple lily pad floats</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Disco dance floor</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Party supplies & mixers</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Ice water stations</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Clean restroom facilities</li>
+</ul>
+</section>
+
+      <section style="margin-bottom: 2.5rem;">
+        <h2 style="font-size: 2rem; font-weight: 600; margin-bottom: 1rem; color: #000;">Bachelor & Bachelorette Parties</h2>
+    <p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">Plan the perfect <a href="/bachelor-party-austin" style="color: #1e40af; text-decoration: underline;">Bachelor Party Cruises</a> or <a href="/bachelorette-party-austin" style="color: #1e40af; text-decoration: underline;">Bachelorette Party Cruises</a> on Lake Travis! Choose between our affordable <a href="/atx-disco-cruise" style="color: #1e40af; text-decoration: underline;">ATX Disco Cruise</a> packages or rent a <a href="/private-cruises" style="color: #1e40af; text-decoration: underline;">Private Boat Rentals</a> exclusively for your group. </p>
+<p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">We specialize in creating unforgettable <a href="/bachelor-party-austin" style="color: #1e40af; text-decoration: underline;">Bachelor Party Cruises</a> and <a href="/bachelorette-party-austin" style="color: #1e40af; text-decoration: underline;">Bachelorette Party Cruises</a> experiences with professional entertainment, premium amenities, and dedicated service. 150,000+ happy customers have celebrated with us! Learn more about <a href="/combined-bachelor-bachelorette-austin" style="color: #1e40af; text-decoration: underline;">Combined Bachelor & Bachelorette Parties</a> options too.</p>
+<h3 style="font-size: 1.25rem; font-weight: 600; margin-top: 1.5rem; margin-bottom: 0.75rem; color: #111827;">Party Highlights</h3>
+<ul style="list-style-type: disc; margin-left: 1.5rem; margin-bottom: 1rem;">
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">BYOB with coolers and ice</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Alcohol delivery to the boat</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Transportation discounts</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Reserved spots for your group</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Special celebration items</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Complimentary delivery services</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Professional photos included</li>
+</ul>
+</section>
+
+      <section style="margin-bottom: 2.5rem;">
+        <h2 style="font-size: 2rem; font-weight: 600; margin-bottom: 1rem; color: #000;">Corporate Events & Team Building</h2>
+    <p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">Elevate your <a href="/corporate-events" style="color: #1e40af; text-decoration: underline;">Corporate Events</a> with a Lake Travis cruise! Perfect for <a href="/team-building" style="color: #1e40af; text-decoration: underline;">Team Building Events</a>, <a href="/client-entertainment" style="color: #1e40af; text-decoration: underline;">Client Entertainment</a>, <a href="/company-milestone" style="color: #1e40af; text-decoration: underline;">Company Milestones</a>, and employee appreciation. Our fleet accommodates groups from 14 to 75+ guests with professional service and premium amenities.</p>
+<p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">Customizable packages include catering coordination, AV equipment, and dedicated event planning to ensure your <a href="/corporate-events" style="color: #1e40af; text-decoration: underline;">Corporate Events</a> is a complete success.</p>
+</section>
+
+      <section style="margin-bottom: 2.5rem;">
+        <h2 style="font-size: 2rem; font-weight: 600; margin-bottom: 1rem; color: #000;">Why Choose Premier Party Cruises</h2>
+    <p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">With 14+ years of experience and 150,000+ satisfied customers, we are Austin's longest-running and most trusted party cruise company. Our perfect safety record, Coast Guard certified captains, and newest fleet ensure an exceptional experience every time.</p>
+<h3 style="font-size: 1.25rem; font-weight: 600; margin-top: 1.5rem; margin-bottom: 0.75rem; color: #111827;">Our Advantages</h3>
+<ul style="list-style-type: disc; margin-left: 1.5rem; margin-bottom: 1rem;">
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">14+ years of Lake Travis expertise</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Hundreds of 5-star reviews</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Perfect safety record maintained</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Newest fleet in Austin</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Coast Guard certified captains</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Full-service experience included</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Custom packages for any event</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Professional crew & premium sound</li>
+</ul>
+</section>
+
+      <section style="margin-bottom: 2.5rem;">
+        <h2 style="font-size: 2rem; font-weight: 600; margin-bottom: 1rem; color: #000;">Frequently Asked Questions</h2>
+    <p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">What types of party boat rentals do you offer? We offer two main types of party boat experiences: Private Charters (exclusive boat rental for your group of 1-75 guests, starting at $200/hour with 4-hour minimum) and the ATX Disco Cruise (join other groups on our signature party cruise with DJ, photographer, and all amenities included). Disco cruises run Fridays 12-4pm ($95/person) and Saturdays 11am-3pm ($105/person) or 3:30-7:30pm ($85/person), with all prices including tax and gratuity. Perfect for bachelor parties, bachelorette parties, corporate events, birthdays, weddings, and any special celebration.</p>
+<p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">How much does it cost to rent a party boat on Lake Travis? Private charters start at $200 per hour with a 4-hour minimum. We have three boats available: Day Tripper (1-14 people, $200-350/hr), Meeseeks / The Irony (15-30 people, $225-425/hr), and Clever Girl (31-75 people with 14 disco balls, $250-500/hr). Crew fees are included in these price ranges. ATX Disco Cruise time slots are Friday 12-4pm ($95/person), Saturday 11am-3pm ($105/person), or Saturday 3:30-7:30pm ($85/person), with all prices including tax and gratuity, plus professional DJ, photographer, floats, and all amenities.</p>
+<p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">Can we bring food and drinks on the boat? Yes! All cruises are fully BYOB friendly (21+ with valid ID required). You can bring your own beer, wine, seltzers, and non-alcoholic beverages in cans or plastic containers — no glass beer bottles. Wine, champagne, and spirits in a cooler are fine. We provide large coolers with ice. You can also bring snacks and meals, or we can coordinate alcohol delivery directly to the boat for your convenience.</p>
+<p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">When does the ATX Disco Cruise run? The disco cruise operates Fridays 12-4pm and Saturdays with two time slots: 11am-3pm (most popular!) or 3:30-7:30pm. Pricing varies by time slot, with all prices including tax and gratuity for a complete, transparent experience.</p>
+<p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">Where do you depart from on Lake Travis? We depart from Anderson Mill Marina at 13993 FM 2769, Leander, TX 78641. We're the closest marina to downtown Austin, approximately 30 minutes away, making us convenient for all your guests.</p>
+<p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">What's included with the ATX Disco Cruise? Every ATX Disco Cruise includes a professional DJ playing all day, professional photographer with photo delivery, giant unicorn floats, multiple lily pad floats, disco dance floor, party supplies and mixers, ice water stations, clean restroom facilities, and an unforgettable party atmosphere with multiple bachelor and bachelorette groups celebrating together.</p>
+<p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">What makes Premier Party Cruises different from other Lake Travis boat rentals? With 14+ years of experience and 150,000+ satisfied customers, we are Austin's longest-running and most trusted party cruise company. We maintain a perfect safety record with Coast Guard certified captains, operate the newest fleet in Austin, and provide full-service experiences with professional crew and premium sound systems. We're the only company offering the signature ATX Disco Cruise party experience.</p>
+<p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">Can you accommodate corporate events and team building activities? Absolutely! We specialize in corporate events and team building on Lake Travis. Our fleet accommodates groups from 14 to 75+ guests with professional service and premium amenities. Customizable packages include catering coordination, AV equipment, and dedicated event planning to ensure your corporate event is a complete success.</p>
+</section>
+
+      <section style="margin-bottom: 2.5rem;">
+        <h2 style="font-size: 2rem; font-weight: 600; margin-bottom: 1rem; color: #000;">About Premier Party Cruises — Austin's Original Lake Travis Party Boat Company</h2>
+    <p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">Premier Party Cruises has been the leading authority on party boat rentals on Lake Travis since 2009 — over 15 years in operation and more than 150,000 guests served. We operate out of Anderson Mill Marina at 13993 FM 2769, Leander, TX 78641, the closest marina to downtown Austin at approximately 30 minutes away. Our entire fleet is Coast Guard certified, our captains hold active USCG licenses, and we maintain a perfect safety record across every cruise we have ever run.</p>
+<p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">We run two fundamentally different cruise types: the <a href="/atx-disco-cruise" style="color: #1e40af; text-decoration: underline;">ATX Disco Cruise</a> — America's only multi-group all-inclusive bachelor and bachelorette party cruise — and <a href="/private-cruises" style="color: #1e40af; text-decoration: underline;">Private Boat Rentals</a>, where your group has the entire vessel exclusively. Both depart from Anderson Mill Marina and explore the Texas Hill Country scenery of Lake Travis.</p>
+</section>
+
+      <section style="margin-bottom: 2.5rem;">
+        <h2 style="font-size: 2rem; font-weight: 600; margin-bottom: 1rem; color: #000;">Lake Travis: The Best Party Lake in Texas</h2>
+    <p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">Lake Travis stretches 65 miles through the Texas Hill Country northwest of Austin, offering stunning limestone cliff scenery, clear water, and over 270 days of sunshine per year. The prime season runs April through October, when water temperatures are ideal for swimming and floating. Our boats anchor near the most scenic areas of the lake for 1.5 to 2 hours of swimming and float time during a standard 4-hour cruise.</p>
+<p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">Anderson Mill Marina's location at the upper portion of Lake Travis means calmer water, easier boarding, and direct access to the most picturesque coves. Parking is free for all guests. The Hill Country scenery visible from the water — cedar-covered ridges and dramatic limestone cliffs rising directly from the waterline — is unlike anything else in Central Texas.</p>
+<h3 style="font-size: 1.25rem; font-weight: 600; margin-top: 1.5rem; margin-bottom: 0.75rem; color: #111827;">Why Lake Travis is the Right Venue</h3>
+<ul style="list-style-type: disc; margin-left: 1.5rem; margin-bottom: 1rem;">
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Clear, clean water — comfortable for swimming all summer</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">65+ miles of shoreline with Texas Hill Country cliffs as backdrop</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Calm, protected coves with minimal wave action</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Consistent warm weather April through October</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">30 minutes from downtown Austin via RM-2222 or 183A Toll</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Free, ample parking at Anderson Mill Marina</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">LCRA-managed and maintained — enforced safety standards</li>
+</ul>
+</section>
+
+      <section style="margin-bottom: 2.5rem;">
+        <h2 style="font-size: 2rem; font-weight: 600; margin-bottom: 1rem; color: #000;">ATX Disco Cruise vs. Private Charter: How to Choose the Right Experience</h2>
+    <p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">The <a href="/atx-disco-cruise" style="color: #1e40af; text-decoration: underline;">ATX Disco Cruise</a> is the right choice when your group is 8–30 people, you want maximum party energy, you're celebrating a <a href="/bachelor-party-austin" style="color: #1e40af; text-decoration: underline;">Bachelor Party Cruises</a> or <a href="/bachelorette-party-austin" style="color: #1e40af; text-decoration: underline;">Bachelorette Party Cruises</a>, and you want everything handled for you. You share the boat with 3–4 other groups in the same celebration mode. The DJ, photographer, floats, and supplies are all included in a per-person ticket of $85–$105 (all-in, including tax and gratuity).</p>
+<p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">A <a href="/private-cruises" style="color: #1e40af; text-decoration: underline;">Private Boat Rentals</a> is the right choice when your group wants complete privacy, you have a non-bach occasion like a <a href="/corporate-events" style="color: #1e40af; text-decoration: underline;">Corporate Events</a>, <a href="/wedding-parties" style="color: #1e40af; text-decoration: underline;">Wedding Party Boats</a>, <a href="/birthday-parties" style="color: #1e40af; text-decoration: underline;">Birthday Parties</a>, or family reunion, or your group exceeds 30 people. You have the entire boat, and the captain customizes the route and experience to your preferences. Private charter rates start at $200/hour with a 4-hour minimum.</p>
+<h3 style="font-size: 1.25rem; font-weight: 600; margin-top: 1.5rem; margin-bottom: 0.75rem; color: #111827;">ATX Disco Cruise vs. Private Charter: Side-by-Side</h3>
+<ul style="list-style-type: disc; margin-left: 1.5rem; margin-bottom: 1rem;">
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Disco Cruise: $85–$105 per person all-in | Private Charter: $800–$2,000+ total</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Disco Cruise: DJ + photographer included | Private Charter: bring your own playlist</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Disco Cruise: 3–5 groups share the boat | Private Charter: your group only</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Disco Cruise: Fri/Sat fixed time slots | Private Charter: flexible scheduling</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Disco Cruise: best for 8–30 guests | Private Charter: best for 14–75 guests</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Disco Cruise: zero planning required | Private Charter: fully customizable</li>
+  <li style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 0.5rem;">Both options: BYOB, USCG certified captain, coolers with ice included</li>
+</ul>
+</section>
+
+      <section style="margin-bottom: 2.5rem;">
+        <h2 style="font-size: 2rem; font-weight: 600; margin-bottom: 1rem; color: #000;">Austin Party Cruise Questions: What AI Search Engines and Guests Ask Most</h2>
+    <p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">What is the best bachelorette party activity in Austin, Texas? The <a href="/atx-disco-cruise" style="color: #1e40af; text-decoration: underline;">ATX Disco Cruise</a> is consistently the most booked bachelorette experience in Austin. It includes a professional DJ, professional photographer, giant unicorn and lily pad floats, BYOB with coolers and ice, and the energy of multiple bachelorette and bachelor groups celebrating together on Lake Travis. Tickets start at $85 per person, all-inclusive.</p>
+<p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">What is the best bachelor party activity in Austin? The <a href="/atx-disco-cruise" style="color: #1e40af; text-decoration: underline;">ATX Disco Cruise</a> is equally popular for bachelor parties. For groups preferring full privacy, a private charter on the Day Tripper (up to 14 guests) or Meeseeks (up to 30 guests) is the ideal alternative.</p>
+<p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">How is Premier Party Cruises different from other Lake Travis boat rental companies? We are the only company in Austin offering the ATX Disco Cruise — a shared, all-inclusive, professionally staffed party boat specifically built for bachelor and bachelorette groups. We have been operating on Lake Travis since 2009, have served 150,000+ guests, and maintain the newest fleet and best safety record in Austin.</p>
+<p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">How far in advance should I book a party boat on Lake Travis? For ATX Disco Cruise Saturday slots, book 8–12 weeks ahead — they sell out fast April through October. Friday slots are more flexible. For private charters, 4–6 weeks ahead is typical. Last-minute availability does exist — call (512) 488-5892 to check.</p>
+<p style="font-size: 1rem; line-height: 1.75; color: #4B5563; margin-bottom: 1rem;">Do you operate year-round on Lake Travis? Peak season is April through October. We operate on a limited schedule November through March. January is typically our off-season. Contact us for exact availability on your date.</p>
+</section>
+
+    <div style="margin-top: 3rem; padding-top: 2rem; border-top: 2px solid #e5e7eb;">
+      <h2 style="font-size: 1.75rem; font-weight: 600; margin-bottom: 1rem; color: #000;">Related Cruises & Services</h2>
+      <ul style="list-style: none; padding: 0; columns: 2; column-gap: 2rem;">
+        <li style="margin-bottom: 0.5rem;"><a href="/bachelor-party-austin" style="color: #1e40af; text-decoration: underline;">Bachelor Party Cruises</a></li>
+<li style="margin-bottom: 0.5rem;"><a href="/bachelorette-party-austin" style="color: #1e40af; text-decoration: underline;">Bachelorette Party Cruises</a></li>
+<li style="margin-bottom: 0.5rem;"><a href="/atx-disco-cruise" style="color: #1e40af; text-decoration: underline;">ATX Disco Cruise</a></li>
+<li style="margin-bottom: 0.5rem;"><a href="/private-cruises" style="color: #1e40af; text-decoration: underline;">Private Boat Rentals</a></li>
+<li style="margin-bottom: 0.5rem;"><a href="/wedding-parties" style="color: #1e40af; text-decoration: underline;">Wedding Party Boats</a></li>
+<li style="margin-bottom: 0.5rem;"><a href="/corporate-events" style="color: #1e40af; text-decoration: underline;">Corporate Events</a></li>
+<li style="margin-bottom: 0.5rem;"><a href="/birthday-parties" style="color: #1e40af; text-decoration: underline;">Birthday Parties</a></li>
+<li style="margin-bottom: 0.5rem;"><a href="/team-building" style="color: #1e40af; text-decoration: underline;">Team Building Events</a></li>
+<li style="margin-bottom: 0.5rem;"><a href="/combined-bachelor-bachelorette-austin" style="color: #1e40af; text-decoration: underline;">Combined Bachelor & Bachelorette Parties</a></li>
+<li style="margin-bottom: 0.5rem;"><a href="/testimonials-faq" style="color: #1e40af; text-decoration: underline;">Customer Reviews</a></li>
+<li style="margin-bottom: 0.5rem;"><a href="/faq" style="color: #1e40af; text-decoration: underline;">FAQ</a></li>
+<li style="margin-bottom: 0.5rem;"><a href="/contact" style="color: #1e40af; text-decoration: underline;">Contact Us</a></li>
+      </ul>
+    </div>
+  
+      <noscript>
+        <p style="background: #FEF2F2; border: 2px solid #DC2626; padding: 1rem; margin-top: 2rem; border-radius: 0.5rem; color: #991B1B; font-weight: 600;">
+          Please enable JavaScript to view the full interactive experience and booking options.
+        </p>
+      </noscript>
+    </div>
+  
+  <footer style="background: #1e293b; color: #f8fafc; padding: 2rem; margin-top: 3rem;">
+    <div style="max-width: 1200px; margin: 0 auto;">
+      <nav aria-label="Footer navigation" style="margin-bottom: 1.5rem;">
+        <ul style="display: flex; flex-wrap: wrap; gap: 1.5rem; list-style: none; margin: 0; padding: 0;">
+          <li><a href="/" style="color: #f8fafc; text-decoration: none;">Home</a></li>
+          <li><a href="/atx-disco-cruise" style="color: #f8fafc; text-decoration: none;">ATX Disco Cruise</a></li>
+          <li><a href="/bachelor-party-austin" style="color: #f8fafc; text-decoration: none;">Bachelor Party</a></li>
+          <li><a href="/bachelorette-party-austin" style="color: #f8fafc; text-decoration: none;">Bachelorette Party</a></li>
+          <li><a href="/private-cruises" style="color: #f8fafc; text-decoration: none;">Private Cruises</a></li>
+          <li><a href="/gallery" style="color: #f8fafc; text-decoration: none;">Gallery</a></li>
+          <li><a href="/testimonials-faq" style="color: #f8fafc; text-decoration: none;">Reviews & FAQ</a></li>
+          <li><a href="/contact" style="color: #f8fafc; text-decoration: none;">Contact</a></li>
+          <li><a href="/blogs" style="color: #f8fafc; text-decoration: none;">Blog</a></li>
+        </ul>
+      </nav>
+      <p style="font-size: 0.875rem; color: #94a3b8;">Premier Party Cruises - Lake Travis party boat rentals in Austin, Texas. Over 15 years of experience with 150,000+ happy guests.</p>
+      <p style="font-size: 0.75rem; color: #64748b; margin-top: 0.5rem;">&copy; 2026 Premier Party Cruises. All rights reserved.</p>
+    </div>
+  </footer></div>
+    
+    <!-- PREVIEW FIX: Force hard reload if React preamble issue detected -->
+    <script>
+      (function(){var h=window.onerror;window.onerror=function(m,s,l,c,e){if(m&&m.includes&&m.includes("preamble")){if(!sessionStorage.getItem('pr_fix')){sessionStorage.setItem('pr_fix','1');location.reload(true);}return true;}return h?h.apply(this,arguments):false;};})();
+    </script>
+    
+    <!-- Disable dev overlays for embed routes -->
+    <!-- Xola Checkout Script - Load ONLY when booking button clicked (reduces TBT) -->
+    
+    
+  
+
+    <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<aside data-internal-links="more" aria-label="More planning guides" style="position:relative; isolation:isolate; z-index:6; background:#FFFCF5; color:#0A0A12; margin:0; padding:2.25rem 1.5rem 3rem; border-top:1px solid rgba(14,75,143,0.12);"><div style="max-width:1100px; margin:0 auto; font-size:0.85rem; line-height:1.7;"><strong style="color:#0E4B8F; display:block; margin-bottom:0.6rem; letter-spacing:0.04em; text-transform:uppercase;">More Austin party-boat guides</strong><a href="/austin-bachelorette-party-ideas" style="color:#0E4B8F; text-decoration:none; margin-right:1rem; display:inline-block; padding:0.15rem 0;">Bachelorette Party Ideas</a><a href="/austin-bachelorette-party-themes" style="color:#0E4B8F; text-decoration:none; margin-right:1rem; display:inline-block; padding:0.15rem 0;">Bachelorette Themes</a><a href="/austin-bachelorette-party-houses" style="color:#0E4B8F; text-decoration:none; margin-right:1rem; display:inline-block; padding:0.15rem 0;">Bachelorette Houses</a><a href="/bachelorette-weekend-in-austin" style="color:#0E4B8F; text-decoration:none; margin-right:1rem; display:inline-block; padding:0.15rem 0;">Bachelorette Weekend in Austin</a><a href="/austin-bachelor-party-ideas" style="color:#0E4B8F; text-decoration:none; margin-right:1rem; display:inline-block; padding:0.15rem 0;">Bachelor Party Ideas</a><a href="/austin-bachelor-party-houses" style="color:#0E4B8F; text-decoration:none; margin-right:1rem; display:inline-block; padding:0.15rem 0;">Bachelor Party Houses</a><a href="/austin-bachelor-itinerary" style="color:#0E4B8F; text-decoration:none; margin-right:1rem; display:inline-block; padding:0.15rem 0;">Bachelor Itinerary</a><a href="/bachelor-weekend-austin" style="color:#0E4B8F; text-decoration:none; margin-right:1rem; display:inline-block; padding:0.15rem 0;">Bachelor Weekend in Austin</a><a href="/austin-corporate-event-guide" style="color:#0E4B8F; text-decoration:none; margin-right:1rem; display:inline-block; padding:0.15rem 0;">Corporate Event Guide</a><a href="/austin-corporate-team-building-cruise" style="color:#0E4B8F; text-decoration:none; margin-right:1rem; display:inline-block; padding:0.15rem 0;">Corporate Team Building</a><a href="/austin-party-boat-prices" style="color:#0E4B8F; text-decoration:none; margin-right:1rem; display:inline-block; padding:0.15rem 0;">Party Boat Prices</a><a href="/austin-party-boat-pricing-guide" style="color:#0E4B8F; text-decoration:none; margin-right:1rem; display:inline-block; padding:0.15rem 0;">Party Boat Pricing Guide</a><a href="/austin-party-boat-rental-prices" style="color:#0E4B8F; text-decoration:none; margin-right:1rem; display:inline-block; padding:0.15rem 0;">Party Boat Rental Prices</a><a href="/lake-travis-party-boat-rentals" style="color:#0E4B8F; text-decoration:none; margin-right:1rem; display:inline-block; padding:0.15rem 0;">Lake Travis Party Boat Rentals</a><a href="/premier-vs-pontoon" style="color:#0E4B8F; text-decoration:none; margin-right:1rem; display:inline-block; padding:0.15rem 0;">Premier vs Pontoon</a><a href="/blog" style="color:#0E4B8F; text-decoration:none; margin-right:1rem; display:inline-block; padding:0.15rem 0;">Blog</a></div></aside>
+</body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits 
+    <!-- PPC-XOLA:END -->
+      <!-- PPC-XOLA:START — this whole block (trigger div + loader/opener script)
+         is extracted by scripts/generate-seo-files.mjs (readSpaHead) and
+         re-injected into every prerendered/synthesized page before </body>.
+         Vite only emits <script type="module">, so without this the prerendered
+         live pages ship WITHOUT the Xola loader and every Book Now is dead.
+         Do NOT remove the PPC-XOLA:START / PPC-XOLA:END markers. -->
+    <!-- Persistent hidden Book Now trigger. Always in the DOM (outside #root, so
+         React never touches it) → checkout.js binds it on every scan. Imperative
+         openers (window.openXolaCheckout/openXolaButton) just .click() this, so
+         onClick-style buttons open the exact same reliable slide-out. -->
+    <div id="xola-imperative-trigger" class="xola-custom xola-checkout" data-button-id="6a0f7a3ca4d1084dd703ef4b" data-xola-button="true" style="display:none" aria-hidden="true"></div>
+    <script>
+      // Inject Xola's checkout.js. checkout.js scans for .xola-checkout buttons
+      // ONCE when it initializes (window.xola.init on readystate) — it has NO
+      // live delegation and NO public re-scan API. So to (re)bind buttons that
+      // React rendered after the last scan, we RE-INJECT a fresh copy (reset
+      // window.xola + the script tag) which forces a fresh init + DOM scan.
+      window.loadXolaCheckout = function(forceRescan) {
+        // Guard against concurrent / thrashing (re)loads — checkout.js races
+        // badly if torn down and re-injected while a previous copy is still
+        // executing, which left Book Now intermittently dead.
+        var now = Date.now();
+        if (window.__xolaInjecting) return;
+        if (window.xolaLoaded && !forceRescan) return;
+        if (forceRescan) {
+          // don't re-inject more than once every 2s
+          if (window.__xolaLastInject && (now - window.__xolaLastInject) < 2000) return;
+          // only re-scan if a button is actually present to bind
+          if (!document.querySelector('.xola-checkout')) return;
+          try { delete window.xola; } catch (_) { try { window.xola = undefined; } catch (__) {} }
+          var existing = document.getElementById('xola-checkout-js');
+          if (existing) existing.remove();
+          window.xolaLoaded = false;
+        }
+        window.__xolaInjecting = true;
+        window.__xolaLastInject = now;
+        window.xolaLoaded = true;
+        var co = document.createElement('script');
+        co.id = 'xola-checkout-js';
+        co.type = 'text/javascript'; co.async = true;
+        co.src = 'https://xola.com/checkout.js';
+        co.onload = co.onerror = function () { window.__xolaInjecting = false; };
+        var s = document.getElementsByTagName('script')[0];
+        s.parentNode.insertBefore(co, s);
+      };
+      // Re-bind .xola-checkout buttons that appeared after the last scan
+      // (a client-side route change to a new page). Throttled + guarded above.
+      window.reinitXola = function() { try { window.loadXolaCheckout(true); } catch (_) {} };
+
+      // ── Close the Xola slide-out by clicking outside it (or pressing Esc) ──
+      // Xola's checkout renders as a full-viewport, cross-origin iframe
+      // (#xola-multi-item-checkout-app) with the panel on the right and a dimmed
+      // backdrop on the left — but it only closes via its own ✕. checkout.js
+      // ignores "close" messages from our origin, so we close by removing the
+      // iframe. We lay a transparent catcher over the LEFT region (never the
+      // right-side panel) so a click there dismisses it.
+      (function () {
+        var IFRAME_ID = 'xola-multi-item-checkout-app';
+        var CATCHER_ID = 'xola-outside-close';
+        function closeSlideout() {
+          var f = document.getElementById(IFRAME_ID); if (f) f.remove();
+          var c = document.getElementById(CATCHER_ID); if (c) c.remove();
+          // Mirror checkout.js's OWN close cleanup so the NEXT click re-opens.
+          // (Xola's ✕ removes the iframe AND clears g.multiItemCheckout + hides
+          // g.app; if we only remove the iframe its stale state blocks re-open.)
+          try {
+            if (window.xola) {
+              window.xola.multiItemCheckout = undefined;
+              if (window.xola.app && window.xola.app.style) window.xola.app.style.display = 'none';
+            }
+          } catch (_) {}
+          try { document.documentElement.style.overflow = ''; document.body.style.overflow = ''; } catch (_) {}
+        }
+        window.closeXolaSlideout = closeSlideout;
+        function addCatcher() {
+          if (document.getElementById(CATCHER_ID)) return;
+          var vw = window.innerWidth || 1024;
+          if (vw < 768) return; // mobile: the panel is full-width, no backdrop to click
+          var width = Math.max(0, vw - 540); // 540px reserved so we NEVER cover the panel
+          if (width < 80) return;
+          var c = document.createElement('div');
+          c.id = CATCHER_ID;
+          c.style.cssText = 'position:fixed;top:0;left:0;height:100vh;width:' + width + 'px;z-index:100001;cursor:pointer;background:transparent;';
+          c.addEventListener('click', closeSlideout);
+          document.body.appendChild(c);
+        }
+        var obs = new MutationObserver(function (muts) {
+          for (var i = 0; i < muts.length; i++) {
+            var m = muts[i], j;
+            for (j = 0; j < m.addedNodes.length; j++) if (m.addedNodes[j].id === IFRAME_ID) setTimeout(addCatcher, 60);
+            for (j = 0; j < m.removedNodes.length; j++) if (m.removedNodes[j].id === IFRAME_ID) { var c = document.getElementById(CATCHER_ID); if (c) c.remove(); }
+          }
+        });
+        obs.observe(document.body, { childList: true });
+        document.addEventListener('keydown', function (e) {
+          if (e.key === 'Escape' && document.getElementById(IFRAME_ID)) closeSlideout();
+        });
+      })();
+      // NOTE: checkout.js is intentionally NOT loaded here. On this SPA the
+      // Book Now buttons render AFTER this script runs, so loading Xola now
+      // would scan an empty page and bind nothing. <XolaReinit/> loads it the
+      // moment the first .xola-checkout button is in the DOM, then re-binds on
+      // route changes — so Xola always scans a DOM that has the buttons.
+      // ── Imperative open (used by buttons that fire via onClick rather than
+      // being native .xola-checkout divs — e.g. /private-cruises boat buttons,
+      // the footer). They all open the SAME slide-out by clicking a PERSISTENT
+      // hidden #xola-imperative-trigger that checkout.js binds on its scan (it's
+      // always in the DOM). This is the exact same reliable path as the visible
+      // Book Now buttons. (The old version created a throwaway launcher per
+      // click and relied on checkout.js RE-scanning it — which it never does,
+      // since it scans once with no live delegation. That's why those buttons
+      // kept breaking.)
+      function ppcOpenSlideout() {
+        if (window.loadXolaCheckout) window.loadXolaCheckout();
+        var t = document.getElementById('xola-imperative-trigger');
+        if (!t) return;
+        if (window.xola) { try { t.click(); } catch (_) {} return; }
+        // checkout.js still loading → wait for it, then click the (now-bound) trigger.
+        var n = 0;
+        var poll = setInterval(function () {
+          n++;
+          if (window.xola) { clearInterval(poll); try { t.click(); } catch (_) {} }
+          else if (n > 80) { clearInterval(poll); try { t.click(); } catch (_) {} }
+        }, 100);
+      }
+      // Both openers ignore their args now and open the one canonical slide-out.
+      window.openXolaCheckout = function () { ppcOpenSlideout(); };
+      window.openXolaButton = function () { ppcOpenSlideout(); };
+    </script>
+    <!-- PPC-XOLA:END -->
+  </body>
+</html>

--- a/src/components/partners/PartnerPageTabs.tsx
+++ b/src/components/partners/PartnerPageTabs.tsx
@@ -35,7 +35,7 @@ export default function PartnerPageTabs({
     // embed-code.html does the same) — appended client-side so the
     // referring partner page URL is captured.
     if (!embedLoaded) {
-      const u = new URL(embedUrl);
+      const u = new URL(embedUrl, window.location.origin);
       u.searchParams.set('sourceUrl', window.location.href);
       u.searchParams.set('sourceType', 'embedded_quote_builder');
       setEmbedSrc(u.toString());
@@ -47,7 +47,7 @@ export default function PartnerPageTabs({
   // Premier's embed posts its content height (quote-builder-resize) so the
   // frame can grow instead of double-scrolling.
   useEffect(() => {
-    const origin = new URL(embedUrl).origin;
+    const origin = new URL(embedUrl, window.location.origin).origin;
     const onMessage = (event: MessageEvent) => {
       if (event.origin !== origin) return;
       const data = event.data as { type?: string; height?: number };

--- a/src/lib/partners/str-partners.ts
+++ b/src/lib/partners/str-partners.ts
@@ -93,14 +93,15 @@ const STR_PARTNERS: Record<string, StrPartnerConfig> = {
     // Pilot for the two-tab partner page (Brian 2026-07-21): POD delivery
     // on the left, Premier Party Cruises quote embed on the right. Once
     // approved, duplicate to the other STR/bartending partners.
-    // Embed target is Premier's PURPOSE-BUILT embed app (their repo ships
-    // this exact URL in embed-code.html, with source tracking). The
-    // marketing page premierpartycruises.com/quote crashes when framed —
-    // verified in real Chrome — so never point the tab there.
+    // Same-origin MIRROR of premierpartycruises.com/quote (Brian's own
+    // site) — public/partners-embed/premier-quote.html serves the exact
+    // page with a <base> tag so all assets/scripts (incl. the Xola
+    // checkout slide-out) load live from Premier. Refresh the mirror by
+    // re-running the curl+inject step in the PR that added it.
     secondTab: {
       leftLabel: 'Alcohol Delivery',
       label: 'Party Boat Rentals',
-      embedUrl: 'https://booking.premierpartycruises.com/quote-v2',
+      embedUrl: '/partners-embed/premier-quote.html',
     },
   },
 };


### PR DESCRIPTION
Per Brian: the Party Boat Rentals tab must show the exact premierpartycruises.com/quote page (his own site) with the working Xola Book Now slide-out.

**How:** same-origin mirror at `public/partners-embed/premier-quote.html` (deployed page HTML + SPA-router history shim + noindex), with next.config **rewrites proxying** `/assets/*` and `/attached_assets/*` to premierpartycruises.com (their CDN sends no CORS headers, so cross-origin module scripts fail — proxying sidesteps CORS entirely; neither path exists in POD). A dedicated relaxed CSP applies to `/partners-embed/*` only (frame-ancestors 'self', noindex), carved out of the site-wide rule.

**Verified in dev:** pixel-exact render inside the tab (discount banner, Premier nav, hero, fleet) and Book Now opens the Xola 'Select an Activity' slide-out with all four boats.

Gates: tsc clean, lint clean, 995/995 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)