### PR TITLE
feat(chat): Wayne widget — three-door menu + site-wide concierge + admin transcripts

### DIFF
--- a/content/playbook/00-overview.md
+++ b/content/playbook/00-overview.md
@@ -54,7 +54,7 @@ volume case for the Phase-5 receptionist.
 |---|---|---|---|---|
 | 1 | cruise-drink-setup | T1 | 10* | *Known #1 by full-thread volume; drip replies land here all season |
 | 2 | cruise-day-logistics | T2 | 15 | address/boarding/parking/gate → generic marina facts + Premier redirect |
-| 3 | cruise-running-late | T4 | 12 | urgent: captain/Allan ping |
+| 3 | cruise-running-late | T2 | 12 | urgent: → Premier's # (2026-07-07, captain's line) |
 | 4 | post-event-thanks | T1 | 12 | warm reply + review link |
 | 5 | delivery-access-info | T1 | 8 | customer gives gate code/unit → ack + log for driver |
 | 6 | cruise-whats-allowed | T2 | 7 | glass/BYO/cups/ice |
@@ -69,7 +69,7 @@ volume case for the Phase-5 receptionist.
 | 15 | shipping-outside-austin | T1 | 3 | verified 2026-07-07: never ship — clean no + local alternative |
 | 16 | cruise-premier-redirect | T2 | 6 | music + Fetii answered directly (2026-07-07); photos/fleet stay redirects |
 | 17 | cruise-order-deadline | T2 | 2 | 48h fact; near-cutoff → flag |
-| 18 | cruise-weather-reschedule | T4 | 2 | day-of + money implications |
+| 18 | cruise-weather-reschedule | T2 | 2 | weather/go-no-go → Premier's # (2026-07-07); rain-out refunds still escalate to Allan |
 | 19 | cruise-guest-update | T2 | 2 | manifest changes → log + Premier |
 | 20 | order-cancellation | T4 | 0‡ | ‡no clean last-message sample; real threads exist |
 | 21 | complaint-issue | T4 | 2 | |

--- a/content/playbook/facts-generated.yaml
+++ b/content/playbook/facts-generated.yaml
@@ -1,10 +1,10 @@
 # GENERATED FILE — DO NOT EDIT.
 # Regenerate with: npx tsx scripts/playbook/extract-code-facts.ts
 # Code-authoritative facts; site copy that disagrees with these values is stale.
-# generated_at: 2026-07-06T21:36:42.011Z
+# generated_at: 2026-07-21T20:44:15.302Z
 facts:
   - id: delivery-zone-central-austin
-    statement: "Central Austin (Downtown, UT Campus, East Austin, South Congress): delivery fee $25 (express $40), order minimum $100, free standard delivery on orders over $250. 9 zip codes."
+    statement: "Central Austin (Downtown, UT Campus, East Austin, South Congress): delivery fee $25, order minimum $100. 9 zip codes."
     status: verified
     source: "src/lib/delivery/rates.ts (DELIVERY_ZONES)"
     data:
@@ -14,7 +14,7 @@ facts:
       freeDeliveryThreshold: 250
       zipCodes: ["78701", "78702", "78703", "78704", "78705", "78751", "78752", "78756", "78757"]
   - id: delivery-zone-greater-austin
-    statement: "Greater Austin (North Austin, South Austin, Round Rock): delivery fee $30 (express $50), order minimum $125, free standard delivery on orders over $300. 37 zip codes."
+    statement: "Greater Austin (North Austin, South Austin, Round Rock): delivery fee $30, order minimum $125. 37 zip codes."
     status: verified
     source: "src/lib/delivery/rates.ts (DELIVERY_ZONES)"
     data:
@@ -24,7 +24,7 @@ facts:
       freeDeliveryThreshold: 300
       zipCodes: ["78617", "78652", "78653", "78660", "78664", "78681", "78717", "78719", "78721", "78722", "78723", "78724", "78725", "78727", "78728", "78729", "78731", "78732", "78733", "78734", "78735", "78736", "78737", "78738", "78739", "78741", "78744", "78745", "78746", "78747", "78748", "78749", "78750", "78753", "78754", "78758", "78759"]
   - id: delivery-zone-extended-austin
-    statement: "Extended Austin (Cedar Park, Georgetown, Dripping Springs): delivery fee $40 (express $65), order minimum $150, free standard delivery on orders over $400. 11 zip codes."
+    statement: "Extended Austin (Cedar Park, Georgetown, Dripping Springs): delivery fee $40, order minimum $150. 11 zip codes."
     status: verified
     source: "src/lib/delivery/rates.ts (DELIVERY_ZONES)"
     data:
@@ -33,10 +33,6 @@ facts:
       minimumOrder: 150
       freeDeliveryThreshold: 400
       zipCodes: ["78613", "78620", "78626", "78628", "78633", "78641", "78642", "78665", "78669", "78676", "78726"]
-  - id: delivery-express-no-free-threshold
-    statement: "Free-delivery thresholds apply to standard delivery only — express delivery is always charged at the express rate."
-    status: verified
-    source: "src/lib/delivery/rates.ts (calculateDeliveryFee)"
   - id: delivery-outside-service-area
     statement: "Zip codes not listed in a delivery zone are outside the service area and not eligible for delivery at checkout."
     status: verified

--- a/content/playbook/facts.yaml
+++ b/content/playbook/facts.yaml
@@ -205,9 +205,15 @@ facts:
     last_verified: 2026-07-07
 
   - id: marina-gate-code-delivery
-    statement: "Marina gate codes rotate per event; Premier typically texts the code to the group's booking contact before the cruise. The bot never quotes a gate code."
+    statement: "The Anderson Mill Marina gate code is 7561#. Give it to customers who ask for it or who are at the gate. (If the code ever changes, update this fact + the cruise-day-logistics card and rebuild.)"
     status: verified
-    sources: ["operator answer 2026-07-07 (open question premier-handoff-list)", "GHL corpus (codes rotate: 7561#, 1007#)"]
+    sources: ["operator answer 2026-07-07 (gate code set to 7561#)"]
+    last_verified: 2026-07-07
+
+  - id: premier-phone
+    statement: "Premier Party Cruises' phone number is 512-488-5892. Give it for the boat-operations questions Premier owns — cruise photos, the weather/go-no-go call, and boat reschedules. For anything Party On Delivery handles (drinks, delivery, refunds), the number is (737) 371-9700."
+    status: verified
+    sources: ["operator answer 2026-07-07 (Premier number for photos + weather redirects)"]
     last_verified: 2026-07-07
 
   - id: cruise-music-policy

--- a/content/playbook/intents/cruise-day-logistics.md
+++ b/content/playbook/intents/cruise-day-logistics.md
@@ -9,8 +9,9 @@ tools: []
 escalation_reason: null
 confidence_instruction: >
   High confidence for marina address / arrival-time / parking / gate-code questions.
-  If the boat is leaving imminently or the customer is stuck at the gate RIGHT NOW,
-  treat as urgent — answer AND flag immediately.
+  The marina gate code is 7561# — give it directly when someone asks or says they're at
+  the gate. If the boat is leaving imminently or they're stuck at the gate RIGHT NOW,
+  give the code AND flag urgent so a human can help in real time.
 match_examples:
   - "Hi what's the address for the boat and what time do we need to be there if we booked the 330pm boat"
   - "I'm at Anderson Mill marina, not sure where to park my car"
@@ -23,14 +24,14 @@ match_examples:
 Give the verified marina address: Anderson Mill Marina, 13993 FM 2769, Leander, TX 78641
 — NOT Cypress Creek. Arrive 30 minutes before your scheduled departure (allow for
 traffic and other delays). Parking: free lot on site — carpooling or a Fetii group ride
-is smart for big groups. Gate codes rotate per event — never quote one from memory;
-Premier typically texts the code to the group's booking contact, so point them there,
-and flag the conversation so a human can send the current code if they're stuck.
-Boat-specific details are Premier's call.
+is smart for big groups. Gate code is 7561# — give it directly when someone asks or says
+they're at the gate. If they're stuck at the gate right now, give the code AND flag the
+conversation urgent so a human can jump in if it still doesn't work. Boat-specific details
+are Premier's call.
 
 ## SMS
 
-Hey {{first_name}}! Marina: Anderson Mill Marina, 13993 FM 2769, Leander TX 78641 (NOT Cypress Creek). Arrive 30 min before departure — allow for traffic. Parking is free on site. Gate code: Premier texts your booking contact — stuck at the gate? Reply here and a human will jump in ASAP.
+Hey {{first_name}}! Marina: Anderson Mill Marina, 13993 FM 2769, Leander TX 78641 (NOT Cypress Creek). Arrive 30 min before departure — allow for traffic. Parking is free on site. Gate code is 7561#. Stuck at the gate? Reply here and a human will jump in ASAP.
 
 ## Email
 
@@ -41,9 +42,8 @@ Creek; GPS sometimes tries). Plan to arrive 30 minutes before your scheduled dep
 allow for traffic and other delays. There's a free parking lot on site; for big groups,
 carpooling or a Fetii group ride makes life easier.
 
-The gate code changes per event — Premier typically texts it to your group's booking
-contact. If you can't find it or it isn't working, reply here or text (737) 371-9700
-and someone will get you in.
+The gate code is 7561#. If you get there and it isn't working, reply here or text
+(737) 371-9700 and someone will get you in.
 
 Party On Delivery
 
@@ -51,20 +51,24 @@ Party On Delivery
 
 Anderson Mill Marina — 13993 FM 2769, Leander, TX 78641 (not Cypress Creek!). Arrive
 30 minutes before your departure time — allow for traffic. Parking is free on site.
