### PR TITLE
feat(partners): automate Premiere refund → POD credit codes (ships dark)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -221,6 +221,21 @@ PREMIER_SHEET_ID=your-sheet-id
 BOAT_SCHEDULE_SYNC_KEY=your-sync-key
 
 # ==========================================
+# PREMIERE CREDIT AUTOMATION — POD CREDITS SHEET
+# ==========================================
+# Reuses PREMIER_SHEET_SERVICE_ACCOUNT_EMAIL / _KEY above (share the masterlist
+# with that service account as VIEWER — access is read-only by design).
+# The 2026 Booking Masterlist spreadsheet id + the credits tab name.
+PREMIERE_CREDITS_SHEET_ID=your-masterlist-sheet-id
+PREMIERE_CREDITS_SHEET_TAB=POD Credits
+# GHL inbound webhook that drives the "Premiere Credit — SMS" workflow.
+# Leave unset until the workflow exists — SMS is a no-op without it.
+GHL_PREMIERE_CREDIT_WEBHOOK_URL=
+# Where the per-tick "codes issued" summary goes so Premiere can update the
+# sheet's POD Code column (e.g. grey@premierpartycruises.com).
+PREMIERE_PARTNER_NOTIFY_EMAIL=
+
+# ==========================================
 # ZAPIER — CONTACT FORM
 # ==========================================
 ZAPIER_CONTACT_WEBHOOK_URL=your-contact-webhook-url

--- a/prisma/migrations/manual/2026-07-21-premiere-credit-emailtype.sql
+++ b/prisma/migrations/manual/2026-07-21-premiere-credit-emailtype.sql
@@ -1,0 +1,11 @@
+-- Premiere Credit automation — PREMIERE_CREDIT EmailType enum value.
+--
+-- Deliberately its own file with NO BEGIN/COMMIT: ALTER TYPE ... ADD VALUE
+-- cannot share a transaction with statements that use the new value, and the
+-- migration runner executes each file as a single query. Keep this file to
+-- exactly this one statement. (Precedent: 2026-07-13-lead-reply-emailtype.sql.)
+--
+-- Companion DDL (premiere_credit_grants table) lives in
+-- 2026-07-21-premiere-credit-grants.sql.
+
+ALTER TYPE "EmailType" ADD VALUE IF NOT EXISTS 'PREMIERE_CREDIT';

