### PR TITLE
fix(db): premiere_credit_grants FK/id must be TEXT not UUID (unblocks prod deploy)

### DIFF
--- a/prisma/migrations/manual/2026-07-21-premiere-credit-grants.sql
+++ b/prisma/migrations/manual/2026-07-21-premiere-credit-grants.sql
@@ -6,12 +6,15 @@
 -- from the linked Discount (usageCount / DiscountUsage). Expiry lives only on
 -- Discount.expiresAt. See src/lib/premiere-credits/.
 --
--- Additive + idempotent per the manual-migration rules (README.md).
+-- Column types match the Prisma model + repo convention: id / *_id are TEXT
+-- (Prisma String @id, uuid supplied app-side via @default(uuid())). The FK
+-- MUST be TEXT because discounts.id is a Prisma String @id (a TEXT column) —
+-- a UUID column cannot reference it. Additive + idempotent (README.md).
 
 BEGIN;
 
 CREATE TABLE IF NOT EXISTS premiere_credit_grants (
-  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  id                  TEXT PRIMARY KEY,
   -- Idempotency: sha256 of normalized client name + booking date + amount.
   -- Row numbers are never identity (humans insert/reorder rows), so this hash
   -- is the dedupe key. UNIQUE so concurrent cron ticks cannot double-mint.
@@ -25,10 +28,11 @@ CREATE TABLE IF NOT EXISTS premiere_credit_grants (
   cruise_date         DATE,
   amount              NUMERIC(10,2) NOT NULL,
   -- Linked minted discount (NULL until minted — NEEDS_CONTACT never mints).
-  discount_id         UUID REFERENCES discounts(id),
+  -- TEXT to match discounts.id (Prisma String @id).
+  discount_id         TEXT REFERENCES discounts(id),
   code                TEXT,
-  -- Lifecycle: PENDING | NEEDS_CONTACT | READY | HELD_FOR_APPROVAL | SENT |
-  -- SEND_FAILED | CANCELED. Stored as TEXT (not a PG enum) so lifecycle
+  -- Lifecycle: PENDING | NEEDS_CONTACT | READY | HELD_FOR_APPROVAL | SENDING |
+  -- SENT | SEND_FAILED | CANCELED. Stored as TEXT (not a PG enum) so lifecycle
   -- tweaks never need a migration.
   status              TEXT NOT NULL DEFAULT 'PENDING',
   hold_reason         TEXT,


### PR DESCRIPTION
## Hotfix — unblocks the prod deploy pipeline

The prod deploy for #289 failed at the manual-migration step:

```
[apply-manual-migrations] FAILED: foreign key constraint
"premiere_credit_grants_discount_id_fkey" cannot be implemented
```

**Cause:** `discounts.id` is a Prisma `String @id` → a **TEXT** column (confirmed against prod `information_schema`). The new `premiere_credit_grants.discount_id` was declared `UUID`, and a UUID column cannot foreign-key a TEXT column. Preview builds passed because migrations only run on prod (`--vercel-prod-only`), so this surfaced only on the prod build — which now blocks every deploy to main until fixed.

**Fix:** `id` and `discount_id` → `TEXT`, matching the referenced column and the repo convention (Prisma `String @id`, uuid supplied app-side). The Prisma model was already `String` (correct); only the raw SQL was wrong.

**Safe to re-run:** the failed migration ran inside `BEGIN; … COMMIT;` and rolled back, so `premiere_credit_grants` was never created and nothing was recorded in the `_manual_migrations` ledger. This corrected file applies cleanly on the next prod deploy.

No app-code change; the feature still ships dark behind its flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)