### PR TITLE
fix(chat): stop parsing verbs after "I'm" as the customer's name

### DIFF
--- a/src/lib/chat/__tests__/chat-capture.test.ts
+++ b/src/lib/chat/__tests__/chat-capture.test.ts
@@ -60,6 +60,17 @@ describe('parseContact', () => {
     expect(parseContact('this is Jessica, thanks!').firstName).toBe('Jessica');
   });
 
+  it('does NOT read a verb after "I\'m" as a name', () => {
+    // Regression: "I'm doing a wedding" used to capture the name "doing".
+    expect(parseContact("I'm doing a wedding").firstName).toBeUndefined();
+    expect(parseContact('I am planning a bachelorette').firstName).toBeUndefined();
+    expect(parseContact("i'm looking for a keg").firstName).toBeUndefined();
+    // A real capitalized name still parses, and phone is still captured alongside.
+    const c = parseContact("I'm doing a wedding, my number is 512-555-1000");
+    expect(c.firstName).toBeUndefined();
+    expect(c.phone).toBe('5125551000');
+  });
+
   it('returns nothing identifiable for a plain message', () => {
     const c = parseContact('do you deliver to 78704?');
     expect(c.email).toBeUndefined();

--- a/src/lib/chat/parse-contact.ts
+++ b/src/lib/chat/parse-contact.ts
@@ -15,8 +15,21 @@ export interface ParsedContact {
 const EMAIL_RE = /[\w.+-]+@[\w-]+(?:\.[\w-]+)+/;
 // (512) 555-1234 / 512-555-1234 / 5125551234 / +1 512 555 1234
 const PHONE_RE = /(?:\+?1[\s.\-]?)?\(?\d{3}\)?[\s.\-]?\d{3}[\s.\-]?\d{4}/;
-// "I'm Sarah" / "my name is Sarah" / "this is Sarah" / "name's Sarah"
-const NAME_RE = /\b(?:i['’]?m|i am|my name is|this is|name['’]?s)\s+([A-Z][a-z]{1,20})\b/i;
+// "I'm Sarah" / "my name is Sarah" / "this is Sarah" / "name's Sarah".
+// The prefix casing is spelled out (I'm/i'm, My/my, …) instead of using the /i
+// flag, because /i also lets the [A-Z] name class match lowercase — which turned
+// "I'm doing a wedding" into the name "doing". Requiring a genuinely capitalized
+// word means verb phrases after "I'm" (typed lowercase) no longer match.
+const NAME_RE =
+  /\b(?:[Ii]['’]?m|[Ii] am|[Mm]y name is|[Tt]his is|[Nn]ame['’]?s)\s+([A-Z][a-z]{1,20})\b/;
+// Common words that follow "I'm …" but aren't names — belt-and-suspenders for the
+// rare case where one is capitalized ("I'm Doing a wedding", sentence-cased).
+const NAME_STOPWORDS = new Set([
+  'doing', 'planning', 'looking', 'having', 'hosting', 'throwing', 'organizing',
+  'trying', 'thinking', 'hoping', 'going', 'gonna', 'interested', 'needing',
+  'wanting', 'wondering', 'just', 'not', 'here', 'ready', 'done', 'still', 'also',
+  'really', 'good', 'great', 'the', 'from', 'with',
+]);
 
 export function parseContact(text: string): ParsedContact {
   const out: ParsedContact = {};
@@ -32,7 +45,9 @@ export function parseContact(text: string): ParsedContact {
   }
 
   const name = text.match(NAME_RE)?.[1];
-  if (name) out.firstName = name.charAt(0).toUpperCase() + name.slice(1);
+  if (name && !NAME_STOPWORDS.has(name.toLowerCase())) {
+    out.firstName = name.charAt(0).toUpperCase() + name.slice(1);
+  }
 
   return out;
 }


### PR DESCRIPTION
**Bug (seen in prod):** a lead came in named **"doing"** — the visitor said *"I'm doing a wedding"* and the name parser grabbed the word after "I'm".

**Root cause:** `NAME_RE` carried the `/i` flag, which also lets its `[A-Z]` (capitalized-name) class match lowercase — so any `I'm <verb>` phrase (doing / planning / looking / …) was read as a name.

**Fix:** spell the prefix casing out (`I'm`/`i'm`, `My`/`my`, …) instead of the `/i` flag, so a genuinely capitalized word is required; plus a small stopword set for the rare sentence-cased `I'm Doing …`. Real names ("I'm Sarah", "my name is Robert", "this is Jessica") still parse; phone/email capture unchanged. +1 regression test.

**Gates:** tsc 0 · lint clean · test:run **1042**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)