### PR TITLE
fix(chat): enroll captured Wayne-chat leads onto the Lead Flow board

### DIFF
--- a/src/lib/chat/capture.ts
+++ b/src/lib/chat/capture.ts
@@ -13,6 +13,7 @@
 import { LeadEventType } from '@prisma/client';
 import { prisma } from '@/lib/database/client';
 import { upsertLead, recordEvent } from '@/lib/leads/leadCapture';
+import { enrollLeadIfEligible } from '@/lib/leads/pipeline';
 import { mirrorLeadToCrm, leadBoardUrl } from '@/lib/leads/crm-mirror';
 import { detectEscalation } from './escalation-keywords';
 import { parseContact, hasContact } from './parse-contact';
@@ -91,6 +92,13 @@ export async function persistChatTurn(input: ChatTurnInput): Promise<void> {
           trustedSubmit: false,
           metadata: { conversationId, via: 'wayne-chat' },
         });
+        // Put the lead on the Lead Flow board as NEW so an operator sees it and
+        // follows up. `enrollLeadIfEligible` only enrolls null-stage leads, so —
+        // unlike the trusted `handleSubmitSignal` — it can NEVER reopen a WON/LOST
+        // card from unauthenticated chat text (that's the HIGH we're avoiding).
+        // allowPartial: a chat contact is a PARTIAL lead, but a genuine inquiry
+        // (Wayne asked for + got their number) an operator should work.
+        await enrollLeadIfEligible(lead.id, { allowPartial: true });
         await prisma.chatConversation.update({
           where: { id: convo.id },
           data: { leadId: lead.id, contactCapturedAt: new Date() },


### PR DESCRIPTION
**Bug (found in prod right after #292 shipped):** a Wayne chat that captures a contact *does* create a Lead (verified: lead `478b2b1b`, phone captured, `source_widget=WAYNE_CHAT`), but it never shows on `/admin/leads` — the lead is `PARTIAL`, and the only enrollment path (`recordEvent` → `handleSubmitSignal` → `enrollLeadIfEligible` with no `allowPartial`) skips PARTIAL leads. So a genuine chat inquiry was invisible to the operator. Latent since Phase 1; the `trustedSubmit:false` security fix didn't cause it but doesn't help either.

**Fix:** `capture.ts` calls `enrollLeadIfEligible(leadId, { allowPartial: true })` right after creating the lead. It enrolls the null-stage lead as **NEW** on the board but — unlike the trusted `handleSubmitSignal` — **can never reopen a WON/LOST card** from unauthenticated chat text (`enrollLeadIfEligible` only touches `pipelineStage === null` leads), so the 2026-07-22 HIGH stays fixed. This is exactly the reviewer's recommended shape (enroll null-stage, never reopen WON/LOST from chat).

**Gates:** tsc 0 · lint clean · test:run 1041 · chat+leads 117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)