### PR TITLE
feat(partners): outreach playbook, Lynn's-template inheritance for STR partners, Company Name model page

### DIFF
--- a/src/app/admin/affiliates/prospects/playbook/page.tsx
+++ b/src/app/admin/affiliates/prospects/playbook/page.tsx
@@ -1,0 +1,213 @@
+import type { Metadata } from 'next';
+import type { ReactElement } from 'react';
+import PartnersHubBand from '@/components/admin/partners/PartnersHubBand';
+
+export const metadata: Metadata = {
+  title: 'Outreach Playbook — Partners',
+  robots: { index: false, follow: false },
+};
+
+/**
+ * Partners hub → Outreach Playbook.
+ *
+ * The full partner-prospect outreach system reference (the approved build
+ * plan, kept current as the system evolves): how prospects become tagged
+ * CRM contacts, how the 2-touch campaign works, the partner-page
+ * replication template, and the send rules Brian set.
+ */
+
+function H2({ children }: { children: React.ReactNode }): ReactElement {
+  return <h2 className="text-xl font-bold text-gray-900 mt-8 mb-3">{children}</h2>;
+}
+
+function Card({ title, children }: { title: string; children: React.ReactNode }): ReactElement {
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-5 mb-4">
+      <h3 className="text-base font-bold text-gray-900 mb-2">{title}</h3>
+      <div className="text-sm text-gray-700 space-y-2">{children}</div>
+    </div>
+  );
+}
+
+export default function OutreachPlaybookPage(): ReactElement {
+  return (
+    <div className="bg-gray-50 min-h-screen">
+      <PartnersHubBand active="playbook" />
+      <div className="max-w-4xl mx-auto px-4 md:px-8 py-8">
+        <h1 className="text-2xl font-bold text-gray-900">Partner Outreach Playbook</h1>
+        <p className="text-sm text-gray-600 mt-2">
+          How the partner-prospect system works end to end: prospect databases → tagged CRM
+          contacts → partner pages → 2-touch email campaign → replies on the Leads board.
+          This is the reference for the system that is now LIVE — kept current as it evolves.
+        </p>
+
+        <H2>The pipeline at a glance</H2>
+        <Card title="1 · Prospect databases (STR + Bartending tabs)">
+          <p>
+            Researched Austin companies with contact info, socials, scraped logos, and a full
+            enrichment per row (management, offering, reputation, partnership angles, and a
+            personalized outreach email). Every row is searchable; the enrichment opens as a
+            dropdown under the company.
+          </p>
+        </Card>
+        <Card title="2 · Sync to CRM — tagged contacts, separated from consumers">
+          <p>
+            The <strong>Sync to CRM</strong> button upserts every company as a Lead:{' '}
+            <code>partner-prospect</code> + vertical tag (<code>str</code> /{' '}
+            <code>bartender</code>), source <code>PARTNER_OUTREACH</code>. Companies whose
+            affiliate is ACTIVE also get <code>partner-active</code> — re-running sync keeps
+            that current, which is how a prospect flips to Active Partner after signing.
+            Every upsert is mirrored to the external CRM (CoreLinq) with its tags.
+          </p>
+          <p>
+            On the Leads board, the source filter has <strong>Partner Prospects</strong> and{' '}
+            <strong>Consumers only</strong> options, and partner leads wear a 🤝 badge —
+            partner outreach never mixes into the consumer pipeline.
+          </p>
+        </Card>
+        <Card title="3 · Partner page + affiliate (commission-ready)">
+          <p>
+            Each partner is a normal POD affiliate: referral code, matching free-delivery
+            discount, commission through the standard engine, portal login, and a live page
+            at <code>/partners/&lt;slug&gt;</code>. Client dashboards created from their page
+            attribute to them automatically and appear in their portal + our admin rosters.
+          </p>
+          <p>
+            <strong>Page template:</strong> the Lynn&apos;s Lodging layout is THE replication
+            template — two tabs: <em>Alcohol Delivery</em> (the standard POD partner page)
+            and <em>Party Boat Rentals</em> (the exact Premier Party Cruises quote page with
+            the working Xola Book Now slide-out, served same-origin). STR partner pages
+            inherit this automatically once their slug is in the prospect database. Model
+            page with placeholder name: <code>/partners/partner-template</code>.
+          </p>
+        </Card>
+        <Card title="4 · The 2-touch campaign (partner-outreach journey)">
+          <ul className="list-disc pl-5 space-y-1">
+            <li>
+              <strong>Touch 1 (immediately on enroll):</strong> the prospect&apos;s
+              personalized enrichment email, looked up fresh at send time — copy edits in
+              the database ship without re-enrolling.
+            </li>
+            <li>
+              <strong>Touch 2 (+48h):</strong> abridged follow-up (tokens{' '}
+              <code>{'{firstName}'}</code>, <code>{'{company}'}</code>,{' '}
+              <code>{'{partnerUrl}'}</code>) — short recap + one CTA. Editable in the
+              follow-ups copy panel without a deploy.
+            </li>
+            <li>
+              <strong>Auto-cancel:</strong> the follow-up dies the moment they reply
+              (inbound email captured), the lead is marked Won/Lost, they become an active
+              partner, or they unsubscribe.
+            </li>
+            <li>
+              <strong>Sender:</strong> info@partyondelivery.com (&quot;Brian at Party On
+              Delivery&quot;) — replies flow through the Gmail poller onto the Leads board.
+            </li>
+            <li>
+              Business-hours send window (9am–7pm CT), jittered sends, suppression list +
+              CAN-SPAM footer on every touch — all inherited from the follow-up engine.
+            </li>
+          </ul>
+        </Card>
+        <Card title="5 · Tracking">
+          <p>
+            Campaign chips on each prospect row (Enrolled / Sent / Replied), queue + sent
+            log in <code>/admin/emails/followups</code>, replies and pipeline stage on{' '}
+            <code>/admin/leads</code>, and per-partner dashboards/engagement in the Partners
+            section.
+          </p>
+        </Card>
+
+        <H2>Send rules (Brian&apos;s constraints — enforced in code)</H2>
+        <Card title="Nothing sends until explicitly approved">
+          <ul className="list-disc pl-5 space-y-1">
+            <li>
+              The <code>partner-outreach</code> feature flag is <strong>OFF by default</strong>.
+              Enrolling queues jobs, but the engine will not send until the flag is flipped
+              in <code>/admin/emails/followups</code>.
+            </li>
+            <li>
+              <strong>Test first:</strong> every email gets a test send to
+              info@partyondelivery.com (the <em>Test → info@</em> button renders both touches
+              in one message with a [TEST] subject prefix) before its batch goes out.
+            </li>
+            <li>
+              <strong>Batches of 5–10:</strong> the Enroll button is capped at 10 per batch,
+              server-side.
+            </li>
+            <li>
+              Partner pages are built before their outreach email goes out — the email
+              references the live page.
+            </li>
+          </ul>
+        </Card>
+
+        <H2>How to run a batch (operator checklist)</H2>
+        <Card title="Step by step">
+          <ol className="list-decimal pl-5 space-y-1">
+            <li>Open STR or Bartending Prospects and click <strong>Sync to CRM</strong>.</li>
+            <li>
+              Confirm the batch&apos;s partner pages exist (Partner page column shows{' '}
+              <strong>✓ /partners/…</strong>). If not, use Copy CSV → Bulk Import.
+            </li>
+            <li>
+              For each prospect in the batch: open the enrichment dropdown, review the
+              email, click <strong>Test → info@</strong>, and check the inbox copy.
+            </li>
+            <li>Tick 5–10 checkboxes and click <strong>Enroll selected</strong>.</li>
+            <li>
+              When ready to go live: flip <code>followups_partner_outreach</code> ON in the
+              follow-ups panel. The engine sends touch 1 on the next tick (in window), and
+              touch 2 at +48h unless they reply.
+            </li>
+            <li>
+              Watch replies on <code>/admin/leads</code> (Partner Prospects filter) — reply
+              handling is manual from there, exactly like consumer leads.
+            </li>
+          </ol>
+        </Card>
+
+        <H2>System internals (for whoever works on this next)</H2>
+        <Card title="What it reuses">
+          <ul className="list-disc pl-5 space-y-1">
+            <li>
+              Follow-up engine (<code>src/lib/followups/</code>): 2-touch journey registry,
+              send window, atomic claim, dedupe keys, suppression — journey key{' '}
+              <code>partner-outreach</code>.
+            </li>
+            <li>
+              <code>sendEmailDetailed()</code> — logged sends with Resend tags, EmailLog
+              open/bounce tracking, webhook status updates.
+            </li>
+            <li>
+              Lead tags (<code>leads.tags</code>, GIN-indexed) + source{' '}
+              <code>PARTNER_OUTREACH</code>; constants in{' '}
+              <code>src/lib/leads/partner-tags.ts</code>.
+            </li>
+            <li>
+              Prospect data: <code>src/data/str-partner-prospects.json</code> +{' '}
+              <code>bartending-partner-prospects.json</code> — enrichment, emails, slugs.
+            </li>
+            <li>
+              APIs (ops-gated): <code>/api/v1/admin/partner-prospects/</code>
+              <code>{'{sync, enroll, test-send}'}</code>.
+            </li>
+            <li>
+              Page template: <code>PartnerPageTabs</code> + the Premier quote mirror at{' '}
+              <code>/partners-embed/premier-quote.html</code> (same-origin, assets proxied —
+              see <code>rewrites()</code> in next.config).
+            </li>
+          </ul>
+        </Card>
+        <Card title="Deliberately deferred">
+          <ul className="list-disc pl-5 space-y-1">
+            <li>Automated reply sequences beyond 2 touches (2-touch max is a locked decision).</li>
+            <li>
+              Auto-enrollment — every batch is human-selected and human-approved by design.
+            </li>
+          </ul>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/partners/PartnersHubBand.tsx
+++ b/src/components/admin/partners/PartnersHubBand.tsx
@@ -7,6 +7,7 @@ const SEGMENTS = [
   { key: 'promotions', label: 'Promotions', href: '/admin/promotions' },
   { key: 'str-prospects', label: 'STR Prospects', href: '/admin/affiliates/prospects/str' },
   { key: 'bartending-prospects', label: 'Bartending Prospects', href: '/admin/affiliates/prospects/bartending' },
+  { key: 'playbook', label: 'Outreach Playbook', href: '/admin/affiliates/prospects/playbook' },
 ];
 
 /**
@@ -17,7 +18,7 @@ const SEGMENTS = [
 export default function PartnersHubBand({
   active,
 }: {
-  active: 'affiliates' | 'promotions' | 'str-prospects' | 'bartending-prospects';
+  active: 'affiliates' | 'promotions' | 'str-prospects' | 'bartending-prospects' | 'playbook';
 }): ReactElement {
   return (
     <NavyBand>

--- a/src/data/bartending-partner-prospects.json
+++ b/src/data/bartending-partner-prospects.json
@@ -474,7 +474,7 @@
     },
     "logoUrl": "https://images.squarespace-cdn.com/content/v1/54e69c7fe4b021b682b883db/0325c773-f7bb-4b33-b5cd-9ee7c7a2a974/DS_logo_2018_NO-tag_LG.png",
     "description": "Turnkey event bartending (TABC permits, liquor liability, staff) — queer-owned, NGLCC-certified; weddings, corporate, festivals.",
-    "partnerSlug": null,
+    "partnerSlug": "drink-slingers",
     "enrichment": {
       "enrichedAt": "2026-07-21",
       "management": {
@@ -551,7 +551,7 @@
     },
     "logoUrl": "https://twistbartendingservice.com/wp-content/uploads/2020/02/Bartending-Service_horizontal-282x63.png",
     "description": "National full-service event bartending company with Austin operations — portable bars, supplies, staff for weddings/corporate/festivals.",
-    "partnerSlug": null,
+    "partnerSlug": "with-a-twist-bartending-service",
     "enrichment": {
       "enrichedAt": "2026-07-21",
       "management": {
@@ -628,7 +628,7 @@
     },
     "logoUrl": "https://www.austinprivatebartending.com/assets/img/logo.png",
     "description": "Full-service mobile bar team for weddings, corporate events, and private parties across Austin + Hill Country.",
-    "partnerSlug": null,
+    "partnerSlug": "austin-private-bartending",
     "enrichment": {
       "enrichedAt": "2026-07-21",
       "management": {
@@ -701,7 +701,7 @@
     },
     "logoUrl": "https://austinbarco.com/wp-content/uploads/2019/06/cropped-logo-austin-bartending-company-SMALL.png",
     "description": "TABC-certified craft-cocktail mobile bartending team carrying $3M liquor liability insurance.",
-    "partnerSlug": null,
+    "partnerSlug": "austin-bartending-co",
     "enrichment": {
       "enrichedAt": "2026-07-21",
       "management": {
@@ -778,7 +778,7 @@
     },
     "logoUrl": null,
     "description": "TABC-certified, insured mobile bartending with fixed-price packages and a branded LED portable bar.",
-    "partnerSlug": null,
+    "partnerSlug": "shaken-not-stirred-bartending",
     "enrichment": {
       "enrichedAt": "2026-07-21",
       "management": {
@@ -859,7 +859,7 @@
     },
     "logoUrl": "https://cdn.prod.website-files.com/62dec25ead95eb5b6a359b9c/62feaa6d2d4126be0f6f7489_ELEVATE%20LOGO%20XL%20B.png",
     "description": "Austin mobile bartending — custom cocktails and bar/event styling with TABC-certified bartenders.",
-    "partnerSlug": null,
+    "partnerSlug": "elevate-professional-bartending",
     "enrichment": {
       "enrichedAt": "2026-07-21",
       "management": {
@@ -936,7 +936,7 @@
     },
     "logoUrl": "https://static.wixstatic.com/media/e9c6a9_1eee788ad4f94de4b1b9d8486b0c54dc~mv2.jpg/v1/fill/w_264,h_197,al_c,q_80,usm_0.66_1.00_0.01,enc_avif,quality_auto/Confetti_Crush_LogoNew%20Jpeg.jpg",
     "description": "Lakeway/Austin TABC-certified dry-hire bartending + mobile bar rental with a converted two-horse trailer.",
-    "partnerSlug": null,
+    "partnerSlug": "confetti-crush-event-rentals",
     "enrichment": {
       "enrichedAt": "2026-07-21",
       "management": {
@@ -1017,7 +1017,7 @@
     },
     "logoUrl": "https://images.squarespace-cdn.com/content/v1/6a565516b1cf6006cc7ae534/259eacfb-466e-4b80-82c5-2a1e7e6aa61f/Bea%E2%80%99s+Primary+Logo+%28Transparent+Background%29.png?format=1500w",
     "description": "Mobile bartending + party-rental one-stop shop (tables, chairs, setup) — Austin, Kyle, Buda, San Marcos.",
-    "partnerSlug": null,
+    "partnerSlug": "bea-s-mobile-bartending",
     "enrichment": {
       "enrichedAt": "2026-07-21",
       "management": {
@@ -1090,7 +1090,7 @@
     },
     "logoUrl": "https://img1.wsimg.com/isteam/ip/976214c5-3666-4756-9c0f-b4fbd0c2c0ce/blob-7d99e45.png/:/rs=h:200,cg:true,m/qt=q:95",
     "description": "Mobile bar service for Austin weddings and private events — customized cocktails, flat pricing (Leander LLC).",
-    "partnerSlug": null,
+    "partnerSlug": "austin-taps-mobile-bar-co",
     "enrichment": {
       "enrichedAt": "2026-07-21",
       "management": {
@@ -1171,7 +1171,7 @@
     },
     "logoUrl": "https://images.squarespace-cdn.com/content/v1/5e8ca5acde1781178c75611b/a0992ea9-6c40-40d1-9df0-0fae51510e6f/RoadHaus+Mobile+Cocktails%402x.png?format=1500w",
     "description": "World-class cocktail catering from a restored 1967 Citroën HY van — run by the team behind The Roosevelt Room.",
-    "partnerSlug": null,
+    "partnerSlug": "roadhaus-mobile-cocktails",
     "enrichment": {
       "enrichedAt": "2026-07-21",
       "management": {
@@ -1244,7 +1244,7 @@
     },
     "logoUrl": "https://pourwagonaustin.com/_assets/images/929ca264b2eaea687604758e967413b3.png",
     "description": "Custom-built mobile bar trailer rental for Austin weddings, parties, and events.",
-    "partnerSlug": null,
+    "partnerSlug": "pour-wagon-austin",
     "enrichment": {
       "enrichedAt": "2026-07-21",
       "management": {
@@ -1325,7 +1325,7 @@
     },
     "logoUrl": null,
     "description": "Women-owned boutique dry-hire mobile bar (client supplies alcohol) — Austin, Cedar Park, Round Rock, Hill Country.",
-    "partnerSlug": null,
+    "partnerSlug": "the-vintage-texan-mobile-bar",
     "enrichment": {
       "enrichedAt": "2026-07-21",
       "management": {
@@ -1398,7 +1398,7 @@
     },
     "logoUrl": "https://www.kombikeg.com/wp-content/uploads/2020/07/KombiKeg-Logo.png",
     "description": "Restored 1974 VW Kombi van mobile bar — draft beer, cider, cocktails, mocktails with TABC-certified staff.",
-    "partnerSlug": null,
+    "partnerSlug": "kombi-keg-atx",
     "enrichment": {
       "enrichedAt": "2026-07-21",
       "management": {
@@ -1475,7 +1475,7 @@
     },
     "logoUrl": "https://img1.wsimg.com/isteam/ip/static/pwa-app/logo-default.png/:/rs=w:57,h:57,m",
     "description": "Father-and-son mobile bartending service for weddings, corporate events, and parties across Austin.",
-    "partnerSlug": null,
+    "partnerSlug": "cheers-bartending-atx",
     "enrichment": {
       "enrichedAt": "2026-07-21",
       "management": {
@@ -1548,7 +1548,7 @@
     },
     "logoUrl": "https://barlamaisontx.com/wp-content/uploads/2024/10/bar-la-maison-logo-removebg-preview.png",
     "description": "Mobile bar + mixology service — handcrafted cocktails for weddings, corporate, private parties throughout Texas.",
-    "partnerSlug": null,
+    "partnerSlug": "bar-la-maison",
     "enrichment": {
       "enrichedAt": "2026-07-21",
       "management": {
@@ -1621,7 +1621,7 @@
     },
     "logoUrl": "https://img1.wsimg.com/isteam/ip/df135c98-8ca1-48ea-8c34-7cf1c89cff82/blob-9f9f0fa.png/:/rs=h:200,cg:true,m/qt=q:95",
     "description": "TABC/TIPS-certified mobile bartending and event staffing for Central Texas weddings, corporate, private parties.",
-    "partnerSlug": null,
+    "partnerSlug": "5-o-clock-somewhere-mobile-bartending",
     "enrichment": {
       "enrichedAt": "2026-07-21",
       "management": {
@@ -1694,7 +1694,7 @@
     },
     "logoUrl": "https://img1.wsimg.com/isteam/ip/6209a828-f724-4158-b425-f234940c67ce/favicon/696b4d54-5618-4371-a698-edbdf2f03653.jpg/:/rs=w:57,h:57,m",
     "description": "Mobile bar catering (est. 2024) — bartenders, custom cocktails, frozen drink machines, vintage Airstream lounges across Central Texas.",
-    "partnerSlug": null,
+    "partnerSlug": "little-rocks-bar-catering",
     "enrichment": {
       "enrichedAt": "2026-07-21",
       "management": {
@@ -1771,7 +1771,7 @@
     },
     "logoUrl": "https://trinityeventstaffing.com/wp-content/uploads/2019/04/Trinity-Event-Staffing-logo-1.jpg",
     "description": "Texas-wide event staffing agency (Dallas/Austin/Houston) supplying TABC-certified temp bartenders and hospitality staff.",
-    "partnerSlug": null,
+    "partnerSlug": "trinity-event-staffing",
     "enrichment": {
       "enrichedAt": "2026-07-21",
       "management": {
@@ -1844,7 +1844,7 @@
     },
     "logoUrl": "https://img1.wsimg.com/isteam/ip/static/pwa-app/logo-default.png/:/rs=w:57,h:57,m",
     "description": "Austin event staffing — TABC-certified bartenders, event coordinators, and security for weddings and celebrations.",
-    "partnerSlug": null,
+    "partnerSlug": "santisi-bartending-and-event-staff",
     "enrichment": {
       "enrichedAt": "2026-07-21",
       "management": {
@@ -1925,7 +1925,7 @@
     },
     "logoUrl": "https://images.squarespace-cdn.com/content/v1/654a82f227ddbc2405277565/ad03b621-8e3f-49a2-adf7-f2640d71234d/logo-300x182.png?format=1500w",
     "description": "Cedar Park bartending + event service since 1998 — preferred vendor at premier Central Texas wedding venues.",
-    "partnerSlug": null,
+    "partnerSlug": "hill-country-events",
     "enrichment": {
       "enrichedAt": "2026-07-21",
       "management": {
@@ -2002,7 +2002,7 @@
     },
     "logoUrl": "https://www.peakbev.com/platform/wp-content/uploads/2025/08/Peak-Beverage-Logo-White-200x78.png",
     "description": "Luxury bar catering — custom cocktail programs, large-format ice, outdoor bar builds for Austin/Hill Country weddings + corporate.",
-    "partnerSlug": null,
+    "partnerSlug": "peak-beverage-austin",
     "enrichment": {
       "enrichedAt": "2026-07-21",
       "management": {
@@ -2083,7 +2083,7 @@
     },
     "logoUrl": null,
     "description": "Mobile bar cart rental + beverage catering for the Austin metro (Georgetown, Round Rock, Cedar Park).",
-    "partnerSlug": null,
+    "partnerSlug": "sip-social-co-austin",
     "enrichment": {
       "enrichedAt": "2026-07-21",
       "management": {
@@ -2164,7 +2164,7 @@
     },
     "logoUrl": "https://uphilltaps.com/apple-touch-icon.png",
     "description": "Mobile tap-trailer + bar service with TABC-certified bartenders — Austin and Hill Country wedding corridors.",
-    "partnerSlug": null,
+    "partnerSlug": "uphill-taps",
     "enrichment": {
       "enrichedAt": "2026-07-21",
       "management": {
@@ -2245,7 +2245,7 @@
     },
     "logoUrl": "https://images.squarespace-cdn.com/content/v1/671a6c1e050267628d1be840/30414281-3d1f-4511-9ef5-5de7ae1076b9/Copy+of+Untitled+Design.png?format=1500w",
     "description": "Woman-owned mobile bartending — full-service bars, beverage catering, cocktail classes across Texas incl. Austin (Houston-area base — verify).",
-    "partnerSlug": null,
+    "partnerSlug": "franny-s-bartending",
     "enrichment": {
       "enrichedAt": "2026-07-21",
       "management": {
@@ -2318,7 +2318,7 @@
     },
     "logoUrl": "https://www.gustologist.com/uploads/5/9/7/1/59716251/published/gustologylogo.png?1610906546",
     "description": "'Best Cocktail Class in Texas' — mobile mixology classes and corporate team-building cocktail events (Austin + 4 metros).",
-    "partnerSlug": null,
+    "partnerSlug": "gustology",
     "enrichment": {
       "enrichedAt": "2026-07-21",
       "management": {
@@ -2395,7 +2395,7 @@
     },
     "logoUrl": "https://images.squarespace-cdn.com/content/v1/64d45236e5a8457b8f4817ad/feeb7e3a-a742-469b-a95b-a945ae69dc19/Assemble+Logo+Variations+1+%282%29.png?format=1500w",
     "description": "Hill Country mixology-class studio (Boerne) whose mobile cocktail workshop serves Austin bachelorette/birthday/corporate events.",
-    "partnerSlug": null,
+    "partnerSlug": "assemble-cocktail-workshop",
     "enrichment": {
       "enrichedAt": "2026-07-21",
       "management": {
@@ -2472,7 +2472,7 @@
     },
     "logoUrl": "https://cdn-ildmlib.nitrocdn.com/tTayJSaIAsLTuEqOUsWUInckKXZrwVKO/assets/images/optimized/rev-2cb9ad6/partyhostboys.com/wp-content/uploads/2025/02/menu-cavanaboys.png",
     "description": "Cowboy-themed private bartenders/party hosts for Airbnb bachelorette parties — drinks, games, music, photos.",
-    "partnerSlug": null,
+    "partnerSlug": "party-host-boys-austin",
     "enrichment": {
       "enrichedAt": "2026-07-21",
       "management": {

--- a/src/data/str-partner-prospects.json
+++ b/src/data/str-partner-prospects.json
@@ -97,7 +97,7 @@
     },
     "logoUrl": "https://bookingenginecdn-2.hostaway.com/43003-logoUrl.jpg?width=3840&quality=70&format=webp&v=2",
     "description": "Self-described 'Austin's Largest Vacation Rental Manager' — locally hosted rentals across Austin, Lake Travis, Marfa. Booking arm of STR Management.",
-    "partnerSlug": null
+    "partnerSlug": "austin-vacay"
   },
   {
     "name": "STR Management, LLC",
@@ -116,7 +116,7 @@
     },
     "logoUrl": "https://www.strmanagement.com/wp-content/uploads/2019/06/STR-Management-logo-WEB-50.png",
     "description": "One of Austin's largest local STR managers (since 2014), Austin + Lakeway, in-house cleaning and revenue management.",
-    "partnerSlug": null
+    "partnerSlug": "str-management-llc"
   },
   {
     "name": "Vacasa (Austin)",
@@ -135,7 +135,7 @@
     },
     "logoUrl": "https://cms-assets.boise.vacasa.com/svg/vacasa_casago_lockup_extra-wide-white.b0c31f473733.svg",
     "description": "North America's largest vacation rental manager with a local Austin team (absorbed Austin-founded TurnKey).",
-    "partnerSlug": null
+    "partnerSlug": "vacasa-austin"
   },
   {
     "name": "NomadSTR",
@@ -154,7 +154,7 @@
     },
     "logoUrl": "https://static.wixstatic.com/media/bad19e_c10dc5385f5644cda9ee247750b31dca%7Emv2.jpg/v1/fill/w_180%2Ch_180%2Clg_1%2Cusm_0.66_1.00_0.01/bad19e_c10dc5385f5644cda9ee247750b31dca%7Emv2.jpg",
     "description": "Austin-based full-service STR manager for Austin + Hill Country; recently acquired KOZE Vacation Rentals.",
-    "partnerSlug": null
+    "partnerSlug": "nomadstr"
   },
   {
     "name": "Hill Country Premier Lodging",
@@ -173,7 +173,7 @@
     },
     "logoUrl": "https://www.hillcountrypremier.com/wp-content/uploads/2024/03/hcpl-logo.png",
     "description": "Regional Hill Country heavyweight (20,000 reservations in 2024) — Wimberley, Dripping Springs, Canyon Lake, greater Austin.",
-    "partnerSlug": null
+    "partnerSlug": "hill-country-premier-lodging"
   },
   {
     "name": "Renters Club",
@@ -192,7 +192,7 @@
     },
     "logoUrl": "https://www.renters-club.com/wp-content/uploads/2023/02/2.png",
     "description": "Membership-style curated luxury vacation home collection in Austin (S Lamar HQ) with concierge support.",
-    "partnerSlug": null
+    "partnerSlug": "renters-club"
   },
   {
     "name": "Vivant Stays",
@@ -211,7 +211,7 @@
     },
     "logoUrl": "https://vivantstays.com/wp-content/uploads/2022/07/vivant_logo.svg",
     "description": "Austin operator of designer STRs, corporate housing, and furnished mid-term stays with data-backed revenue management.",
-    "partnerSlug": null
+    "partnerSlug": "vivant-stays"
   },
   {
     "name": "Evolve (Austin)",
@@ -230,7 +230,7 @@
     },
     "logoUrl": null,
     "description": "National light-touch vacation rental platform (10-15% fee) with dozens of Austin properties.",
-    "partnerSlug": null
+    "partnerSlug": "evolve-austin"
   },
   {
     "name": "Vacay Hill Country",
@@ -249,7 +249,7 @@
     },
     "logoUrl": "https://vacayhillcountry.com/wp-content/uploads/2021/12/Vacayhill-country-fixed.png",
     "description": "Local Hill Country company (~50+ homes) in Wimberley, Canyon Lake, New Braunfels; 92% owner retention.",
-    "partnerSlug": null
+    "partnerSlug": "vacay-hill-country"
   },
   {
     "name": "GuestSpaces",
@@ -268,7 +268,7 @@
     },
     "logoUrl": "https://guestspaces.com/wp-content/uploads/2021/02/cropped-cropped-guestspaces_logo_-_light_background-4-250x67.jpg",
     "description": "Award-winning boutique manager of luxury STR homes and lake houses — Austin, Dripping Springs, Texas lake communities.",
-    "partnerSlug": null
+    "partnerSlug": "guestspaces"
   },
   {
     "name": "AvantStay (Austin)",
@@ -287,7 +287,7 @@
     },
     "logoUrl": "https://avantstay.com/apple-touch-icon.png",
     "description": "National luxury/group STR brand with a dedicated Austin portfolio and local ops team — big bachelorette-group inventory.",
-    "partnerSlug": null
+    "partnerSlug": "avantstay-austin"
   },
   {
     "name": "Walker Luxury Vacation Rentals",
@@ -306,7 +306,7 @@
     },
     "logoUrl": "https://www.walkervr.com/wp-content/uploads/2024/11/logo-walkervr.png",
     "description": "Austin's first boutique property manager focused exclusively on high-end luxury vacation homes incl. Lake Austin waterfront.",
-    "partnerSlug": null
+    "partnerSlug": "walker-luxury-vacation-rentals"
   },
   {
     "name": "North Shore Vacation Rentals",
@@ -325,7 +325,7 @@
     },
     "logoUrl": "https://www.theislandonlaketravis.com/wp-content/uploads/2025/09/north-shore-vacation-rentals-logo-188x50.png",
     "description": "Manages 30+ privately owned condos and homes on Lake Travis's North Shore (Island Resort, The Hollows, Point Venture).",
-    "partnerSlug": null
+    "partnerSlug": "north-shore-vacation-rentals"
   },
   {
     "name": "ABOVE Vacation Residences",
@@ -344,7 +344,7 @@
     },
     "logoUrl": "https://www.bookabove.com/sites/natx/files/styles/ngt_logo/public/natx/ngt_logo/AboveAustin-23.png",
     "description": "Austin-HQ'd (Bee Cave) luxury estate rental brand with concierge managers and house valets — Lake Austin, Lake Travis, Lake LBJ.",
-    "partnerSlug": null
+    "partnerSlug": "above-vacation-residences"
   },
   {
     "name": "Five Star Vacation Home Rentals",
@@ -363,7 +363,7 @@
     },
     "logoUrl": "https://cdn.prod.website-files.com/61ef18a9db64b07a0eae8a06/69d33e741eacef5c3179de12_61f2b39b0638949d51645a64_Five%2520Star%2520White%2520Hor.webp",
     "description": "Top-rated luxury STR manager in Central Texas (Austin, Lake Austin, Hill Country, San Antonio); 3,000+ five-star reviews.",
-    "partnerSlug": null
+    "partnerSlug": "five-star-vacation-home-rentals"
   },
   {
     "name": "SkyRun Austin",
@@ -382,7 +382,7 @@
     },
     "logoUrl": "https://cdn.skyrun.com/wp-content/uploads/2023/04/12205314/logo.svg",
     "description": "Locally owned SkyRun franchise managing vacation homes, condos, and townhomes across Austin and Lake Travis.",
-    "partnerSlug": null
+    "partnerSlug": "skyrun-austin"
   },
   {
     "name": "Grand Welcome Austin",
@@ -401,7 +401,7 @@
     },
     "logoUrl": "https://cdn.prod.website-files.com/64b95f5eb93062069a6a0f1d/64b95f5eb93062069a6a0f59_grand-welcome-256.png",
     "description": "Locally owned boutique franchise for Austin + Highland Lakes; already partners with Bach Babes on bachelorette homes.",
-    "partnerSlug": null
+    "partnerSlug": "grand-welcome-austin"
   },
   {
     "name": "512 Retreat",
@@ -420,7 +420,7 @@
     },
     "logoUrl": "https://512retreat.com/wp-content/uploads/2022/04/512Retreat_NewLogo-e1650569324429.png",
     "description": "Locally grown luxury Austin vacation rental company with concierge services (chefs, event planning, yachts) and a bachelorette collection.",
-    "partnerSlug": null
+    "partnerSlug": "512-retreat"
   },
   {
     "name": "BacheloretteStays",
@@ -439,7 +439,7 @@
     },
     "logoUrl": "https://www.bachelorettestays.com/images/instagram-logo.avif",
     "description": "Themed party rentals (flower walls, neon murals) for bachelorette/birthday/girls' trips with Austin properties — perfect ICP overlap.",
-    "partnerSlug": null
+    "partnerSlug": "bachelorettestays"
   },
   {
     "name": "SPRKhost",
@@ -458,7 +458,7 @@
     },
     "logoUrl": null,
     "description": "Husband-and-wife Austin luxury vacation rental brand with pool/lakefront homes, direct booking, concierge service.",
-    "partnerSlug": null
+    "partnerSlug": "sprkhost"
   },
   {
     "name": "Stay Local Austin",
@@ -477,7 +477,7 @@
     },
     "logoUrl": "https://austinvacationrentals.com/wp-content/uploads/2025/11/StayAustin-rgb-cropped.svg",
     "description": "Local vacation rental manager (Portoro-affiliated) covering downtown Austin to Hill Country and Lake Travis.",
-    "partnerSlug": null
+    "partnerSlug": "stay-local-austin"
   },
   {
     "name": "Guest Haus",
@@ -496,7 +496,7 @@
     },
     "logoUrl": "https://guesthausrentals.com/wp-content/uploads/2024/02/Austin-Texas-Keep-the-shadow-transparend-background-768x768.webp",
     "description": "Austin-local STR/mid-term manager with net-revenue-share pricing and STR permit/compliance handling.",
-    "partnerSlug": null
+    "partnerSlug": "guest-haus"
   },
   {
     "name": "Barclé Group",
@@ -515,7 +515,7 @@
     },
     "logoUrl": "https://barclegroup.com/wp-content/uploads/2025/05/logo-barcle-club.png",
     "description": "Premium Austin STR management firm — marketing, guest screening, dynamic pricing, luxury interior design.",
-    "partnerSlug": null
+    "partnerSlug": "barcl-group"
   },
   {
     "name": "Surge",
@@ -534,7 +534,7 @@
     },
     "logoUrl": "https://www.gowithsurge.com/surge-logo-teal.png",
     "description": "Austin-rooted full-service STR company (management, brokerage, interior design) at a 15% fee; 4.9 Superhost rating.",
-    "partnerSlug": null
+    "partnerSlug": "surge"
   },
   {
     "name": "Oberg Properties",
@@ -553,7 +553,7 @@
     },
     "logoUrl": "https://lirp.cdn-website.com/cdcd1caf/dms3rep/multi/opt/white-logo-icon-1920w.png",
     "description": "Lakeway/Lake Travis property management firm operating vacation rentals since 1984.",
-    "partnerSlug": null
+    "partnerSlug": "oberg-properties"
   },
   {
     "name": "MOD Property Management",
@@ -572,7 +572,7 @@
     },
     "logoUrl": "https://modpmco.com/wp-content/uploads/2020/09/MOD1.png",
     "description": "Austin-based Airbnb management and hosting company covering Greater Austin and the Hill Country.",
-    "partnerSlug": null
+    "partnerSlug": "mod-property-management"
   },
   {
     "name": "Hill Country Lakes Rentals",
@@ -591,7 +591,7 @@
     },
     "logoUrl": "https://www.hillcountrylakesrentals.com/wp-content/uploads/2025/09/cropped-hclc-logo-1-220x55.png",
     "description": "Local manager of privately owned vacation homes on Lake Travis's North Shore (Hollows Resort, Jonestown area).",
-    "partnerSlug": null
+    "partnerSlug": "hill-country-lakes-rentals"
   },
   {
     "name": "Management With Love",
@@ -610,7 +610,7 @@
     },
     "logoUrl": null,
     "description": "Boutique manager of ~10 lakeside vacation homes in Point Venture on Lake Travis's north shore.",
-    "partnerSlug": null
+    "partnerSlug": "management-with-love"
   },
   {
     "name": "Bach Bros Properties",
@@ -629,7 +629,7 @@
     },
     "logoUrl": "https://le-de.cdn-website.com/08ade2e0ba474aa58a76e4d7bad4d58f/dms3rep/multi/opt/Bach-Bros-Logos--286-29-320w.png",
     "description": "Family-owned Hill Country STR manager with Austin inventory; AirDNA #1 US property manager for 2025.",
-    "partnerSlug": null
+    "partnerSlug": "bach-bros-properties"
   },
   {
     "name": "Lazy H Retreats",
@@ -648,7 +648,7 @@
     },
     "logoUrl": "https://www.lazyhretreats.com/wp-content/uploads/2024/12/LHR-circle-logo-transparent-color-1-e1733850393429.png",
     "description": "Hill Country vacation rental manager whose service area includes Austin, Kyle, Canyon Lake, New Braunfels.",
-    "partnerSlug": null
+    "partnerSlug": "lazy-h-retreats"
   },
   {
     "name": "One Fine BnB",
@@ -667,7 +667,7 @@
     },
     "logoUrl": "https://onefinebnb.com/wp-content/uploads/2024/09/Join-the-One-Fine-Bnb-Family-and-Start-Growing-Your-Business-Today-.webp",
     "description": "Austin-headquartered flat 10%-fee Airbnb management company using AI-driven optimization across 50+ platforms.",
-    "partnerSlug": null
+    "partnerSlug": "one-fine-bnb"
   },
   {
     "name": "MasterHost (Austin)",
@@ -686,7 +686,7 @@
     },
     "logoUrl": null,
     "description": "International Airbnb management company (est. 2015) with a large claimed Austin portfolio; contact via web form.",
-    "partnerSlug": null
+    "partnerSlug": "masterhost-austin"
   },
   {
     "name": "Twinity Properties",
@@ -705,7 +705,7 @@
     },
     "logoUrl": "https://twinityproperties.com/wp-content/uploads/2023/05/tp-logo-primary.svg",
     "description": "Texas STR management firm handling housekeeping, pricing, permits, and tax remittance for Austin owners.",
-    "partnerSlug": null
+    "partnerSlug": "twinity-properties"
   },
   {
     "name": "Guestable",
@@ -724,7 +724,7 @@
     },
     "logoUrl": "https://www.guestable.com/wp-content/uploads/2018/07/Guestable_Logo.svg",
     "description": "Data-driven multi-city Airbnb management company with a dedicated Austin operation (HQ Toronto — verify local team).",
-    "partnerSlug": null
+    "partnerSlug": "guestable"
   },
   {
     "name": "Nest Vacation Rentals",
@@ -743,7 +743,7 @@
     },
     "logoUrl": "https://www.nestvr.com/wp-content/uploads/2016/02/logo-254x122-300x157-215x113.jpg",
     "description": "Boutique luxury Austin vacation rental company — downtown bungalows to Hill Country estates.",
-    "partnerSlug": null
+    "partnerSlug": "nest-vacation-rentals"
   },
   {
     "name": "Casago Austin",
@@ -762,7 +762,7 @@
     },
     "logoUrl": "https://casago.com/images/logos/casago-logo.svg",
     "description": "Locally owned Casago franchise offering full-service vacation rental management in Austin/Round Rock.",
-    "partnerSlug": null
+    "partnerSlug": "casago-austin"
   },
   {
     "name": "Awning",
@@ -781,7 +781,7 @@
     },
     "logoUrl": "https://cdn.prod.website-files.com/6124d988b927e9bf3788a541/6391252247a38f08f0fabb25_awning-logo-new.svg",
     "description": "Tech-enabled nationwide Airbnb/STR management company (from 10% of revenue) with Austin operators.",
-    "partnerSlug": null
+    "partnerSlug": "awning"
   },
   {
     "name": "Locale Hospitality",
@@ -800,7 +800,7 @@
     },
     "logoUrl": null,
     "description": "Austin-founded (2016) tech-forward hospitality company operating furnished apartments/extended stays across Austin.",
-    "partnerSlug": null
+    "partnerSlug": "locale-hospitality"
   },
   {
     "name": "Restoration 43",
@@ -819,7 +819,7 @@
     },
     "logoUrl": "https://static.wixstatic.com/media/7be61d_c78818483e0c45ed8edaad2ccaa48a62~mv2.png/v1/fill/w_141,h_98,al_c,q_85,usm_0.66_1.00_0.01,enc_avif,quality_auto/Website%20Logo.png",
     "description": "TREC-registered short/mid-term rental management team in Austin, Houston, and Dallas with 24/7 support.",
-    "partnerSlug": null
+    "partnerSlug": "restoration-43"
   },
   {
     "name": "HostStarter",
@@ -838,7 +838,7 @@
     },
     "logoUrl": "https://hoststarter.net/wp-content/uploads/2026/04/hoststarter-logo-v2.png",
     "description": "Flat-fee (12.5%) full-service STR management with a dedicated Austin market incl. licensing support.",
-    "partnerSlug": null
+    "partnerSlug": "hoststarter"
   },
   {
     "name": "Clear Stay Properties",
@@ -857,7 +857,7 @@
     },
     "logoUrl": "https://images.squarespace-cdn.com/content/v1/637f7dd1f0e600118df48095/f17acbf7-f349-45b9-baf4-22072ccf0c7c/CS_Logo_RGB_03.png?format=1500w",
     "description": "Boutique design-driven STR management serving Austin, Dripping Springs, and the Hill Country (contact via discovery-call form).",
-    "partnerSlug": null
+    "partnerSlug": "clear-stay-properties"
   },
   {
     "name": "JW Properties (Lake Travis)",
@@ -876,7 +876,7 @@
     },
     "logoUrl": "https://laketravisrental.net/website/agent_zseries_files/3939/logo.png",
     "description": "Owner-operated luxury waterfront vacation rental + real estate company on Lake Travis and Lake Austin.",
-    "partnerSlug": null
+    "partnerSlug": "jw-properties-lake-travis"
   },
   {
     "name": "iTrip Vacations Austin",
@@ -895,7 +895,7 @@
     },
     "logoUrl": "http://pittsburgh.itrip.co/wp-content/uploads/sites/149/2025/08/Vrbo-Logo.png",
     "description": "Locally owned iTrip franchise managing vacation rentals across greater Austin (Round Rock, Lago Vista, Lakeway, Dripping Springs) on 80+ channels.",
-    "partnerSlug": null
+    "partnerSlug": "itrip-vacations-austin"
   },
   {
     "name": "Via Luxury Rentals",
@@ -914,7 +914,7 @@
     },
     "logoUrl": "https://vialuxuryrentals.com/wp-content/uploads/2025/12/cropped-Via-Luxury-Rentals-Logo-512x512-1-180x180.png",
     "description": "Boutique Austin luxury STR manager founded by ex-Airbnb Superhosts (East Austin HQ).",
-    "partnerSlug": null
+    "partnerSlug": "via-luxury-rentals"
   },
   {
     "name": "Austin BNB Management",
@@ -933,7 +933,7 @@
     },
     "logoUrl": "https://4b11d1dded.clvaw-cdnwnd.com/a9bbcea42d0a88d79a3d1da2f40e472e/200000019-7c5207c523/Correct_Area_logo-01-01.PNG?ph=4b11d1dded",
     "description": "Local '100% hands-off' STR manager (W 10th St); claims $3.1M+ earned for clients, Superhost status on all properties.",
-    "partnerSlug": null
+    "partnerSlug": "austin-bnb-management"
   },
   {
     "name": "PMI ATX Properties",
@@ -952,7 +952,7 @@
     },
     "logoUrl": "https://pmi-resources.nesthub.com/images/logos/PMI-ATX-Properties.png",
     "description": "Locally owned PMI franchise managing STR vacation rentals + residential properties in Austin.",
-    "partnerSlug": null
+    "partnerSlug": "pmi-atx-properties"
   },
   {
     "name": "ATX Luxury Rentals",
@@ -971,7 +971,7 @@
     },
     "logoUrl": "https://atxluxuryrentals.com/wp-content/uploads/2025/03/045-431259-16012-Canard-Circle20221119_0066_12020489.webp",
     "description": "Austin Airbnb management specialist — furnishing, revenue optimization, STR licensing, cleaning, maintenance.",
-    "partnerSlug": null
+    "partnerSlug": "atx-luxury-rentals"
   },
   {
     "name": "Placemakr (Austin)",
@@ -990,7 +990,7 @@
     },
     "logoUrl": "https://www.placemakr.com/hubfs/logo.svg",
     "description": "Apartment-hotel operator with flexible furnished stays in downtown Austin (Placemakr Downtown + Littlefield Lofts); corporate/group housing arm.",
-    "partnerSlug": null
+    "partnerSlug": "placemakr-austin"
   },
   {
     "name": "Kasa (Austin)",
@@ -1009,7 +1009,7 @@
     },
     "logoUrl": "https://kasa.com/favicons/apple-icon-180x180.png",
     "description": "Tech-enabled flexible-stay operator running furnished apartment-hotels in Austin incl. Kasa Downtown Austin.",
-    "partnerSlug": null
+    "partnerSlug": "kasa-austin"
   },
   {
     "name": "Mint House (Austin)",
@@ -1028,7 +1028,7 @@
     },
     "logoUrl": "https://framerusercontent.com/images/FB6WD3lPzOcxWjBGCgbTjOIj0.jpg",
     "description": "Apartment-hotel brand with a 25-unit South Congress property (1007 S Congress Ave).",
-    "partnerSlug": null
+    "partnerSlug": "mint-house-austin"
   },
   {
     "name": "Log Country Cove",
@@ -1047,7 +1047,7 @@
     },
     "logoUrl": "https://logcountrycove.com/wp-content/uploads/2020/05/LCC-2020-Logo-003-e1589429010608.png",
     "description": "Waterfront cabin resort on Lake LBJ (Burnet) — 37 furnished units, popular Austin group-getaway destination.",
-    "partnerSlug": null
+    "partnerSlug": "log-country-cove"
   },
   {
     "name": "Blueground (Austin)",
@@ -1066,7 +1066,7 @@
     },
     "logoUrl": "https://cdn.theblueground.com/website/static/img/logo-icon-wordmark-blue-main.e8343518eda1a7cc3f03.svg",
     "description": "Global furnished-apartment operator with premium month-to-month stays across Austin (corporate/mid-term skew).",
-    "partnerSlug": null
+    "partnerSlug": "blueground-austin"
   },
   {
     "name": "Limestone Country Properties",
@@ -1085,6 +1085,6 @@
     },
     "logoUrl": null,
     "description": "Hill Country property manager covering vacation + residential rentals in Canyon Lake and New Braunfels.",
-    "partnerSlug": null
+    "partnerSlug": "limestone-country-properties"
   }
 ]

--- a/src/lib/partners/prospect-datasets.ts
+++ b/src/lib/partners/prospect-datasets.ts
@@ -50,3 +50,8 @@ export function findProspectByWebsite(website: string): ProspectWithVertical | n
   const key = websiteKey(website);
   return getAllProspects().find((p) => websiteKey(p.website) === key) ?? null;
 }
+
+/** Find one prospect by its partner-page slug (set once the page exists). */
+export function findProspectBySlug(slug: string): ProspectWithVertical | null {
+  return getAllProspects().find((p) => p.partnerSlug === slug) ?? null;
+}

--- a/src/lib/partners/str-partners.ts
+++ b/src/lib/partners/str-partners.ts
@@ -14,6 +14,7 @@
  */
 
 import type { DeliveryContextType } from '@/lib/group-orders-v2/types';
+import { findProspectBySlug } from '@/lib/partners/prospect-datasets';
 
 /** One bookable rental property belonging to an STR partner. */
 export interface StrProperty {
@@ -104,6 +105,23 @@ const STR_PARTNERS: Record<string, StrPartnerConfig> = {
       embedUrl: '/partners-embed/premier-quote.html',
     },
   },
+  // The MODEL page — identical to the Lynn's Lodging layout but with the
+  // placeholder business name "Company Name" (backed by a DRAFT affiliate
+  // with partnerSlug 'partner-template'). Reference/demo only; never send
+  // this URL to a real partner.
+  'partner-template': {
+    code: 'PARTNERTEMPLATE',
+    slug: 'partner-template',
+    name: 'Company Name',
+    deliveryContextType: 'HOUSE',
+    allowCustomAddress: true,
+    properties: [],
+    secondTab: {
+      leftLabel: 'Alcohol Delivery',
+      label: 'Party Boat Rentals',
+      embedUrl: '/partners-embed/premier-quote.html',
+    },
+  },
 };
 
 /** Normalize an affiliate code for comparison (uppercase, strip dashes). */
@@ -111,12 +129,45 @@ function normalizeCode(code: string): string {
   return code.toUpperCase().replace(/-/g, '');
 }
 
+/**
+ * Lynn's Lodging is THE template for partner-page replication (Brian,
+ * 2026-07-21): the two-tab layout with the POD delivery page on the left
+ * and the Premier Party Cruises quote mirror on the right. Every STR
+ * partner page not explicitly configured above inherits this via
+ * defaultStrConfigFor() below.
+ */
+export const LYNNS_TEMPLATE_SECOND_TAB: PartnerSecondTab = {
+  leftLabel: 'Alcohol Delivery',
+  label: 'Party Boat Rentals',
+  embedUrl: '/partners-embed/premier-quote.html',
+};
+
+/**
+ * Build the Lynn's-template config for an STR prospect that has a live
+ * partner page (partnerSlug) but no hand-written registry entry. Keeps
+ * "add an STR partner" down to: bulk-import the affiliate + slug in the
+ * prospect JSON — no code change per partner.
+ */
+function defaultStrConfigFor(slug: string): StrPartnerConfig | null {
+  const prospect = findProspectBySlug(slug);
+  if (!prospect || prospect.vertical !== 'str') return null;
+  return {
+    code: normalizeCode(slug),
+    slug,
+    name: prospect.name,
+    deliveryContextType: 'HOUSE',
+    allowCustomAddress: true,
+    properties: [],
+    secondTab: LYNNS_TEMPLATE_SECOND_TAB,
+  };
+}
+
 /** Look up an STR partner by its route slug (e.g. "five-star"). */
 export function getStrPartnerBySlug(
   slug: string | null | undefined
 ): StrPartnerConfig | null {
   if (!slug) return null;
-  return STR_PARTNERS[slug] ?? null;
+  return STR_PARTNERS[slug] ?? defaultStrConfigFor(slug);
 }
 
 /** Look up an STR partner by affiliate code (normalized match). */


### PR DESCRIPTION
Per Brian:

1. **Outreach Playbook** — new Partners hub segment documenting the full campaign system (pipeline, send rules, operator checklist, internals) at `/admin/affiliates/prospects/playbook`.
2. **Lynn's Lodging = the replication template** — `getStrPartnerBySlug()` now generates a Lynn's-style config (two-tab layout w/ Premier quote mirror) for any STR prospect with a partnerSlug; adding a partner needs no code.
3. **Model page** — `/partners/partner-template` renders the identical layout with the placeholder name 'Company Name' (registry entry + DRAFT affiliate).
4. **All 87 prospects are commission-ready affiliates** — 80 created in prod (DRAFT + referral code + free-delivery discount + logo from prospect data), slugs backfilled into both prospect JSONs.

Verified in dev: new partner (austin-vacay) inherits the two-tab template with Start Your Order; template page shows Company Name + Party Boat Rentals; playbook renders. Gates: tsc clean, lint clean, 996/996 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)