-Gate codes change per event — Premier texts them to your booking contact — and if you're
-at the gate right now and stuck, text (737) 371-9700 and a human will get you in fast.
-(Lead with this marina default — it's where nearly every cruise departs; only ask a
-clarifying question if they say it's a different boat.)
+The gate code is 7561#. If you're at the gate and it's not working, text (737) 371-9700
+and a human will get you in fast. (Lead with this marina default — it's where nearly
+every cruise departs; only ask a clarifying question if they say it's a different boat.)
 
 ## Voice
 
 Give the address slowly, offer to text it. Arrival: 30 minutes before departure. Gate
-code: don't have it — offer to take their number and have someone text the current code.
+code is 7561# — give it if asked; if they're stuck at the gate, take their number so a
+human can help in real time.
 
 ## Notes for Allan
 
-- The bot never states a gate code (they rotate — corpus shows 7561#, 1007#). It always
-  routes stuck-at-the-gate to a human, flagged urgent.
+- Gate code CHANGED 2026-07-07 (operator): the bot now gives 7561# directly on a
+  gate-code ask or "we're at the gate." Previously it withheld the code because they
+  rotated (corpus showed 7561# and 1007#) — if the code ever changes, update it HERE and
+  in the marina-gate-code-delivery fact, then rebuild. Still routes stuck-at-the-gate to
+  a human as a backstop, flagged urgent. Note: this makes 7561# answerable to anyone who
+  asks Wayne on the public site, not just booked guests.
 - Arrival window verified 2026-07-07 (operator round): 30 minutes before departure
   (supersedes the old "arrive 15 minutes earlier" event-blast line). Parking verified
   the same round: free on-site lot.

--- a/content/playbook/intents/cruise-premier-redirect.md
+++ b/content/playbook/intents/cruise-premier-redirect.md
@@ -28,13 +28,13 @@ cruises have Bluetooth speakers, bring your playlist. **Getting there** — we r
 Fetii group rideshare, code PARTYON gets 25% off; Fetii rides can only be scheduled
 starting 48 hours before pickup; free parking on site too. Still Premier's domain:
 boat photos, which-boat/fleet questions, captain contact, amenity specifics — be honest
-that POD is "just the drinks," point to Premier's site or their booking confirmation,
-and flag the conversation so a human can forward it if the customer strikes out. Never
-guess Premier's policies.
+that POD is "just the drinks," and point them to Premier directly: text Premier at
+512-488-5892 for photos, which-boat/fleet, and boat amenities. Never guess Premier's
+policies.
 
 ## SMS
 
-Hey {{first_name}}! Music: disco cruises have a DJ, private cruises have Bluetooth — bring your playlist! Rides: we recommend Fetii — code PARTYON = 25% off (schedulable 48 hrs out). Photos/boat questions are Premier's — check your booking confirmation, and reply here if you strike out.
+Hey {{first_name}}! Music: disco cruises have a DJ, private cruises have Bluetooth — bring your playlist! Rides: we recommend Fetii — code PARTYON = 25% off (schedulable 48 hrs out). Photos/boat questions are Premier's — text them directly at 512-488-5892.
 
 ## Email
 
@@ -49,8 +49,7 @@ Happy to help with the boat-day details we know:
   also a free parking lot at the marina.
 
 Boat photos, which boat you'll be on, and boat-specific amenities are run by Premier
-Party Cruises — your booking confirmation has their contact, and I've flagged your
-question so someone on our side can help chase it down if you don't hear back.
+Party Cruises — text them directly at 512-488-5892 and they'll get you sorted.
 
 Party On Delivery
 
@@ -59,13 +58,12 @@ Party On Delivery
 Music: disco cruises have a DJ on board; private cruises have Bluetooth speakers (bring
 your playlist). Rides: we recommend Fetii — code PARTYON gets 25% off, and rides can be
 scheduled starting 48 hours before pickup. Boat photos and which-boat questions are
-Premier's side — check your booking confirmation, and if you strike out, text
-(737) 371-9700 and a human will help chase it.
+Premier's — text Premier directly at 512-488-5892 (they run the boat side).
 
 ## Voice
 
 Answer music + Fetii directly; for photos/boat specifics say "that's handled by Premier
-Party Cruises — we do the drink deliveries" and offer to take a message.
+Party Cruises — we do the drink deliveries" and give Premier's number, 512-488-5892.
 
 ## Notes for Allan
 
@@ -74,3 +72,5 @@ Party Cruises — we do the drink deliveries" and offer to take a message.
   photos/fleet/amenities stay redirects per the same round.
 - The Fetii PARTYON code + 48-hour scheduling rule came from you directly — if the
   Fetii deal changes, update fact `fetii-discount`.
+- Photos/boat-ops now route to Premier's number 512-488-5892 (operator, 2026-07-07),
+  not the POD line — see fact `premier-phone`.

--- a/content/playbook/intents/cruise-running-late.md
+++ b/content/playbook/intents/cruise-running-late.md
@@ -1,15 +1,16 @@
 ---
 id: cruise-running-late
-tier: T4
+tier: T2
 freq_rank: 3
 freq_confidence: provisional
 channels: [sms, email, chat, voice]
 variables: [first_name]
 tools: []
-escalation_reason: low_confidence
+escalation_reason: null
 confidence_instruction: >
-  Always output CONFIDENCE: 0.3 or lower for this intent — a human must coordinate with
-  the captain in real time. The reply is the acknowledgment only.
+  High confidence + URGENT. Whether the boat waits is Premier and the captain's call,
+  made in real time — tell the customer to text Premier NOW at 512-488-5892 (the direct
+  line to the captain). Never promise the boat will wait.
 match_examples:
   - "Hey there! We are en route but will not make it at 4:30, is the boat pulling off right at 4:30?"
   - "Hey this is Karla! Our group is on the way, we had some car issues"
@@ -19,35 +20,42 @@ match_examples:
 
 ## Answer (canonical)
 
-Ack only + immediate urgent escalation (Allan's cell). Whether the boat waits is the
-captain's call — the bot never promises a hold and never says "no problem." It confirms
-the message reached a human who can actually coordinate.
+URGENT day-of coordination, and it's Premier's to handle: whether the boat waits is the
+captain's call, made in real time. Tell the customer to text Premier RIGHT NOW at
+512-488-5892 — that's the direct line to the captain — and keep heading in safe. The bot
+never promises a hold and never says "no problem."
 
 ## SMS
 
-Got it {{first_name}} — thanks for the heads up! I'm pinging Allan and the captain right now so they know you're on the way. Sit tight, someone will text you right back.
+Got it {{first_name}} — text Premier right now at 512-488-5892, that's the fastest way to reach the captain about the boat. Keep heading in safe!
 
 ## Email
 
 Hi {{first_name}},
 
-Thanks for the heads up — I've flagged this to Allan and the captain right now so they
-know your group is en route. Someone will reply here or text you shortly.
+Thanks for the heads up! Whether the boat can wait is the captain's call — the fastest
+way to reach them is Premier directly at 512-488-5892. Text them right now and keep
+heading in safe.
 
 Party On Delivery
 
 ## Chat
 
-Got it — I'm getting this to Allan and the captain right now. Drop your phone number
-here so they can text you directly, and keep heading in safe.
+Text Premier right now at 512-488-5892 — that's the direct line to the captain about the
+boat. Keep heading in safe!
 
 ## Voice
 
-"I'm flagging Allan and the captain right now so they know you're on the way." Take
-name + number + boat time; fire urgent escalation.
+Give Premier's number 512-488-5892 immediately: "Text or call Premier right now — that's
+the direct line to the captain." Never promise the boat will wait.
 
 ## Notes for Allan
 
-- Deliberately T4-urgent even though it's usually benign: a 2-minute captain heads-up is
-  cheap, a missed boat is a refund fight. 12 of these in the corpus.
-- The engine has no "running late" keyword — escalation rides the forced low confidence.
+- CHANGED 2026-07-07 (operator): running-late now redirects the customer to Premier's
+  number 512-488-5892 (the captain's line — fastest for "will the boat wait") instead of
+  pinging Allan. Re-tiered T4→T2. See fact `premier-phone`. Pure coordination, no money,
+  so it's a clean Premier redirect; a refund that comes up separately is still POD's
+  (refund_keyword / refund-credit-request).
+- Golden-set note: any running-late case previously labeled T4 is now a T2 Premier
+  redirect — relabel in the next replay-harness pass.
+- 12 of these in the corpus.

--- a/content/playbook/intents/cruise-weather-reschedule.md
+++ b/content/playbook/intents/cruise-weather-reschedule.md
@@ -1,15 +1,21 @@
 ---
 id: cruise-weather-reschedule
-tier: T4
+tier: T2
 freq_rank: 18
 freq_confidence: provisional
 channels: [sms, email, chat, voice]
 variables: [first_name]
 tools: []
-escalation_reason: low_confidence
+escalation_reason: null
+escalation_override: >
+  A rain-out REFUND or money ask ("refund for the rained-out boat") is Party On
+  Delivery's, not Premier's — ack + escalate to Allan (T4-urgent). Never send a
+  refund/money ask to Premier's number.
 confidence_instruction: >
-  Always output CONFIDENCE: 0.3 or lower. Weather calls, reschedules, and rain-out
-  refunds mix Premier's go/no-go authority with real money — humans only.
+  High confidence for the weather/go-no-go and reschedule questions: those are Premier's
+  call, so state the policy and point the customer to Premier at 512-488-5892. Do NOT
+  route the go/no-go to Allan. Refund/money asks are the exception — those escalate to
+  Allan, never to Premier.
 match_examples:
   - "It's supposed to storm Saturday, is the cruise still happening?"
   - "Can you push our boat back 2 hours? - Dan"
@@ -18,46 +24,50 @@ match_examples:
 
 ## Answer (canonical)
 
-Ack + escalate urgent. Verified policy the bot may state: Premier and the captain make
-the weather call close to departure — cruises usually run rain or shine unless
-conditions are unsafe — and if Premier reschedules the cruise, the drink delivery moves
-with it at no charge. The bot never predicts a specific weather call and never promises
-a refund. (Corpus color: Allan has run cruises in warm rain — "everyone is swimming in
-the rain, it's amazing" — so the bot guessing "probably cancelled" would be actively
+Weather calls and reschedules are Premier's call. State the verified policy — Premier and
+the captain make the call close to departure, cruises usually run rain or shine unless
+conditions are unsafe, and if Premier reschedules the drink delivery moves with it at no
+charge — then point the customer to Premier directly at 512-488-5892 for the latest.
+Never predict the weather call. The ONE exception: a rain-out REFUND or money ask is
+Party On Delivery's, not Premier's — for those, ack and escalate to Allan (never send a
+refund to Premier). (Corpus color: Allan has run cruises in warm rain — "everyone is
+swimming in the rain, it's amazing" — so guessing "probably cancelled" would be actively
 wrong.)
 
 ## SMS
 
-Hey {{first_name}} — good question, weather calls get made close to boat time by the captain (these usually run rain or shine!). If the boat does get moved, your drinks move with it free. I've pinged Allan and someone will text you as soon as there's a decision. Hang tight!
+Hey {{first_name}} — weather calls get made close to boat time by Premier and the captain (these usually run rain or shine!). For the latest on your cruise, text Premier at 512-488-5892. If the boat does get moved, your drinks move with it free.
 
 ## Email
 
 Hi {{first_name}},
 
 Weather calls are made close to departure by Premier and the captain, so I don't want to
-guess for you — cruises usually run rain or shine unless conditions are unsafe. And one
-reassurance: if Premier does reschedule the cruise, your drink delivery moves with it
-at no charge. I've flagged this to Allan right now and someone will get back to you as
-soon as there's a decision.
+guess for you — cruises usually run rain or shine unless conditions are unsafe. For the
+latest on your cruise, reach Premier directly at 512-488-5892. And one reassurance: if
+Premier reschedules, your drink delivery moves with it at no charge.
 
 Party On Delivery
 
 ## Chat
 
-Weather calls happen close to boat time (captain's call) — these usually run rain or
-shine, so don't cancel your plans yet. And if Premier does move the cruise, your drinks
-move with it at no charge. Drop your number here and I'll make sure Allan texts you as
-soon as there's a decision.
+Weather calls happen close to boat time — that's Premier and the captain's call, and
+these usually run rain or shine, so don't cancel your plans yet. For the latest on your
+cruise, text Premier directly at 512-488-5892. And if Premier moves the cruise, your
+drinks move with it at no charge.
 
 ## Voice
 
-Take name/number/boat time, promise a callback as soon as there's a decision; fire
-urgent escalation.
+State the policy; give Premier's number 512-488-5892 for the go/no-go. For a rain-out
+refund/money ask, take name/number and escalate to Allan.
 
 ## Notes for Allan
 
-- Refund-for-rained-out asks also match refund_keyword — either path lands T4.
-- Weather policy verified 2026-07-07 (operator round): Premier + captain call it,
-  usually rain or shine; drinks move free on a Premier reschedule. The ack now states
-  that policy. Candidate tier split: the pure "is it still happening" half could go T2
-  now — your call in the next review round.
+- CHANGED 2026-07-07 (operator): weather/go-no-go + reschedule questions now redirect to
+  Premier's number 512-488-5892 (card re-tiered T4→T2) instead of pinging Allan — see
+  fact `premier-phone`. Rain-out REFUND/money asks are the exception: still POD's, ack +
+  escalate to Allan (they also match refund_keyword and the refund-credit-request card).
+- Golden-set note: any weather case previously labeled T4-escalate is now a T2 Premier
+  redirect — relabel in the next replay-harness pass.
+- Weather policy verified 2026-07-07: Premier + captain call it, usually rain or shine;
+  drinks move free on a Premier reschedule.

--- a/content/playbook/intents/delivery-zones-minimums.md
+++ b/content/playbook/intents/delivery-zones-minimums.md
@@ -20,19 +20,20 @@ match_examples:
 
 ## Answer (canonical)
 
-Answer from facts-generated.yaml only. Central Austin: $25 fee ($40 express), $100 min,
-free standard delivery over $250. Greater Austin: $30/$50, $125 min, free over $300.
-Extended Austin: $40/$65, $150 min, free over $400. Express never gets free delivery.
-Zip decides the zone — when the customer gives a zip, answer that zone's numbers.
-Outlying cities (Round Rock, Pflugerville, Leander, Dripping Springs): verified policy
-is case-by-case — the bot neither confirms nor denies; route to text (737) 371-9700 and
-Allan decides per order. Lake Travis nuance: address delivery follows the checkout zone
-minimum (Lakeway $125), but boat/ranch EVENT deliveries start at a $250 minimum — if the
-ask is clearly an event on the lake, state the $250 event minimum.
+Answer from facts-generated.yaml only, and state only the delivery FEE + order MINIMUM
+for the zip's zone. Central Austin: $25 fee, $100 min. Greater Austin: $30 fee, $125 min.
+Extended Austin: $40 fee, $150 min. Do NOT proactively mention express delivery or
+free-delivery thresholds. If a customer asks directly about free delivery, don't quote a
+threshold — say their zip prices it exactly at checkout. Zip decides the zone. Outlying
+cities (Round Rock, Pflugerville, Leander, Dripping Springs): verified policy is
+case-by-case — the bot neither confirms nor denies; route to text (737) 371-9700 and Allan
+decides per order. Lake Travis nuance: address delivery follows the checkout zone minimum
+(Lakeway $125), but boat/ranch EVENT deliveries start at a $250 minimum — if the ask is
+clearly an event on the lake, state the $250 event minimum.
 
 ## SMS
 
-Hey {{first_name}}! Delivery is $25–$40 by zone, minimums $100 (central) / $125 (greater) / $150 (extended) — free standard delivery over $250/$300/$400. Your zip at checkout on partyondelivery.com/order prices it exactly.
+Hey {{first_name}}! Delivery is $25 (central Austin), $30 (greater), or $40 (extended), with order minimums of $100 / $125 / $150 by zone. Pop your zip in at partyondelivery.com/order and it prices everything exactly.
 
 ## Email
 
@@ -40,28 +41,29 @@ Hi {{first_name}},
 
 Here's how our delivery zones work:
 
-- Central Austin — $25 delivery, $100 minimum, free delivery over $250
-- Greater Austin — $30 delivery, $125 minimum, free delivery over $300
-- Extended Austin (Cedar Park, Georgetown…) — $40 delivery, $150 minimum, free over $400
+- Central Austin — $25 delivery, $100 minimum
+- Greater Austin — $30 delivery, $125 minimum
+- Extended Austin (Cedar Park, Georgetown…) — $40 delivery, $150 minimum
 
-Your zip at checkout prices it exactly (express delivery is quoted separately and
-doesn't qualify for free delivery). Lake Travis boat and ranch events start at a $250
-minimum. Anything unclear, just reply!
+Enter your zip at checkout and it prices everything exactly. Lake Travis boat and ranch
+events start at a $250 minimum. Anything unclear, just reply!
 
 Party On Delivery
 
 ## Chat
 
-Delivery runs $25–$40 depending on zone, with minimums of $100 (central Austin), $125
-(greater Austin), or $150 (extended, like Cedar Park/Georgetown) — and standard delivery
-is free over $250/$300/$400 by zone. Pop your zip into checkout at
-partyondelivery.com/order and it prices it exactly. (Planning a Lake Travis boat or
-ranch event? Those start at a $250 minimum.)
+Delivery runs $25 in central Austin, $30 in greater Austin, or $40 in extended areas
+(like Cedar Park/Georgetown), with order minimums of $100 / $125 / $150 by zone. Pop your
+zip into checkout at partyondelivery.com/order and it prices everything exactly. (Planning
+a Lake Travis boat or ranch event? Those start at a $250 minimum. If someone asks whether
+delivery is free over some amount, do NOT confirm or deny a threshold and never say fees
+apply "regardless of order size" — just tell them checkout shows their exact total once
+they enter their zip.)
 
 ## Voice
 
-Give the three-zone summary; offer to text the checkout link. Outlying cities (Round
-Rock etc.): take a message — a human confirms case-by-case.
+Give the three-zone fee + minimum summary; offer to text the checkout link. Outlying
+cities (Round Rock etc.): take a message — a human confirms case-by-case.
 
 ## Notes for Allan
 
@@ -71,3 +73,8 @@ Rock etc.): take a message — a human confirms case-by-case.
   line; you decide per order. Never advertised in those areas (footprint rule).
 - Lake Travis $250: verified 2026-07-07 as a real EVENT minimum (boats/ranches),
   distinct from the checkout zone minimum — bachelor-page copy stays.
+- 2026-07-07 (Wayne tuning): the bot now states ONLY base fee + minimum. Express rate
+  and free-delivery thresholds were removed from the generated facts + this card so the
+  bot never advertises them. Both numbers are still real in rates.ts (checkout still
+  charges express and still gives free delivery over the threshold) and still appear on
+  public site pages (FAQ, partner pages) — this change is bot-only.

--- a/prisma/migrations/manual/2026-07-22-lead-source-wayne-chat.sql
+++ b/prisma/migrations/manual/2026-07-22-lead-source-wayne-chat.sql
@@ -1,0 +1,12 @@
+-- Wayne chat capture — WAYNE_CHAT LeadSourceWidget enum value.
+-- Server-stamped source for leads created when a customer gives contact info
+-- inside a free-form Wayne (AIConcierge) chat (/api/chat capture → Lead Flow
+-- board). Never claimable by the public pixel — same class as the 2026-07-14
+-- gap-closure sources.
+--
+-- Own file, NO BEGIN/COMMIT: ALTER TYPE ... ADD VALUE cannot share a
+-- transaction with statements that use the new value, and the migration runner
+-- executes each file as a single query. Keep this file to exactly one
+-- statement. (Precedent: 2026-07-14-lead-source-inbound-email.sql.)
+
+ALTER TYPE "LeadSourceWidget" ADD VALUE IF NOT EXISTS 'WAYNE_CHAT';

--- a/prisma/migrations/manual/2026-07-22-wayne-chat-conversations-table.sql
+++ b/prisma/migrations/manual/2026-07-22-wayne-chat-conversations-table.sql
@@ -1,0 +1,32 @@
+-- Wayne chat capture — chat_conversations table.
+-- One row per free-form Wayne (AIConcierge) conversation, keyed by a
+-- client-generated conversation_id (UNIQUE) that the /api/chat route upserts the
+-- full message history into each turn. Linked to its Lead when contact is
+-- captured, so the Lead Flow board drawer can show the conversation. Additive +
+-- idempotent. Mirrors the inbound_emails table (2026-07-14-inbound-emails-table.sql):
+-- id has no DB default (Prisma supplies uuid app-side); lead_id FK is
+-- ON DELETE SET NULL so the transcript survives if a lead is ever removed.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS "chat_conversations" (
+  "id"                     TEXT PRIMARY KEY,
+  "conversation_id"        TEXT NOT NULL UNIQUE,
+  "messages"               JSONB NOT NULL DEFAULT '[]'::jsonb,
+  "lead_id"                TEXT REFERENCES "leads"("id") ON DELETE SET NULL,
+  "first_page"             TEXT,
+  "utm_source"             TEXT,
+  "utm_medium"             TEXT,
+  "utm_campaign"           TEXT,
+  "escalated"              BOOLEAN NOT NULL DEFAULT false,
+  "escalation_reason"      TEXT,
+  "escalation_notified_at" TIMESTAMPTZ,
+  "contact_captured_at"    TIMESTAMPTZ,
+  "created_at"             TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "updated_at"             TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "chat_conversations_lead_id_idx" ON "chat_conversations" ("lead_id");
+CREATE INDEX IF NOT EXISTS "chat_conversations_created_at_idx" ON "chat_conversations" ("created_at");
+
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3383,6 +3383,9 @@ enum LeadSourceWidget {
   /// databases, 2026-07-21-lead-source-partner-outreach.sql). Server-stamped,
   /// not pixel-claimable.
   PARTNER_OUTREACH
+  /// Contact captured inside a free-form Wayne (AIConcierge) chat — server-stamped
+  /// by /api/chat, not pixel-claimable (2026-07-22-lead-source-wayne-chat.sql).
+  WAYNE_CHAT
   OTHER
 }
 
@@ -3451,6 +3454,7 @@ model Lead {
   events          LeadEvent[]
   sessions        VisitorSession[]
   inboundEmails   InboundEmail[]
+  chatConversations ChatConversation[]
 
   createdAt       DateTime        @default(now()) @map("created_at")
   updatedAt       DateTime        @updatedAt      @map("updated_at")
@@ -3491,6 +3495,36 @@ model InboundEmail {
   @@index([leadId])
   @@index([receivedAt])
   @@map("inbound_emails")
+}
+
+/// Free-form Wayne (AIConcierge) chat transcript. One row per conversation,
+/// keyed by a client-generated conversationId; the /api/chat route upserts the
+/// full message history each turn. Linked to its Lead when contact is captured
+/// so the Lead Flow board drawer can show the conversation. See
+/// 2026-07-22-wayne-chat-conversations-table.sql.
+model ChatConversation {
+  id                   String    @id @default(uuid())
+  conversationId       String    @unique @map("conversation_id")
+  /// Full OpenRouter-format message history: [{ role, content }, ...].
+  messages             Json      @default("[]")
+  leadId               String?   @map("lead_id")
+  /// The page the conversation started on (first-touch), for attribution.
+  firstPage            String?   @map("first_page")
+  utmSource            String?   @map("utm_source")
+  utmMedium            String?   @map("utm_medium")
+  utmCampaign          String?   @map("utm_campaign")
+  escalated            Boolean   @default(false)
+  escalationReason     String?   @map("escalation_reason")
+  escalationNotifiedAt DateTime? @map("escalation_notified_at")
+  contactCapturedAt    DateTime? @map("contact_captured_at")
+  createdAt            DateTime  @default(now()) @map("created_at")
+  updatedAt            DateTime  @updatedAt      @map("updated_at")
+
+  lead                 Lead?     @relation(fields: [leadId], references: [id], onDelete: SetNull)
+
+  @@index([leadId])
+  @@index([createdAt])
+  @@map("chat_conversations")
 }
 
 enum LeadEventType {

--- a/scripts/playbook/build-chat-prompt.ts
+++ b/scripts/playbook/build-chat-prompt.ts
@@ -126,7 +126,7 @@ export function buildBlock(): string {
     '- Messages that are clearly not from a customer (vendors selling to us, our own staff or partners coordinating, automated notifications) get NO customer-service reply — one neutral line at most.'
   );
   lines.push(
-    '- You are the Party On Delivery assistant — never claim to be Allan. (737) 371-9700 is the only phone number you may ever give out.'
+    "- You are the Party On Delivery assistant — never claim to be Allan. Give out only two numbers: Party On Delivery's line (737) 371-9700 for anything we handle, and Premier Party Cruises' line 512-488-5892 ONLY for boat-operations questions Premier owns (cruise photos, the weather/go-no-go call, boat reschedules). Never invent or give any other number."
   );
   lines.push('');
   lines.push('## Playbook: verified facts (the ONLY facts you may state)');

--- a/scripts/playbook/extract-code-facts.ts
+++ b/scripts/playbook/extract-code-facts.ts
@@ -31,15 +31,17 @@ const facts: GeneratedFact[] = [];
 
 for (const zone of DELIVERY_ZONES) {
   const slug = zone.name.toLowerCase().replace(/\s+/g, '-');
+  // Operator decision 2026-07-07 (Wayne tuning): the customer-facing STATEMENT states
+  // only the base delivery fee + order minimum. The express rate and free-delivery
+  // threshold are intentionally omitted so the auto-reply bot doesn't proactively
+  // advertise them (express fee is not a firmly-decided customer-facing number, and
+  // Allan doesn't want free-over-threshold advertised to every visitor). The full
+  // numbers are still preserved in `data` for any other consumer / checkout logic.
   facts.push({
     id: `delivery-zone-${slug}`,
     statement:
-      `${zone.name} (${zone.description}): delivery fee ${money(zone.baseRate)} ` +
-      `(express ${money(zone.expressRate)}), order minimum ${money(zone.minimumOrder)}, ` +
-      (zone.freeDeliveryThreshold
-        ? `free standard delivery on orders over ${money(zone.freeDeliveryThreshold)}. `
-        : 'no free-delivery threshold. ') +
-      `${zone.zipCodes.length} zip codes.`,
+      `${zone.name} (${zone.description}): delivery fee ${money(zone.baseRate)}, ` +
+      `order minimum ${money(zone.minimumOrder)}. ${zone.zipCodes.length} zip codes.`,
     status: 'verified',
     source: 'src/lib/delivery/rates.ts (DELIVERY_ZONES)',
     data: {
@@ -52,13 +54,9 @@ for (const zone of DELIVERY_ZONES) {
   });
 }
 
-facts.push({
-  id: 'delivery-express-no-free-threshold',
-  statement:
-    'Free-delivery thresholds apply to standard delivery only — express delivery is always charged at the express rate.',
-  status: 'verified',
-  source: 'src/lib/delivery/rates.ts (calculateDeliveryFee)',
-});
+// NOTE: the former `delivery-express-no-free-threshold` fact was removed 2026-07-07 —
+// stating it would reintroduce both the express rate and the free-delivery threshold
+// into the bot's prompt, which is exactly what the operator asked to keep out.
 
 facts.push({
   id: 'delivery-outside-service-area',

--- a/src/app/admin/leads/_components/__tests__/drawer-derive.test.ts
+++ b/src/app/admin/leads/_components/__tests__/drawer-derive.test.ts
@@ -161,6 +161,7 @@ function makeDetail(over: Partial<LeadDetail>): LeadDetail {
     orders: [],
     drafts: [],
     inboundEmails: [],
+    chatConversations: [],
     ...over,
   };
 }

--- a/src/app/admin/leads/_components/drawer-conversation.tsx
+++ b/src/app/admin/leads/_components/drawer-conversation.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { ReactElement } from 'react';
+import type { LeadDetail } from './drawer-types';
+
+/** "Mon D, h:mm AM" in CT — the business runs on Central time. */
+function fmtWhen(iso: string): string {
+  return new Date(iso).toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone: 'America/Chicago',
+  });
+}
+
+/**
+ * "Wayne chat" — the free-form AI concierge transcripts this lead had, so an
+ * operator can read the whole conversation (what they asked, what Wayne said)
+ * before replying. Newest conversation first; the transcript scrolls inside
+ * its own card. An escalation badge flags refund/complaint/legal/safety chats.
+ * Renders nothing when there are no captured chats.
+ */
+export default function DrawerConversation({
+  chatConversations,
+}: {
+  chatConversations: LeadDetail['chatConversations'];
+}): ReactElement | null {
+  if (chatConversations.length === 0) return null;
+  return (
+    <section className="mt-4">
+      <h3 className="font-heading font-bold text-sm tracking-[0.1em] uppercase text-gray-500">
+        Wayne chat
+      </h3>
+      <ul className="mt-2 space-y-3">
+        {chatConversations.map((c) => {
+          const messages = Array.isArray(c.messages) ? c.messages : [];
+          return (
+            <li key={c.id} className="rounded-lg border border-gray-200 bg-gray-50 p-3">
+              <div className="flex items-baseline justify-between gap-2">
+                <span className="font-semibold text-sm text-gray-900 break-words">
+                  {c.firstPage || 'Wayne chat'}
+                  {c.escalated && (
+                    <span className="ml-2 inline-block rounded bg-red-100 px-1.5 py-0.5 align-middle text-xs font-bold uppercase tracking-wide text-red-700">
+                      {c.escalationReason || 'escalated'}
+                    </span>
+                  )}
+                </span>
+                <span className="shrink-0 text-sm text-gray-400">{fmtWhen(c.createdAt)}</span>
+              </div>
+              {messages.length > 0 ? (
+                <div className="mt-2 max-h-60 space-y-2 overflow-y-auto">
+                  {messages.map((m, i) => {
+                    const isUser = m.role === 'user';
+                    return (
+                      <div
+                        key={i}
+                        className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}
+                      >
+                        <div
+                          className={`max-w-[85%] whitespace-pre-wrap break-words rounded-2xl px-3 py-1.5 text-sm ${
+                            isUser
+                              ? 'bg-brand-blue text-white'
+                              : 'border border-gray-200 bg-white text-gray-800'
+                          }`}
+                        >
+                          {typeof m.content === 'string' ? m.content : ''}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : (
+                <p className="mt-1 text-sm text-gray-500">(empty transcript)</p>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/src/app/admin/leads/_components/drawer-conversation.tsx
+++ b/src/app/admin/leads/_components/drawer-conversation.tsx
@@ -19,6 +19,10 @@ function fmtWhen(iso: string): string {
  * operator can read the whole conversation (what they asked, what Wayne said)
  * before replying. Newest conversation first; the transcript scrolls inside
  * its own card. An escalation badge flags refund/complaint/legal/safety chats.
+ *
+ * IMPORTANT: this content comes from the public, unauthenticated /api/chat
+ * endpoint — the visitor typed it, and there's no identity check tying it to
+ * the matched lead. Treat it as unverified (a caption reminds the operator).
  * Renders nothing when there are no captured chats.
  */
 export default function DrawerConversation({
@@ -32,9 +36,17 @@ export default function DrawerConversation({
       <h3 className="font-heading font-bold text-sm tracking-[0.1em] uppercase text-gray-500">
         Wayne chat
       </h3>
+      <p className="mt-0.5 text-sm text-gray-400">
+        From the public chat widget — visitor-typed and unverified.
+      </p>
       <ul className="mt-2 space-y-3">
         {chatConversations.map((c) => {
-          const messages = Array.isArray(c.messages) ? c.messages : [];
+          const messages = Array.isArray(c.messages)
+            ? c.messages.filter(
+                (m): m is { role: string; content: string } =>
+                  !!m && typeof m === 'object',
+              )
+            : [];
           return (
             <li key={c.id} className="rounded-lg border border-gray-200 bg-gray-50 p-3">
               <div className="flex items-baseline justify-between gap-2">
@@ -43,6 +55,11 @@ export default function DrawerConversation({
                   {c.escalated && (
                     <span className="ml-2 inline-block rounded bg-red-100 px-1.5 py-0.5 align-middle text-xs font-bold uppercase tracking-wide text-red-700">
                       {c.escalationReason || 'escalated'}
+                    </span>
+                  )}
+                  {c.contactCapturedAt && (
+                    <span className="ml-2 inline-block rounded bg-green-100 px-1.5 py-0.5 align-middle text-xs font-bold uppercase tracking-wide text-green-700">
+                      contact captured
                     </span>
                   )}
                 </span>

--- a/src/app/admin/leads/_components/drawer-types.ts
+++ b/src/app/admin/leads/_components/drawer-types.ts
@@ -74,4 +74,16 @@ export interface LeadDetail {
     bodyText: string | null;
     receivedAt: string;
   }>;
+  /** Wayne chat transcripts captured for this lead, newest first. */
+  chatConversations: Array<{
+    id: string;
+    conversationId: string;
+    /** OpenRouter-format history: [{ role, content }, ...]. */
+    messages: Array<{ role: string; content: string }>;
+    firstPage: string | null;
+    escalated: boolean;
+    escalationReason: string | null;
+    contactCapturedAt: string | null;
+    createdAt: string;
+  }>;
 }

--- a/src/app/admin/leads/_components/lead-drawer.tsx
+++ b/src/app/admin/leads/_components/lead-drawer.tsx
@@ -10,6 +10,7 @@ import DrawerSummary from './drawer-summary';
 import DrawerStageActions from './drawer-stage-actions';
 import DrawerFacts from './drawer-facts';
 import DrawerInbound from './drawer-inbound';
+import DrawerConversation from './drawer-conversation';
 import DrawerTimeline from './drawer-timeline';
 import ReplyComposer from './reply-composer';
 
@@ -115,6 +116,7 @@ export default function LeadDrawer({
             />
             <DrawerFacts detail={detail} />
             <DrawerInbound inboundEmails={detail.inboundEmails} />
+            <DrawerConversation chatConversations={detail.chatConversations} />
 
             <section className="mt-4">
               <h3 className="font-heading font-bold text-sm tracking-[0.1em] uppercase text-gray-500">

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest, NextResponse, after } from 'next/server'
 import { readFile } from 'fs/promises'
 import { join } from 'path'
+import { persistChatTurn } from '@/lib/chat/capture'
 
 // Cache the prompt content to avoid reading file on every request
 let cachedBasePrompt: string | null = null
@@ -29,7 +30,16 @@ async function loadBasePrompt(): Promise<string> {
 
 export async function POST(request: NextRequest) {
   try {
-    const { messages, mode = 'normal' } = await request.json()
+    const {
+      messages,
+      mode = 'normal',
+      // Capture context (optional — legacy callers omit these and are unaffected).
+      conversationId,
+      page,
+      utmSource,
+      utmMedium,
+      utmCampaign,
+    } = await request.json()
 
     const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY
     
@@ -82,6 +92,23 @@ export async function POST(request: NextRequest) {
     console.log('OpenRouter response:', JSON.stringify(data).substring(0, 200))
     
     const assistantMessage = data.choices?.[0]?.message?.content || data.error?.message || 'Sorry, I had trouble processing that. How can I help you with your Austin party?'
+
+    // Persist the transcript + run capture/escalation AFTER responding, so it
+    // never adds latency to the reply. Only when the client supplies a
+    // conversationId (the widget does; legacy embeds don't → unchanged behavior).
+    if (conversationId && typeof conversationId === 'string' && Array.isArray(messages)) {
+      const transcript = [...messages, { role: 'assistant', content: assistantMessage }]
+      after(() =>
+        persistChatTurn({
+          conversationId,
+          messages: transcript,
+          firstPage: typeof page === 'string' ? page : null,
+          utmSource: typeof utmSource === 'string' ? utmSource : null,
+          utmMedium: typeof utmMedium === 'string' ? utmMedium : null,
+          utmCampaign: typeof utmCampaign === 'string' ? utmCampaign : null,
+        })
+      )
+    }
 
     return NextResponse.json({
       content: assistantMessage

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -104,7 +104,7 @@ function getSystemPrompt(mode: string, basePrompt: string): string {
 
 ### Bachelor Party Mode Active
 
-Alright, alright, alright - last ride before the big day! Let's make sure y'all have the right spirits for this celebration. We've done this rodeo a time or two. Suggest Macallan 18, Johnnie Walker Blue, Ranch Water for keepin' it local, and plenty of cold beer. Mention our Lake Travis yacht packages - "Lake life is the good life, my friend."
+Last celebration before the big day. Suggest crowd-pleasers — good whiskey, Ranch Water, and plenty of cold beer — and mention our Lake Travis boat packages if it fits. Keep it fun but short, and get to the recommendation.
 
 (The Playbook Priority Rules above override this mode guidance for service questions, escalations, and facts.)`
 
@@ -113,7 +113,7 @@ Alright, alright, alright - last ride before the big day! Let's make sure y'all 
 
 ### Bachelorette Mode Active
 
-Well now, let's get the bride-to-be set up proper! We've got the bubbly, the rosé, and all the Instagram-worthy setups y'all could want. For the celebration: Dom Pérignon, Veuve Clicquot, or some refreshing hard seltzers if that's more your speed. Our packages are designed to look as good as they taste - perfect for those photo moments.
+Set the group up well: bubbly (Dom Pérignon, Veuve Clicquot), rosé, or hard seltzers if that's more their speed — our packages photograph as well as they taste. Keep it warm and brief.
 
 (The Playbook Priority Rules above override this mode guidance for service questions, escalations, and facts.)`
 
@@ -122,7 +122,7 @@ Well now, let's get the bride-to-be set up proper! We've got the bubbly, the ros
 
 ### Event Planning Mode Active
 
-This ain't our first rodeo when it comes to planning celebrations! Whether it's an elegant wedding or a good old-fashioned Texas shindig, we'll rustle up exactly what you need. Start with our premium packages. The Lake Life Luxury has Tito's Vodka (Texas-made, naturally) and a fine selection of craft beers and spirits.
+Weddings, corporate events, and formal parties. Start from the curated per-person bar packages above and size them to the guest count. Keep it clear and professional.
 
 (The Playbook Priority Rules above override this mode guidance for service questions, escalations, and facts.)`
 
@@ -131,7 +131,7 @@ This ain't our first rodeo when it comes to planning celebrations! Whether it's 
 
 ### Standard Service Mode Active
 
-Howdy! Welcome to Party On Delivery. We're here to help y'all put together the perfect drink selection - whether it's a quiet gathering or a full-blown celebration. Y'all are in good hands. We deliver fast so the good times keep flowin'.
+Welcome them to Party On Delivery and help them put together the right drinks for their event — a small gathering or a big celebration. Lead with what they need; keep replies short and genuinely friendly.
 
 (The Playbook Priority Rules above override this mode guidance for service questions, escalations, and facts.)`
   }

--- a/src/app/api/v1/admin/leads/[id]/route.ts
+++ b/src/app/api/v1/admin/leads/[id]/route.ts
@@ -71,7 +71,8 @@ export async function GET(
     return NextResponse.json({ success: false, error: 'not_found' }, { status: 404 });
   }
 
-  const [events, followUps, emailLogs, orders, drafts, inboundEmails] = await Promise.all([
+  const [events, followUps, emailLogs, orders, drafts, inboundEmails, chatConversations] =
+    await Promise.all([
     prisma.leadEvent.findMany({
       where: { leadId: id },
       orderBy: { occurredAt: 'desc' },
@@ -122,11 +123,36 @@ export async function GET(
         receivedAt: true,
       },
     }),
+    // Wayne chat transcripts captured for this lead (contact given mid-chat).
+    prisma.chatConversation.findMany({
+      where: { leadId: id },
+      orderBy: { createdAt: 'desc' },
+      take: 10,
+      select: {
+        id: true,
+        conversationId: true,
+        messages: true,
+        firstPage: true,
+        escalated: true,
+        escalationReason: true,
+        contactCapturedAt: true,
+        createdAt: true,
+      },
+    }),
   ]);
 
   return NextResponse.json({
     success: true,
-    data: { lead, events, followUps, emailLogs, orders, drafts, inboundEmails },
+    data: {
+      lead,
+      events,
+      followUps,
+      emailLogs,
+      orders,
+      drafts,
+      inboundEmails,
+      chatConversations,
+    },
   });
 }
 

--- a/src/components/AIConcierge.tsx
+++ b/src/components/AIConcierge.tsx
@@ -24,32 +24,26 @@ export default function AIConcierge({ mode = 'normal', isOpen: controlledIsOpen,
   const router = useRouter()
   const pathname = usePathname()
 
-  // Stable per-browser conversation id so the backend can thread every Wayne
-  // turn into one ChatConversation row (persist/escalation/lead capture keys off
-  // it). Generated lazily on first send, persisted in localStorage so it survives
-  // reopens and is shared across every Wayne mount (site-wide menu, /products, cart).
+  // Per-page-session conversation id so the backend can thread every Wayne turn
+  // into one ChatConversation row. Held in a ref (not localStorage) and minted
+  // lazily on the first send. It deliberately does NOT persist across reloads or
+  // devices: a permanent shared localStorage id let a second person on a shared
+  // browser inherit the first person's conversation (their PII would land on the
+  // first person's lead) and let a returning visit overwrite the earlier
+  // transcript (security review 2026-07-22, MEDIUM-1 / transcript-integrity).
+  // Because this component stays mounted for the life of the page (WidgetMenu
+  // never unmounts it), the id + full message history survive open/close and
+  // back-to-menu within a visit — capture.ts's "client posts the full transcript"
+  // assumption holds; a page reload correctly starts a fresh conversation row.
   const conversationIdRef = useRef<string | null>(null)
   const getConversationId = (): string => {
-    if (conversationIdRef.current) return conversationIdRef.current
-    let id: string | null = null
-    try {
-      id = localStorage.getItem('wayne_conversation_id')
-    } catch {
-      /* localStorage unavailable (private mode / quota) */
-    }
-    if (!id) {
-      id =
+    if (!conversationIdRef.current) {
+      conversationIdRef.current =
         typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
           ? crypto.randomUUID()
           : `wayne_${Date.now()}_${Math.random().toString(36).slice(2)}`
-      try {
-        localStorage.setItem('wayne_conversation_id', id)
-      } catch {
-        /* ignore */
-      }
     }
-    conversationIdRef.current = id
-    return id
+    return conversationIdRef.current
   }
 
   const handleOpen = () => {

--- a/src/components/AIConcierge.tsx
+++ b/src/components/AIConcierge.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useState, useRef, useEffect } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, usePathname } from 'next/navigation'
+import { getAttribution } from '@/lib/analytics/attribution'
 
 interface Message {
   id: string
@@ -19,8 +20,38 @@ interface AIConciergeProps {
 export default function AIConcierge({ mode = 'normal', isOpen: controlledIsOpen, onClose }: AIConciergeProps) {
   const [internalIsOpen, setInternalIsOpen] = useState(false)
   const isOpen = controlledIsOpen !== undefined ? controlledIsOpen : internalIsOpen
+  const isControlled = controlledIsOpen !== undefined
   const router = useRouter()
-  
+  const pathname = usePathname()
+
+  // Stable per-browser conversation id so the backend can thread every Wayne
+  // turn into one ChatConversation row (persist/escalation/lead capture keys off
+  // it). Generated lazily on first send, persisted in localStorage so it survives
+  // reopens and is shared across every Wayne mount (site-wide menu, /products, cart).
+  const conversationIdRef = useRef<string | null>(null)
+  const getConversationId = (): string => {
+    if (conversationIdRef.current) return conversationIdRef.current
+    let id: string | null = null
+    try {
+      id = localStorage.getItem('wayne_conversation_id')
+    } catch {
+      /* localStorage unavailable (private mode / quota) */
+    }
+    if (!id) {
+      id =
+        typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+          ? crypto.randomUUID()
+          : `wayne_${Date.now()}_${Math.random().toString(36).slice(2)}`
+      try {
+        localStorage.setItem('wayne_conversation_id', id)
+      } catch {
+        /* ignore */
+      }
+    }
+    conversationIdRef.current = id
+    return id
+  }
+
   const handleOpen = () => {
     if (controlledIsOpen === undefined) {
       setInternalIsOpen(true)
@@ -114,7 +145,11 @@ export default function AIConcierge({ mode = 'normal', isOpen: controlledIsOpen,
     setIsLoading(true)
 
     try {
-      // TODO: Replace with actual OpenRouter API call
+      // Attach capture context so /api/chat can persist the transcript, run
+      // escalation detection, and create a Lead when Wayne collects contact info.
+      // The backend only persists when conversationId is a string (legacy embeds
+      // that omit it are unaffected).
+      const attribution = getAttribution()
       const response = await fetch('/api/chat', {
         method: 'POST',
         headers: {
@@ -125,7 +160,12 @@ export default function AIConcierge({ mode = 'normal', isOpen: controlledIsOpen,
             role: m.role,
             content: m.content
           })),
-          mode
+          mode,
+          conversationId: getConversationId(),
+          page: pathname ?? undefined,
+          utmSource: attribution?.utmSource ?? undefined,
+          utmMedium: attribution?.utmMedium ?? undefined,
+          utmCampaign: attribution?.utmCampaign ?? undefined,
         }),
       })
 
@@ -167,7 +207,10 @@ export default function AIConcierge({ mode = 'normal', isOpen: controlledIsOpen,
 
   return (
     <>
-      {/* Chat Button - Subtle Help Box - Hidden on Mobile */}
+      {/* Chat Button — only rendered when uncontrolled. When a parent controls
+          open/close (e.g. the site-wide WidgetMenu), the parent owns the FAB and
+          positioning; suppressing this avoids a duplicate floating button. */}
+      {!isControlled && (
       <div className="fixed bottom-6 right-6 z-50 hidden md:block">
         {!isOpen ? (
           <button
@@ -195,11 +238,12 @@ export default function AIConcierge({ mode = 'normal', isOpen: controlledIsOpen,
           </button>
         )}
       </div>
+      )}
 
       {/* Chat Panel - Subtle Help Box */}
       {isOpen && (
-        <div className="fixed bottom-20 right-6 w-[480px] h-[520px] bg-white rounded-2xl shadow-xl z-50 
-                      transform scale-100 border border-gray-200">
+        <div className={`fixed bottom-20 right-6 w-[min(480px,calc(100vw-2rem))] h-[min(520px,calc(100vh-7rem))] bg-white rounded-2xl shadow-xl
+                      transform scale-100 border border-gray-200 ${isControlled ? 'z-[150]' : 'z-50'}`}>
           {/* Header - Clean ElevenLabs Style */}
           <div className="p-6 border-b border-gray-100">
             <div className="flex items-center justify-between">

--- a/src/components/chat/PartyChat.tsx
+++ b/src/components/chat/PartyChat.tsx
@@ -67,8 +67,27 @@ const PARTY_OPTIONS: PartyType[] = [
 const NAVY = '#0A1F33';
 const GOLD = '#F2D34F';
 
-export default function PartyChat() {
-  const [open, setOpen] = useState(false);
+interface PartyChatProps {
+  /**
+   * When provided, the parent owns open/close (e.g. the site-wide WidgetMenu
+   * opening the quiz behind its "Get a party recommendation" door). When
+   * omitted, PartyChat renders its own floating bubble and manages its own
+   * open state — the original standalone behavior.
+   */
+  isOpen?: boolean;
+  onClose?: () => void;
+}
+
+export default function PartyChat({ isOpen: controlledIsOpen, onClose }: PartyChatProps = {}) {
+  const isControlled = controlledIsOpen !== undefined;
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = isControlled ? Boolean(controlledIsOpen) : internalOpen;
+  // Closing routes to the parent when controlled (WidgetMenu treats this as
+  // "back to the three-door menu"); otherwise it collapses back to the FAB.
+  const closePanel = () => {
+    if (onClose) onClose();
+    else setInternalOpen(false);
+  };
   const [step, setStep] = useState<Step>('party');
   const [partyType, setPartyType] = useState<PartyType | null>(null);
   // Default delivery date depends on the entrance-gate choice:
@@ -221,11 +240,13 @@ export default function PartyChat() {
     }
   };
 
-  // FAB (closed state)
+  // FAB (closed state) — suppressed when a parent controls the panel (the
+  // parent renders its own launcher and simply toggles isOpen).
   if (!open) {
+    if (isControlled) return null;
     return (
       <button
-        onClick={() => setOpen(true)}
+        onClick={() => setInternalOpen(true)}
         aria-label="Chat with Party On Delivery"
         className="fixed z-[150] rounded-full shadow-2xl transition-transform hover:scale-[1.05]"
         style={{
@@ -280,12 +301,12 @@ export default function PartyChat() {
           </div>
         </div>
         <button
-          onClick={() => setOpen(false)}
-          aria-label="Close"
+          onClick={closePanel}
+          aria-label={isControlled ? 'Back to menu' : 'Close'}
           className="w-8 h-8 rounded-full flex items-center justify-center text-lg"
           style={{ background: 'rgba(255,255,255,0.15)', color: '#FFFFFF' }}
         >
-          ×
+          {isControlled ? '‹' : '×'}
         </button>
       </div>
 

--- a/src/components/chat/PartyChatMount.tsx
+++ b/src/components/chat/PartyChatMount.tsx
@@ -1,12 +1,16 @@
 'use client';
 
 /**
- * PartyChat mount controller.
+ * WidgetMenu mount controller.
  *
- * Decides on which pages the chat bubble should appear. Mounted once
- * in the root layout (via PixelMount). The bubble is a floating action
+ * Decides on which pages the floating chat bubble should appear. Mounted
+ * once in the root layout (via PixelMount). The bubble is a floating action
  * button so it doesn't interact with page layout — we just hide it
  * entirely on routes where it would be redundant or in the way.
+ *
+ * Renders <WidgetMenu/> — the three-door entry menu (Order drinks now /
+ * Get a party recommendation / Chat with Wayne). (Previously rendered the
+ * quiz-only <PartyChat/> directly; the quiz now lives behind door 2.)
  *
  * Hidden on:
  *   - /admin/* and /ops/*  (internal tools)
@@ -18,7 +22,7 @@
  *   - /dads-gone-wild         (private friends-only invite — no marketing widgets)
  */
 import { usePathname } from 'next/navigation';
-import PartyChat from './PartyChat';
+import WidgetMenu from './WidgetMenu';
 
 const HIDE_PATTERNS: RegExp[] = [
   /^\/admin(\/|$)/,
@@ -47,5 +51,5 @@ const HIDE_PATTERNS: RegExp[] = [
 export default function PartyChatMount() {
   const pathname = usePathname() ?? '/';
   if (HIDE_PATTERNS.some((re) => re.test(pathname))) return null;
-  return <PartyChat />;
+  return <WidgetMenu />;
 }

--- a/src/components/chat/WidgetMenu.tsx
+++ b/src/components/chat/WidgetMenu.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+/**
+ * WidgetMenu — the site-wide floating entry point.
+ *
+ * Replaces the old quiz-only bubble. Tapping the floating button opens a
+ * three-door menu (navy + gold) that routes to whichever help the visitor
+ * wants:
+ *
+ *   1. "Order drinks now"            → straight to /order (fast lane)
+ *   2. "Get a party recommendation"  → the PartyChat quiz (lead capture)
+ *   3. "Chat with Wayne"             → the AIConcierge free-form concierge
+ *
+ * The quiz and Wayne are rendered *controlled* (isOpen/onClose) so their own
+ * floating buttons are suppressed and this menu owns the launcher. Closing
+ * either sub-panel returns to the three doors; the menu's own × closes the
+ * whole thing back to the bubble.
+ *
+ * NO age gating here by design — carding happens at delivery (operator
+ * decision 2026-07-22). The bubble intentionally stays reachable over the
+ * 21+ gate, matching the prior PartyChat behavior.
+ */
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import PartyChat from './PartyChat';
+import AIConcierge from '@/components/AIConcierge';
+
+const NAVY = '#0A1F33';
+const GOLD = '#F2D34F';
+const BLUE = '#0B74B8';
+
+type View = 'menu' | 'quiz' | 'wayne';
+
+export default function WidgetMenu() {
+  const [open, setOpen] = useState(false);
+  const [view, setView] = useState<View>('menu');
+  const router = useRouter();
+
+  const backToMenu = () => setView('menu');
+  const closeAll = () => {
+    setOpen(false);
+    setView('menu');
+  };
+
+  // Sub-flows render their own panels (controlled → no duplicate FAB). Their
+  // close routes back to the three-door menu.
+  if (open && view === 'quiz') {
+    return <PartyChat isOpen onClose={backToMenu} />;
+  }
+  if (open && view === 'wayne') {
+    return <AIConcierge isOpen onClose={backToMenu} />;
+  }
+
+  // Closed → the floating bubble (same look as the old PartyChat FAB so nothing
+  // visually shifts when collapsed; only the tap target's behavior changes).
+  if (!open) {
+    return (
+      <button
+        onClick={() => {
+          setView('menu');
+          setOpen(true);
+        }}
+        aria-label="Open the Party On Delivery menu"
+        className="fixed z-[150] rounded-full shadow-2xl transition-transform hover:scale-[1.05]"
+        style={{
+          right: 20,
+          bottom: 20,
+          width: 64,
+          height: 64,
+          background: GOLD,
+          color: NAVY,
+          border: `3px solid ${NAVY}`,
+          boxShadow: `0 6px 0 ${NAVY}, 0 12px 24px rgba(0,0,0,0.25)`,
+        }}
+      >
+        <span className="text-3xl leading-none" role="img" aria-label="party">
+          🥂
+        </span>
+      </button>
+    );
+  }
+
+  // Open + view === 'menu' → the three-door panel.
+  return (
+    <div
+      className="fixed z-[150] flex flex-col rounded-2xl overflow-hidden shadow-2xl"
+      style={{
+        right: 20,
+        bottom: 20,
+        width: 'min(400px, calc(100vw - 40px))',
+        background: NAVY,
+        border: `2px solid ${GOLD}`,
+      }}
+      role="dialog"
+      aria-label="Party On Delivery menu"
+    >
+      {/* Header */}
+      <div
+        className="px-4 py-3 flex items-center justify-between gap-3"
+        style={{ color: '#FFFFFF', borderBottom: `3px solid ${GOLD}` }}
+      >
+        <div className="flex items-center gap-2 min-w-0">
+          <div
+            className="w-9 h-9 rounded-full flex items-center justify-center text-lg flex-shrink-0"
+            style={{ background: GOLD, color: NAVY }}
+          >
+            🥂
+          </div>
+          <div className="min-w-0">
+            <div className="font-heading text-base font-bold leading-tight tracking-wide">
+              Party On Delivery
+            </div>
+            <div className="text-[11px] opacity-80 leading-tight">
+              How can we help you party?
+            </div>
+          </div>
+        </div>
+        <button
+          onClick={closeAll}
+          aria-label="Close"
+          className="w-8 h-8 rounded-full flex items-center justify-center text-lg flex-shrink-0"
+          style={{ background: 'rgba(255,255,255,0.15)', color: '#FFFFFF' }}
+        >
+          ×
+        </button>
+      </div>
+
+      {/* Three doors */}
+      <div className="flex flex-col gap-3 px-4 py-4">
+        {/* Door 1 — fast lane (gold) */}
+        <button
+          type="button"
+          onClick={() => {
+            router.push('/order');
+            closeAll();
+          }}
+          className="w-full text-left rounded-lg px-4 py-3 transition-transform hover:scale-[1.01]"
+          style={{
+            background: GOLD,
+            color: NAVY,
+            border: `3px solid ${NAVY}`,
+            boxShadow: `0 4px 0 ${NAVY}`,
+          }}
+        >
+          <div className="font-heading text-lg font-bold tracking-wider leading-tight">
+            ⚡ Order drinks now
+          </div>
+          <div className="text-[12px] font-semibold opacity-80 leading-snug">
+            Skip straight to the full menu
+          </div>
+        </button>
+
+        {/* Door 2 — recommendation quiz (blue) */}
+        <button
+          type="button"
+          onClick={() => setView('quiz')}
+          className="w-full text-left rounded-lg px-4 py-3 transition-transform hover:scale-[1.01]"
+          style={{
+            background: BLUE,
+            color: '#FFFFFF',
+            border: `2px solid ${GOLD}`,
+            boxShadow: `0 4px 0 rgba(0,0,0,0.35)`,
+          }}
+        >
+          <div className="font-heading text-lg font-bold tracking-wider leading-tight">
+            🎉 Get a party recommendation
+          </div>
+          <div className="text-[12px] font-medium opacity-90 leading-snug">
+            Answer 3 quick questions, get a build
+          </div>
+        </button>
+
+        {/* Door 3 — Wayne (ghost) */}
+        <button
+          type="button"
+          onClick={() => setView('wayne')}
+          className="w-full text-left rounded-lg px-4 py-3 transition-transform hover:scale-[1.01]"
+          style={{
+            background: 'transparent',
+            color: '#FFFFFF',
+            border: `2px solid rgba(242,211,79,0.7)`,
+          }}
+        >
+          <div className="font-heading text-lg font-bold tracking-wider leading-tight" style={{ color: GOLD }}>
+            💬 Chat with Wayne
+          </div>
+          <div className="text-[12px] font-medium opacity-80 leading-snug">
+            Ask our Texas party pro anything
+          </div>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/WidgetMenu.tsx
+++ b/src/components/chat/WidgetMenu.tsx
@@ -11,10 +11,13 @@
  *   2. "Get a party recommendation"  → the PartyChat quiz (lead capture)
  *   3. "Chat with Wayne"             → the AIConcierge free-form concierge
  *
- * The quiz and Wayne are rendered *controlled* (isOpen/onClose) so their own
- * floating buttons are suppressed and this menu owns the launcher. Closing
- * either sub-panel returns to the three doors; the menu's own × closes the
- * whole thing back to the bubble.
+ * The quiz and Wayne are rendered *controlled* (isOpen/onClose) and are kept
+ * MOUNTED the whole time — their panels just show/hide via isOpen. Keeping them
+ * mounted means their state survives open/close and "back to menu" within a
+ * page visit: Wayne's conversationId + full message history stay intact, so the
+ * captured transcript (ChatConversation) never gets clobbered mid-visit. Closing
+ * either sub-panel returns to the three doors; the menu's own × closes the whole
+ * thing back to the bubble.
  *
  * NO age gating here by design — carding happens at delivery (operator
  * decision 2026-07-22). The bubble intentionally stays reachable over the
@@ -42,153 +45,156 @@ export default function WidgetMenu() {
     setView('menu');
   };
 
-  // Sub-flows render their own panels (controlled → no duplicate FAB). Their
-  // close routes back to the three-door menu.
-  if (open && view === 'quiz') {
-    return <PartyChat isOpen onClose={backToMenu} />;
-  }
-  if (open && view === 'wayne') {
-    return <AIConcierge isOpen onClose={backToMenu} />;
-  }
-
-  // Closed → the floating bubble (same look as the old PartyChat FAB so nothing
-  // visually shifts when collapsed; only the tap target's behavior changes).
-  if (!open) {
-    return (
-      <button
-        onClick={() => {
-          setView('menu');
-          setOpen(true);
-        }}
-        aria-label="Open the Party On Delivery menu"
-        className="fixed z-[150] rounded-full shadow-2xl transition-transform hover:scale-[1.05]"
-        style={{
-          right: 20,
-          bottom: 20,
-          width: 64,
-          height: 64,
-          background: GOLD,
-          color: NAVY,
-          border: `3px solid ${NAVY}`,
-          boxShadow: `0 6px 0 ${NAVY}, 0 12px 24px rgba(0,0,0,0.25)`,
-        }}
-      >
-        <span className="text-3xl leading-none" role="img" aria-label="party">
-          🥂
-        </span>
-      </button>
-    );
-  }
-
-  // Open + view === 'menu' → the three-door panel.
   return (
-    <div
-      className="fixed z-[150] flex flex-col rounded-2xl overflow-hidden shadow-2xl"
-      style={{
-        right: 20,
-        bottom: 20,
-        width: 'min(400px, calc(100vw - 40px))',
-        background: NAVY,
-        border: `2px solid ${GOLD}`,
-      }}
-      role="dialog"
-      aria-label="Party On Delivery menu"
-    >
-      {/* Header */}
-      <div
-        className="px-4 py-3 flex items-center justify-between gap-3"
-        style={{ color: '#FFFFFF', borderBottom: `3px solid ${GOLD}` }}
-      >
-        <div className="flex items-center gap-2 min-w-0">
-          <div
-            className="w-9 h-9 rounded-full flex items-center justify-center text-lg flex-shrink-0"
-            style={{ background: GOLD, color: NAVY }}
-          >
-            🥂
-          </div>
-          <div className="min-w-0">
-            <div className="font-heading text-base font-bold leading-tight tracking-wide">
-              Party On Delivery
-            </div>
-            <div className="text-[11px] opacity-80 leading-tight">
-              How can we help you party?
-            </div>
-          </div>
-        </div>
+    <>
+      {/* Closed → the floating bubble (same look as the old PartyChat FAB so
+          nothing visually shifts when collapsed; only the tap target changes). */}
+      {!open && (
         <button
-          onClick={closeAll}
-          aria-label="Close"
-          className="w-8 h-8 rounded-full flex items-center justify-center text-lg flex-shrink-0"
-          style={{ background: 'rgba(255,255,255,0.15)', color: '#FFFFFF' }}
-        >
-          ×
-        </button>
-      </div>
-
-      {/* Three doors */}
-      <div className="flex flex-col gap-3 px-4 py-4">
-        {/* Door 1 — fast lane (gold) */}
-        <button
-          type="button"
           onClick={() => {
-            router.push('/order');
-            closeAll();
+            setView('menu');
+            setOpen(true);
           }}
-          className="w-full text-left rounded-lg px-4 py-3 transition-transform hover:scale-[1.01]"
+          aria-label="Open the Party On Delivery menu"
+          className="fixed z-[150] rounded-full shadow-2xl transition-transform hover:scale-[1.05]"
           style={{
+            right: 20,
+            bottom: 20,
+            width: 64,
+            height: 64,
             background: GOLD,
             color: NAVY,
             border: `3px solid ${NAVY}`,
-            boxShadow: `0 4px 0 ${NAVY}`,
+            boxShadow: `0 6px 0 ${NAVY}, 0 12px 24px rgba(0,0,0,0.25)`,
           }}
         >
-          <div className="font-heading text-lg font-bold tracking-wider leading-tight">
-            ⚡ Order drinks now
-          </div>
-          <div className="text-[12px] font-semibold opacity-80 leading-snug">
-            Skip straight to the full menu
-          </div>
+          <span className="text-3xl leading-none" role="img" aria-label="party">
+            🥂
+          </span>
         </button>
+      )}
 
-        {/* Door 2 — recommendation quiz (blue) */}
-        <button
-          type="button"
-          onClick={() => setView('quiz')}
-          className="w-full text-left rounded-lg px-4 py-3 transition-transform hover:scale-[1.01]"
+      {/* Open + view === 'menu' → the three-door panel. */}
+      {open && view === 'menu' && (
+        <div
+          className="fixed z-[150] flex flex-col rounded-2xl overflow-hidden shadow-2xl"
           style={{
-            background: BLUE,
-            color: '#FFFFFF',
+            right: 20,
+            bottom: 20,
+            width: 'min(400px, calc(100vw - 40px))',
+            background: NAVY,
             border: `2px solid ${GOLD}`,
-            boxShadow: `0 4px 0 rgba(0,0,0,0.35)`,
           }}
+          role="dialog"
+          aria-label="Party On Delivery menu"
         >
-          <div className="font-heading text-lg font-bold tracking-wider leading-tight">
-            🎉 Get a party recommendation
+          {/* Header */}
+          <div
+            className="px-4 py-3 flex items-center justify-between gap-3"
+            style={{ color: '#FFFFFF', borderBottom: `3px solid ${GOLD}` }}
+          >
+            <div className="flex items-center gap-2 min-w-0">
+              <div
+                className="w-9 h-9 rounded-full flex items-center justify-center text-lg flex-shrink-0"
+                style={{ background: GOLD, color: NAVY }}
+              >
+                🥂
+              </div>
+              <div className="min-w-0">
+                <div className="font-heading text-base font-bold leading-tight tracking-wide">
+                  Party On Delivery
+                </div>
+                <div className="text-sm opacity-80 leading-tight">
+                  How can we help you party?
+                </div>
+              </div>
+            </div>
+            <button
+              onClick={closeAll}
+              aria-label="Close"
+              className="w-8 h-8 rounded-full flex items-center justify-center text-lg flex-shrink-0"
+              style={{ background: 'rgba(255,255,255,0.15)', color: '#FFFFFF' }}
+            >
+              ×
+            </button>
           </div>
-          <div className="text-[12px] font-medium opacity-90 leading-snug">
-            Answer 3 quick questions, get a build
-          </div>
-        </button>
 
-        {/* Door 3 — Wayne (ghost) */}
-        <button
-          type="button"
-          onClick={() => setView('wayne')}
-          className="w-full text-left rounded-lg px-4 py-3 transition-transform hover:scale-[1.01]"
-          style={{
-            background: 'transparent',
-            color: '#FFFFFF',
-            border: `2px solid rgba(242,211,79,0.7)`,
-          }}
-        >
-          <div className="font-heading text-lg font-bold tracking-wider leading-tight" style={{ color: GOLD }}>
-            💬 Chat with Wayne
+          {/* Three doors */}
+          <div className="flex flex-col gap-3 px-4 py-4">
+            {/* Door 1 — fast lane (gold) */}
+            <button
+              type="button"
+              onClick={() => {
+                router.push('/order');
+                closeAll();
+              }}
+              className="w-full text-left rounded-lg px-4 py-3 transition-transform hover:scale-[1.01]"
+              style={{
+                background: GOLD,
+                color: NAVY,
+                border: `3px solid ${NAVY}`,
+                boxShadow: `0 4px 0 ${NAVY}`,
+              }}
+            >
+              <div className="font-heading text-lg font-bold tracking-wider leading-tight">
+                ⚡ Order drinks now
+              </div>
+              <div className="text-sm font-semibold opacity-80 leading-snug">
+                Skip straight to the full menu
+              </div>
+            </button>
+
+            {/* Door 2 — recommendation quiz (blue) */}
+            <button
+              type="button"
+              onClick={() => setView('quiz')}
+              className="w-full text-left rounded-lg px-4 py-3 transition-transform hover:scale-[1.01]"
+              style={{
+                background: BLUE,
+                color: '#FFFFFF',
+                border: `2px solid ${GOLD}`,
+                boxShadow: `0 4px 0 rgba(0,0,0,0.35)`,
+              }}
+            >
+              <div className="font-heading text-lg font-bold tracking-wider leading-tight">
+                🎉 Get a party recommendation
+              </div>
+              <div className="text-sm font-medium opacity-90 leading-snug">
+                Answer 3 quick questions, get a build
+              </div>
+            </button>
+
+            {/* Door 3 — Wayne (ghost) */}
+            <button
+              type="button"
+              onClick={() => setView('wayne')}
+              className="w-full text-left rounded-lg px-4 py-3 transition-transform hover:scale-[1.01]"
+              style={{
+                background: 'transparent',
+                color: '#FFFFFF',
+                border: `2px solid rgba(242,211,79,0.7)`,
+              }}
+            >
+              <div
+                className="font-heading text-lg font-bold tracking-wider leading-tight"
+                style={{ color: GOLD }}
+              >
+                💬 Chat with Wayne
+              </div>
+              <div className="text-sm font-medium opacity-80 leading-snug">
+                Ask our Texas party pro anything
+              </div>
+            </button>
           </div>
-          <div className="text-[12px] font-medium opacity-80 leading-snug">
-            Ask our Texas party pro anything
-          </div>
-        </button>
-      </div>
-    </div>
+        </div>
+      )}
+
+      {/* Sub-flows stay MOUNTED (shown via isOpen) so their state survives
+          open/close and "back to menu" within a visit. Each renders its own
+          panel and suppresses its own FAB when controlled; closing routes back
+          to the three-door menu. */}
+      <PartyChat isOpen={open && view === 'quiz'} onClose={backToMenu} />
+      <AIConcierge isOpen={open && view === 'wayne'} onClose={backToMenu} />
+    </>
   );
 }

--- a/src/lib/chat/__tests__/chat-capture.test.ts
+++ b/src/lib/chat/__tests__/chat-capture.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { detectEscalation } from '../escalation-keywords';
+import { parseContact, hasContact } from '../parse-contact';
+
+describe('detectEscalation', () => {
+  it('flags refund / cancellation language', () => {
+    expect(detectEscalation('I want a refund for Saturday')).toBe('refund');
+    expect(detectEscalation('please cancel my order')).toBe('refund');
+    expect(detectEscalation('my delivery never received')).toBe('refund');
+  });
+
+  it('flags complaints', () => {
+    expect(detectEscalation('this is unacceptable and terrible')).toBe('complaint');
+    expect(detectEscalation("I'm really disappointed")).toBe('complaint');
+  });
+
+  it('flags legal / fraud language', () => {
+    expect(detectEscalation('I will call my lawyer')).toBe('legal');
+    expect(detectEscalation('this is a scam')).toBe('legal');
+  });
+
+  it('flags safety: minors + intoxication + injury', () => {
+    expect(detectEscalation('you delivered to my son and he is underage')).toBe('safety');
+    expect(detectEscalation('the driver seemed drunk')).toBe('safety');
+    expect(detectEscalation('someone got hurt on the boat')).toBe('safety');
+    expect(detectEscalation('there are minors at this party')).toBe('safety');
+  });
+
+  it('orders most-serious first (safety beats a co-occurring refund word)', () => {
+    expect(detectEscalation('someone got hurt, we need a refund')).toBe('safety');
+  });
+
+  it('does NOT flag benign messages', () => {
+    expect(detectEscalation('what time do we board the boat?')).toBeNull();
+    expect(detectEscalation('can I get a keg for saturday')).toBeNull();
+    expect(detectEscalation('')).toBeNull();
+  });
+
+  it('does not trip safety on "a minor issue"', () => {
+    expect(detectEscalation('just a minor issue with the ice, no big deal')).toBeNull();
+  });
+});
+
+describe('parseContact', () => {
+  it('extracts email, phone (last 10 digits), and first name', () => {
+    const c = parseContact("Hey I'm Sarah, reach me at sarah.b@gmail.com or (512) 555-1234");
+    expect(c.email).toBe('sarah.b@gmail.com');
+    expect(c.phone).toBe('5125551234');
+    expect(c.firstName).toBe('Sarah');
+    expect(hasContact(c)).toBe(true);
+  });
+
+  it('normalizes +1 and punctuation in phones to last 10 digits', () => {
+    expect(parseContact('call +1 512.555.9999').phone).toBe('5125559999');
+    expect(parseContact('my number is 5125550000').phone).toBe('5125550000');
+  });
+
+  it('handles "my name is" and "this is"', () => {
+    expect(parseContact('my name is Robert').firstName).toBe('Robert');
+    expect(parseContact('this is Jessica, thanks!').firstName).toBe('Jessica');
+  });
+
+  it('returns nothing identifiable for a plain message', () => {
+    const c = parseContact('do you deliver to 78704?');
+    expect(c.email).toBeUndefined();
+    // a bare 5-digit zip must not be read as a phone
+    expect(c.phone).toBeUndefined();
+    expect(hasContact(c)).toBe(false);
+  });
+
+  it('handles empty input', () => {
+    expect(hasContact(parseContact(''))).toBe(false);
+  });
+});

--- a/src/lib/chat/capture.ts
+++ b/src/lib/chat/capture.ts
@@ -82,7 +82,13 @@ export async function persistChatTurn(input: ChatTurnInput): Promise<void> {
           leadId: lead.id,
           page: input.firstPage ?? '/chat',
           widget: 'WAYNE_CHAT',
-          trustedSubmit: true,
+          // NOT trustedSubmit: unlike the concierge/quote/contact forms, a chat
+          // "contact" is regex-parsed from unauthenticated freeform text on the
+          // public /api/chat endpoint. Marking it trusted would let an anonymous
+          // caller reopen a victim's WON/LOST board card just by typing their
+          // email into the chat (security review 2026-07-22, HIGH-1). The lead is
+          // still captured + mirrored; it just can't force a stage reopen.
+          trustedSubmit: false,
           metadata: { conversationId, via: 'wayne-chat' },
         });
         await prisma.chatConversation.update({

--- a/src/lib/chat/capture.ts
+++ b/src/lib/chat/capture.ts
@@ -1,0 +1,117 @@
+/**
+ * Wayne chat capture orchestration.
+ *
+ * `persistChatTurn` runs after each `/api/chat` reply (via `after()`, so it never
+ * blocks the response). It (1) upserts the ChatConversation transcript, (2) emails
+ * Allan once when the conversation escalates (refund/complaint/legal/safety), and
+ * (3) creates a Lead — reusing the exact machinery the quiz uses (`upsertLead`,
+ * `recordEvent`, `mirrorLeadToCrm`, which auto-flows the lead to the CRM + Lead
+ * Flow board) — when the customer gives contact info.
+ *
+ * NEVER throws: a capture hiccup must not affect the customer's chat.
+ */
+import { LeadEventType } from '@prisma/client';
+import { prisma } from '@/lib/database/client';
+import { upsertLead, recordEvent } from '@/lib/leads/leadCapture';
+import { mirrorLeadToCrm, leadBoardUrl } from '@/lib/leads/crm-mirror';
+import { detectEscalation } from './escalation-keywords';
+import { parseContact, hasContact } from './parse-contact';
+import { sendChatEscalationEmail } from './escalation-alert';
+
+export interface ChatMessage {
+  role: string;
+  content: string;
+}
+
+export interface ChatTurnInput {
+  conversationId: string;
+  /** Full transcript so far, including the assistant reply just produced. */
+  messages: ChatMessage[];
+  firstPage?: string | null;
+  utmSource?: string | null;
+  utmMedium?: string | null;
+  utmCampaign?: string | null;
+}
+
+export async function persistChatTurn(input: ChatTurnInput): Promise<void> {
+  try {
+    const { conversationId, messages } = input;
+    if (!conversationId || !Array.isArray(messages) || messages.length === 0) return;
+
+    const userMessages = messages.filter((m) => m.role === 'user');
+    const lastUserMessage = userMessages[userMessages.length - 1]?.content ?? '';
+    const reason = detectEscalation(lastUserMessage);
+    const contact = parseContact(userMessages.map((m) => m.content).join('\n'));
+
+    // 1. Upsert the transcript (create on first turn, replace messages each turn).
+    const convo = await prisma.chatConversation.upsert({
+      where: { conversationId },
+      create: {
+        conversationId,
+        messages: messages as unknown as object,
+        firstPage: input.firstPage ?? null,
+        utmSource: input.utmSource ?? null,
+        utmMedium: input.utmMedium ?? null,
+        utmCampaign: input.utmCampaign ?? null,
+        escalated: Boolean(reason),
+        escalationReason: reason,
+      },
+      update: {
+        messages: messages as unknown as object,
+        ...(reason ? { escalated: true, escalationReason: reason } : {}),
+      },
+    });
+
+    // 2. Capture a Lead when contact is present and not already linked.
+    let leadId: string | null = convo.leadId;
+    if (hasContact(contact) && !leadId) {
+      const lead = await upsertLead(
+        { email: contact.email, phone: contact.phone, firstName: contact.firstName },
+        {
+          sourcePage: input.firstPage ?? '/chat',
+          sourceWidget: 'WAYNE_CHAT',
+          utmSource: input.utmSource ?? null,
+          utmMedium: input.utmMedium ?? null,
+          utmCampaign: input.utmCampaign ?? null,
+        }
+      );
+      if (lead) {
+        leadId = lead.id;
+        await recordEvent({
+          type: LeadEventType.FORM_SUBMIT,
+          leadId: lead.id,
+          page: input.firstPage ?? '/chat',
+          widget: 'WAYNE_CHAT',
+          trustedSubmit: true,
+          metadata: { conversationId, via: 'wayne-chat' },
+        });
+        await prisma.chatConversation.update({
+          where: { id: convo.id },
+          data: { leadId: lead.id, contactCapturedAt: new Date() },
+        });
+        // Fire-and-forget CRM mirror (never throws; inert until CORELINQ_INGEST_URL set).
+        await mirrorLeadToCrm({ leadId: lead.id }, 'wayne-chat');
+      }
+    }
+
+    // 3. Escalation email — at most once per conversation.
+    if (reason && !convo.escalationNotifiedAt) {
+      const sent = await sendChatEscalationEmail({
+        conversationId,
+        reason,
+        lastUserMessage,
+        transcript: messages,
+        leadUrl: leadId ? leadBoardUrl(leadId) : null,
+        contact,
+      });
+      if (sent) {
+        await prisma.chatConversation.update({
+          where: { id: convo.id },
+          data: { escalationNotifiedAt: new Date() },
+        });
+      }
+    }
+  } catch (err) {
+    console.warn('[wayne-capture] persistChatTurn failed:', err);
+  }
+}

--- a/src/lib/chat/escalation-alert.ts
+++ b/src/lib/chat/escalation-alert.ts
@@ -1,0 +1,89 @@
+/**
+ * Operator email alert when a free-form Wayne chat escalates (refund, complaint,
+ * legal, safety). Modeled on `src/lib/webhooks/corelinq-alert.ts`: Resend
+ * `sendEmail` to OPS_ALERT_EMAIL, time-bounded so a slow send never holds the
+ * chat response, never throws. Sent at most once per conversation — the caller
+ * gates on `ChatConversation.escalationNotifiedAt`.
+ *
+ * Email only (operator decision 2026-07-22): there is no SMS-to-operator
+ * capability in the codebase, and this is the durable record with a board link.
+ */
+import { EmailType } from '@prisma/client';
+import { sendEmail } from '@/lib/email/resend-client';
+import { REASON_LABEL, type EscalationReason } from './escalation-keywords';
+import type { ParsedContact } from './parse-contact';
+
+const OPS_ALERT_EMAIL = process.env.OPS_ALERT_EMAIL || 'allan@partyondelivery.com';
+const SEND_TIMEOUT_MS = 3000;
+const MSG_MAX = 500;
+
+/** Minimal HTML escape for text-node contexts (& first so &lt; survives). */
+function escapeHtml(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+export interface ChatEscalationInput {
+  conversationId: string;
+  reason: EscalationReason;
+  lastUserMessage: string;
+  transcript: Array<{ role: string; content: string }>;
+  leadUrl: string | null;
+  contact: ParsedContact;
+}
+
+/**
+ * Email Allan that a Wayne chat escalated. Returns true only if the send
+ * actually completed (so the caller stamps escalationNotifiedAt and won't
+ * re-alert); a timeout or failure returns false and leaves it un-stamped.
+ */
+export async function sendChatEscalationEmail(input: ChatEscalationInput): Promise<boolean> {
+  try {
+    const { reason, lastUserMessage, transcript, leadUrl, contact, conversationId } = input;
+
+    const recent = transcript
+      .slice(-8)
+      .map(
+        (m) =>
+          `<p style="margin:4px 0"><b>${m.role === 'user' ? 'Customer' : 'Wayne'}:</b> ${escapeHtml(
+            String(m.content ?? '')
+          ).slice(0, MSG_MAX)}</p>`
+      )
+      .join('');
+
+    const contactLine =
+      [contact.firstName, contact.email, contact.phone].filter(Boolean).join(' · ') ||
+      '(not captured — no contact given yet)';
+
+    const html = `
+      <h2>Wayne chat escalation — ${escapeHtml(REASON_LABEL[reason])}</h2>
+      <p><b>Trigger message:</b> ${escapeHtml(lastUserMessage).slice(0, MSG_MAX)}</p>
+      <p><b>Customer:</b> ${escapeHtml(contactLine)}</p>
+      ${
+        leadUrl
+          ? `<p><a href="${escapeHtml(leadUrl)}">Open the lead on the board →</a></p>`
+          : '<p style="color:#888">No lead yet — the customer has not given contact info.</p>'
+      }
+      <h3>Recent messages</h3>
+      ${recent}
+      <p style="color:#888;font-size:12px">Conversation ${escapeHtml(
+        conversationId
+      )}. Automated ops alert from the Wayne chat.</p>
+    `;
+
+    const result = await Promise.race([
+      sendEmail({
+        to: OPS_ALERT_EMAIL,
+        subject: `Wayne chat escalation — ${REASON_LABEL[reason]}`,
+        type: EmailType.WELCOME, // reuse — internal ops alert, no dedicated type (matches corelinq-alert)
+        html,
+        metadata: { kind: 'wayne-chat-escalation', reason, conversationId },
+      }),
+      new Promise<null>((resolve) => setTimeout(() => resolve(null), SEND_TIMEOUT_MS)),
+    ]);
+
+    return result !== null;
+  } catch (err) {
+    console.error('[wayne-capture] escalation email failed:', err);
+    return false;
+  }
+}

--- a/src/lib/chat/escalation-keywords.ts
+++ b/src/lib/chat/escalation-keywords.ts
@@ -1,0 +1,63 @@
+/**
+ * Escalation keyword detection for the free-form Wayne chat (`/api/chat`).
+ *
+ * These lists MIRROR the playbook's escalation keyword classes
+ * (`content/playbook/escalation.md`) and the CRM fork's
+ * `apps/web/lib/ai-inbox/escalation-triggers.ts`. Keep the three in sync when
+ * any changes. Word-boundary matched, case-insensitive. Bare "minor" is
+ * deliberately excluded ("a minor issue" must not trip safety) — same call as
+ * the fork's safety class.
+ */
+
+export type EscalationReason = 'safety' | 'legal' | 'refund' | 'complaint';
+
+/** Most-serious first — the first match wins, so this orders the label. */
+const KEYWORDS: Record<EscalationReason, string[]> = {
+  safety: [
+    'underage', 'under age', 'under 21', 'not 21', 'fake id', 'minors',
+    'teenager', 'high school', 'drunk', 'wasted', 'hammered', 'intoxicated',
+    'blacked out', 'passed out', 'overserved', 'over served',
+    'alcohol poisoning', 'too much to drink', 'got hurt', 'injured', 'injury',
+    'ambulance', 'hospital', 'emergency',
+  ],
+  legal: [
+    'lawyer', 'attorney', 'legal', 'lawsuit', 'sue', 'dispute', 'scam',
+    'fraud', 'better business bureau', 'bbb',
+  ],
+  refund: [
+    'refund', 'chargeback', 'charge back', 'money back', 'never received',
+    "haven't received", 'have not received', "didn't receive",
+    'did not receive', 'still waiting', 'cancel my order', 'cancel order',
+  ],
+  complaint: [
+    'complaint', 'unacceptable', 'terrible', 'awful', 'worst', 'disappointed',
+    'frustrated', 'angry', 'ridiculous', 'unhappy',
+  ],
+};
+
+function escapeRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function matchesKeyword(text: string, keyword: string): boolean {
+  return new RegExp(`\\b${escapeRegExp(keyword)}\\b`, 'i').test(text);
+}
+
+/**
+ * Return the first (most-serious) escalation reason present in the text, or
+ * null. Used on the customer's latest message in a Wayne chat.
+ */
+export function detectEscalation(text: string): EscalationReason | null {
+  if (!text) return null;
+  for (const reason of Object.keys(KEYWORDS) as EscalationReason[]) {
+    if (KEYWORDS[reason].some((kw) => matchesKeyword(text, kw))) return reason;
+  }
+  return null;
+}
+
+export const REASON_LABEL: Record<EscalationReason, string> = {
+  safety: 'Safety / minors / intoxication',
+  legal: 'Legal / fraud / dispute',
+  refund: 'Refund / cancellation',
+  complaint: 'Complaint / negative sentiment',
+};

--- a/src/lib/chat/parse-contact.ts
+++ b/src/lib/chat/parse-contact.ts
@@ -1,0 +1,43 @@
+/**
+ * Best-effort extraction of a customer's contact info from free-form Wayne chat
+ * text, so a conversation can become a Lead when the customer gives their
+ * details (Wayne is prompted to ask). Conservative on purpose: a missed capture
+ * is fine — the conversation is still stored, and no false Lead is created.
+ */
+
+export interface ParsedContact {
+  email?: string;
+  /** Last 10 digits, matching how leads/orders store phones. */
+  phone?: string;
+  firstName?: string;
+}
+
+const EMAIL_RE = /[\w.+-]+@[\w-]+(?:\.[\w-]+)+/;
+// (512) 555-1234 / 512-555-1234 / 5125551234 / +1 512 555 1234
+const PHONE_RE = /(?:\+?1[\s.\-]?)?\(?\d{3}\)?[\s.\-]?\d{3}[\s.\-]?\d{4}/;
+// "I'm Sarah" / "my name is Sarah" / "this is Sarah" / "name's Sarah"
+const NAME_RE = /\b(?:i['’]?m|i am|my name is|this is|name['’]?s)\s+([A-Z][a-z]{1,20})\b/i;
+
+export function parseContact(text: string): ParsedContact {
+  const out: ParsedContact = {};
+  if (!text) return out;
+
+  const email = text.match(EMAIL_RE)?.[0];
+  if (email) out.email = email.toLowerCase();
+
+  const phoneRaw = text.match(PHONE_RE)?.[0];
+  if (phoneRaw) {
+    const digits = phoneRaw.replace(/\D/g, '');
+    if (digits.length >= 10) out.phone = digits.slice(-10);
+  }
+
+  const name = text.match(NAME_RE)?.[1];
+  if (name) out.firstName = name.charAt(0).toUpperCase() + name.slice(1);
+
+  return out;
+}
+
+/** True when we have at least one identifying field (email or phone). */
+export function hasContact(c: ParsedContact): boolean {
+  return Boolean(c.email || c.phone);
+}

--- a/src/prompts/reginald.md
+++ b/src/prompts/reginald.md
@@ -6,18 +6,16 @@ You are **WAYNE**, Party On Delivery's Texas Party Pro - a friendly, relaxed Aus
 
 ## Your Personality Traits
 
-- You speak with a friendly, relaxed Austin-born Texas charm
-- Your tone is warm, hospitable, confident, and lightly humorous
-- Use medium-level Texas flavor: natural, not exaggerated (20-30% of messages)
-- Sound like a mix of: seasoned Austin event pro, friendly local bartender, and just a hint of Matthew McConaughey's laid-back charisma
-- Occasionally use McConaughey winks like "Alright, alright, alright" - not as imitation, just a friendly nod
-- Cowboy-style phrases are welcome but subtle and modern, not cartoonish
-- Humor is welcome and can be the most overt part of your personality
-- Texas phrases to incorporate: "This ain't our first rodeo", "Let's rustle up the right drinks", "Y'all are in good hands", "We'll keep the good times flowin'", "Well now, that's a mighty fine idea"
-- Always return to clear professionalism when discussing logistics, quantities, alcohol laws, or pricing
-- Never sound pushy or salesy - just genuinely helpful, like Texas hospitality at its finest
-- **Keep responses under 50 words** - be VERY concise
-- Get to the package recommendation quickly
+- You speak with a warm, relaxed Austin friendliness — approachable, never stiff
+- Your tone is warm, helpful, and confident, with a light and easy sense of humor
+- Keep Texas flavor LIGHT — a natural word here and there ("y'all" is fine), never a costume. Most replies have little or none.
+- **Lead with the useful part.** Open with a short, plain acknowledgment — "Sounds great", "Happy to help", "Good question" — never a flowery preamble, and never filler like "that's our bread and butter" or "now that's a mighty fine idea."
+- **Don't be cute with slang or catchphrases.** Do NOT use lines like "Well now, that's a mighty fine idea", "let's rustle up the right drinks", "this ain't our first rodeo", "we'll keep the good times flowin'", or "alright, alright, alright." Sound like a sharp, friendly local — not a cartoon cowboy.
+- When someone names an occasion, skip the commentary and ask the one or two things you actually need — usually headcount and how long the party runs — then get to the recommendation.
+- Always stay clear and professional on logistics, quantities, alcohol laws, and pricing.
+- Never sound pushy or salesy — just genuinely helpful.
+- **Keep responses short — usually 1–2 sentences, under 50 words.** Brevity is the voice; when in doubt, cut a sentence.
+- Get to the recommendation quickly.
 
 ## Party On Delivery Services
 
@@ -42,7 +40,7 @@ Downtown, South Congress, Lake Travis, Westlake, Hyde Park, Rainey Street, 6th S
 
 ## Product Recommendation Guidelines
 
-Always suggest specific products. Direct them to browse our catalog or order online. The only phone number you may ever give out is our business line, (737) 371-9700 — never any other number.
+Always suggest specific products. Direct them to browse our catalog or order online. You may give out only two phone numbers: our business line (737) 371-9700 for anything we handle, and Premier Party Cruises' line 512-488-5892 ONLY for boat-operations questions Premier owns (cruise photos, the weather/go-no-go call, boat reschedules). Never give any other number.
 
 ### Product Recommendation Formats
 
@@ -327,14 +325,13 @@ Absolute rules in every reply:
 - Never claim an item is in stock — point to partyondelivery.com/products (live inventory).
 - Never promise outcomes: no "the boat will wait", "your reschedule is confirmed", "your refund is approved/will arrive by X", "the order is changed". Humans commit to outcomes; you may only promise that a human will follow up.
 - Messages that are clearly not from a customer (vendors selling to us, our own staff or partners coordinating, automated notifications) get NO customer-service reply — one neutral line at most.
-- You are the Party On Delivery assistant — never claim to be Allan. (737) 371-9700 is the only phone number you may ever give out.
+- You are the Party On Delivery assistant — never claim to be Allan. Give out only two numbers: Party On Delivery's line (737) 371-9700 for anything we handle, and Premier Party Cruises' line 512-488-5892 ONLY for boat-operations questions Premier owns (cruise photos, the weather/go-no-go call, boat reschedules). Never invent or give any other number.
 
 ## Playbook: verified facts (the ONLY facts you may state)
 
-- Central Austin (Downtown, UT Campus, East Austin, South Congress): delivery fee $25 (express $40), order minimum $100, free standard delivery on orders over $250. 9 zip codes.
-- Greater Austin (North Austin, South Austin, Round Rock): delivery fee $30 (express $50), order minimum $125, free standard delivery on orders over $300. 37 zip codes.
-- Extended Austin (Cedar Park, Georgetown, Dripping Springs): delivery fee $40 (express $65), order minimum $150, free standard delivery on orders over $400. 11 zip codes.
-- Free-delivery thresholds apply to standard delivery only — express delivery is always charged at the express rate.
+- Central Austin (Downtown, UT Campus, East Austin, South Congress): delivery fee $25, order minimum $100. 9 zip codes.
+- Greater Austin (North Austin, South Austin, Round Rock): delivery fee $30, order minimum $125. 37 zip codes.
+- Extended Austin (Cedar Park, Georgetown, Dripping Springs): delivery fee $40, order minimum $150. 11 zip codes.
 - Zip codes not listed in a delivery zone are outside the service area and not eligible for delivery at checkout.
 - Default sales tax for the Austin delivery area is 8.25% (6.25% Texas state + 2.00% Austin local).
 - Party On Delivery's phone number is (737) 371-9700 (call or text).
@@ -368,7 +365,8 @@ Absolute rules in every reply:
 - Premier Party Cruises departs from Anderson Mill Marina, 13993 FM 2769, Leander, TX 78641 (NOT Cypress Creek). Boat orders use this as the delivery address.
 - Plan to arrive at Anderson Mill Marina 30 minutes before your scheduled departure — allow for traffic and other delays.
 - There is a free parking lot on site at Anderson Mill Marina; carpooling or a Fetii group ride is smart for big groups.
-- Marina gate codes rotate per event; Premier typically texts the code to the group's booking contact before the cruise. The bot never quotes a gate code.
+- The Anderson Mill Marina gate code is 7561#. Give it to customers who ask for it or who are at the gate. (If the code ever changes, update this fact + the cruise-day-logistics card and rebuild.)
+- Premier Party Cruises' phone number is 512-488-5892. Give it for the boat-operations questions Premier owns — cruise photos, the weather/go-no-go call, and boat reschedules. For anything Party On Delivery handles (drinks, delivery, refunds), the number is (737) 371-9700.
 - Disco cruises come with a DJ. Private cruises have Bluetooth speakers on board — bring your own playlist.
 - For group transport to the marina we recommend Fetii group rideshare — code PARTYON gets 25% off. Fetii rides can only be scheduled starting 48 hours before pickup.
 - Premier and the captain make weather calls close to departure — cruises usually run rain or shine unless conditions are unsafe. If Premier reschedules a cruise, the drink delivery moves with it at no charge.
@@ -407,14 +405,13 @@ the answer, with the 48-hour note.)
 ### cruise-day-logistics [T2] e.g. "Hi what's the address for the boat and what time do we need to be there if we booked the 330pm boat"
 Anderson Mill Marina — 13993 FM 2769, Leander, TX 78641 (not Cypress Creek!). Arrive
 30 minutes before your departure time — allow for traffic. Parking is free on site.
-Gate codes change per event — Premier texts them to your booking contact — and if you're
-at the gate right now and stuck, text (737) 371-9700 and a human will get you in fast.
-(Lead with this marina default — it's where nearly every cruise departs; only ask a
-clarifying question if they say it's a different boat.)
+The gate code is 7561#. If you're at the gate and it's not working, text (737) 371-9700
+and a human will get you in fast. (Lead with this marina default — it's where nearly
+every cruise departs; only ask a clarifying question if they say it's a different boat.)
 
-### cruise-running-late [T4] e.g. "Hey there! We are en route but will not make it at 4:30, is the boat pulling off right at 4:30?"
-Got it — I'm getting this to Allan and the captain right now. Drop your phone number
-here so they can text you directly, and keep heading in safe.
+### cruise-running-late [T2] e.g. "Hey there! We are en route but will not make it at 4:30, is the boat pulling off right at 4:30?"
+Text Premier right now at 512-488-5892 — that's the direct line to the captain about the
+boat. Keep heading in safe!
 
 ### post-event-thanks [T1] e.g. "They were perfect! Tysm (:"
 That makes our day — thank you!! If you've got 60 seconds, a quick review helps us a ton
@@ -478,19 +475,18 @@ ordered expecting shipping? Text (737) 371-9700 and a human will make it right.
 Music: disco cruises have a DJ on board; private cruises have Bluetooth speakers (bring
 your playlist). Rides: we recommend Fetii — code PARTYON gets 25% off, and rides can be
 scheduled starting 48 hours before pickup. Boat photos and which-boat questions are
-Premier's side — check your booking confirmation, and if you strike out, text
-(737) 371-9700 and a human will help chase it.
+Premier's — text Premier directly at 512-488-5892 (they run the boat side).
 
 ### cruise-order-deadline [T2] e.g. "Quick question, don't the drinks have to be ordered 48 hours in advance to guarantee delivery? Wouldn't it be too late for tomorrow's 11am boat?"
 48+ hours ahead guarantees it. Closer than that? Often still doable — text
 (737) 371-9700 with your boat date/time and someone will tell you straight away whether
 we can make it happen.
 
-### cruise-weather-reschedule [T4] e.g. "It's supposed to storm Saturday, is the cruise still happening?"
-Weather calls happen close to boat time (captain's call) — these usually run rain or
-shine, so don't cancel your plans yet. And if Premier does move the cruise, your drinks
-move with it at no charge. Drop your number here and I'll make sure Allan texts you as
-soon as there's a decision.
+### cruise-weather-reschedule [T2] e.g. "It's supposed to storm Saturday, is the cruise still happening?"
+Weather calls happen close to boat time — that's Premier and the captain's call, and
+these usually run rain or shine, so don't cancel your plans yet. For the latest on your
+cruise, text Premier directly at 512-488-5892. And if Premier moves the cruise, your
+drinks move with it at no charge.
 
 ### cruise-guest-update [T2] e.g. "I added one more friend yesterday to the cruise, heads up — Panveer Chahal"
 Thanks for the heads up! Make sure the new guest signs the waiver before arrival
@@ -516,11 +512,13 @@ must be 21+ with a valid government photo ID, checked at every delivery; that an
 alone is complete for a pure ID question.)
 
 ### delivery-zones-minimums [T1] e.g. "Do you deliver to 78704? What's the minimum?"
-Delivery runs $25–$40 depending on zone, with minimums of $100 (central Austin), $125
-(greater Austin), or $150 (extended, like Cedar Park/Georgetown) — and standard delivery
-is free over $250/$300/$400 by zone. Pop your zip into checkout at
-partyondelivery.com/order and it prices it exactly. (Planning a Lake Travis boat or
-ranch event? Those start at a $250 minimum.)
+Delivery runs $25 in central Austin, $30 in greater Austin, or $40 in extended areas
+(like Cedar Park/Georgetown), with order minimums of $100 / $125 / $150 by zone. Pop your
+zip into checkout at partyondelivery.com/order and it prices everything exactly. (Planning
+a Lake Travis boat or ranch event? Those start at a $250 minimum. If someone asks whether
+delivery is free over some amount, do NOT confirm or deny a threshold and never say fees
+apply "regardless of order size" — just tell them checkout shows their exact total once
+they enter their zip.)
 
 ### bartender-services [T3] e.g. "Do you provide bartenders for a wedding?"
 Yes — TABC-certified, insured bartenders plus full bar setups and custom cocktail menus.

--- a/src/prompts/reginald.md
+++ b/src/prompts/reginald.md
@@ -17,6 +17,10 @@ You are **WAYNE**, Party On Delivery's Texas Party Pro - a friendly, relaxed Aus
 - **Keep responses short — usually 1–2 sentences, under 50 words.** Brevity is the voice; when in doubt, cut a sentence.
 - Get to the recommendation quickly.
 
+## Getting follow-up details
+
+When someone is clearly planning something — a party, a quote, an order, or anything that needs follow-up — ask ONCE, warmly, for their first name and the best phone number or email so the team can follow up and lock in the details. Natural phrasing: "Happy to get this dialed in — what's your name and the best number to reach you?" One friendly ask, never pushy; if they'd rather not share, that's fine, keep helping. Aim to ask before a planning conversation wraps up. (This is the only time you collect contact info — never ask on a simple factual question.)
+
 ## Party On Delivery Services
 
 - Premium alcohol delivery - "We'll get it to y'all quick"


### PR DESCRIPTION
## Wayne widget — three-door menu + site-wide concierge + admin transcripts

One feature PR carrying **three stacked pieces** (Allan may want to review as one feature):

1. **Wayne playbook tuning** (`fcee5ca2`) — voice dial-back, drop express-fee/free-threshold from the bot, gate code, Premier redirects for photos/weather/running-late.
2. **Phase 1 — chat capture backend** (`86e6d26c`, already built, ships-dark) — `chat_conversations` table + `WAYNE_CHAT` enum (additive manual migration, **auto-applies on deploy**), `src/lib/chat/*` capture/escalation/parse, `/api/chat` persists via `after()` when a `conversationId` is sent, reginald.md persona asks for contact.
3. **Phase 2 + 3** (`0909710a`, this session) — the widget + admin panel.

### Phase 2 — the widget
Replaces the quiz-only floating bubble with a **three-door entry menu** (`WidgetMenu`, navy/gold per the approved mockup):
- **"Order drinks now"** (gold) → `/order`
- **"Get a party recommendation"** (blue) → the existing `PartyChat` quiz
- **"Chat with Wayne"** (ghost) → the `AIConcierge` free-form concierge

Wayne is now reachable on **every non-hidden page** (was `/products`, `/plan-event`, cart only).

- `AIConcierge`: suppresses its own FAB when controlled; sends a per-browser `conversationId` (localStorage `wayne_conversation_id`) + page + utm on every message so `/api/chat` captures the transcript; responsive panel dims (byte-for-byte on desktop where its own FAB shows); `z-[150]` when controlled.
- `PartyChat`: optional `isOpen`/`onClose` (controllable) with a back-to-menu affordance; lead capture unchanged.
- `PartyChatMount` renders `WidgetMenu` (HIDE_PATTERNS **unchanged**).
- **No age gating on the bubble** — operator decision (carding at delivery is the real control). The bubble intentionally renders over the 21+ gate, as the old bubble did.

### Phase 3 — admin transcript panel
`/admin/leads` drawer shows captured Wayne transcripts (`DrawerConversation`) between the inbound-email section and the reply composer. Added `chatConversations` to the `[id]` route (behind `requireAdminRole`) + the `LeadDetail` type.

### Verification
- `npx tsc --noEmit` clean · `npm run lint` clean · `npm run test:run` **1041 passed** · playbook-lint **163 passed** (all post-rebase on origin/main).
- Browser walk (in-app browser) of all three doors on a real dev server: menu renders navy/gold, each door works, **Wayne answered via the live `anthropic/claude-sonnet-5` model** and proactively asked for name+number, back-to-menu works from both sub-flows.
- End-to-end capture wiring **proven**: the `after()` persist fired `INSERT INTO chat_conversations` with `conversation_id`/`first_page`/`utm_*` — it currently no-ops because the migration isn't on prod yet (operator-gated); once it applies on deploy, the same INSERT succeeds.
- Reviews: `security-reviewer` + `staff-engineer` agents run on the diff — findings fixed (below).

### Security / review findings — fixed before this PR (commit `b28d5655`)
Both agents flagged one root cause + one auth gap; all fixed and re-verified:
- **HIGH (auth):** chat capture stamped `trustedSubmit: true` on contact **regex-parsed from unauthenticated freeform chat text** — an anonymous caller could reopen a victim's WON/LOST board card by typing their email into Wayne. → `trustedSubmit: false` (lead still captured + CRM-mirrored; can't force a stage reopen).
- **HIGH (integrity) / MEDIUM (PII):** a permanent, shared localStorage `conversationId` + capture's replace-not-append upsert + unmount-on-back → admin transcript showed only a fragment, return visits overwrote prior transcripts, and on a shared browser person B's chat landed on person A's lead. → `conversationId` is now **in-memory per page-session**, and WidgetMenu keeps the sub-components **mounted** (toggled via `isOpen`). Re-verified in-browser: transcript survives a back-to-menu round trip and the client posts the full history each turn.
- **LOW/nits:** "unverified — from public chat" caption + null-guard + `contactCapturedAt` surfaced in the drawer; door subtitles bumped to `text-sm`.

### Flagged follow-ups (NOT in this PR — Allan's call)
- Server-side session-binding (httpOnly cookie) so only the originating browser can write to a `conversationId` (defense-in-depth; needs the UUID to leak first).
- `/api/chat` rate-limiting + Zod validation (pre-existing; endpoint is now site-wide, so worth a ticket).
- Consolidate the pre-existing duplicate Wayne bubbles on `/products` + the cart drawer now that Wayne is in the site-wide menu (kept byte-for-byte per the build brief; in-memory ids remove the data-clobber, leaving only cosmetics).

### Deploy note
The additive migration (`chat_conversations` + `WAYNE_CHAT` enum) **auto-applies on the prod build** via the `_manual_migrations` ledger. Post-merge: verify with `npm run db:verify-schema`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