--- a/prisma/migrations/manual/2026-07-21-premiere-credit-grants.sql
+++ b/prisma/migrations/manual/2026-07-21-premiere-credit-grants.sql
@@ -1,0 +1,52 @@
+-- Premiere Credit automation — grants ledger.
+--
+-- One row per POD-credit grant sourced from the Premiere "POD Credits" sheet
+-- tab. Each grant mints a single-use FIXED_AMOUNT Discount and delivers the
+-- code to the customer. Redemption is NOT stored here — it is derived live
+-- from the linked Discount (usageCount / DiscountUsage). Expiry lives only on
+-- Discount.expiresAt. See src/lib/premiere-credits/.
+--
+-- Additive + idempotent per the manual-migration rules (README.md).
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS premiere_credit_grants (
+  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- Idempotency: sha256 of normalized client name + booking date + amount.
+  -- Row numbers are never identity (humans insert/reorder rows), so this hash
+  -- is the dedupe key. UNIQUE so concurrent cron ticks cannot double-mint.
+  source_key          TEXT NOT NULL UNIQUE,
+  -- Last-seen 1-based sheet row (informational only, for the admin UI).
+  sheet_row           INTEGER,
+  client_name         TEXT NOT NULL,
+  email               TEXT,
+  phone               TEXT,
+  booking_date        DATE,
+  cruise_date         DATE,
+  amount              NUMERIC(10,2) NOT NULL,
+  -- Linked minted discount (NULL until minted — NEEDS_CONTACT never mints).
+  discount_id         UUID REFERENCES discounts(id),
+  code                TEXT,
+  -- Lifecycle: PENDING | NEEDS_CONTACT | READY | HELD_FOR_APPROVAL | SENT |
+  -- SEND_FAILED | CANCELED. Stored as TEXT (not a PG enum) so lifecycle
+  -- tweaks never need a migration.
+  status              TEXT NOT NULL DEFAULT 'PENDING',
+  hold_reason         TEXT,
+  error               TEXT,
+  approved_at         TIMESTAMPTZ,
+  approved_by         TEXT,
+  email_sent_at       TIMESTAMPTZ,
+  sms_sent_at         TIMESTAMPTZ,
+  partner_notified_at TIMESTAMPTZ,
+  -- Raw sheet cells captured at ingest, for audit / debugging.
+  raw_row             JSONB,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS premiere_credit_grants_status_idx
+  ON premiere_credit_grants (status);
+CREATE INDEX IF NOT EXISTS premiere_credit_grants_discount_idx
+  ON premiere_credit_grants (discount_id);
+
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1378,6 +1378,7 @@ enum EmailType {
   RECEIPT
   FOLLOW_UP
   LEAD_REPLY
+  PREMIERE_CREDIT
 }
 
 enum EmailStatus {
@@ -1502,11 +1503,59 @@ model Discount {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  usageHistory DiscountUsage[]
+  usageHistory   DiscountUsage[]
+  premiereCredit PremiereCreditGrant[]
 
   @@index([code])
   @@index([isActive])
   @@map("discounts")
+}
+
+/// Premiere Party Cruises POD-credit grant.
+///
+/// One row per credit sourced from the Premiere "POD Credits" sheet tab. Each
+/// grant mints a single-use FIXED_AMOUNT Discount and delivers the code to the
+/// customer by email + SMS. Redemption is NOT stored — derive it live from the
+/// linked Discount (usageCount / usageHistory). Expiry lives only on
+/// Discount.expiresAt. See src/lib/premiere-credits/.
+model PremiereCreditGrant {
+  id         String @id @default(uuid())
+  /// sha256(normalized client name + booking date + amount) — idempotency key.
+  sourceKey  String @unique @map("source_key")
+  /// Last-seen 1-based sheet row (informational only).
+  sheetRow   Int?   @map("sheet_row")
+  clientName String @map("client_name")
+  email      String?
+  phone      String?
+  bookingDate DateTime? @map("booking_date") @db.Date
+  cruiseDate  DateTime? @map("cruise_date") @db.Date
+  amount      Decimal   @db.Decimal(10, 2)
+
+  /// Linked minted discount (null until minted — NEEDS_CONTACT never mints).
+  discountId String? @map("discount_id")
+  code       String?
+
+  /// PENDING | NEEDS_CONTACT | READY | HELD_FOR_APPROVAL | SENDING | SENT | SEND_FAILED | CANCELED
+  status     String  @default("PENDING")
+  holdReason String? @map("hold_reason")
+  error      String?
+
+  approvedAt        DateTime? @map("approved_at")
+  approvedBy        String?   @map("approved_by")
+  emailSentAt       DateTime? @map("email_sent_at")
+  smsSentAt         DateTime? @map("sms_sent_at")
+  partnerNotifiedAt DateTime? @map("partner_notified_at")
+
+  rawRow Json? @map("raw_row")
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  discount Discount? @relation(fields: [discountId], references: [id])
+
+  @@index([status])
+  @@index([discountId])
+  @@map("premiere_credit_grants")
 }
 
 model DiscountUsage {

--- a/src/app/admin/premiere-credits/_components/GrantsTable.tsx
+++ b/src/app/admin/premiere-credits/_components/GrantsTable.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { ReactElement } from 'react';
+import type { GrantView } from '@/lib/premiere-credits/admin';
+
+const money = (n: number): string => `$${n.toFixed(2)}`;
+const shortDate = (iso: string | null): string =>
+  iso ? new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) : '—';
+
+const BADGE: Record<string, string> = {
+  READY: 'bg-blue-100 text-blue-900',
+  HELD_FOR_APPROVAL: 'bg-indigo-100 text-indigo-900',
+  SENDING: 'bg-sky-100 text-sky-900',
+  SENT: 'bg-green-100 text-green-900',
+  SEND_FAILED: 'bg-red-100 text-red-900',
+  NEEDS_CONTACT: 'bg-amber-100 text-amber-900',
+  CANCELED: 'bg-gray-100 text-gray-700',
+  PENDING: 'bg-gray-100 text-gray-700',
+};
+
+export interface GrantsTableProps {
+  grants: GrantView[];
+  busyId: string | null;
+  onApprove: (id: string) => void;
+  onResend: (id: string) => void;
+  onContact: (id: string) => void;
+  onCancel: (id: string) => void;
+}
+
+/** Redemption / expiry cell text. */
+function redemptionLabel(g: GrantView): string {
+  if (g.redeemed) return `Redeemed ${shortDate(g.redeemedAt)}`;
+  if (g.expiresAt && new Date(g.expiresAt).getTime() < Date.now()) return 'Expired';
+  return 'Unused';
+}
+
+export default function GrantsTable(props: GrantsTableProps): ReactElement {
+  const { grants, busyId } = props;
+  if (grants.length === 0) {
+    return <div className="card text-gray-600">No grants match this filter.</div>;
+  }
+
+  return (
+    <div className="card overflow-x-auto p-0">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-gray-200 text-left text-gray-600">
+            <th className="p-3">Client</th>
+            <th className="p-3">Amount</th>
+            <th className="p-3">Code</th>
+            <th className="p-3">Status</th>
+            <th className="p-3">Redemption</th>
+            <th className="p-3">Expires</th>
+            <th className="p-3 text-right">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {grants.map((g) => (
+            <tr key={g.id} className="border-b border-gray-100 align-top">
+              <td className="p-3">
+                <div className="font-medium text-gray-900">{g.clientName}</div>
+                <div className="text-gray-500">{g.email || <span className="text-amber-700">no email</span>}</div>
+                {g.error ? <div className="text-red-700 text-xs mt-1">{g.error}</div> : null}
+              </td>
+              <td className="p-3 text-gray-900">{money(g.amount)}</td>
+              <td className="p-3 font-mono text-gray-900">{g.code || '—'}</td>
+              <td className="p-3">
+                <span className={`inline-block rounded px-2 py-0.5 text-xs font-semibold ${BADGE[g.status] || BADGE.PENDING}`}>
+                  {g.status.replace(/_/g, ' ')}
+                </span>
+                {g.holdReason ? <div className="text-xs text-gray-500 mt-1">{g.holdReason}</div> : null}
+              </td>
+              <td className="p-3 text-gray-700">
+                {redemptionLabel(g)}
+                {g.redeemed ? <div className="text-xs text-gray-500">applied {money(g.amountSaved)}</div> : null}
+              </td>
+              <td className="p-3 text-gray-700">{shortDate(g.expiresAt)}</td>
+              <td className="p-3">
+                <RowActions {...props} grant={g} disabled={busyId === g.id} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function RowActions({
+  grant, disabled, onApprove, onResend, onContact, onCancel,
+}: GrantsTableProps & { grant: GrantView; disabled: boolean }): ReactElement {
+  const g = grant;
+  const cancellable = !g.redeemed && ['READY', 'HELD_FOR_APPROVAL', 'SEND_FAILED', 'NEEDS_CONTACT'].includes(g.status);
+  return (
+    <div className="flex flex-wrap justify-end gap-2">
+      {g.status === 'HELD_FOR_APPROVAL' && (
+        <button className="btn-primary text-sm px-3 py-1" disabled={disabled} onClick={() => onApprove(g.id)}>
+          Approve &amp; Send
+        </button>
+      )}
+      {(g.status === 'SENT' || g.status === 'SEND_FAILED') && (
+        <button className="btn-secondary text-sm px-3 py-1" disabled={disabled} onClick={() => onResend(g.id)}>
+          Resend
+        </button>
+      )}
+      {g.status === 'NEEDS_CONTACT' && (
+        <button className="btn-primary text-sm px-3 py-1" disabled={disabled} onClick={() => onContact(g.id)}>
+          Add contact
+        </button>
+      )}
+      {cancellable && (
+        <button className="btn-ghost text-sm px-3 py-1 text-red-700" disabled={disabled} onClick={() => onCancel(g.id)}>
+          Cancel
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/premiere-credits/_components/InvoiceSummary.tsx
+++ b/src/app/admin/premiere-credits/_components/InvoiceSummary.tsx
@@ -1,0 +1,37 @@
+import { ReactElement } from 'react';
+import type { ListResult } from '@/lib/premiere-credits/admin';
+
+const money = (n: number): string => `$${n.toFixed(2)}`;
+
+/**
+ * Invoice roll-up for a date range: what Premiere gets billed. Shows BOTH
+ * billing bases — the granted amount and the amount actually redeemed
+ * (DiscountUsage.amountSaved) — so the operator can pick the basis.
+ */
+export default function InvoiceSummary({ summary }: { summary: ListResult['summary'] }): ReactElement {
+  return (
+    <div className="card mb-6">
+      <h3 className="text-lg font-bold tracking-[0.08em] text-gray-900 mb-4">Invoice summary</h3>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <Stat label="Grants shown" value={String(summary.count)} />
+        <Stat label="Redeemed" value={String(summary.redeemedCount)} />
+        <Stat label="Redeemed — granted total" value={money(summary.totalRedeemedGranted)} highlight />
+        <Stat label="Redeemed — actual applied" value={money(summary.totalRedeemedSaved)} />
+      </div>
+      <p className="text-sm text-gray-600 mt-4">
+        Bill Premiere only for redeemed codes. &ldquo;Granted total&rdquo; is the face value of
+        redeemed credits; &ldquo;actual applied&rdquo; is the dollars actually taken off orders
+        (lower when a credit exceeded the order). Pick the basis you invoice on.
+      </p>
+    </div>
+  );
+}
+
+function Stat({ label, value, highlight }: { label: string; value: string; highlight?: boolean }): ReactElement {
+  return (
+    <div className={`rounded-lg border p-4 ${highlight ? 'border-brand-blue bg-blue-50' : 'border-gray-200 bg-white'}`}>
+      <div className="text-sm text-gray-600">{label}</div>
+      <div className="text-2xl font-bold text-gray-900 mt-1">{value}</div>
+    </div>
+  );
+}

--- a/src/app/admin/premiere-credits/page.tsx
+++ b/src/app/admin/premiere-credits/page.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { ReactElement, useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import PartnersHubBand from '@/components/admin/partners/PartnersHubBand';
+import GrantsTable from './_components/GrantsTable';
+import InvoiceSummary from './_components/InvoiceSummary';
+import type { ListResult } from '@/lib/premiere-credits/admin';
+
+const STATUS_TABS: Array<{ key: string; label: string }> = [
+  { key: '', label: 'All' },
+  { key: 'NEEDS_CONTACT', label: 'Needs contact' },
+  { key: 'HELD_FOR_APPROVAL', label: 'Held' },
+  { key: 'READY', label: 'Ready' },
+  { key: 'SENT', label: 'Sent' },
+  { key: 'SEND_FAILED', label: 'Failed' },
+];
+
+/**
+ * Admin — Premiere credit grants. List + operator actions (approve & send,
+ * resend, add contact, cancel) and an invoice view (redeemed in a date range).
+ */
+export default function PremiereCreditsPage(): ReactElement {
+  const [data, setData] = useState<ListResult | null>(null);
+  const [status, setStatus] = useState('');
+  const [invoiceMode, setInvoiceMode] = useState(false);
+  const [from, setFrom] = useState('');
+  const [to, setTo] = useState('');
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    const params = new URLSearchParams();
+    if (invoiceMode) {
+      params.set('redeemed', 'true');
+      if (from) params.set('from', from);
+      if (to) params.set('to', to);
+    } else if (status) {
+      params.set('status', status);
+    }
+    try {
+      const res = await fetch(`/api/v1/admin/premiere-credits?${params.toString()}`);
+      const json = await res.json();
+      if (json.success) setData(json.data);
+    } catch (err) {
+      console.error('load failed', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [status, invoiceMode, from, to]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const act = useCallback(
+    async (id: string, path: string, opts?: RequestInit) => {
+      setBusyId(id);
+      try {
+        const res = await fetch(`/api/v1/admin/premiere-credits/${id}/${path}`, { method: 'POST', ...opts });
+        const json = await res.json();
+        if (!json.success) alert(json.error || 'Action failed');
+      } catch (err) {
+        alert('Request failed');
+        console.error(err);
+      } finally {
+        setBusyId(null);
+        await load();
+      }
+    },
+    [load],
+  );
+
+  const onApprove = (id: string): void => {
+    if (confirm('Approve and send this credit code to the customer now?')) void act(id, 'approve');
+  };
+  const onResend = (id: string): void => {
+    if (confirm('Resend this credit code to the customer?')) void act(id, 'resend');
+  };
+  const onCancel = (id: string): void => {
+    if (confirm('Cancel this grant and deactivate the code? This cannot be undone.')) void act(id, 'cancel');
+  };
+  const onContact = (id: string): void => {
+    const email = prompt('Customer email for this credit:');
+    if (!email) return;
+    const phone = prompt('Customer phone (optional):') || undefined;
+    void act(id, 'contact', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, phone }),
+    });
+  };
+
+  return (
+    <>
+      <PartnersHubBand active="premiere-credits" />
+      <div className="container-custom section-padding">
+        <div className="flex items-center justify-between flex-wrap gap-3 mb-2">
+          <h1 className="text-3xl md:text-4xl font-heading tracking-[0.1em] text-gray-900">Premiere Credits</h1>
+          <button
+            className={invoiceMode ? 'btn-primary' : 'btn-secondary'}
+            onClick={() => setInvoiceMode((v) => !v)}
+          >
+            {invoiceMode ? 'Back to grants' : 'Invoice view'}
+          </button>
+        </div>
+        <p className="text-sm text-gray-600 mb-6">
+          Automation state is controlled by the <code>premiere_credits_master</code> and{' '}
+          <code>premiere_credits_send</code> flags in{' '}
+          <Link href="/admin/features" className="text-brand-blue underline">Features</Link>.
+        </p>
+
+        {invoiceMode ? (
+          <div className="card mb-6 flex flex-wrap items-end gap-4">
+            <label className="text-base text-gray-900">
+              From
+              <input type="date" className="input-premium mt-1 block" value={from} onChange={(e) => setFrom(e.target.value)} />
+            </label>
+            <label className="text-base text-gray-900">
+              To
+              <input type="date" className="input-premium mt-1 block" value={to} onChange={(e) => setTo(e.target.value)} />
+            </label>
+            <span className="text-sm text-gray-600">Shows credits redeemed in the range.</span>
+          </div>
+        ) : (
+          <div className="flex flex-wrap gap-2 mb-6">
+            {STATUS_TABS.map((t) => (
+              <button
+                key={t.key || 'all'}
+                onClick={() => setStatus(t.key)}
+                className={`rounded-lg px-3 py-1.5 text-sm font-semibold tracking-[0.08em] ${
+                  status === t.key ? 'bg-brand-blue text-white' : 'bg-white text-gray-700 border border-gray-200'
+                }`}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {data && <InvoiceSummary summary={data.summary} />}
+
+        {loading && !data ? (
+          <div className="card text-gray-600">Loading…</div>
+        ) : (
+          <GrantsTable
+            grants={data?.grants ?? []}
+            busyId={busyId}
+            onApprove={onApprove}
+            onResend={onResend}
+            onContact={onContact}
+            onCancel={onCancel}
+          />
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/app/api/cron/premiere-credits/route.ts
+++ b/src/app/api/cron/premiere-credits/route.ts
@@ -1,0 +1,39 @@
+/**
+ * GET /api/cron/premiere-credits
+ *
+ * Vercel cron, every 15 minutes. One tick of the Premiere credit engine —
+ * see src/lib/premiere-credits/engine.ts (feature-flag kill switches, sheet
+ * read, per-row-isolated mint, gated send, partner + operator notifications).
+ *
+ * Both flags off → fast `{ paused: true }` no-op.
+ *
+ * Auth: requires CRON_SECRET in the Authorization header (Vercel sets this
+ * automatically for scheduled cron jobs). Fails CLOSED — this route can mint
+ * spendable value and send customer email, so a misconfigured environment must
+ * not leave it open.
+ */
+
+import { NextResponse, type NextRequest } from 'next/server';
+import { runPremiereCreditsTick } from '@/lib/premiere-credits/engine';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+// Sheet read + up to PER_RUN_CAP mints + sends — needs more than the default.
+export const maxDuration = 300;
+
+const CRON_SECRET = process.env.CRON_SECRET;
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const auth = req.headers.get('authorization');
+  if (!CRON_SECRET || auth !== `Bearer ${CRON_SECRET}`) {
+    return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const result = await runPremiereCreditsTick();
+    return NextResponse.json(result, { status: result.ok ? 200 : 500 });
+  } catch (error) {
+    console.error('[premiere-credits] tick crashed:', error);
+    return NextResponse.json({ ok: false, error: 'engine tick failed' }, { status: 500 });
+  }
+}

--- a/src/app/api/v1/admin/premiere-credits/[id]/approve/route.ts
+++ b/src/app/api/v1/admin/premiere-credits/[id]/approve/route.ts
@@ -1,0 +1,32 @@
+/**
+ * POST /api/v1/admin/premiere-credits/[id]/approve
+ *
+ * Approve a HELD_FOR_APPROVAL grant and send its code to the customer
+ * (mints the discount first if the hold was a possible-duplicate that never
+ * minted). Ops-gated; sends real customer email/SMS.
+ */
+
+import { NextResponse } from 'next/server';
+import { requireAdminRole } from '@/lib/auth/ops-session';
+import { approveAndSend } from '@/lib/premiere-credits/admin';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const auth = await requireAdminRole();
+  if (auth instanceof NextResponse) return auth;
+  const { id } = await params;
+
+  try {
+    const result = await approveAndSend(id, auth.role);
+    const ok = result.status === 'SENT';
+    return NextResponse.json({ success: ok, data: result }, { status: ok ? 200 : 502 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'approve failed';
+    console.error('[premiere-credits admin] approve failed:', message);
+    return NextResponse.json({ success: false, error: message }, { status: 400 });
+  }
+}

--- a/src/app/api/v1/admin/premiere-credits/[id]/cancel/route.ts
+++ b/src/app/api/v1/admin/premiere-credits/[id]/cancel/route.ts
@@ -1,0 +1,30 @@
+/**
+ * POST /api/v1/admin/premiere-credits/[id]/cancel
+ *
+ * Void a grant and deactivate its (unredeemed) discount. Refuses to cancel a
+ * grant whose code has already been redeemed. Ops-gated.
+ */
+
+import { NextResponse } from 'next/server';
+import { requireAdminRole } from '@/lib/auth/ops-session';
+import { cancel } from '@/lib/premiere-credits/admin';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const auth = await requireAdminRole();
+  if (auth instanceof NextResponse) return auth;
+  const { id } = await params;
+
+  try {
+    const result = await cancel(id);
+    return NextResponse.json({ success: true, data: result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'cancel failed';
+    console.error('[premiere-credits admin] cancel failed:', message);
+    return NextResponse.json({ success: false, error: message }, { status: 400 });
+  }
+}

--- a/src/app/api/v1/admin/premiere-credits/[id]/contact/route.ts
+++ b/src/app/api/v1/admin/premiere-credits/[id]/contact/route.ts
@@ -1,0 +1,44 @@
+/**
+ * PATCH /api/v1/admin/premiere-credits/[id]/contact
+ *
+ * Fill in email/phone for a NEEDS_CONTACT grant, then mint its code. Sending
+ * follows the normal gated path (cron send phase, or Approve if held).
+ * Ops-gated; Zod-validated body.
+ */
+
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireAdminRole } from '@/lib/auth/ops-session';
+import { setContact } from '@/lib/premiere-credits/admin';
+
+export const dynamic = 'force-dynamic';
+
+const bodySchema = z.object({
+  email: z.string().trim().email(),
+  phone: z.string().trim().min(7).max(32).optional(),
+});
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const auth = await requireAdminRole();
+  if (auth instanceof NextResponse) return auth;
+  const { id } = await params;
+
+  let parsed;
+  try {
+    parsed = bodySchema.parse(await request.json());
+  } catch {
+    return NextResponse.json({ success: false, error: 'invalid body — email required' }, { status: 400 });
+  }
+
+  try {
+    const result = await setContact(id, parsed.email, parsed.phone ?? null);
+    return NextResponse.json({ success: true, data: result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'set contact failed';
+    console.error('[premiere-credits admin] contact failed:', message);
+    return NextResponse.json({ success: false, error: message }, { status: 400 });
+  }
+}

--- a/src/app/api/v1/admin/premiere-credits/[id]/resend/route.ts
+++ b/src/app/api/v1/admin/premiere-credits/[id]/resend/route.ts
@@ -1,0 +1,30 @@
+/**
+ * POST /api/v1/admin/premiere-credits/[id]/resend
+ *
+ * Resend a grant's code (valid from SENT or SEND_FAILED). Ops-gated.
+ */
+
+import { NextResponse } from 'next/server';
+import { requireAdminRole } from '@/lib/auth/ops-session';
+import { resend } from '@/lib/premiere-credits/admin';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const auth = await requireAdminRole();
+  if (auth instanceof NextResponse) return auth;
+  const { id } = await params;
+
+  try {
+    const result = await resend(id);
+    const ok = result.status === 'SENT';
+    return NextResponse.json({ success: ok, data: result }, { status: ok ? 200 : 502 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'resend failed';
+    console.error('[premiere-credits admin] resend failed:', message);
+    return NextResponse.json({ success: false, error: message }, { status: 400 });
+  }
+}

--- a/src/app/api/v1/admin/premiere-credits/route.ts
+++ b/src/app/api/v1/admin/premiere-credits/route.ts
@@ -1,0 +1,34 @@
+/**
+ * GET /api/v1/admin/premiere-credits
+ *
+ * List Premiere credit grants with live redemption info + invoice totals.
+ * Query params: status, redeemed ('true'|'false'), from, to (ISO dates that
+ * filter on the redemption date — the invoice view). Middleware gates
+ * /api/v1/admin/*; this read also requires an admin-role session inline
+ * (matches the admin-only nav placement — the list contains customer PII).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdminRole } from '@/lib/auth/ops-session';
+import { listGrants } from '@/lib/premiere-credits/admin';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = await requireAdminRole();
+  if (auth instanceof NextResponse) return auth;
+
+  const sp = request.nextUrl.searchParams;
+  try {
+    const result = await listGrants({
+      status: sp.get('status'),
+      redeemed: sp.get('redeemed'),
+      from: sp.get('from'),
+      to: sp.get('to'),
+    });
+    return NextResponse.json({ success: true, data: result });
+  } catch (error) {
+    console.error('[premiere-credits admin] list failed:', error);
+    return NextResponse.json({ success: false, error: 'failed to list grants' }, { status: 500 });
+  }
+}

--- a/src/components/admin/partners/PartnersHubBand.tsx
+++ b/src/components/admin/partners/PartnersHubBand.tsx
@@ -5,6 +5,7 @@ import SegmentedControl from '@/components/backend/kit/SegmentedControl';
 const SEGMENTS = [
   { key: 'affiliates', label: 'Affiliates', href: '/admin/affiliates' },
   { key: 'promotions', label: 'Promotions', href: '/admin/promotions' },
+  { key: 'premiere-credits', label: 'Premiere Credits', href: '/admin/premiere-credits' },
   { key: 'str-prospects', label: 'STR Prospects', href: '/admin/affiliates/prospects/str' },
   { key: 'bartending-prospects', label: 'Bartending Prospects', href: '/admin/affiliates/prospects/bartending' },
   { key: 'playbook', label: 'Outreach Playbook', href: '/admin/affiliates/prospects/playbook' },
@@ -18,7 +19,7 @@ const SEGMENTS = [
 export default function PartnersHubBand({
   active,
 }: {
-  active: 'affiliates' | 'promotions' | 'str-prospects' | 'bartending-prospects' | 'playbook';
+  active: 'affiliates' | 'promotions' | 'premiere-credits' | 'str-prospects' | 'bartending-prospects' | 'playbook';
 }): ReactElement {
   return (
     <NavyBand>

--- a/src/components/backend/shell/nav-config.ts
+++ b/src/components/backend/shell/nav-config.ts
@@ -58,7 +58,7 @@ export const BUSINESS_DESTS: NavDest[] = [
   { href: '/admin/finance', label: 'Money', icon: 'money', match: ['/admin/finance'], roles: ['admin'] },
   { href: '/admin/strategy', label: 'Game Plan', icon: 'gameplan', match: ['/admin/strategy'], roles: ['admin'] },
   { href: '/admin/reports', label: 'Reports', icon: 'reports', match: ['/admin/reports'], roles: ['admin'] },
-  { href: '/admin/affiliates', label: 'Partners', icon: 'partners', match: ['/admin/affiliates', '/admin/promotions'], roles: ['admin'] },
+  { href: '/admin/affiliates', label: 'Partners', icon: 'partners', match: ['/admin/affiliates', '/admin/promotions', '/admin/premiere-credits'], roles: ['admin'] },
 ];
 
 /** Second More-sheet group. */
@@ -99,6 +99,7 @@ const SCREEN_TITLES: Array<[string, string]> = [
   ['/admin/reports', 'Reports'],
   ['/admin/affiliates', 'Partners'],
   ['/admin/promotions', 'Partners'],
+  ['/admin/premiere-credits', 'Partners'],
   ['/admin/brians-stuff', "Brian's Stuff"],
   ['/admin/settings', 'Settings'],
   ['/admin/operations', 'Operations'],

--- a/src/lib/email/templates/__tests__/premiere-credit.test.ts
+++ b/src/lib/email/templates/__tests__/premiere-credit.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  generatePremiereCreditEmail,
+  generatePremiereCreditText,
+  premiereCreditSubject,
+} from '../premiere-credit';
+
+const data = {
+  customerName: 'Sarah LeBlanc',
+  code: 'LEBLANC33621',
+  amount: 336.21,
+  expiresAt: new Date('2026-09-20T12:00:00Z'),
+  redeemUrl: 'https://partyondelivery.com',
+};
+
+describe('premiere-credit email', () => {
+  it('renders the code, amount, and CTA', () => {
+    const html = generatePremiereCreditEmail(data);
+    expect(html).toContain('LEBLANC33621');
+    expect(html).toContain('$336.21');
+    expect(html).toContain('ORDER NOW');
+    expect(html).toContain('one-time use');
+  });
+
+  it('states the expiry prominently — at least twice', () => {
+    const html = generatePremiereCreditEmail(data);
+    const occurrences = html.split('September 20, 2026').length - 1;
+    expect(occurrences).toBeGreaterThanOrEqual(2);
+  });
+
+  it('escapes HTML in the customer name', () => {
+    const html = generatePremiereCreditEmail({ ...data, customerName: '<script>x</script> Doe' });
+    expect(html).not.toContain('<script>x</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('plaintext carries code + expiry, subject carries amount', () => {
+    const text = generatePremiereCreditText(data);
+    expect(text).toContain('LEBLANC33621');
+    expect(text).toContain('September 20, 2026');
+    expect(premiereCreditSubject(336.21)).toContain('$336.21');
+  });
+});

--- a/src/lib/email/templates/premiere-credit.ts
+++ b/src/lib/email/templates/premiere-credit.ts
@@ -1,0 +1,169 @@
+/**
+ * Premiere Credit Email Template
+ *
+ * Delivers a single-use POD credit code to a Premiere Party Cruises customer
+ * after their cruise refund. The 60-day expiry is stated prominently — twice —
+ * per the product decision that customers must clearly understand the deadline.
+ */
+
+import { formatCurrency } from '../resend-client';
+
+export interface PremiereCreditEmailData {
+  customerName: string;
+  code: string;
+  amount: number;
+  /** Expiry date (60 days from issue). */
+  expiresAt: Date;
+  /** Where to redeem — the storefront. */
+  redeemUrl: string;
+}
+
+/** Long-form date for customer-facing copy, e.g. "September 20, 2026". */
+function formatLongDate(date: Date): string {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'America/Chicago',
+  }).format(date);
+}
+
+/** Minimal HTML escape for interpolated external text (name). */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/** Subject line for the credit email. */
+export function premiereCreditSubject(amount: number): string {
+  return `Your ${formatCurrency(amount)} Party On Delivery credit from Premiere Party Cruises`;
+}
+
+/**
+ * Generate the credit email HTML. Styled to match the invoice template (dark
+ * header, gold accents) with a prominent code block and expiry callout.
+ */
+export function generatePremiereCreditEmail(data: PremiereCreditEmailData): string {
+  const firstName = escapeHtml(data.customerName.trim().split(/\s+/)[0] || 'there');
+  const expiry = formatLongDate(data.expiresAt);
+  const amount = formatCurrency(data.amount);
+  const code = escapeHtml(data.code);
+  const year = new Date().getFullYear();
+
+  return `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #f9fafb;">
+  <table cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #f9fafb; padding: 40px 20px;">
+    <tr>
+      <td align="center">
+        <table cellpadding="0" cellspacing="0" border="0" width="600" style="max-width: 600px; background-color: #ffffff; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.1);">
+          <!-- Header -->
+          <tr>
+            <td style="background-color: #1a1a1a; padding: 32px; text-align: center; border-radius: 8px 8px 0 0;">
+              <img src="https://partyondelivery.com/images/pod-logo-2025.png" alt="Party On Delivery" width="180" style="width: 180px; max-width: 100%; height: auto; margin-bottom: 12px;" />
+              <p style="color: #ffffff; margin: 0; font-size: 14px; letter-spacing: 0.05em;">PREMIUM ALCOHOL DELIVERY</p>
+            </td>
+          </tr>
+          <!-- Body -->
+          <tr>
+            <td style="padding: 36px 32px 8px 32px;">
+              <p style="margin: 0 0 16px 0; color: #111827; font-size: 18px;">Hi ${firstName},</p>
+              <p style="margin: 0 0 24px 0; color: #4b5563; font-size: 16px; line-height: 1.6;">
+                Premiere Party Cruises and Party On Delivery have you covered — here is a
+                <strong>${amount}</strong> credit toward drinks delivered to your door.
+              </p>
+
+              <!-- Code block -->
+              <table cellpadding="0" cellspacing="0" border="0" width="100%" style="margin: 0 0 8px 0;">
+                <tr>
+                  <td style="background-color: #f3f4f6; border: 2px dashed #9ca3af; border-radius: 8px; padding: 20px; text-align: center;">
+                    <p style="margin: 0 0 6px 0; color: #6b7280; font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase;">Your credit code</p>
+                    <p style="margin: 0; color: #111827; font-size: 30px; font-weight: 700; font-family: 'Courier New', Courier, monospace; letter-spacing: 0.06em;">${code}</p>
+                  </td>
+                </tr>
+              </table>
+
+              <!-- Expiry callout (prominent, appears directly under the code) -->
+              <table cellpadding="0" cellspacing="0" border="0" width="100%" style="margin: 0 0 28px 0;">
+                <tr>
+                  <td style="background-color: #fef9e7; border-left: 4px solid #D4AF37; border-radius: 4px; padding: 14px 18px;">
+                    <p style="margin: 0; color: #7c5e10; font-size: 15px; line-height: 1.5;">
+                      <strong>This credit expires ${expiry}</strong> — 60 days from today. Use it before then, or it's gone. It's one-time use.
+                    </p>
+                  </td>
+                </tr>
+              </table>
+
+              <!-- CTA -->
+              <table cellpadding="0" cellspacing="0" border="0" width="100%" style="margin: 0 0 28px 0;">
+                <tr>
+                  <td align="center">
+                    <a href="${data.redeemUrl}" style="display: inline-block; background-color: #D4AF37; color: #1a1a1a; text-decoration: none; font-weight: 700; font-size: 16px; letter-spacing: 0.06em; padding: 15px 40px; border-radius: 8px;">ORDER NOW</a>
+                  </td>
+                </tr>
+              </table>
+
+              <!-- How to redeem -->
+              <p style="margin: 0 0 10px 0; color: #111827; font-size: 15px; font-weight: 700;">How to use your credit</p>
+              <ol style="margin: 0 0 24px 0; padding-left: 20px; color: #4b5563; font-size: 15px; line-height: 1.7;">
+                <li>Add your drinks to the cart at <a href="${data.redeemUrl}" style="color: #0B74B8;">partyondelivery.com</a>.</li>
+                <li>Enter code <strong>${code}</strong> at checkout — <strong>${amount}</strong> comes off instantly.</li>
+                <li>For the full value, build an order of at least ${amount}; the credit is one-time use and any unused balance is forfeited.</li>
+              </ol>
+
+              <p style="margin: 0 0 24px 0; color: #6b7280; font-size: 14px; line-height: 1.6;">
+                Standard delivery minimums apply. Delivery is available across the Austin area.
+              </p>
+            </td>
+          </tr>
+          <!-- Footer -->
+          <tr>
+            <td style="padding: 20px 32px 32px 32px; border-top: 1px solid #e5e7eb;">
+              <p style="margin: 0 0 6px 0; color: #6b7280; font-size: 13px;">
+                Reminder: code <strong>${code}</strong> expires <strong>${expiry}</strong>.
+              </p>
+              <p style="margin: 0 0 6px 0; color: #9ca3af; font-size: 13px;">Questions? Contact us at info@partyondelivery.com</p>
+              <p style="margin: 0; color: #9ca3af; font-size: 12px;">${year} Party On Delivery. Austin, Texas.</p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+}
+
+/** Plaintext fallback. */
+export function generatePremiereCreditText(data: PremiereCreditEmailData): string {
+  const firstName = data.customerName.trim().split(/\s+/)[0] || 'there';
+  const expiry = formatLongDate(data.expiresAt);
+  const amount = formatCurrency(data.amount);
+  return [
+    `Hi ${firstName},`,
+    '',
+    `Premiere Party Cruises and Party On Delivery have you covered — here is a ${amount} credit toward drinks delivered to your door.`,
+    '',
+    `Your credit code: ${data.code}`,
+    '',
+    `THIS CREDIT EXPIRES ${expiry} — 60 days from today. Use it before then. It's one-time use.`,
+    '',
+    'How to use it:',
+    `1. Add your drinks to the cart at ${data.redeemUrl}`,
+    `2. Enter code ${data.code} at checkout — ${amount} comes off instantly.`,
+    `3. For the full value, build an order of at least ${amount}; any unused balance is forfeited.`,
+    '',
+    'Standard delivery minimums apply. Delivery is available across the Austin area.',
+    '',
+    `Reminder: ${data.code} expires ${expiry}.`,
+    'Questions? info@partyondelivery.com',
+  ].join('\n');
+}

--- a/src/lib/features/feature-flags.ts
+++ b/src/lib/features/feature-flags.ts
@@ -52,6 +52,13 @@ export const FEATURE_FLAGS = {
   // resume selling. See src/lib/full-moon/event-state.ts.
   FULL_MOON_POSTPONED: 'full_moon_postponed',
 
+  // Premiere credit automation (src/lib/premiere-credits) — master kill switch
+  // + a separate send gate. MASTER off → the cron is a no-op. With MASTER on
+  // and SEND off, the cron mints codes + writes grants but sends nothing (the
+  // safe dry-run mode used to eyeball the first real batch). Both default off.
+  PREMIERE_CREDITS_MASTER: 'premiere_credits_master',
+  PREMIERE_CREDITS_SEND: 'premiere_credits_send',
+
   // Not a rollout flag — a debounce stamp. The row's updatedAt records when
   // the operator was last emailed about CoreLinq ingest failures, so a CRM
   // outage alerts once per window instead of once per form submit. See

--- a/src/lib/premiere-credits/__tests__/parse.test.ts
+++ b/src/lib/premiere-credits/__tests__/parse.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+import {
+  locateHeader,
+  mapHeaders,
+  normalizeHeader,
+  normalizeName,
+  extractLastName,
+  parseBookingDateToISO,
+  parseCruiseDateToISO,
+  parseCurrencyUSD,
+  parseRows,
+} from '../parse';
+import type { HeaderMap, RawCreditRow } from '../types';
+
+// The real POD Credits tab header (order matters for index assertions).
+const HEADER = [
+  'POD Credit', 'POD Code', 'Status', 'Booking Date', 'Client Name',
+  'Phone Number', 'Email Address', 'Actual Cruise Date', 'Actual Time Slot',
+  'Experience', 'Boat', 'Girls', 'Guys', 'ADD-ON/S',
+];
+
+describe('parseCurrencyUSD', () => {
+  it('parses common cell formats to USD numbers', () => {
+    expect(parseCurrencyUSD('$125.26')).toBe(125.26);
+    expect(parseCurrencyUSD('₱250.00')).toBe(250);
+    expect(parseCurrencyUSD('$1,234.56')).toBe(1234.56);
+    expect(parseCurrencyUSD('250')).toBe(250);
+    expect(parseCurrencyUSD('₱ 300')).toBe(300);
+    expect(parseCurrencyUSD('$0.00')).toBe(0);
+    expect(parseCurrencyUSD('(50)')).toBe(-50);
+  });
+
+  it('returns null for blank / unparseable', () => {
+    expect(parseCurrencyUSD('')).toBeNull();
+    expect(parseCurrencyUSD('   ')).toBeNull();
+    expect(parseCurrencyUSD('abc')).toBeNull();
+    expect(parseCurrencyUSD(null)).toBeNull();
+    expect(parseCurrencyUSD(undefined)).toBeNull();
+  });
+});
+
+describe('normalizeHeader / mapHeaders', () => {
+  it('normalizes to alnum-only uppercase', () => {
+    expect(normalizeHeader('POD Credit')).toBe('PODCREDIT');
+    expect(normalizeHeader('Email Address')).toBe('EMAILADDRESS');
+    expect(normalizeHeader('ADD-ON/S')).toBe('ADDONS');
+  });
+
+  it('maps the real header row to the right indexes', () => {
+    const h = mapHeaders(HEADER);
+    expect(h.amount).toBe(0);
+    expect(h.code).toBe(1);
+    expect(h.status).toBe(2);
+    expect(h.bookingDate).toBe(3);
+    expect(h.client).toBe(4);
+    expect(h.phone).toBe(5);
+    expect(h.email).toBe(6);
+    expect(h.cruiseDate).toBe(7);
+  });
+
+  it('tolerates renamed / reordered / missing columns', () => {
+    const h = mapHeaders(['Client Name', 'POD Credit Amount', 'Cruise Date']);
+    expect(h.client).toBe(0);
+    expect(h.amount).toBe(1);
+    expect(h.cruiseDate).toBe(2);
+    expect(h.email).toBeNull();
+  });
+});
+
+describe('locateHeader', () => {
+  it('skips leading blank/merged rows and finds the header', () => {
+    const grid = [[], ['', '', ''], HEADER, ['$50', '', '', '', 'Jane Doe']];
+    const located = locateHeader(grid);
+    expect(located).not.toBeNull();
+    expect(located?.headerIndex).toBe(2);
+    expect(located?.header.client).toBe(4);
+  });
+
+  it('returns null when there is no amount+client header', () => {
+    expect(locateHeader([['Foo', 'Bar'], ['a', 'b']])).toBeNull();
+  });
+});
+
+describe('date parsing', () => {
+  it('parses MM-DD-YYYY and M/D/YYYY booking dates', () => {
+    expect(parseBookingDateToISO('10-21-2025')).toBe('2025-10-21');
+    expect(parseBookingDateToISO('3/6/2026')).toBe('2026-03-06');
+    expect(parseBookingDateToISO('')).toBeNull();
+    expect(parseBookingDateToISO('May 1, 2026')).toBeNull();
+    expect(parseBookingDateToISO('13-40-2026')).toBeNull();
+  });
+
+  it('rejects impossible calendar dates', () => {
+    expect(parseBookingDateToISO('02-30-2026')).toBeNull();
+    expect(parseBookingDateToISO('04-31-2026')).toBeNull();
+    expect(parseBookingDateToISO('02-29-2026')).toBeNull(); // 2026 not a leap year
+    expect(parseBookingDateToISO('02-29-2028')).toBe('2028-02-29'); // leap year OK
+    expect(parseCruiseDateToISO('February 30, 2026')).toBeNull();
+  });
+
+  it('parses long-form cruise dates', () => {
+    expect(parseCruiseDateToISO('May 23, 2026')).toBe('2026-05-23');
+    expect(parseCruiseDateToISO('April 2, 2026')).toBe('2026-04-02');
+    expect(parseCruiseDateToISO('Foo 1, 2026')).toBeNull();
+    // tolerates a numeric cruise date too
+    expect(parseCruiseDateToISO('06-19-2026')).toBe('2026-06-19');
+  });
+});
+
+describe('name helpers', () => {
+  it('extracts an uppercase last name', () => {
+    expect(extractLastName('Sarah LeBlanc')).toBe('LEBLANC');
+    expect(extractLastName('Connor Hartman')).toBe('HARTMAN');
+    expect(extractLastName('Madonna')).toBe('MADONNA');
+    expect(extractLastName('  ')).toBe('');
+  });
+
+  it('normalizes names for the key', () => {
+    expect(normalizeName('  Sarah   LeBlanc ')).toBe('sarah leblanc');
+    expect(normalizeName("O'Brien")).toBe('obrien');
+  });
+});
+
+describe('parseRows', () => {
+  const header: HeaderMap = mapHeaders(HEADER);
+  const row = (cells: Partial<Record<number, string>>): RawCreditRow => {
+    const arr = new Array(HEADER.length).fill('');
+    Object.entries(cells).forEach(([i, v]) => (arr[Number(i)] = v));
+    return { sheetRow: 5, cells: arr };
+  };
+
+  it('keeps a good row and derives fields', () => {
+    const { rows } = parseRows(header, [
+      row({ 0: '$336.21', 3: '12-24-2025', 4: 'Sarah LeBlanc', 5: '2817148839', 6: 'sarah@example.com', 7: 'July 19, 2026' }),
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].amount).toBe(336.21);
+    expect(rows[0].clientName).toBe('Sarah LeBlanc');
+    expect(rows[0].email).toBe('sarah@example.com');
+    expect(rows[0].bookingDateISO).toBe('2025-12-24');
+    expect(rows[0].cruiseDateISO).toBe('2026-07-19');
+    expect(rows[0].sourceKey).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('skips existing-code, $0.00, and blank-client rows', () => {
+    const { rows } = parseRows(header, [
+      row({ 0: '$125.26', 1: 'CARNEY12526', 4: 'Nicole Carney' }), // already coded
+      row({ 0: '$0.00' }),                                          // filler
+      row({ 0: '$100.00', 4: '' }),                                 // no client
+    ]);
+    expect(rows).toHaveLength(0);
+  });
+
+  it('parses a no-email row (contact resolved later by the planner)', () => {
+    const { rows } = parseRows(header, [row({ 0: '$50', 4: 'No Email' })]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].email).toBeNull();
+  });
+});

--- a/src/lib/premiere-credits/__tests__/planner.test.ts
+++ b/src/lib/premiere-credits/__tests__/planner.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import {
+  generateCodeBase,
+  isPossibleDuplicate,
+  isValidEmail,
+  planRowAction,
+} from '../planner';
+import type { ParsedCreditRow } from '../types';
+
+function makeRow(overrides: Partial<ParsedCreditRow>): ParsedCreditRow {
+  return {
+    sheetRow: 5,
+    clientName: 'Jane Doe',
+    email: 'jane@example.com',
+    phone: '5125551234',
+    bookingDateISO: '2026-01-01',
+    cruiseDateISO: '2026-02-01',
+    amount: 50,
+    sourceKey: 'key-1',
+    rawRow: {},
+    ...overrides,
+  };
+}
+
+describe('isValidEmail', () => {
+  it('accepts valid, rejects invalid/blank', () => {
+    expect(isValidEmail('jane@example.com')).toBe(true);
+    expect(isValidEmail('  jane@example.com ')).toBe(true);
+    expect(isValidEmail('nope')).toBe(false);
+    expect(isValidEmail('')).toBe(false);
+    expect(isValidEmail(null)).toBe(false);
+  });
+});
+
+describe('planRowAction', () => {
+  it('needs contact when there is no valid email', () => {
+    expect(planRowAction(makeRow({ email: null })).kind).toBe('needs-contact');
+    expect(planRowAction(makeRow({ email: 'garbage' })).kind).toBe('needs-contact');
+  });
+
+  it('mints without hold at or below the $300 threshold', () => {
+    expect(planRowAction(makeRow({ amount: 50 }))).toEqual({ kind: 'mint', hold: false });
+    expect(planRowAction(makeRow({ amount: 300 }))).toEqual({ kind: 'mint', hold: false });
+  });
+
+  it('holds strictly above $300 (over-threshold)', () => {
+    expect(planRowAction(makeRow({ amount: 300.01 }))).toEqual({
+      kind: 'mint', hold: true, holdReason: 'over-threshold',
+    });
+    expect(planRowAction(makeRow({ amount: 336.21 })).kind).toBe('mint');
+  });
+
+  it('holds with sanity-cap reason above $1000', () => {
+    expect(planRowAction(makeRow({ amount: 1000.01 }))).toEqual({
+      kind: 'mint', hold: true, holdReason: 'sanity-cap',
+    });
+  });
+});
+
+describe('generateCodeBase', () => {
+  it('matches the existing LASTNAME + amount-digits convention', () => {
+    expect(generateCodeBase('Sarah LeBlanc', 336.21)).toBe('LEBLANC33621');
+    expect(generateCodeBase('Olivia Haraden', 125.26)).toBe('HARADEN12526');
+    expect(generateCodeBase('Daniel Benson', 138.44)).toBe('BENSON13844');
+  });
+
+  it('falls back gracefully for single-word / empty names', () => {
+    expect(generateCodeBase('Madonna', 100)).toBe('MADONNA10000');
+    expect(generateCodeBase('123', 50)).toBe('PODCREDIT5000');
+  });
+});
+
+describe('isPossibleDuplicate', () => {
+  const row = makeRow({ sourceKey: 'key-A' });
+
+  it('is true when a sibling has a different source key', () => {
+    expect(isPossibleDuplicate(row, [{ sourceKey: 'key-B' }])).toBe(true);
+  });
+
+  it('is false with no siblings or only same-key siblings', () => {
+    expect(isPossibleDuplicate(row, [])).toBe(false);
+    expect(isPossibleDuplicate(row, [{ sourceKey: 'key-A' }])).toBe(false);
+  });
+});

--- a/src/lib/premiere-credits/__tests__/source-key.test.ts
+++ b/src/lib/premiere-credits/__tests__/source-key.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { computeSourceKey } from '../parse';
+
+describe('computeSourceKey', () => {
+  it('is stable across name whitespace / casing', () => {
+    const a = computeSourceKey('Sarah LeBlanc', '2025-12-24', 336.21);
+    const b = computeSourceKey('  sarah   leblanc ', '2025-12-24', 336.21);
+    expect(a).toBe(b);
+  });
+
+  it('is stable across amount decimal representation', () => {
+    expect(computeSourceKey('Jane Doe', '2026-01-01', 138.4)).toBe(
+      computeSourceKey('Jane Doe', '2026-01-01', 138.40),
+    );
+  });
+
+  it('changes when the amount changes (the duplicate-different-amount case)', () => {
+    const a = computeSourceKey('Jane Doe', '2026-01-01', 125.26);
+    const b = computeSourceKey('Jane Doe', '2026-01-01', 138.44);
+    expect(a).not.toBe(b);
+  });
+
+  it('changes when the booking date changes', () => {
+    const a = computeSourceKey('Jane Doe', '2026-01-01', 100);
+    const b = computeSourceKey('Jane Doe', '2026-02-01', 100);
+    expect(a).not.toBe(b);
+  });
+
+  it('handles a null booking date deterministically', () => {
+    const a = computeSourceKey('Jane Doe', null, 100);
+    const b = computeSourceKey('Jane Doe', null, 100);
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[a-f0-9]{64}$/);
+  });
+});

--- a/src/lib/premiere-credits/admin.ts
+++ b/src/lib/premiere-credits/admin.ts
@@ -1,0 +1,215 @@
+/**
+ * Premiere Credit automation — admin operations.
+ *
+ * Powers /admin/premiere-credits: list grants with live redemption (joined
+ * from the linked Discount), and the operator actions (approve & send, resend,
+ * add contact, cancel). Redemption is always derived from the Discount, never
+ * stored on the grant. All mutations run behind requireOpsAuth in the routes.
+ */
+
+import { prisma } from '@/lib/database/client';
+import { mintForGrant, sendGrant, type DeliveredInfo } from './grant-service';
+import type { GrantStatus } from './types';
+
+/** A grant enriched with derived redemption info for the admin UI. */
+export interface GrantView {
+  id: string;
+  clientName: string;
+  email: string | null;
+  phone: string | null;
+  amount: number;
+  code: string | null;
+  status: string;
+  holdReason: string | null;
+  error: string | null;
+  bookingDate: string | null;
+  cruiseDate: string | null;
+  createdAt: string;
+  emailSentAt: string | null;
+  expiresAt: string | null;
+  /** True when the linked discount has been used at least once. */
+  redeemed: boolean;
+  redeemedAt: string | null;
+  /** Dollars actually taken off orders (sum of DiscountUsage.amountSaved). */
+  amountSaved: number;
+}
+
+export interface ListFilters {
+  status?: string | null;
+  redeemed?: string | null; // 'true' | 'false'
+  from?: string | null;     // ISO date, filters on redemption date
+  to?: string | null;
+}
+
+export interface ListResult {
+  grants: GrantView[];
+  summary: {
+    count: number;
+    totalGranted: number;      // sum of grant amounts
+    redeemedCount: number;
+    totalRedeemedGranted: number; // grant amount of redeemed grants (billing basis A)
+    totalRedeemedSaved: number;   // actual amountSaved of redeemed grants (billing basis B)
+  };
+}
+
+/** Load grants + derive redemption, apply filters, and total for invoicing. */
+export async function listGrants(filters: ListFilters): Promise<ListResult> {
+  const where = filters.status ? { status: filters.status } : {};
+  const rows = await prisma.premiereCreditGrant.findMany({
+    where,
+    orderBy: { createdAt: 'desc' },
+    take: 1000, // bound the response; one row per Premiere refund, so ample
+
+    include: {
+      discount: {
+        select: {
+          usageCount: true,
+          expiresAt: true,
+          usageHistory: { select: { usedAt: true, amountSaved: true }, orderBy: { usedAt: 'asc' } },
+        },
+      },
+    },
+  });
+
+  const fromMs = filters.from ? Date.parse(filters.from) : null;
+  const toMs = filters.to ? Date.parse(filters.to) + 24 * 60 * 60 * 1000 - 1 : null;
+
+  const grants: GrantView[] = [];
+  for (const g of rows) {
+    const usage = g.discount?.usageHistory ?? [];
+    const redeemed = (g.discount?.usageCount ?? 0) >= 1;
+    const redeemedAt = usage[0]?.usedAt ?? null;
+    const amountSaved = usage.reduce((sum, u) => sum + Number(u.amountSaved), 0);
+
+    if (filters.redeemed === 'true' && !redeemed) continue;
+    if (filters.redeemed === 'false' && redeemed) continue;
+    if ((fromMs || toMs) && redeemedAt) {
+      const t = redeemedAt.getTime();
+      if (fromMs && t < fromMs) continue;
+      if (toMs && t > toMs) continue;
+    } else if (fromMs || toMs) {
+      continue; // date-window filter implies "redeemed in window"
+    }
+
+    grants.push({
+      id: g.id,
+      clientName: g.clientName,
+      email: g.email,
+      phone: g.phone,
+      amount: Number(g.amount),
+      code: g.code,
+      status: g.status,
+      holdReason: g.holdReason,
+      error: g.error,
+      bookingDate: g.bookingDate ? g.bookingDate.toISOString().slice(0, 10) : null,
+      cruiseDate: g.cruiseDate ? g.cruiseDate.toISOString().slice(0, 10) : null,
+      createdAt: g.createdAt.toISOString(),
+      emailSentAt: g.emailSentAt ? g.emailSentAt.toISOString() : null,
+      expiresAt: g.discount?.expiresAt ? g.discount.expiresAt.toISOString() : null,
+      redeemed,
+      redeemedAt: redeemedAt ? redeemedAt.toISOString() : null,
+      amountSaved,
+    });
+  }
+
+  const redeemedGrants = grants.filter((g) => g.redeemed);
+  return {
+    grants,
+    summary: {
+      count: grants.length,
+      totalGranted: round2(grants.reduce((s, g) => s + g.amount, 0)),
+      redeemedCount: redeemedGrants.length,
+      totalRedeemedGranted: round2(redeemedGrants.reduce((s, g) => s + g.amount, 0)),
+      totalRedeemedSaved: round2(redeemedGrants.reduce((s, g) => s + g.amountSaved, 0)),
+    },
+  };
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/** Approve a held grant and send it. Mints first if it has no discount yet. */
+export async function approveAndSend(
+  grantId: string,
+  approvedBy: string,
+): Promise<{ status: GrantStatus; error?: string; delivered?: DeliveredInfo }> {
+  const grant = await prisma.premiereCreditGrant.findUnique({ where: { id: grantId } });
+  if (!grant) throw new Error('grant not found');
+  if (grant.status !== 'HELD_FOR_APPROVAL') throw new Error(`cannot approve grant in status ${grant.status}`);
+
+  if (!grant.discountId) await mintForGrant(grant);
+  // Held grants mint INACTIVE (the code isn't redeemable pre-approval).
+  // Approval is what makes it live — activate before the send goes out.
+  const fresh = await prisma.premiereCreditGrant.findUnique({
+    where: { id: grantId },
+    select: { discountId: true },
+  });
+  if (fresh?.discountId) {
+    await prisma.discount.update({ where: { id: fresh.discountId }, data: { isActive: true } });
+  }
+  await prisma.premiereCreditGrant.update({
+    where: { id: grantId },
+    data: { approvedAt: new Date(), approvedBy },
+  });
+  return sendGrant(grantId);
+}
+
+/** Resend a grant's code (already sent or previously failed). */
+export async function resend(grantId: string): Promise<{ status: GrantStatus; error?: string }> {
+  const grant = await prisma.premiereCreditGrant.findUnique({ where: { id: grantId }, select: { status: true } });
+  if (!grant) throw new Error('grant not found');
+  if (grant.status !== 'SENT' && grant.status !== 'SEND_FAILED') {
+    throw new Error(`cannot resend grant in status ${grant.status}`);
+  }
+  return sendGrant(grantId);
+}
+
+/**
+ * Fill in contact info for a NEEDS_CONTACT grant and mint its code. Sending
+ * then follows the normal gated path (cron send phase, or Approve if held).
+ */
+export async function setContact(
+  grantId: string,
+  email: string,
+  phone: string | null,
+): Promise<{ status: GrantStatus }> {
+  const grant = await prisma.premiereCreditGrant.findUnique({ where: { id: grantId } });
+  if (!grant) throw new Error('grant not found');
+  if (grant.status !== 'NEEDS_CONTACT') throw new Error(`cannot set contact on grant in status ${grant.status}`);
+
+  const updated = await prisma.premiereCreditGrant.update({
+    where: { id: grantId },
+    data: { email, phone: phone ?? grant.phone },
+  });
+  const minted = await mintForGrant(updated);
+  return { status: minted.status as GrantStatus };
+}
+
+/** Cancel a grant and deactivate its (unredeemed) discount. */
+export async function cancel(grantId: string): Promise<{ status: GrantStatus }> {
+  const grant = await prisma.premiereCreditGrant.findUnique({
+    where: { id: grantId },
+    select: { id: true, status: true, discountId: true },
+  });
+  if (!grant) throw new Error('grant not found');
+  // Never cancel mid-send — a race with sendGrant would leave the customer
+  // holding a code that was just deactivated, with a nondeterministic status.
+  if (grant.status === 'SENDING') throw new Error('cannot cancel while a send is in flight');
+  if (grant.status === 'CANCELED') throw new Error('grant already canceled');
+
+  await prisma.$transaction(async (tx) => {
+    if (grant.discountId) {
+      // Re-check redemption INSIDE the transaction (TOCTOU): a redemption that
+      // landed since the read above must still block the cancel.
+      const disc = await tx.discount.findUnique({
+        where: { id: grant.discountId },
+        select: { usageCount: true },
+      });
+      if ((disc?.usageCount ?? 0) >= 1) throw new Error('cannot cancel a redeemed credit');
+      await tx.discount.update({ where: { id: grant.discountId }, data: { isActive: false } });
+    }
+    await tx.premiereCreditGrant.update({ where: { id: grantId }, data: { status: 'CANCELED' } });
+  });
+  return { status: 'CANCELED' };
+}

--- a/src/lib/premiere-credits/engine.ts
+++ b/src/lib/premiere-credits/engine.ts
@@ -1,0 +1,178 @@
+/**
+ * Premiere Credit automation — cron engine.
+ *
+ * One tick: read the POD Credits sheet, mint codes for new rows (each row
+ * isolated so one bad row can't stop the rest), send READY grants (only when
+ * the send flag is on), then notify the partner of delivered codes and alert
+ * the operator about anything needing a human. All work is gated behind two
+ * feature flags; with both absent the tick is a fast no-op.
+ */
+
+import { prisma } from '@/lib/database/client';
+import { FEATURE_FLAGS, isFeatureEnabled } from '@/lib/features/feature-flags';
+import { readCreditSheet, isPremiereCreditsSheetConfigured } from './sheet';
+import { ingestRow, sendGrant, type DeliveredInfo } from './grant-service';
+import { PER_RUN_CAP } from './planner';
+import {
+  sendPartnerCodeSummary,
+  sendOpsAttentionAlert,
+  type AttentionItem,
+  type DeliveredCode,
+} from './notify';
+import type { ParsedCreditRow, TickResult } from './types';
+
+/** Ingest new rows, bounded by PER_RUN_CAP new grants per tick. */
+async function ingestPhase(
+  rows: ParsedCreditRow[],
+): Promise<{ minted: number; held: number; needsContact: number; attention: AttentionItem[]; errors: TickResult['rowErrors'] }> {
+  let minted = 0;
+  let held = 0;
+  let needsContact = 0;
+  let created = 0;
+  const attention: AttentionItem[] = [];
+  const errors: TickResult['rowErrors'] = [];
+
+  for (const row of rows) {
+    if (created >= PER_RUN_CAP) {
+      errors.push({ sheetRow: row.sheetRow, error: `deferred — per-run cap (${PER_RUN_CAP}) reached` });
+      continue;
+    }
+    try {
+      const { grant, outcome } = await ingestRow(row);
+      if (outcome === 'exists') continue;
+      created += 1;
+      if (outcome === 'minted') minted += 1;
+      if (outcome === 'held') {
+        held += 1;
+        attention.push({ clientName: grant.clientName, amount: Number(grant.amount), status: 'HELD_FOR_APPROVAL', reason: grant.holdReason || 'over-threshold' });
+      }
+      if (outcome === 'needs-contact') {
+        needsContact += 1;
+        attention.push({ clientName: grant.clientName, amount: Number(grant.amount), status: 'NEEDS_CONTACT', reason: 'no email on sheet row' });
+      }
+    } catch (err) {
+      errors.push({ sheetRow: row.sheetRow, error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
+  return { minted, held, needsContact, attention, errors };
+}
+
+/** Milliseconds after which a grant stuck in SENDING is treated as crashed. */
+const SENDING_STUCK_MS = 15 * 60 * 1000;
+
+/**
+ * Recover grants stuck in SENDING from a crashed prior send (cron OR a manual
+ * admin approve/resend, which run regardless of the send flag). The send claim
+ * excludes SENDING, so a real in-flight send (seconds) is never reset here —
+ * only rows older than the stuck threshold, which then re-enter the queue.
+ * Runs every tick, independent of the send flag.
+ */
+async function recoverStuckSending(): Promise<void> {
+  await prisma.premiereCreditGrant.updateMany({
+    where: { status: 'SENDING', updatedAt: { lt: new Date(Date.now() - SENDING_STUCK_MS) } },
+    data: { status: 'READY' },
+  });
+}
+
+/** Send every READY grant, isolating failures. */
+async function sendPhase(): Promise<{ sent: number; sendFailed: number; delivered: DeliveredInfo[]; attention: AttentionItem[] }> {
+  const ready = await prisma.premiereCreditGrant.findMany({ where: { status: 'READY' }, select: { id: true } });
+  let sent = 0;
+  let sendFailed = 0;
+  const delivered: DeliveredInfo[] = [];
+  const attention: AttentionItem[] = [];
+
+  for (const { id } of ready) {
+    try {
+      const result = await sendGrant(id);
+      if (result.status === 'SENT' && result.delivered) {
+        sent += 1;
+        delivered.push(result.delivered);
+      } else if (result.status === 'SEND_FAILED') {
+        sendFailed += 1;
+        const g = await prisma.premiereCreditGrant.findUnique({ where: { id }, select: { clientName: true, amount: true } });
+        if (g) attention.push({ clientName: g.clientName, amount: Number(g.amount), status: 'SEND_FAILED', reason: result.error });
+      }
+    } catch (err) {
+      sendFailed += 1;
+      console.error(`[premiere-credits] sendGrant ${id} threw:`, err);
+    }
+  }
+
+  return { sent, sendFailed, delivered, attention };
+}
+
+/** Run one full tick. Never throws — returns a structured result. */
+export async function runPremiereCreditsTick(): Promise<TickResult> {
+  const empty: TickResult = { ok: true, scanned: 0, minted: 0, held: 0, needsContact: 0, sent: 0, sendFailed: 0, rowErrors: [] };
+
+  if (!(await isFeatureEnabled(FEATURE_FLAGS.PREMIERE_CREDITS_MASTER))) {
+    return { ...empty, paused: true };
+  }
+  if (!isPremiereCreditsSheetConfigured()) {
+    return { ...empty, ok: false, rowErrors: [{ sheetRow: 0, error: 'sheet env not configured' }] };
+  }
+
+  let scanned = 0;
+  const attention: AttentionItem[] = [];
+  const rowErrors: TickResult['rowErrors'] = [];
+  let minted = 0;
+  let held = 0;
+  let needsContact = 0;
+  let sent = 0;
+  let sendFailed = 0;
+  const delivered: DeliveredInfo[] = [];
+
+  try {
+    // Runs every tick, before the send-flag branch, so a crash mid-send (cron
+    // OR a manual admin approve/resend) always gets recovered.
+    await recoverStuckSending();
+
+    const { rows, warnings } = await readCreditSheet();
+    scanned = rows.length;
+    if (warnings.length) console.log('[premiere-credits] sheet warnings:', warnings);
+
+    const ingest = await ingestPhase(rows);
+    minted = ingest.minted;
+    held = ingest.held;
+    needsContact = ingest.needsContact;
+    attention.push(...ingest.attention);
+    rowErrors.push(...ingest.errors);
+
+    if (await isFeatureEnabled(FEATURE_FLAGS.PREMIERE_CREDITS_SEND)) {
+      const send = await sendPhase();
+      sent = send.sent;
+      sendFailed = send.sendFailed;
+      delivered.push(...send.delivered);
+      attention.push(...send.attention);
+    }
+  } catch (err) {
+    // Log only .message — a googleapis GaxiosError can carry the signed JWT in
+    // its config/response objects (CWE-532).
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('[premiere-credits] tick failed:', message);
+    rowErrors.push({ sheetRow: 0, error: message });
+  }
+
+  // Notify partner + operator (best-effort; never fail the tick over these).
+  try {
+    const deliveredCodes: DeliveredCode[] = delivered.map((d) => ({ clientName: d.clientName, amount: d.amount, code: d.code, expiresAt: d.expiresAt }));
+    if (await sendPartnerCodeSummary(deliveredCodes)) await stampPartnerNotified(delivered);
+    await sendOpsAttentionAlert(attention, rowErrors);
+  } catch (err) {
+    console.error('[premiere-credits] notification failed:', err);
+  }
+
+  return { ok: rowErrors.length === 0, scanned, minted, held, needsContact, sent, sendFailed, rowErrors };
+}
+
+/** Stamp partner_notified_at on the grants whose codes were summarized. */
+async function stampPartnerNotified(delivered: DeliveredInfo[]): Promise<void> {
+  if (delivered.length === 0) return;
+  const codes = delivered.map((d) => d.code);
+  await prisma.premiereCreditGrant.updateMany({
+    where: { code: { in: codes } },
+    data: { partnerNotifiedAt: new Date() },
+  });
+}

--- a/src/lib/premiere-credits/grant-service.ts
+++ b/src/lib/premiere-credits/grant-service.ts
@@ -1,0 +1,345 @@
+/**
+ * Premiere Credit automation — grant service (mint + send).
+ *
+ * Mints single-use FIXED_AMOUNT discount codes and delivers them. The discount
+ * config MATCHES the codes Premiere already issues by hand (verified against
+ * the live REINAUER / MOTYKA / SCLAFANI / BENSON13844 rows): combinable +
+ * freeShipping true, maxUsageCount 1, appliesToAll true, no minOrderAmount. The
+ * only intentional difference is a 60-day expiry (existing codes never expired).
+ */
+
+import { randomInt } from 'crypto';
+import { Prisma, type PremiereCreditGrant } from '@prisma/client';
+import { prisma } from '@/lib/database/client';
+import { normalizeName } from './parse';
+import {
+  CODE_ALPHABET,
+  HOLD_THRESHOLD_USD,
+  generateCodeBase,
+  isPossibleDuplicate,
+  planRowAction,
+} from './planner';
+import type { HoldReason } from './types';
+import { sendPremiereCreditEmail } from './send-email';
+import { notifyPremiereCreditIssued } from '@/lib/webhooks/ghl-premiere-credit';
+import type { GrantStatus, ParsedCreditRow } from './types';
+
+/** Days until a minted credit expires. */
+export const EXPIRY_DAYS = 60;
+
+const REDEEM_URL = 'https://partyondelivery.com';
+const MAX_CODE_ATTEMPTS = 5;
+
+/** Outcome of ingesting a single sheet row. */
+export type IngestOutcome = 'exists' | 'needs-contact' | 'held' | 'minted';
+
+/** Add whole days to a date without mutating the input. */
+export function addDays(base: Date, days: number): Date {
+  const d = new Date(base.getTime());
+  d.setUTCDate(d.getUTCDate() + days);
+  return d;
+}
+
+/** A random N-char suffix from the unambiguous alphabet. */
+function randomSuffix(len: number): string {
+  let out = '';
+  for (let i = 0; i < len; i++) out += CODE_ALPHABET[randomInt(CODE_ALPHABET.length)];
+  return out;
+}
+
+/**
+ * Generate a unique discount code. Starts from Premiere's convention
+ * (LASTNAME + amount digits); on collision appends a 2-char random suffix.
+ * Throws after MAX_CODE_ATTEMPTS distinct tries.
+ */
+export async function generateCreditCode(clientName: string, amount: number): Promise<string> {
+  const base = generateCodeBase(clientName, amount);
+  for (let attempt = 0; attempt < MAX_CODE_ATTEMPTS; attempt++) {
+    const candidate = attempt === 0 ? base : `${base}-${randomSuffix(2)}`;
+    const clash = await prisma.discount.findUnique({ where: { code: candidate }, select: { id: true } });
+    if (!clash) return candidate;
+  }
+  throw new Error(`Could not generate a unique code for ${base} after ${MAX_CODE_ATTEMPTS} attempts`);
+}
+
+/** Booking-date DB value from an ISO string (Date column). */
+function bookingDateValue(iso: string | null): Date | null {
+  return iso ? new Date(`${iso}T00:00:00.000Z`) : null;
+}
+
+/**
+ * Create the Discount + link it onto an existing grant, inside one
+ * transaction. Used both at mint time and when an operator resolves a
+ * NEEDS_CONTACT / possible-duplicate hold. Returns the updated grant.
+ */
+async function attachDiscount(
+  grant: PremiereCreditGrant,
+  targetStatus: GrantStatus,
+  holdReason: HoldReason | null = null,
+): Promise<PremiereCreditGrant> {
+  const amount = Number(grant.amount);
+  const code = await generateCreditCode(grant.clientName, amount);
+  const now = new Date();
+  const bookingLabel = grant.bookingDate ? grant.bookingDate.toISOString().slice(0, 10) : 'unknown';
+
+  try {
+    return await prisma.$transaction(async (tx) => {
+      const discount = await tx.discount.create({
+        data: {
+          code,
+          name: `POD Credit - ${grant.clientName}`,
+          description: `POD Credit forwarded from booking ${bookingLabel} - ${grant.clientName}`,
+          type: 'FIXED_AMOUNT',
+          value: new Prisma.Decimal(amount.toFixed(2)),
+          appliesToAll: true,
+          combinable: true,
+          freeShipping: true,
+          maxUsageCount: 1,
+          usagePerCustomer: 1,
+          startsAt: now,
+          expiresAt: addDays(now, EXPIRY_DAYS),
+          // Held grants mint INACTIVE — the code isn't redeemable until an
+          // operator approves it. This contains the money for the sanity-cap
+          // case (a garbage cell must not create a live spendable code) and
+          // for over-threshold holds. approveAndSend reactivates before send.
+          isActive: targetStatus !== 'HELD_FOR_APPROVAL',
+        },
+      });
+      // Compare-and-swap: only claim the grant if it still has no discount.
+      // A concurrent mint (double-submit of approve/contact, overlapping ticks)
+      // loses here, and throwing rolls back the discount.create above so no
+      // orphaned, spendable code is left behind.
+      const claimed = await tx.premiereCreditGrant.updateMany({
+        where: { id: grant.id, discountId: null },
+        data: { discountId: discount.id, code: discount.code, status: targetStatus, holdReason, error: null },
+      });
+      if (claimed.count === 0) throw new AlreadyMintedError();
+      const updated = await tx.premiereCreditGrant.findUnique({ where: { id: grant.id } });
+      if (!updated) throw new Error(`grant ${grant.id} vanished mid-mint`);
+      return updated;
+    });
+  } catch (err) {
+    // Lost the mint race (CAS miss, or a unique-code collision from a
+    // simultaneous identical mint) — return the grant that actually won.
+    const raced =
+      err instanceof AlreadyMintedError ||
+      (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002');
+    if (raced) {
+      const winner = await prisma.premiereCreditGrant.findUnique({ where: { id: grant.id } });
+      if (winner?.discountId) return winner;
+    }
+    throw err;
+  }
+}
+
+/** Internal sentinel — a concurrent caller minted this grant first. */
+class AlreadyMintedError extends Error {}
+
+/**
+ * Ingest one parsed sheet row: idempotent by sourceKey, then plan → mint /
+ * needs-contact / duplicate-hold. Never sends — the engine's send phase does
+ * that only for READY grants. Concurrency-safe (unique sourceKey).
+ */
+export async function ingestRow(
+  row: ParsedCreditRow,
+): Promise<{ grant: PremiereCreditGrant; outcome: IngestOutcome }> {
+  const existing = await prisma.premiereCreditGrant.findUnique({ where: { sourceKey: row.sourceKey } });
+  if (existing && existing.status !== 'PENDING') return { grant: existing, outcome: 'exists' };
+  if (existing && existing.status === 'PENDING') {
+    // A prior tick committed the shell but its mint failed afterward (mint
+    // txn error, code-generation exhaustion, crash between the two writes).
+    // Resume the mint rather than leaving the credit silently stuck at PENDING
+    // forever. holdReason on the shell tells us whether it should be held.
+    const hold = existing.holdReason as HoldReason | null;
+    const grant = await attachDiscount(existing, hold ? 'HELD_FOR_APPROVAL' : 'READY', hold);
+    return { grant, outcome: hold ? 'held' : 'minted' };
+  }
+
+  const base = {
+    sourceKey: row.sourceKey,
+    sheetRow: row.sheetRow,
+    clientName: row.clientName,
+    email: row.email,
+    phone: row.phone,
+    bookingDate: bookingDateValue(row.bookingDateISO),
+    cruiseDate: bookingDateValue(row.cruiseDateISO),
+    amount: new Prisma.Decimal(row.amount.toFixed(2)),
+    rawRow: row.rawRow as Prisma.InputJsonValue,
+  };
+
+  const action = planRowAction(row);
+
+  // No reachable email — record the grant, mint nothing.
+  if (action.kind === 'needs-contact') {
+    const grant = await createGrant({ ...base, status: 'NEEDS_CONTACT' });
+    return { grant, outcome: 'needs-contact' };
+  }
+
+  // Ambiguous duplicate (same person + booking, different amount) — hold
+  // WITHOUT minting; an operator resolves it via approve or cancel.
+  if (row.bookingDateISO) {
+    const bookingSiblings = await prisma.premiereCreditGrant.findMany({
+      where: { bookingDate: bookingDateValue(row.bookingDateISO), sourceKey: { not: row.sourceKey } },
+      select: { sourceKey: true, clientName: true },
+    });
+    const sameName = bookingSiblings.filter((s) => normalizeName(s.clientName) === normalizeName(row.clientName));
+    if (isPossibleDuplicate(row, sameName)) {
+      const grant = await createGrant({ ...base, status: 'HELD_FOR_APPROVAL', holdReason: 'possible-duplicate' });
+      return { grant, outcome: 'held' };
+    }
+  }
+
+  // Mint. Over-threshold / sanity-cap amounts are minted but held for approval.
+  const targetStatus: GrantStatus = action.hold ? 'HELD_FOR_APPROVAL' : 'READY';
+  try {
+    const holdReason = action.hold ? action.holdReason : null;
+    const shell = await createGrant({ ...base, status: 'PENDING', holdReason });
+    const grant = await attachDiscount(shell, targetStatus, holdReason);
+    return { grant, outcome: action.hold ? 'held' : 'minted' };
+  } catch (err) {
+    // Lost a concurrency race on the unique sourceKey — return the winner, but
+    // only if it is actually a fully-formed grant. A winner still stuck at
+    // PENDING means this is not the sourceKey race but an unresolved failure
+    // (e.g. a rare code collision); rethrow so it surfaces as a row error/alert
+    // rather than a silently stuck grant.
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
+      const winner = await prisma.premiereCreditGrant.findUnique({ where: { sourceKey: row.sourceKey } });
+      if (winner && winner.status !== 'PENDING') return { grant: winner, outcome: 'exists' };
+    }
+    throw err;
+  }
+}
+
+/** Create a grant row with the given status/fields. */
+async function createGrant(
+  data: Prisma.PremiereCreditGrantUncheckedCreateInput,
+): Promise<PremiereCreditGrant> {
+  return prisma.premiereCreditGrant.create({ data });
+}
+
+/**
+ * Mint a discount for a grant that doesn't have one yet (NEEDS_CONTACT after a
+ * contact was filled in, or an approved possible-duplicate). Re-plans the
+ * threshold so a large amount still lands in HELD_FOR_APPROVAL.
+ */
+export async function mintForGrant(grant: PremiereCreditGrant): Promise<PremiereCreditGrant> {
+  if (grant.discountId) return grant;
+  const amount = Number(grant.amount);
+  const held = amount > HOLD_THRESHOLD_USD; // re-checked on late mint
+  return attachDiscount(grant, held ? 'HELD_FOR_APPROVAL' : 'READY', held ? 'over-threshold' : null);
+}
+
+/** Details of a code delivered to a customer (for the partner summary email). */
+export interface DeliveredInfo {
+  clientName: string;
+  amount: number;
+  code: string;
+  expiresAt: Date;
+}
+
+/** Statuses a grant may be sent from (cron: READY; approve: HELD/READY; resend: SENT/SEND_FAILED). */
+const SENDABLE_STATUSES = ['READY', 'HELD_FOR_APPROVAL', 'SENT', 'SEND_FAILED'];
+
+/**
+ * Deliver a grant's code: customer email (authoritative for SENT/SEND_FAILED)
+ * + fire-and-forget SMS. The single send path used by the cron, the approve
+ * action, and resend. Requires a minted discount and an email.
+ *
+ * Concurrency-safe: atomically claims the grant into a transient SENDING state
+ * before doing any outbound work, so overlapping cron ticks — or an approve
+ * racing the cron — cannot double-send. A lost claim returns without sending.
+ */
+export async function sendGrant(
+  grantId: string,
+): Promise<{ status: GrantStatus; error?: string; delivered?: DeliveredInfo }> {
+  const claim = await prisma.premiereCreditGrant.updateMany({
+    where: { id: grantId, status: { in: SENDABLE_STATUSES } },
+    data: { status: 'SENDING' },
+  });
+  if (claim.count === 0) {
+    const current = await prisma.premiereCreditGrant.findUnique({ where: { id: grantId }, select: { status: true } });
+    if (!current) throw new Error(`Grant ${grantId} not found`);
+    // Another worker owns the send (or the grant isn't sendable) — no-op.
+    return { status: current.status as GrantStatus, error: 'not claimable' };
+  }
+
+  const grant = await prisma.premiereCreditGrant.findUnique({
+    where: { id: grantId },
+    include: { discount: { select: { code: true, value: true, expiresAt: true } } },
+  });
+  if (!grant) throw new Error(`Grant ${grantId} not found`);
+  if (!grant.email) return failSend(grant.id, 'no email on grant');
+  if (!grant.discount || !grant.code) return failSend(grant.id, 'grant has no minted discount');
+
+  const amount = Number(grant.discount.value);
+  const expiresAt = grant.discount.expiresAt ?? addDays(new Date(), EXPIRY_DAYS);
+
+  try {
+    const result = await sendPremiereCreditEmail({
+      to: grant.email,
+      customerName: grant.clientName,
+      code: grant.code,
+      amount,
+      expiresAt,
+      grantId: grant.id,
+      discountId: grant.discountId ?? undefined,
+    });
+
+    if (!result.sent) {
+      return failSend(grant.id, result.error || 'email send failed');
+    }
+
+    // SMS is best-effort — never blocks the SENT status.
+    let smsSent = false;
+    if (grant.phone) {
+      try {
+        await notifyPremiereCreditIssued({
+          event: 'premiere.credit.issued',
+          first_name: grant.clientName.trim().split(/\s+/)[0] || '',
+          last_name: grant.clientName.trim().split(/\s+/).slice(1).join(' '),
+          email: grant.email,
+          phone: grant.phone,
+          credit_code: grant.code,
+          credit_amount: amount.toFixed(2),
+          expires_on: formatExpiryForSms(expiresAt),
+          redeem_url: REDEEM_URL,
+          tags: ['premiere-credit'],
+        });
+        smsSent = true;
+      } catch (err) {
+        console.error('[premiere-credits] SMS notify failed:', err instanceof Error ? err.message : String(err));
+      }
+    }
+
+    await prisma.premiereCreditGrant.update({
+      where: { id: grant.id },
+      data: { status: 'SENT', emailSentAt: new Date(), smsSentAt: smsSent ? new Date() : grant.smsSentAt, error: null },
+    });
+    return {
+      status: 'SENT',
+      delivered: { clientName: grant.clientName, amount, code: grant.code, expiresAt },
+    };
+  } catch (err) {
+    // Never leave a grant stuck in SENDING — resolve to SEND_FAILED on any throw.
+    return failSend(grant.id, err instanceof Error ? err.message : String(err));
+  }
+}
+
+/** Mark a grant's send as failed and record the error. */
+async function failSend(grantId: string, error: string): Promise<{ status: GrantStatus; error: string }> {
+  await prisma.premiereCreditGrant.update({
+    where: { id: grantId },
+    data: { status: 'SEND_FAILED', error },
+  });
+  return { status: 'SEND_FAILED', error };
+}
+
+/** Long-form expiry for the SMS template variable. */
+function formatExpiryForSms(date: Date): string {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'America/Chicago',
+  }).format(date);
+}

--- a/src/lib/premiere-credits/notify.ts
+++ b/src/lib/premiere-credits/notify.ts
@@ -1,0 +1,141 @@
+/**
+ * Premiere Credit automation — partner + operator notifications.
+ *
+ * Replaces sheet write-back (access is read-only): after codes are delivered to
+ * customers, email Premiere a summary so their VA can paste codes into the
+ * sheet's own POD Code column. Separately, alert the operator whenever a tick
+ * produces something that needs a human — a held grant, a missing contact, a
+ * failed send, or a row error.
+ */
+
+import { sendEmail } from '@/lib/email/resend-client';
+import { formatCurrency } from '@/lib/email/resend-client';
+
+const PARTNER_NOTIFY_EMAIL = process.env.PREMIERE_PARTNER_NOTIFY_EMAIL;
+const OPS_ALERT_EMAIL = process.env.OPS_ALERT_EMAIL || 'allan@partyondelivery.com';
+const ADMIN_URL = 'https://partyondelivery.com/admin/premiere-credits';
+
+/** Minimal HTML escape for interpolated text. */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/** A code that was delivered to a customer this tick. */
+export interface DeliveredCode {
+  clientName: string;
+  amount: number;
+  code: string;
+  expiresAt: Date;
+}
+
+function longDate(date: Date): string {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short', day: 'numeric', year: 'numeric', timeZone: 'America/Chicago',
+  }).format(date);
+}
+
+/**
+ * Email Premiere the codes delivered this tick so they can update their sheet.
+ * No-ops (returns false) when there are no codes or no recipient configured.
+ * Cc's the operator when that address differs from the partner recipient.
+ */
+export async function sendPartnerCodeSummary(delivered: DeliveredCode[]): Promise<boolean> {
+  if (delivered.length === 0 || !PARTNER_NOTIFY_EMAIL) return false;
+
+  const rows = delivered
+    .map(
+      (d) => `
+        <tr>
+          <td style="padding:8px 12px;border-bottom:1px solid #e5e7eb;">${escapeHtml(d.clientName)}</td>
+          <td style="padding:8px 12px;border-bottom:1px solid #e5e7eb;font-family:monospace;font-weight:700;">${escapeHtml(d.code)}</td>
+          <td style="padding:8px 12px;border-bottom:1px solid #e5e7eb;text-align:right;">${formatCurrency(d.amount)}</td>
+          <td style="padding:8px 12px;border-bottom:1px solid #e5e7eb;">${longDate(d.expiresAt)}</td>
+        </tr>`,
+    )
+    .join('');
+
+  const cc = OPS_ALERT_EMAIL && OPS_ALERT_EMAIL !== PARTNER_NOTIFY_EMAIL ? [OPS_ALERT_EMAIL] : undefined;
+
+  await sendEmail({
+    to: PARTNER_NOTIFY_EMAIL,
+    cc,
+    subject: `POD credit codes issued (${delivered.length}) — please update the sheet`,
+    type: 'PREMIERE_CREDIT',
+    metadata: { kind: 'partner-summary', count: delivered.length },
+    html: `
+      <h2 style="font-family:Arial,sans-serif;">POD credit codes issued</h2>
+      <p style="font-family:Arial,sans-serif;color:#4b5563;">Party On Delivery just sent these credit codes to your customers by email and text. Please paste each code into the <strong>POD Code</strong> column of the POD Credits tab.</p>
+      <table cellpadding="0" cellspacing="0" style="border-collapse:collapse;font-family:Arial,sans-serif;font-size:14px;">
+        <tr style="background:#f3f4f6;">
+          <th style="padding:8px 12px;text-align:left;">Client</th>
+          <th style="padding:8px 12px;text-align:left;">Code</th>
+          <th style="padding:8px 12px;text-align:right;">Amount</th>
+          <th style="padding:8px 12px;text-align:left;">Expires</th>
+        </tr>
+        ${rows}
+      </table>
+      <p style="font-family:Arial,sans-serif;color:#9ca3af;font-size:13px;">Full history: ${ADMIN_URL}</p>
+    `,
+  });
+  return true;
+}
+
+/** A grant needing operator attention. */
+export interface AttentionItem {
+  clientName: string;
+  amount: number;
+  status: string;
+  reason?: string;
+}
+
+/**
+ * Alert the operator about grants that need a human (held, needs-contact,
+ * send-failed) plus any row-level errors. No-ops when there is nothing to
+ * report.
+ */
+export async function sendOpsAttentionAlert(
+  items: AttentionItem[],
+  rowErrors: Array<{ sheetRow: number; error: string }>,
+): Promise<void> {
+  if (items.length === 0 && rowErrors.length === 0) return;
+
+  const itemRows = items
+    .map(
+      (it) => `
+        <tr>
+          <td style="padding:6px 12px;border-bottom:1px solid #e5e7eb;">${escapeHtml(it.clientName)}</td>
+          <td style="padding:6px 12px;border-bottom:1px solid #e5e7eb;text-align:right;">${formatCurrency(it.amount)}</td>
+          <td style="padding:6px 12px;border-bottom:1px solid #e5e7eb;">${escapeHtml(it.status)}</td>
+          <td style="padding:6px 12px;border-bottom:1px solid #e5e7eb;">${escapeHtml(it.reason || '')}</td>
+        </tr>`,
+    )
+    .join('');
+
+  const errorRows = rowErrors
+    .map((e) => `<li>Row ${e.sheetRow}: ${escapeHtml(e.error)}</li>`)
+    .join('');
+
+  await sendEmail({
+    to: OPS_ALERT_EMAIL,
+    subject: `Premiere credits need attention (${items.length + rowErrors.length})`,
+    type: 'PREMIERE_CREDIT',
+    metadata: { kind: 'ops-alert', items: items.length, errors: rowErrors.length },
+    html: `
+      <h2 style="font-family:Arial,sans-serif;">Premiere credits need a look</h2>
+      ${
+        items.length
+          ? `<table cellpadding="0" cellspacing="0" style="border-collapse:collapse;font-family:Arial,sans-serif;font-size:14px;">
+              <tr style="background:#f3f4f6;"><th style="padding:6px 12px;text-align:left;">Client</th><th style="padding:6px 12px;text-align:right;">Amount</th><th style="padding:6px 12px;text-align:left;">Status</th><th style="padding:6px 12px;text-align:left;">Reason</th></tr>
+              ${itemRows}
+            </table>`
+          : ''
+      }
+      ${errorRows ? `<p style="font-family:Arial,sans-serif;font-weight:700;margin-top:16px;">Row errors</p><ul style="font-family:Arial,sans-serif;color:#b91c1c;">${errorRows}</ul>` : ''}
+      <p style="font-family:Arial,sans-serif;">Review and act: ${ADMIN_URL}</p>
+    `,
+  });
+}

--- a/src/lib/premiere-credits/parse.ts
+++ b/src/lib/premiere-credits/parse.ts
@@ -1,0 +1,241 @@
+/**
+ * Premiere Credit automation — pure parsing.
+ *
+ * No IO, no Prisma, no googleapis — every function here is deterministic and
+ * unit-tested. Handles the quirks of the Premiere "POD Credits" sheet tab:
+ * leading blank rows, header renames/reordering, `$0.00` filler rows, `₱`
+ * locale symbols (values are USD), emails with stray spaces, and two date
+ * formats (MM-DD-YYYY booking dates, "Month D, YYYY" cruise dates).
+ */
+
+import { createHash } from 'crypto';
+import type { HeaderMap, ParsedCreditRow, RawCreditRow } from './types';
+
+const MONTHS = [
+  'january', 'february', 'march', 'april', 'may', 'june',
+  'july', 'august', 'september', 'october', 'november', 'december',
+];
+
+/** Uppercase + strip everything but A–Z0–9 for tolerant header matching. */
+export function normalizeHeader(raw: string): string {
+  return (raw || '').toUpperCase().replace(/[^A-Z0-9]/g, '');
+}
+
+/** Header synonyms, matched against the normalized header text. */
+const HEADER_SYNONYMS: Record<keyof HeaderMap, string[]> = {
+  amount: ['PODCREDIT', 'CREDITAMOUNT', 'PODCREDITAMOUNT', 'CREDIT', 'AMOUNT'],
+  code: ['PODCODE', 'CODE'],
+  status: ['STATUS'],
+  bookingDate: ['BOOKINGDATE'],
+  client: ['CLIENTNAME', 'CLIENT', 'NAME'],
+  phone: ['PHONENUMBER', 'PHONE', 'CELL'],
+  email: ['EMAILADDRESS', 'EMAIL'],
+  cruiseDate: ['ACTUALCRUISEDATE', 'CRUISEDATE'],
+};
+
+/**
+ * Map a header row to column indexes. First exact-normalized match wins per
+ * field; unmatched fields are null. Earlier synonyms take priority so that
+ * e.g. "POD CREDIT" binds to `amount` before a bare "CREDIT" elsewhere.
+ */
+export function mapHeaders(headerRow: string[]): HeaderMap {
+  const normalized = headerRow.map(normalizeHeader);
+  const find = (field: keyof HeaderMap): number | null => {
+    for (const syn of HEADER_SYNONYMS[field]) {
+      const idx = normalized.indexOf(syn);
+      if (idx !== -1) return idx;
+    }
+    return null;
+  };
+  return {
+    amount: find('amount'),
+    code: find('code'),
+    status: find('status'),
+    bookingDate: find('bookingDate'),
+    client: find('client'),
+    phone: find('phone'),
+    email: find('email'),
+    cruiseDate: find('cruiseDate'),
+  };
+}
+
+/**
+ * Locate the header row within raw sheet data (the tab has leading blank/merged
+ * rows). The header is the first row that resolves BOTH an amount and a client
+ * column. Returns the 0-based array index and its map, or null if none.
+ */
+export function locateHeader(
+  sheetData: string[][],
+): { headerIndex: number; header: HeaderMap } | null {
+  for (let i = 0; i < sheetData.length; i++) {
+    const header = mapHeaders(sheetData[i] || []);
+    if (header.amount !== null && header.client !== null) {
+      return { headerIndex: i, header };
+    }
+  }
+  return null;
+}
+
+/**
+ * Parse a currency cell to a USD number. Strips `$`, `₱` (sheet locale
+ * artifact), commas and spaces; treats `(50)` as -50. Returns null for
+ * unparseable/blank cells, 0 for an explicit zero.
+ */
+export function parseCurrencyUSD(raw: string | undefined | null): number | null {
+  if (raw == null) return null;
+  let s = String(raw).trim();
+  if (s === '') return null;
+  let sign = 1;
+  if (/^\(.*\)$/.test(s)) {
+    sign = -1;
+    s = s.slice(1, -1);
+  }
+  s = s.replace(/[$₱,\s]/g, '');
+  if (s.startsWith('-')) {
+    sign *= -1;
+    s = s.slice(1);
+  }
+  if (s === '' || !/^\d*\.?\d+$/.test(s)) return null;
+  const n = Number(s);
+  return Number.isFinite(n) ? sign * n : null;
+}
+
+/** Zero-pad to 2 digits. */
+function pad2(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+/**
+ * Parse a numeric booking date (`MM-DD-YYYY` or `M/D/YYYY`) to ISO YYYY-MM-DD.
+ * Returns null if it does not look like a numeric mm dd yyyy triple.
+ */
+export function parseBookingDateToISO(raw: string | undefined | null): string | null {
+  if (raw == null) return null;
+  const s = String(raw).trim();
+  const m = s.match(/^(\d{1,2})[-/](\d{1,2})[-/](\d{4})$/);
+  if (!m) return null;
+  const month = Number(m[1]);
+  const day = Number(m[2]);
+  const year = Number(m[3]);
+  if (!isRealDate(year, month, day)) return null;
+  return `${year}-${pad2(month)}-${pad2(day)}`;
+}
+
+/** True when year/month/day is a real calendar date (rejects e.g. 02-30). */
+function isRealDate(year: number, month: number, day: number): boolean {
+  if (month < 1 || month > 12 || day < 1 || day > 31) return false;
+  const d = new Date(Date.UTC(year, month - 1, day));
+  return d.getUTCFullYear() === year && d.getUTCMonth() === month - 1 && d.getUTCDate() === day;
+}
+
+/**
+ * Parse a long-form cruise date ("May 23, 2026" / "April 2, 2026") to ISO
+ * YYYY-MM-DD. Returns null if the month name is not recognized.
+ */
+export function parseCruiseDateToISO(raw: string | undefined | null): string | null {
+  if (raw == null) return null;
+  const s = String(raw).trim().toLowerCase();
+  const m = s.match(/^([a-z]+)\s+(\d{1,2}),?\s+(\d{4})$/);
+  if (!m) return parseBookingDateToISO(raw); // tolerate a numeric cruise date too
+  const monthIdx = MONTHS.indexOf(m[1]);
+  if (monthIdx === -1) return null;
+  const day = Number(m[2]);
+  const year = Number(m[3]);
+  if (!isRealDate(year, monthIdx + 1, day)) return null;
+  return `${year}-${pad2(monthIdx + 1)}-${pad2(day)}`;
+}
+
+/** Lowercase, strip non-alphanumerics, collapse whitespace — for the key. */
+export function normalizeName(raw: string | undefined | null): string {
+  return (raw || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Extract an uppercase last name (last whitespace token, letters only). Used
+ * for the discount code string. "Sarah LeBlanc" → "LEBLANC".
+ */
+export function extractLastName(raw: string | undefined | null): string {
+  const cleaned = (raw || '').trim().replace(/\s+/g, ' ');
+  if (cleaned === '') return '';
+  const tokens = cleaned.split(' ');
+  const last = tokens[tokens.length - 1];
+  return last.toUpperCase().replace(/[^A-Z]/g, '');
+}
+
+/**
+ * Stable idempotency key for a credit row: sha256 of normalized name + booking
+ * date + amount. Row numbers are never part of it (rows get inserted/reordered
+ * by humans). Amount is fixed to 2 decimals so 138.4 and 138.40 match.
+ */
+export function computeSourceKey(
+  clientName: string,
+  bookingDateISO: string | null,
+  amount: number,
+): string {
+  const material = `premiere-credit|${normalizeName(clientName)}|${bookingDateISO ?? ''}|${amount.toFixed(2)}`;
+  return createHash('sha256').update(material).digest('hex');
+}
+
+/** Trim a cell, returning null for blank. */
+function cell(row: string[], idx: number | null): string | null {
+  if (idx == null) return null;
+  const v = (row[idx] ?? '').trim();
+  return v === '' ? null : v;
+}
+
+/**
+ * Turn raw sheet rows into parsed candidate rows, applying the skip filter:
+ * blank client, amount ≤ 0 / unparseable, or an existing POD Code in the sheet
+ * (already handled manually — this also grandfathers previously-issued codes).
+ * Every skip is recorded as a warning.
+ */
+export function parseRows(
+  header: HeaderMap,
+  rawRows: RawCreditRow[],
+): { rows: ParsedCreditRow[]; warnings: string[] } {
+  const rows: ParsedCreditRow[] = [];
+  const warnings: string[] = [];
+
+  for (const { sheetRow, cells } of rawRows) {
+    const clientName = cell(cells, header.client);
+    const amountRaw = header.amount == null ? null : cells[header.amount];
+    const amount = parseCurrencyUSD(amountRaw);
+    const existingCode = cell(cells, header.code);
+
+    if (existingCode) continue; // already issued — silent skip (grandfathered)
+    if (!clientName) {
+      if (amount && amount > 0) warnings.push(`row ${sheetRow}: amount but no client name — skipped`);
+      continue;
+    }
+    if (amount == null || amount <= 0) continue; // filler / zero rows
+
+    const bookingDateISO = parseBookingDateToISO(cell(cells, header.bookingDate) ?? undefined);
+    const cruiseDateISO = parseCruiseDateToISO(cell(cells, header.cruiseDate) ?? undefined);
+    const email = cell(cells, header.email);
+    const phone = cell(cells, header.phone);
+
+    const rawRow: Record<string, string> = {};
+    (Object.keys(header) as Array<keyof HeaderMap>).forEach((k) => {
+      const idx = header[k];
+      if (idx != null && cells[idx] != null) rawRow[k] = String(cells[idx]).trim();
+    });
+
+    rows.push({
+      sheetRow,
+      clientName,
+      email,
+      phone,
+      bookingDateISO,
+      cruiseDateISO,
+      amount,
+      sourceKey: computeSourceKey(clientName, bookingDateISO, amount),
+      rawRow,
+    });
+  }
+
+  return { rows, warnings };
+}

--- a/src/lib/premiere-credits/planner.ts
+++ b/src/lib/premiere-credits/planner.ts
@@ -1,0 +1,80 @@
+/**
+ * Premiere Credit automation — pure decision logic.
+ *
+ * Given a parsed row (and, for the duplicate guard, its DB siblings), decide
+ * what to do. No IO here — grant-service does the minting/sending and feeds
+ * this module the sibling data it needs. Unit-tested.
+ */
+
+import { z } from 'zod';
+import { extractLastName, normalizeName } from './parse';
+import type { ParsedCreditRow, RowAction } from './types';
+
+/** Amounts strictly above this are minted but HELD for operator approval. */
+export const HOLD_THRESHOLD_USD = 300;
+
+/**
+ * Amounts strictly above this are held with a distinct reason — a backstop
+ * against a garbage cell (e.g. a locale mis-parse) minting a huge credit.
+ */
+export const SANITY_CAP_USD = 1000;
+
+/** Max new rows minted per cron tick — guards against a bad bulk paste. */
+export const PER_RUN_CAP = 20;
+
+/** Unambiguous code alphabet for the collision suffix (no I/L/O/0/1). */
+export const CODE_ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+
+const emailSchema = z.string().trim().email();
+
+/** True when the string is a syntactically valid email. */
+export function isValidEmail(email: string | null | undefined): boolean {
+  if (!email) return false;
+  return emailSchema.safeParse(email).success;
+}
+
+/**
+ * Decide the action for a parsed row, based only on the row itself:
+ *   - no valid email        → needs-contact (never mint an unreachable code)
+ *   - amount > sanity cap    → mint, held (sanity-cap)
+ *   - amount > hold threshold → mint, held (over-threshold)
+ *   - otherwise              → mint, not held
+ *
+ * The duplicate guard (same person + booking, different amount) needs DB state
+ * and is applied separately by grant-service via `isPossibleDuplicate`.
+ */
+export function planRowAction(row: ParsedCreditRow): RowAction {
+  if (!isValidEmail(row.email)) return { kind: 'needs-contact' };
+  if (row.amount > SANITY_CAP_USD) return { kind: 'mint', hold: true, holdReason: 'sanity-cap' };
+  if (row.amount > HOLD_THRESHOLD_USD) return { kind: 'mint', hold: true, holdReason: 'over-threshold' };
+  return { kind: 'mint', hold: false };
+}
+
+/**
+ * The deterministic discount code base, matching Premiere's existing
+ * convention: LASTNAME + amount digits (e.g. $336.21 → "LEBLANC33621",
+ * $125.26 → "HARADEN12526"). Falls back to the normalized full name (letters
+ * only) when there is no distinct last name. Never returns an empty string.
+ */
+export function generateCodeBase(clientName: string, amount: number): string {
+  const digits = amount.toFixed(2).replace('.', '');
+  let last = extractLastName(clientName);
+  if (!last) last = normalizeName(clientName).toUpperCase().replace(/[^A-Z]/g, '');
+  if (!last) last = 'PODCREDIT';
+  return `${last}${digits}`;
+}
+
+/**
+ * Duplicate guard: given the candidate and any existing grants that share its
+ * normalized client name + booking date, return true when at least one has a
+ * DIFFERENT source key (i.e. a different amount for the same person+booking).
+ * That is the ambiguous case we never auto-mint on — grant-service holds it.
+ * An existing grant with the SAME source key is the idempotent re-run, not a
+ * duplicate.
+ */
+export function isPossibleDuplicate(
+  candidate: ParsedCreditRow,
+  siblings: Array<{ sourceKey: string }>,
+): boolean {
+  return siblings.some((s) => s.sourceKey !== candidate.sourceKey);
+}

--- a/src/lib/premiere-credits/send-email.ts
+++ b/src/lib/premiere-credits/send-email.ts
@@ -1,0 +1,52 @@
+/**
+ * Premiere Credit automation — customer email send.
+ *
+ * Thin wrapper over sendEmailDetailed that builds the credit email and logs it
+ * with the PREMIERE_CREDIT type. Kept separate from grant-service so the SMS +
+ * status logic there stays readable.
+ */
+
+import { sendEmailDetailed } from '@/lib/email/resend-client';
+import {
+  generatePremiereCreditEmail,
+  generatePremiereCreditText,
+  premiereCreditSubject,
+} from '@/lib/email/templates/premiere-credit';
+
+const REDEEM_URL = 'https://partyondelivery.com';
+
+export interface SendPremiereCreditEmailInput {
+  to: string;
+  customerName: string;
+  code: string;
+  amount: number;
+  expiresAt: Date;
+  grantId: string;
+  discountId?: string;
+}
+
+/** Build + send the customer credit email. Returns the send result. */
+export async function sendPremiereCreditEmail(
+  input: SendPremiereCreditEmailInput,
+): Promise<{ sent: boolean; error?: string }> {
+  const data = {
+    customerName: input.customerName,
+    code: input.code,
+    amount: input.amount,
+    expiresAt: input.expiresAt,
+    redeemUrl: REDEEM_URL,
+  };
+
+  const result = await sendEmailDetailed({
+    to: input.to,
+    subject: premiereCreditSubject(input.amount),
+    html: generatePremiereCreditEmail(data),
+    text: generatePremiereCreditText(data),
+    type: 'PREMIERE_CREDIT',
+    replyTo: 'info@partyondelivery.com',
+    tags: [{ name: 'campaign', value: 'premiere-credit' }],
+    metadata: { kind: 'premiere-credit', grantId: input.grantId, discountId: input.discountId, code: input.code },
+  });
+
+  return { sent: result.sent, error: result.error };
+}

--- a/src/lib/premiere-credits/sheet.ts
+++ b/src/lib/premiere-credits/sheet.ts
@@ -1,0 +1,80 @@
+/**
+ * Premiere Credit automation — Google Sheet reader (READ-ONLY).
+ *
+ * Reads the Premiere "POD Credits" tab with the `spreadsheets.readonly` scope
+ * — this module has no write capability by design. Premiere maintains the POD
+ * Code / Status columns themselves; the automation delivers codes to customers
+ * and notifies the partner by email instead of writing back to the sheet.
+ *
+ * Reuses the existing Premier service-account credentials (shared with the
+ * masterlist as a Viewer). See src/lib/premier/sheet-parser.ts for the sibling
+ * boat-schedule reader that established this pattern.
+ */
+
+import { google } from 'googleapis';
+import { locateHeader, parseRows } from './parse';
+import type { RawCreditRow, SheetReadResult } from './types';
+
+const SHEETS_SCOPES = ['https://www.googleapis.com/auth/spreadsheets.readonly'];
+
+/** True when the sheet env vars are all present. */
+export function isPremiereCreditsSheetConfigured(): boolean {
+  return Boolean(
+    process.env.PREMIER_SHEET_SERVICE_ACCOUNT_EMAIL &&
+      process.env.PREMIER_SHEET_SERVICE_ACCOUNT_KEY &&
+      process.env.PREMIERE_CREDITS_SHEET_ID,
+  );
+}
+
+/** Raw 2D cell grid for the configured POD Credits tab. */
+async function readRawSheet(): Promise<string[][]> {
+  const email = process.env.PREMIER_SHEET_SERVICE_ACCOUNT_EMAIL;
+  const privateKey = process.env.PREMIER_SHEET_SERVICE_ACCOUNT_KEY;
+  const sheetId = process.env.PREMIERE_CREDITS_SHEET_ID;
+  const tab = process.env.PREMIERE_CREDITS_SHEET_TAB || 'POD Credits';
+
+  if (!email || !privateKey || !sheetId) {
+    throw new Error(
+      'Missing Premiere credits sheet env vars. Required: PREMIERE_CREDITS_SHEET_ID, ' +
+        'PREMIER_SHEET_SERVICE_ACCOUNT_EMAIL, PREMIER_SHEET_SERVICE_ACCOUNT_KEY',
+    );
+  }
+
+  // Env-stored PEM keys carry escaped newlines — unescape (per sheet-parser.ts).
+  const formattedKey = privateKey.replace(/\\n/g, '\n');
+  const auth = new google.auth.JWT({ email, key: formattedKey, scopes: SHEETS_SCOPES });
+  const sheets = google.sheets({ version: 'v4', auth });
+
+  const response = await sheets.spreadsheets.values.get({
+    spreadsheetId: sheetId,
+    range: `'${tab}'`,
+    valueRenderOption: 'FORMATTED_VALUE',
+  });
+
+  return (response.data.values || []) as string[][];
+}
+
+/**
+ * Read + parse the POD Credits tab into candidate credit rows. Throws only on
+ * a hard failure (auth/config error, or a sheet with no locatable header row);
+ * per-row issues become warnings, never throws.
+ */
+export async function readCreditSheet(): Promise<SheetReadResult> {
+  const grid = await readRawSheet();
+  const located = locateHeader(grid);
+  if (!located) {
+    throw new Error(
+      'POD Credits sheet: could not locate a header row (need an amount + a client column)',
+    );
+  }
+
+  const { headerIndex, header } = located;
+  // Sheet rows are 1-based; data starts on the row after the header.
+  const rawRows: RawCreditRow[] = [];
+  for (let i = headerIndex + 1; i < grid.length; i++) {
+    rawRows.push({ sheetRow: i + 1, cells: grid[i] || [] });
+  }
+
+  const { rows, warnings } = parseRows(header, rawRows);
+  return { header, rows, warnings };
+}

--- a/src/lib/premiere-credits/types.ts
+++ b/src/lib/premiere-credits/types.ts
@@ -1,0 +1,108 @@
+/**
+ * Premiere Credit automation — shared types.
+ *
+ * The pipeline: read the Premiere "POD Credits" sheet tab → parse rows → plan
+ * an action per row → mint a single-use FIXED_AMOUNT Discount → deliver the
+ * code by email + SMS. Redemption is derived live from the linked Discount,
+ * never stored on the grant. See src/lib/premiere-credits/.
+ */
+
+/**
+ * Grant lifecycle. Stored as a plain string column (not a Postgres enum) so
+ * lifecycle tweaks never need a migration.
+ *
+ * - NEEDS_CONTACT — no usable email on the row; NO discount is minted.
+ * - READY — discount minted, amount within auto-send threshold, awaiting send.
+ * - HELD_FOR_APPROVAL — discount minted, amount over threshold; needs approval.
+ * - SENDING — transient claim while a send is in flight (concurrency guard).
+ * - SENT — customer email send succeeded.
+ * - SEND_FAILED — customer email send failed; `error` is populated.
+ * - CANCELED — voided by an operator; the linked discount is deactivated.
+ */
+export type GrantStatus =
+  | 'PENDING'
+  | 'NEEDS_CONTACT'
+  | 'READY'
+  | 'HELD_FOR_APPROVAL'
+  | 'SENDING'
+  | 'SENT'
+  | 'SEND_FAILED'
+  | 'CANCELED';
+
+/** Why a grant is held / needs attention (free-form, for the admin UI). */
+export type HoldReason = 'over-threshold' | 'sanity-cap' | 'possible-duplicate';
+
+/**
+ * Column index map resolved from the sheet's header row. Any column the parser
+ * could not locate is `null`. `amount` and `client` are the only required
+ * columns — a missing one is a hard, surfaced error.
+ */
+export interface HeaderMap {
+  amount: number | null;
+  code: number | null;
+  status: number | null;
+  bookingDate: number | null;
+  client: number | null;
+  phone: number | null;
+  email: number | null;
+  cruiseDate: number | null;
+}
+
+/** A raw sheet row paired with its 1-based sheet row number. */
+export interface RawCreditRow {
+  /** 1-based row number in the sheet (header row is row 1). */
+  sheetRow: number;
+  cells: string[];
+}
+
+/**
+ * A parsed, validated candidate row ready for planning. Produced only for rows
+ * that pass the skip filter (positive amount, non-blank client, no existing
+ * POD Code in the sheet).
+ */
+export interface ParsedCreditRow {
+  sheetRow: number;
+  clientName: string;
+  email: string | null;
+  phone: string | null;
+  /** ISO YYYY-MM-DD, or null if unparseable. */
+  bookingDateISO: string | null;
+  cruiseDateISO: string | null;
+  amount: number;
+  /** sha256 idempotency key derived from name + booking date + amount. */
+  sourceKey: string;
+  /** The raw cells, captured for audit on the grant row. */
+  rawRow: Record<string, string>;
+}
+
+/** Result of reading + parsing the sheet. */
+export interface SheetReadResult {
+  header: HeaderMap;
+  rows: ParsedCreditRow[];
+  /** Non-fatal issues (skipped rows, unparseable cells) for logging. */
+  warnings: string[];
+}
+
+/**
+ * The action the planner decides for a single parsed row. Rows that should be
+ * ignored entirely are filtered out earlier (parseRows), so the planner only
+ * ever decides between minting and needing contact info.
+ */
+export type RowAction =
+  | { kind: 'mint'; hold: false }
+  | { kind: 'mint'; hold: true; holdReason: HoldReason }
+  | { kind: 'needs-contact' };
+
+/** Aggregate outcome of one cron tick. */
+export interface TickResult {
+  ok: boolean;
+  paused?: boolean;
+  scanned: number;
+  minted: number;
+  held: number;
+  needsContact: number;
+  sent: number;
+  sendFailed: number;
+  /** Per-row failures that did not stop the tick. */
+  rowErrors: Array<{ sheetRow: number; error: string }>;
+}

--- a/src/lib/webhooks/ghl-premiere-credit.ts
+++ b/src/lib/webhooks/ghl-premiere-credit.ts
@@ -1,0 +1,58 @@
+/**
+ * Go High Level (GHL) Webhook — Premiere Credit SMS.
+ *
+ * Fires the inbound webhook that drives the "Premiere Credit — SMS" GHL
+ * workflow (upsert contact → tag → send SMS with the code + expiry). Lives in
+ * its own file because src/lib/webhooks/ghl.ts is already near the 500-line
+ * limit. Mirrors every event to CoreLinq via the shared postToCoreLinq helper.
+ *
+ * Fire-and-forget: logs errors, never throws. No-ops silently when
+ * GHL_PREMIERE_CREDIT_WEBHOOK_URL is not set — inert until the workflow exists.
+ */
+
+import { postToCoreLinq } from './ghl';
+
+const GHL_PREMIERE_CREDIT_WEBHOOK_URL = process.env.GHL_PREMIERE_CREDIT_WEBHOOK_URL;
+
+export interface GhlPremiereCreditPayload {
+  event: 'premiere.credit.issued';
+  /** GHL-standard contact fields (used by the Upsert Contact action). */
+  first_name: string;
+  last_name: string;
+  email: string;
+  phone: string;
+  /** Template variables for the SMS body. */
+  credit_code: string;
+  credit_amount: string; // e.g. "336.21"
+  expires_on: string;    // human-formatted, e.g. "September 20, 2026"
+  redeem_url: string;
+  /** Tag the receiving workflow applies to the contact. */
+  tags: ['premiere-credit'];
+}
+
+/**
+ * POST a Premiere credit to the GHL webhook so the receiving workflow can
+ * upsert the contact and text them the code. The CoreLinq mirror still fires
+ * even when the GHL URL is unset.
+ */
+export async function notifyPremiereCreditIssued(
+  payload: GhlPremiereCreditPayload,
+): Promise<void> {
+  await postToCoreLinq(payload);
+  if (!GHL_PREMIERE_CREDIT_WEBHOOK_URL) return;
+
+  try {
+    const res = await fetch(GHL_PREMIERE_CREDIT_WEBHOOK_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      console.error('[GHL Premiere Credit Webhook] Failed:', res.status, await res.text());
+    } else {
+      console.log('[GHL Premiere Credit Webhook] Sent:', payload.credit_code);
+    }
+  } catch (err) {
+    console.error('[GHL Premiere Credit Webhook] Error:', err);
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -111,6 +111,10 @@
     {
       "path": "/api/cron/inbound-email",
       "schedule": "*/15 * * * *"
+    },
+    {
+      "path": "/api/cron/premiere-credits",
+      "schedule": "*/15 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## What & why

Premiere Party Cruises refunds a cruise customer → today someone manually creates a per-customer discount code and sends it. This automates that end-to-end. A cron reads the **POD Credits** tab of Premiere's 2026 Booking Masterlist (read-only), mints a single-use FIXED_AMOUNT code matching the existing `POD Credit` convention, and delivers it by branded email + GHL SMS.

**Ships completely dark** — behind two feature flags (`premiere_credits_master`, `premiere_credits_send`), both default OFF. Nothing runs until Allan flips them.

## How it works
- **Cron** `/api/cron/premiere-credits` (every 15 min, fail-closed CRON_SECRET). Reads the sheet → mints new rows → sends READY grants (send-flag gated) → notifies partner + operator.
- **Discount config verified against live DB** (REINAUER/MOTYKA/SCLAFANI/BENSON13844 etc.): `combinable + freeShipping true`, `maxUsageCount 1`, `appliesToAll true`, name `POD Credit - <name>`. Only intentional divergence: **60-day expiry** (existing codes never expired — Allan's new-policy decision), stated prominently to the customer.
- **Guardrails**: amounts **> $300 held** for admin approval; **$1000 sanity cap**; per-run cap of 20; single-use.
- **Read-only sheet access** — no write-back. A per-tick summary email tells Premiere the new codes so their VA updates their own POD Code column.
- **Grants ledger** `premiere_credit_grants` (manual migration). Redemption is **never stored** — derived live from the linked Discount, so "invoice Premiere only for redeemed codes" is one filtered query.
- **Admin** `/admin/premiere-credits`: list w/ live redemption, Approve & Send, Resend, Add Contact, Cancel, and an Invoice view (redeemed-in-range, both billing bases shown).

## Reviews (both mandatory for money-adjacent code — done)
- **security-reviewer**: no HIGH/CRITICAL. 4 MEDIUM + 3 LOW fixed (atomic mint via compare-and-swap, atomic send claim, admin-role gating, JWT-safe logging, threshold-constant reuse, bounded list). MEDIUM-3 (predictable `LASTNAME+amount` code format) left as-is — it's an intentional decision to match Premiere's convention; see decision note below.
- **staff-engineer correctness pass**: confirmed the concurrency guards sound; fixed PENDING-resume (silent-drop), held→inactive-until-approval, unconditional SENDING recovery, cancel in-flight/TOCTOU guard, calendar-date validation.

## Gates
- `npx tsc --noEmit` — clean (3 pre-existing unrelated errors only)
- `npm run lint` — clean
- `npm run test:run` — 1029 pass, incl. 33 new (parse, source-key, planner, code-format, template)

## Migrations (auto-apply on deploy)
- `2026-07-21-premiere-credit-emailtype.sql` — `PREMIERE_CREDIT` EmailType
- `2026-07-21-premiere-credit-grants.sql` — `premiere_credit_grants` table

## One-time setup before flipping flags (not in this PR)
1. Share the masterlist with the Premier service account as **Viewer**.
2. Env: `PREMIERE_CREDITS_SHEET_ID`, `PREMIERE_CREDITS_SHEET_TAB="POD Credits"`, `GHL_PREMIERE_CREDIT_WEBHOOK_URL`, `PREMIERE_PARTNER_NOTIFY_EMAIL`.
3. Build the "Premiere Credit — SMS" GHL workflow.
4. Rollout: `master` ON / `send` OFF (mints the 6-row backlog, sends nothing → eyeball admin) → approve the $336.21 hold → `send` ON.

## Decision left for Allan
Code format is `LASTNAME+amount` (e.g. `LEBLANC33621`) to match Premiere's existing codes — predictable but bounded by 60-day expiry + single-use + odd cent amounts. Flipping to an always-random suffix is a one-line change if abuse ever appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)